### PR TITLE
feat: snapshot unit config onto subscription - OM-399

### DIFF
--- a/e2e/billinginvoice_unitconfig_test.go
+++ b/e2e/billinginvoice_unitconfig_test.go
@@ -1,0 +1,260 @@
+package e2e
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/openmeterio/openmeter/api/client/go"
+	apiv3 "github.com/openmeterio/openmeter/api/v3"
+)
+
+// TestInvoiceUnitConfigConvertedQuantity drives the full unit_config billing
+// pipeline against the live e2e stack and asserts that a usage-based invoice
+// line records the raw metered quantity alongside the unit-config-converted
+// invoiced quantity.
+//
+// Scenario: a SUM meter over `$.value`, billed per 1000 units rounded up
+// (unit_config: divide by 1000, ceiling). Ingesting a single 7400 event yields
+// meteredQuantity=7400 (raw) and quantity=ceil(7400/1000)=8 (converted).
+func TestInvoiceUnitConfigConvertedQuantity(t *testing.T) {
+	c := newV3Client(t)
+	v1 := initClient(t)
+
+	uniq := uniqueKey("ucbill")
+	meterKey := "uc_bill_meter_" + uniq
+	eventType := "uc_bill_event_" + uniq
+	featureKey := "uc_bill_feature_" + uniq
+	customerKey := "uc_bill_customer_" + uniq
+	subjectKey := "uc_bill_subject_" + uniq
+
+	var meter *apiv3.Meter
+	var feature *apiv3.Feature
+	var plan *apiv3.BillingPlan
+	var customer *api.Customer
+	var subscription *apiv3.BillingSubscription
+
+	// given:
+	// - a SUM meter over $.value and a feature bound to it
+	// - a published plan whose single usage-based rate card carries a
+	//   divide-by-1000 ceiling unit_config
+	// when:
+	// - the catalog fixtures are created via the v3 API
+	// then:
+	// - the plan publishes and is ready for subscription
+	runRequired(t, "creates unit_config catalog fixtures", func(t *testing.T) {
+		status, createdMeter, problem := c.CreateMeter(apiv3.CreateMeterRequest{
+			Key:           meterKey,
+			Name:          "Unit Config Meter " + uniq,
+			Aggregation:   apiv3.MeterAggregationSum,
+			EventType:     eventType,
+			ValueProperty: lo.ToPtr("$.value"),
+		})
+		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, createdMeter)
+		meter = createdMeter
+
+		status, createdFeature, problem := c.CreateFeature(apiv3.CreateFeatureRequest{
+			Key:   featureKey,
+			Name:  "Unit Config Feature " + uniq,
+			Meter: &apiv3.FeatureMeterReference{Id: meter.Id},
+		})
+		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, createdFeature)
+		feature = createdFeature
+
+		// Unit price billed per converted unit. Unit prices require an
+		// in-arrears payment term; unit_config divides raw usage by 1000 and
+		// rounds the invoiced quantity up to whole units.
+		cadence := apiv3.ISO8601Duration("P1M")
+		term := apiv3.BillingPricePaymentTermInArrears
+		price := apiv3.BillingPrice{}
+		require.NoError(t, price.FromBillingPriceUnit(apiv3.BillingPriceUnit{
+			Type:   apiv3.BillingPriceUnitTypeUnit,
+			Amount: "0.10",
+		}))
+
+		rateCard := apiv3.BillingRateCard{
+			Key:            feature.Key,
+			Name:           "Unit Config Rate Card " + uniq,
+			Price:          price,
+			BillingCadence: &cadence,
+			PaymentTerm:    &term,
+			Feature:        &apiv3.FeatureReference{Id: feature.Id},
+			UnitConfig: &apiv3.BillingUnitConfig{
+				Operation:        apiv3.BillingUnitConfigOperationDivide,
+				ConversionFactor: "1000",
+				Rounding:         lo.ToPtr(apiv3.BillingUnitConfigRoundingModeCeiling),
+				Precision:        lo.ToPtr(0),
+			},
+		}
+
+		status, createdPlan, problem := c.CreatePlan(apiv3.CreatePlanRequest{
+			Key:            "uc_bill_plan_" + uniq,
+			Name:           "Unit Config Plan " + uniq,
+			Currency:       "USD",
+			BillingCadence: apiv3.ISO8601Duration("P1M"),
+			Phases: []apiv3.BillingPlanPhase{{
+				Key:       "phase_1",
+				Name:      "Unit Config Phase",
+				RateCards: []apiv3.BillingRateCard{rateCard},
+			}},
+		})
+		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, createdPlan)
+
+		status, plan, problem = c.PublishPlan(createdPlan.Id)
+		require.Equal(t, http.StatusOK, status, "problem: %+v", problem)
+		require.NotNil(t, plan)
+		require.Equal(t, apiv3.BillingPlanStatusActive, plan.Status)
+	})
+
+	// given:
+	// - a customer with usage attribution to the ingested subject key
+	// - a published unit_config plan
+	// when:
+	// - the customer subscribes in credit-then-invoice mode
+	// then:
+	// - the subscription is active and exposes its billing anchor
+	runRequired(t, "creates customer and starts subscription", func(t *testing.T) {
+		// The v3 create-customer request does not model usage-attribution
+		// subject keys, so the customer (and its subject) is provisioned via
+		// the v1 SDK helper to bind the ingested subject to the customer.
+		customer = CreateCustomerWithSubject(t, v1, customerKey, subjectKey)
+		require.NotNil(t, customer)
+
+		status, createdSubscription, problem := c.CreateSubscription(apiv3.BillingSubscriptionCreate{
+			Customer: struct {
+				Id  *apiv3.ULID                `json:"id,omitempty"`
+				Key *apiv3.ExternalResourceKey `json:"key,omitempty"`
+			}{
+				Id: lo.ToPtr(customer.Id),
+			},
+			Plan: struct {
+				Id      *apiv3.ULID        `json:"id,omitempty"`
+				Key     *apiv3.ResourceKey `json:"key,omitempty"`
+				Version *int               `json:"version,omitempty"`
+			}{
+				Id: lo.ToPtr(plan.Id),
+			},
+			SettlementMode: lo.ToPtr(apiv3.BillingSettlementModeCreditThenInvoice),
+		})
+		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, createdSubscription)
+		require.Equal(t, apiv3.BillingSubscriptionStatusActive, createdSubscription.Status)
+		subscription = createdSubscription
+	})
+
+	// given:
+	// - an active subscription with a known billing anchor
+	// when:
+	// - a single event carrying value=7400 is ingested at the billing anchor
+	//   so the usage lands inside the in-arrears period
+	// then:
+	// - the (asynchronous) sink eventually aggregates the meter to 7400
+	runRequired(t, "ingests usage and waits for the meter to aggregate", func(t *testing.T) {
+		ev := cloudevents.New()
+		ev.SetID(uniqueKey("uc_bill_evt"))
+		ev.SetSource("uc-bill-e2e")
+		ev.SetType(eventType)
+		ev.SetSubject(subjectKey)
+		ev.SetTime(subscription.BillingAnchor)
+		require.NoError(t, ev.SetData("application/json", map[string]string{
+			"value": "7400",
+		}))
+
+		resp, err := v1.IngestEventWithResponse(t.Context(), ev)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode(), "ingest event: %s", string(resp.Body))
+
+		// The sink worker processes events asynchronously, so poll the meter
+		// until the single ingested value is visible.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			status, result, err := QueryMeterV3(t, meter.Id, apiv3.MeterQueryRequest{})
+			require.NoError(collect, err)
+			require.Equal(collect, http.StatusOK, status)
+			require.NotNil(collect, result)
+			require.NotEmpty(collect, result.Data)
+			require.Equal(collect, float64(7400), numericToFloat(collect, result.Data[0].Value))
+		}, time.Minute, time.Second)
+	})
+
+	// given:
+	// - aggregated usage of 7400 on an in-arrears subscription
+	// when:
+	// - the subscription is canceled, closing the period so the billing-worker
+	//   produces an invoice, and the usage-based line's quantities are snapshotted
+	// then:
+	// - the usage line records meteredQuantity=7400 (raw) and quantity=8
+	//   (ceil(7400/1000)) from the unit_config conversion
+	runRequired(t, "cancels the subscription and asserts converted invoice quantity", func(t *testing.T) {
+		status, canceledSubscription, problem := c.CancelSubscription(subscription.Id, apiv3.BillingSubscriptionCancel{})
+		require.Equal(t, http.StatusOK, status, "problem: %+v", problem)
+		require.NotNil(t, canceledSubscription)
+		require.Equal(t, apiv3.BillingSubscriptionStatusInactive, canceledSubscription.Status)
+
+		usageLine := waitForSnapshottedUsageLine(t, v1, customer.Id, featureKey)
+
+		require.NotNil(t, usageLine.MeteredQuantity, "usage line metered quantity")
+		require.NotNil(t, usageLine.Quantity, "usage line invoiced quantity")
+		assert.Equal(t, float64(7400), numericToFloat(t, *usageLine.MeteredQuantity), "raw metered quantity")
+		assert.Equal(t, float64(8), numericToFloat(t, *usageLine.Quantity), "unit-config-converted invoiced quantity")
+	})
+}
+
+func waitForSnapshottedUsageLine(t *testing.T, client *api.ClientWithResponses, customerID, featureKey string) api.InvoiceLine {
+	t.Helper()
+
+	ctx := t.Context()
+	customers := api.InvoiceListParamsCustomers{customerID}
+	expand := api.InvoiceListParamsExpand{api.InvoiceExpandLines}
+	snapshotRequested := map[string]bool{}
+	var usageLine api.InvoiceLine
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp, err := client.ListInvoicesWithResponse(ctx, &api.ListInvoicesParams{
+			Customers: &customers,
+			Expand:    &expand,
+			PageSize:  lo.ToPtr(api.PaginationPageSize(100)),
+		})
+		require.NoError(collect, err)
+		require.Equal(collect, http.StatusOK, resp.StatusCode(), "list invoices: %s", string(resp.Body))
+		require.NotNil(collect, resp.JSON200)
+
+		for _, invoice := range resp.JSON200.Items {
+			if invoice.Lines == nil {
+				continue
+			}
+
+			idx := slices.IndexFunc(*invoice.Lines, func(line api.InvoiceLine) bool {
+				return line.FeatureKey != nil && *line.FeatureKey == featureKey
+			})
+			if idx == -1 {
+				continue
+			}
+
+			line := (*invoice.Lines)[idx]
+			if line.MeteredQuantity != nil && line.Quantity != nil {
+				usageLine = line
+				return
+			}
+
+			if invoice.StatusDetails.AvailableActions.SnapshotQuantities != nil && !snapshotRequested[invoice.Id] {
+				snapshotResp, err := client.SnapshotQuantitiesInvoiceActionWithResponse(ctx, invoice.Id)
+				require.NoError(collect, err)
+				require.Equal(collect, http.StatusOK, snapshotResp.StatusCode(), "snapshot quantities: %s", string(snapshotResp.Body))
+				snapshotRequested[invoice.Id] = true
+			}
+		}
+
+		require.Fail(collect, "usage-based invoice line with snapshotted quantities not found yet")
+	}, 2*time.Minute, time.Second)
+
+	return usageLine
+}

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -48,6 +48,9 @@ credits:
   enabled: true
   enableCreditThenInvoice: true
 
+unitConfig:
+  enabled: true
+
 notification:
   lock:
     owner: lock-owner

--- a/e2e/plans_v3_test.go
+++ b/e2e/plans_v3_test.go
@@ -603,24 +603,3 @@ func TestV3PlanReadTranslatesV1DynamicAndPackagePrices(t *testing.T) {
 		assert.Equal(t, apiv3.BillingUnitConfigRoundingModeCeiling, *pkgRC.UnitConfig.Rounding)
 	})
 }
-
-// TestV3PlanRejectsUnitConfigWhenFlagDisabled verifies that, while the UnitConfig
-// feature flag is off (the default in the e2e environment), authoring a plan whose
-// rate card carries a unit_config is rejected on create. unit_config stays
-// read-only — synthesized from v1 dynamic/package prices on the response path only
-// — until the flag is enabled per environment. The reject guard fires before price
-// validation, so a flat rate card is enough to exercise it (no feature needed).
-func TestV3PlanRejectsUnitConfigWhenFlagDisabled(t *testing.T) {
-	c := newV3Client(t)
-
-	body := validPlanRequest("unit_config_rejected")
-	body.Phases[0].RateCards[0].UnitConfig = &apiv3.BillingUnitConfig{
-		Operation:        apiv3.BillingUnitConfigOperationMultiply,
-		ConversionFactor: apiv3.Numeric("1.2"),
-	}
-
-	status, plan, problem := c.CreatePlan(body)
-	require.Equal(t, http.StatusBadRequest, status, "problem: %+v", problem)
-	require.Nil(t, plan)
-	assertProblemDetail(t, problem, "unit_config")
-}

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -5018,6 +5018,7 @@ var (
 		{Name: "billing_cadence", Type: field.TypeString, Nullable: true},
 		{Name: "price", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "discounts", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "entitlement_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "phase_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -5030,19 +5031,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "subscription_items_entitlements_subscription_item",
-				Columns:    []*schema.Column{SubscriptionItemsColumns[22]},
+				Columns:    []*schema.Column{SubscriptionItemsColumns[23]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "subscription_items_subscription_phases_items",
-				Columns:    []*schema.Column{SubscriptionItemsColumns[23]},
+				Columns:    []*schema.Column{SubscriptionItemsColumns[24]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "subscription_items_tax_codes_subscription_items",
-				Columns:    []*schema.Column{SubscriptionItemsColumns[24]},
+				Columns:    []*schema.Column{SubscriptionItemsColumns[25]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -5061,7 +5062,7 @@ var (
 			{
 				Name:    "subscriptionitem_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionItemsColumns[24]},
+				Columns: []*schema.Column{SubscriptionItemsColumns[25]},
 			},
 			{
 				Name:    "subscriptionitem_namespace_id",
@@ -5071,7 +5072,7 @@ var (
 			{
 				Name:    "subscriptionitem_namespace_phase_id_key",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionItemsColumns[1], SubscriptionItemsColumns[23], SubscriptionItemsColumns[10]},
+				Columns: []*schema.Column{SubscriptionItemsColumns[1], SubscriptionItemsColumns[24], SubscriptionItemsColumns[10]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -106686,6 +106686,7 @@ type SubscriptionItemMutation struct {
 	billing_cadence                              *datetime.ISODurationString
 	price                                        **productcatalog.Price
 	discounts                                    **productcatalog.Discounts
+	unit_config                                  **productcatalog.UnitConfig
 	clearedFields                                map[string]struct{}
 	phase                                        *string
 	clearedphase                                 bool
@@ -107902,6 +107903,55 @@ func (m *SubscriptionItemMutation) ResetDiscounts() {
 	delete(m.clearedFields, subscriptionitem.FieldDiscounts)
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (m *SubscriptionItemMutation) SetUnitConfig(pc *productcatalog.UnitConfig) {
+	m.unit_config = &pc
+}
+
+// UnitConfig returns the value of the "unit_config" field in the mutation.
+func (m *SubscriptionItemMutation) UnitConfig() (r *productcatalog.UnitConfig, exists bool) {
+	v := m.unit_config
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnitConfig returns the old "unit_config" field's value of the SubscriptionItem entity.
+// If the SubscriptionItem object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SubscriptionItemMutation) OldUnitConfig(ctx context.Context) (v *productcatalog.UnitConfig, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnitConfig is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnitConfig requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnitConfig: %w", err)
+	}
+	return oldValue.UnitConfig, nil
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (m *SubscriptionItemMutation) ClearUnitConfig() {
+	m.unit_config = nil
+	m.clearedFields[subscriptionitem.FieldUnitConfig] = struct{}{}
+}
+
+// UnitConfigCleared returns if the "unit_config" field was cleared in this mutation.
+func (m *SubscriptionItemMutation) UnitConfigCleared() bool {
+	_, ok := m.clearedFields[subscriptionitem.FieldUnitConfig]
+	return ok
+}
+
+// ResetUnitConfig resets all changes to the "unit_config" field.
+func (m *SubscriptionItemMutation) ResetUnitConfig() {
+	m.unit_config = nil
+	delete(m.clearedFields, subscriptionitem.FieldUnitConfig)
+}
+
 // ClearPhase clears the "phase" edge to the SubscriptionPhase entity.
 func (m *SubscriptionItemMutation) ClearPhase() {
 	m.clearedphase = true
@@ -108287,7 +108337,7 @@ func (m *SubscriptionItemMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SubscriptionItemMutation) Fields() []string {
-	fields := make([]string, 0, 24)
+	fields := make([]string, 0, 25)
 	if m.namespace != nil {
 		fields = append(fields, subscriptionitem.FieldNamespace)
 	}
@@ -108360,6 +108410,9 @@ func (m *SubscriptionItemMutation) Fields() []string {
 	if m.discounts != nil {
 		fields = append(fields, subscriptionitem.FieldDiscounts)
 	}
+	if m.unit_config != nil {
+		fields = append(fields, subscriptionitem.FieldUnitConfig)
+	}
 	return fields
 }
 
@@ -108416,6 +108469,8 @@ func (m *SubscriptionItemMutation) Field(name string) (ent.Value, bool) {
 		return m.Price()
 	case subscriptionitem.FieldDiscounts:
 		return m.Discounts()
+	case subscriptionitem.FieldUnitConfig:
+		return m.UnitConfig()
 	}
 	return nil, false
 }
@@ -108473,6 +108528,8 @@ func (m *SubscriptionItemMutation) OldField(ctx context.Context, name string) (e
 		return m.OldPrice(ctx)
 	case subscriptionitem.FieldDiscounts:
 		return m.OldDiscounts(ctx)
+	case subscriptionitem.FieldUnitConfig:
+		return m.OldUnitConfig(ctx)
 	}
 	return nil, fmt.Errorf("unknown SubscriptionItem field %s", name)
 }
@@ -108650,6 +108707,13 @@ func (m *SubscriptionItemMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetDiscounts(v)
 		return nil
+	case subscriptionitem.FieldUnitConfig:
+		v, ok := value.(*productcatalog.UnitConfig)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnitConfig(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionItem field %s", name)
 }
@@ -108731,6 +108795,9 @@ func (m *SubscriptionItemMutation) ClearedFields() []string {
 	if m.FieldCleared(subscriptionitem.FieldDiscounts) {
 		fields = append(fields, subscriptionitem.FieldDiscounts)
 	}
+	if m.FieldCleared(subscriptionitem.FieldUnitConfig) {
+		fields = append(fields, subscriptionitem.FieldUnitConfig)
+	}
 	return fields
 }
 
@@ -108795,6 +108862,9 @@ func (m *SubscriptionItemMutation) ClearField(name string) error {
 		return nil
 	case subscriptionitem.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case subscriptionitem.FieldUnitConfig:
+		m.ClearUnitConfig()
 		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionItem nullable field %s", name)
@@ -108875,6 +108945,9 @@ func (m *SubscriptionItemMutation) ResetField(name string) error {
 		return nil
 	case subscriptionitem.FieldDiscounts:
 		m.ResetDiscounts()
+		return nil
+	case subscriptionitem.FieldUnitConfig:
+		m.ResetUnitConfig()
 		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionItem field %s", name)

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -2844,6 +2844,9 @@ func init() {
 	// subscriptionitemDescDiscounts is the schema descriptor for discounts field.
 	subscriptionitemDescDiscounts := subscriptionitemFields[16].Descriptor()
 	subscriptionitem.ValueScanner.Discounts = subscriptionitemDescDiscounts.ValueScanner.(field.TypeValueScanner[*productcatalog.Discounts])
+	// subscriptionitemDescUnitConfig is the schema descriptor for unit_config field.
+	subscriptionitemDescUnitConfig := subscriptionitemFields[17].Descriptor()
+	subscriptionitem.ValueScanner.UnitConfig = subscriptionitemDescUnitConfig.ValueScanner.(field.TypeValueScanner[*productcatalog.UnitConfig])
 	// subscriptionitemDescID is the schema descriptor for id field.
 	subscriptionitemDescID := subscriptionitemMixinFields0[0].Descriptor()
 	// subscriptionitem.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -5619,6 +5619,20 @@ func (u *SubscriptionItemUpdateOne) SetOrClearDiscounts(value **productcatalog.D
 	return u.SetDiscounts(*value)
 }
 
+func (u *SubscriptionItemUpdate) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *SubscriptionItemUpdate {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
+func (u *SubscriptionItemUpdateOne) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *SubscriptionItemUpdateOne {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
 func (u *SubscriptionPhaseUpdate) SetOrClearDeletedAt(value *time.Time) *SubscriptionPhaseUpdate {
 	if value == nil {
 		return u.ClearDeletedAt()

--- a/openmeter/ent/db/subscriptionitem.go
+++ b/openmeter/ent/db/subscriptionitem.go
@@ -72,6 +72,8 @@ type SubscriptionItem struct {
 	Price *productcatalog.Price `json:"price,omitempty"`
 	// Discounts holds the value of the "discounts" field.
 	Discounts *productcatalog.Discounts `json:"discounts,omitempty"`
+	// UnitConfig holds the value of the "unit_config" field.
+	UnitConfig *productcatalog.UnitConfig `json:"unit_config,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SubscriptionItemQuery when eager-loading is set.
 	Edges        SubscriptionItemEdges `json:"edges"`
@@ -202,6 +204,8 @@ func (*SubscriptionItem) scanValues(columns []string) ([]any, error) {
 			values[i] = subscriptionitem.ValueScanner.Price.ScanValue()
 		case subscriptionitem.FieldDiscounts:
 			values[i] = subscriptionitem.ValueScanner.Discounts.ScanValue()
+		case subscriptionitem.FieldUnitConfig:
+			values[i] = subscriptionitem.ValueScanner.UnitConfig.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -380,6 +384,12 @@ func (_m *SubscriptionItem) assignValues(columns []string, values []any) error {
 			} else {
 				_m.Discounts = value
 			}
+		case subscriptionitem.FieldUnitConfig:
+			if value, err := subscriptionitem.ValueScanner.UnitConfig.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				_m.UnitConfig = value
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -555,6 +565,11 @@ func (_m *SubscriptionItem) String() string {
 	builder.WriteString(", ")
 	if v := _m.Discounts; v != nil {
 		builder.WriteString("discounts=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.UnitConfig; v != nil {
+		builder.WriteString("unit_config=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
 	builder.WriteByte(')')

--- a/openmeter/ent/db/subscriptionitem/subscriptionitem.go
+++ b/openmeter/ent/db/subscriptionitem/subscriptionitem.go
@@ -66,6 +66,8 @@ const (
 	FieldPrice = "price"
 	// FieldDiscounts holds the string denoting the discounts field in the database.
 	FieldDiscounts = "discounts"
+	// FieldUnitConfig holds the string denoting the unit_config field in the database.
+	FieldUnitConfig = "unit_config"
 	// EdgePhase holds the string denoting the phase edge name in mutations.
 	EdgePhase = "phase"
 	// EdgeEntitlement holds the string denoting the entitlement edge name in mutations.
@@ -169,6 +171,7 @@ var Columns = []string{
 	FieldBillingCadence,
 	FieldPrice,
 	FieldDiscounts,
+	FieldUnitConfig,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -205,6 +208,7 @@ var (
 		TaxConfig           field.TypeValueScanner[*productcatalog.TaxConfig]
 		Price               field.TypeValueScanner[*productcatalog.Price]
 		Discounts           field.TypeValueScanner[*productcatalog.Discounts]
+		UnitConfig          field.TypeValueScanner[*productcatalog.UnitConfig]
 	}
 )
 
@@ -339,6 +343,11 @@ func ByPrice(opts ...sql.OrderTermOption) OrderOption {
 // ByDiscounts orders the results by the discounts field.
 func ByDiscounts(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDiscounts, opts...).ToFunc()
+}
+
+// ByUnitConfig orders the results by the unit_config field.
+func ByUnitConfig(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUnitConfig, opts...).ToFunc()
 }
 
 // ByPhaseField orders the results by phase field.

--- a/openmeter/ent/db/subscriptionitem/where.go
+++ b/openmeter/ent/db/subscriptionitem/where.go
@@ -1337,6 +1337,16 @@ func DiscountsNotNil() predicate.SubscriptionItem {
 	return predicate.SubscriptionItem(sql.FieldNotNull(FieldDiscounts))
 }
 
+// UnitConfigIsNil applies the IsNil predicate on the "unit_config" field.
+func UnitConfigIsNil() predicate.SubscriptionItem {
+	return predicate.SubscriptionItem(sql.FieldIsNull(FieldUnitConfig))
+}
+
+// UnitConfigNotNil applies the NotNil predicate on the "unit_config" field.
+func UnitConfigNotNil() predicate.SubscriptionItem {
+	return predicate.SubscriptionItem(sql.FieldNotNull(FieldUnitConfig))
+}
+
 // HasPhase applies the HasEdge predicate on the "phase" edge.
 func HasPhase() predicate.SubscriptionItem {
 	return predicate.SubscriptionItem(func(s *sql.Selector) {

--- a/openmeter/ent/db/subscriptionitem_create.go
+++ b/openmeter/ent/db/subscriptionitem_create.go
@@ -282,6 +282,12 @@ func (_c *SubscriptionItemCreate) SetDiscounts(v *productcatalog.Discounts) *Sub
 	return _c
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_c *SubscriptionItemCreate) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemCreate {
+	_c.mutation.SetUnitConfig(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *SubscriptionItemCreate) SetID(v string) *SubscriptionItemCreate {
 	_c.mutation.SetID(v)
@@ -503,6 +509,11 @@ func (_c *SubscriptionItemCreate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.unit_config": %w`, err)}
+		}
+	}
 	if len(_c.mutation.PhaseIDs()) == 0 {
 		return &ValidationError{Name: "phase", err: errors.New(`db: missing required edge "SubscriptionItem.phase"`)}
 	}
@@ -648,6 +659,14 @@ func (_c *SubscriptionItemCreate) createSpec() (*SubscriptionItem, *sqlgraph.Cre
 		}
 		_spec.SetField(subscriptionitem.FieldDiscounts, field.TypeString, vv)
 		_node.Discounts = value
+	}
+	if value, ok := _c.mutation.UnitConfig(); ok {
+		vv, err := subscriptionitem.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(subscriptionitem.FieldUnitConfig, field.TypeString, vv)
+		_node.UnitConfig = value
 	}
 	if nodes := _c.mutation.PhaseIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1174,6 +1193,24 @@ func (u *SubscriptionItemUpsert) ClearDiscounts() *SubscriptionItemUpsert {
 	return u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (u *SubscriptionItemUpsert) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemUpsert {
+	u.Set(subscriptionitem.FieldUnitConfig, v)
+	return u
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *SubscriptionItemUpsert) UpdateUnitConfig() *SubscriptionItemUpsert {
+	u.SetExcluded(subscriptionitem.FieldUnitConfig)
+	return u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *SubscriptionItemUpsert) ClearUnitConfig() *SubscriptionItemUpsert {
+	u.SetNull(subscriptionitem.FieldUnitConfig)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1630,6 +1667,27 @@ func (u *SubscriptionItemUpsertOne) UpdateDiscounts() *SubscriptionItemUpsertOne
 func (u *SubscriptionItemUpsertOne) ClearDiscounts() *SubscriptionItemUpsertOne {
 	return u.Update(func(s *SubscriptionItemUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *SubscriptionItemUpsertOne) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemUpsertOne {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *SubscriptionItemUpsertOne) UpdateUnitConfig() *SubscriptionItemUpsertOne {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *SubscriptionItemUpsertOne) ClearUnitConfig() *SubscriptionItemUpsertOne {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 
@@ -2259,6 +2317,27 @@ func (u *SubscriptionItemUpsertBulk) UpdateDiscounts() *SubscriptionItemUpsertBu
 func (u *SubscriptionItemUpsertBulk) ClearDiscounts() *SubscriptionItemUpsertBulk {
 	return u.Update(func(s *SubscriptionItemUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *SubscriptionItemUpsertBulk) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemUpsertBulk {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *SubscriptionItemUpsertBulk) UpdateUnitConfig() *SubscriptionItemUpsertBulk {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *SubscriptionItemUpsertBulk) ClearUnitConfig() *SubscriptionItemUpsertBulk {
+	return u.Update(func(s *SubscriptionItemUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 

--- a/openmeter/ent/db/subscriptionitem_update.go
+++ b/openmeter/ent/db/subscriptionitem_update.go
@@ -364,6 +364,18 @@ func (_u *SubscriptionItemUpdate) ClearDiscounts() *SubscriptionItemUpdate {
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *SubscriptionItemUpdate) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemUpdate {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *SubscriptionItemUpdate) ClearUnitConfig() *SubscriptionItemUpdate {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetEntitlement sets the "entitlement" edge to the Entitlement entity.
 func (_u *SubscriptionItemUpdate) SetEntitlement(v *Entitlement) *SubscriptionItemUpdate {
 	return _u.SetEntitlementID(v.ID)
@@ -639,6 +651,11 @@ func (_u *SubscriptionItemUpdate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.unit_config": %w`, err)}
+		}
+	}
 	if _u.mutation.PhaseCleared() && len(_u.mutation.PhaseIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "SubscriptionItem.phase"`)
 	}
@@ -775,6 +792,16 @@ func (_u *SubscriptionItemUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(subscriptionitem.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := subscriptionitem.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(subscriptionitem.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(subscriptionitem.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.EntitlementCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1405,6 +1432,18 @@ func (_u *SubscriptionItemUpdateOne) ClearDiscounts() *SubscriptionItemUpdateOne
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *SubscriptionItemUpdateOne) SetUnitConfig(v *productcatalog.UnitConfig) *SubscriptionItemUpdateOne {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *SubscriptionItemUpdateOne) ClearUnitConfig() *SubscriptionItemUpdateOne {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetEntitlement sets the "entitlement" edge to the Entitlement entity.
 func (_u *SubscriptionItemUpdateOne) SetEntitlement(v *Entitlement) *SubscriptionItemUpdateOne {
 	return _u.SetEntitlementID(v.ID)
@@ -1693,6 +1732,11 @@ func (_u *SubscriptionItemUpdateOne) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "SubscriptionItem.unit_config": %w`, err)}
+		}
+	}
 	if _u.mutation.PhaseCleared() && len(_u.mutation.PhaseIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "SubscriptionItem.phase"`)
 	}
@@ -1846,6 +1890,16 @@ func (_u *SubscriptionItemUpdateOne) sqlSave(ctx context.Context) (_node *Subscr
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(subscriptionitem.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := subscriptionitem.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(subscriptionitem.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(subscriptionitem.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.EntitlementCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/schema/subscription.go
+++ b/openmeter/ent/schema/subscription.go
@@ -214,6 +214,14 @@ func (SubscriptionItem) Fields() []ent.Field {
 			}).
 			Optional().
 			Nillable(),
+		field.String("unit_config").
+			GoType(&productcatalog.UnitConfig{}).
+			ValueScanner(UnitConfigValueScanner).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -161,14 +161,14 @@ var ErrRateCardBillingCadenceMismatch = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
-const ErrCodeRateCardUnitConfigMismatch models.ErrorCode = "rate_card_unit_config_mismatch"
+const ErrCodeAddonRateCardUnitConfigMismatch models.ErrorCode = "addon_rate_card_unit_config_mismatch"
 
-// ErrRateCardUnitConfigMismatch is raised when an addon rate card carries a unit_config that differs
+// ErrAddonRateCardUnitConfigMismatch is raised when an addon rate card carries a unit_config that differs
 // from the rate card it extends. Addons layer price/entitlement/discounts additively but do not
 // redefine the unit conversion; a divergent unit_config would be silently dropped by the overlay, so
 // it is rejected here rather than accepted and ignored.
-var ErrRateCardUnitConfigMismatch = models.NewValidationIssue(
-	ErrCodeRateCardUnitConfigMismatch,
+var ErrAddonRateCardUnitConfigMismatch = models.NewValidationIssue(
+	ErrCodeAddonRateCardUnitConfigMismatch,
 	"unit config must match",
 	models.WithFieldString("unitConfig"),
 	models.WithWarningSeverity(),

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -161,6 +161,20 @@ var ErrRateCardBillingCadenceMismatch = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUnitConfigMismatch models.ErrorCode = "rate_card_unit_config_mismatch"
+
+// ErrRateCardUnitConfigMismatch is raised when an addon rate card carries a unit_config that differs
+// from the rate card it extends. Addons layer price/entitlement/discounts additively but do not
+// redefine the unit conversion; a divergent unit_config would be silently dropped by the overlay, so
+// it is rejected here rather than accepted and ignored.
+var ErrRateCardUnitConfigMismatch = models.NewValidationIssue(
+	ErrCodeRateCardUnitConfigMismatch,
+	"unit config must match",
+	models.WithFieldString("unitConfig"),
+	models.WithWarningSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 const ErrCodeRateCardEntitlementTemplateTypeMismatch models.ErrorCode = "rate_card_entitlement_template_type_mismatch"
 
 var ErrRateCardEntitlementTemplateTypeMismatch = models.NewValidationIssue(

--- a/openmeter/productcatalog/planaddon_test.go
+++ b/openmeter/productcatalog/planaddon_test.go
@@ -601,3 +601,36 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePlanPhaseAndAddonRateCardsAreCompatibleUnitConfig(t *testing.T) {
+	cadence := datetime.MustParseDuration(t, "P1M")
+	usageCard := func(uc *UnitConfig) RateCard {
+		return &UsageBasedRateCard{
+			RateCardMeta: RateCardMeta{
+				Key:        "feat-1",
+				Name:       "rate card",
+				UnitConfig: uc,
+			},
+			BillingCadence: cadence,
+		}
+	}
+	divide := func(factor int64) *UnitConfig {
+		return &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: alpacadecimal.NewFromInt(factor)}
+	}
+
+	t.Run("rejects an addon whose unit_config diverges from the plan phase rate card", func(t *testing.T) {
+		phase := Phase{RateCards: RateCards{usageCard(divide(1000))}}
+		addonRateCards := RateCards{usageCard(divide(500))}
+
+		err := ValidatePlanPhaseAndAddonRateCardsAreCompatible(addonRateCards)(phase)
+		assert.ErrorIs(t, err, ErrAddonRateCardUnitConfigMismatch)
+	})
+
+	t.Run("accepts a matching unit_config", func(t *testing.T) {
+		phase := Phase{RateCards: RateCards{usageCard(divide(1000))}}
+		addonRateCards := RateCards{usageCard(divide(1000))}
+
+		err := ValidatePlanPhaseAndAddonRateCardsAreCompatible(addonRateCards)(phase)
+		assert.NoError(t, err)
+	})
+}

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -926,6 +926,30 @@ var ValidateRateCardsHaveCompatibleDiscounts = models.ValidatorFunc[RateCardWith
 	return nil
 })
 
+// ValidateRateCardsHaveCompatibleUnitConfig rejects an overlay (addon) rate card that carries a
+// unit_config differing from the base rate card it extends. In the addon overlay, base is the addon
+// rate card and overlay is the subscription's target rate card (see NewRateCardWithOverlay call sites
+// in subscription/addon/extend.go). The addon merge keeps the target's unit_config and never applies
+// the addon's own, so a divergent addon unit_config would be silently dropped — we reject it instead of
+// accepting it and ignoring it. An addon that omits unit_config (nil) is compatible: it leaves the
+// target's conversion untouched.
+var ValidateRateCardsHaveCompatibleUnitConfig = models.ValidatorFunc[RateCardWithOverlay](func(r RateCardWithOverlay) error {
+	if r.base == nil || r.overlay == nil {
+		return nil
+	}
+
+	addonMeta, targetMeta := r.base.AsMeta(), r.overlay.AsMeta()
+
+	if addonMeta.UnitConfig != nil && !addonMeta.UnitConfig.Equal(targetMeta.UnitConfig) {
+		fieldSelector := models.NewFieldSelectorGroup(models.NewFieldSelector("ratecards").
+			WithExpression(models.NewFieldAttrValue("key", r.base.Key())))
+
+		return models.ErrorWithFieldPrefix(fieldSelector, ErrRateCardUnitConfigMismatch)
+	}
+
+	return nil
+})
+
 func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatureResolver) func(cards RateCards) error {
 	return func(rateCards RateCards) error {
 		var errs []error

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -744,6 +744,7 @@ func (r RateCardWithOverlay) Validate() error {
 		ValidateRateCardsHaveCompatibleBillingCadence,
 		ValidateRateCardsHaveCompatibleEntitlementTemplate,
 		ValidateRateCardsHaveCompatibleDiscounts,
+		ValidateRateCardsHaveCompatibleUnitConfig,
 	)
 }
 
@@ -926,25 +927,18 @@ var ValidateRateCardsHaveCompatibleDiscounts = models.ValidatorFunc[RateCardWith
 	return nil
 })
 
-// ValidateRateCardsHaveCompatibleUnitConfig rejects an overlay (addon) rate card that carries a
-// unit_config differing from the base rate card it extends. In the addon overlay, base is the addon
-// rate card and overlay is the subscription's target rate card (see NewRateCardWithOverlay call sites
-// in subscription/addon/extend.go). The addon merge keeps the target's unit_config and never applies
-// the addon's own, so a divergent addon unit_config would be silently dropped — we reject it instead of
-// accepting it and ignoring it. An addon that omits unit_config (nil) is compatible: it leaves the
-// target's conversion untouched.
 var ValidateRateCardsHaveCompatibleUnitConfig = models.ValidatorFunc[RateCardWithOverlay](func(r RateCardWithOverlay) error {
 	if r.base == nil || r.overlay == nil {
 		return nil
 	}
 
-	addonMeta, targetMeta := r.base.AsMeta(), r.overlay.AsMeta()
+	rMeta, vMeta := r.base.AsMeta(), r.overlay.AsMeta()
 
-	if addonMeta.UnitConfig != nil && !addonMeta.UnitConfig.Equal(targetMeta.UnitConfig) {
+	if rMeta.UnitConfig != nil && vMeta.UnitConfig != nil && !rMeta.UnitConfig.Equal(vMeta.UnitConfig) {
 		fieldSelector := models.NewFieldSelectorGroup(models.NewFieldSelector("ratecards").
 			WithExpression(models.NewFieldAttrValue("key", r.base.Key())))
 
-		return models.ErrorWithFieldPrefix(fieldSelector, ErrRateCardUnitConfigMismatch)
+		return models.ErrorWithFieldPrefix(fieldSelector, ErrAddonRateCardUnitConfigMismatch)
 	}
 
 	return nil

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -1371,10 +1371,6 @@ func TestRateCardMetaUnitConfig(t *testing.T) {
 }
 
 func TestValidateRateCardsHaveCompatibleUnitConfig(t *testing.T) {
-	// In the addon overlay (subscription/addon/extend.go), base is the ADDON rate card and overlay is
-	// the subscription's target rate card. An addon that carries a unit_config differing from the target
-	// must be rejected — the addon merge keeps the target's conversion and would silently drop the
-	// addon's, so a divergent value is a caller error rather than a no-op.
 	card := func(uc *UnitConfig) RateCard {
 		return &UsageBasedRateCard{
 			RateCardMeta: RateCardMeta{
@@ -1410,11 +1406,12 @@ func TestValidateRateCardsHaveCompatibleUnitConfig(t *testing.T) {
 		assert.NoError(t, validate(card(nil), card(nil)))
 	})
 
-	t.Run("addon with divergent unit_config is rejected", func(t *testing.T) {
-		assert.ErrorIs(t, validate(card(divide500()), card(divide1000())), ErrRateCardUnitConfigMismatch)
+	t.Run("two differing unit_configs are rejected", func(t *testing.T) {
+		assert.ErrorIs(t, validate(card(divide500()), card(divide1000())), ErrAddonRateCardUnitConfigMismatch)
 	})
 
-	t.Run("addon introducing a unit_config the target lacks is rejected", func(t *testing.T) {
-		assert.ErrorIs(t, validate(card(divide1000()), card(nil)), ErrRateCardUnitConfigMismatch)
+	t.Run("a unit_config on only one side is compatible", func(t *testing.T) {
+		assert.NoError(t, validate(card(divide1000()), card(nil)))
+		assert.NoError(t, validate(card(nil), card(divide1000())))
 	})
 }

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -1369,3 +1369,52 @@ func TestRateCardMetaUnitConfig(t *testing.T) {
 		assert.NoError(t, valid.Validate())
 	})
 }
+
+func TestValidateRateCardsHaveCompatibleUnitConfig(t *testing.T) {
+	// In the addon overlay (subscription/addon/extend.go), base is the ADDON rate card and overlay is
+	// the subscription's target rate card. An addon that carries a unit_config differing from the target
+	// must be rejected — the addon merge keeps the target's conversion and would silently drop the
+	// addon's, so a divergent value is a caller error rather than a no-op.
+	card := func(uc *UnitConfig) RateCard {
+		return &UsageBasedRateCard{
+			RateCardMeta: RateCardMeta{
+				Key:        "feat-1",
+				Name:       "Feature 1",
+				FeatureKey: lo.ToPtr("feat-1"),
+				Price:      NewPriceFrom(UnitPrice{Amount: decimal.NewFromInt(1)}),
+				UnitConfig: uc,
+			},
+		}
+	}
+
+	divide1000 := func() *UnitConfig {
+		return &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000)}
+	}
+	divide500 := func() *UnitConfig {
+		return &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(500)}
+	}
+
+	validate := func(addon, target RateCard) error {
+		return NewRateCardWithOverlay(addon, target).ValidateWith(ValidateRateCardsHaveCompatibleUnitConfig)
+	}
+
+	t.Run("addon without unit_config leaves target untouched (compatible)", func(t *testing.T) {
+		assert.NoError(t, validate(card(nil), card(divide1000())))
+	})
+
+	t.Run("addon with equal unit_config is compatible", func(t *testing.T) {
+		assert.NoError(t, validate(card(divide1000()), card(divide1000())))
+	})
+
+	t.Run("both without unit_config is compatible", func(t *testing.T) {
+		assert.NoError(t, validate(card(nil), card(nil)))
+	})
+
+	t.Run("addon with divergent unit_config is rejected", func(t *testing.T) {
+		assert.ErrorIs(t, validate(card(divide500()), card(divide1000())), ErrRateCardUnitConfigMismatch)
+	})
+
+	t.Run("addon introducing a unit_config the target lacks is rejected", func(t *testing.T) {
+		assert.ErrorIs(t, validate(card(divide1000()), card(nil)), ErrRateCardUnitConfigMismatch)
+	})
+}

--- a/openmeter/subscription/addon/extend.go
+++ b/openmeter/subscription/addon/extend.go
@@ -35,6 +35,7 @@ func (a SubscriptionAddonRateCard) Apply(target productcatalog.RateCard, annotat
 		productcatalog.ValidateRateCardsHaveCompatibleBillingCadence,
 		productcatalog.ValidateRateCardsHaveCompatibleEntitlementTemplate,
 		productcatalog.ValidateRateCardsHaveCompatibleDiscounts,
+		productcatalog.ValidateRateCardsHaveCompatibleUnitConfig,
 	); err != nil {
 		return err
 	}
@@ -125,6 +126,8 @@ func (a SubscriptionAddonRateCard) Restore(target productcatalog.RateCard, annot
 		productcatalog.ValidateRateCardsHaveCompatibleBillingCadence,
 		productcatalog.ValidateRateCardsHaveCompatibleEntitlementTemplate,
 		productcatalog.ValidateRateCardsHaveCompatibleDiscounts,
+		// No unit_config compatibility check here (as with price): restore is teardown and never
+		// reapplies it, so gating on it could strand a removable addon if the target's config drifted.
 	); err != nil {
 		return err
 	}

--- a/openmeter/subscription/addon/extend_test.go
+++ b/openmeter/subscription/addon/extend_test.go
@@ -222,6 +222,35 @@ func TestValidations(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "billing cadence must match")
 	})
+
+	t.Run("Should error on UsageBasedRateCards with divergent UnitConfig", func(t *testing.T) {
+		meta := someMeta.Clone()
+		meta.Price = nil
+
+		addonMeta := meta.Clone()
+		addonMeta.UnitConfig = &productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationDivide,
+			ConversionFactor: alpacadecimal.NewFromInt(500),
+		}
+		rc := getTestAddonRateCard(&productcatalog.UsageBasedRateCard{
+			RateCardMeta:   addonMeta,
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		})
+
+		targetMeta := meta.Clone()
+		targetMeta.UnitConfig = &productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationDivide,
+			ConversionFactor: alpacadecimal.NewFromInt(1000),
+		}
+		target := &productcatalog.UsageBasedRateCard{
+			RateCardMeta:   targetMeta,
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		}
+
+		err := rc.Apply(target, models.Annotations{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unit config must match")
+	})
 }
 
 func TestExtendApply(t *testing.T) {

--- a/openmeter/subscription/repo/mapping.go
+++ b/openmeter/subscription/repo/mapping.go
@@ -136,6 +136,7 @@ func MapDBSubscriptionItem(item *db.SubscriptionItem) (subscription.Subscription
 		TaxConfig:           item.TaxConfig,
 		Price:               item.Price,
 		Discounts:           lo.FromPtr(item.Discounts),
+		UnitConfig:          item.UnitConfig,
 		Key:                 item.Key,
 		// NOTE: resolving feature is done on service level as there is no direct relationship between subscription items and features.
 		FeatureID: nil,

--- a/openmeter/subscription/repo/subscriptionitemrepo.go
+++ b/openmeter/subscription/repo/subscriptionitemrepo.go
@@ -163,10 +163,8 @@ func (r *subscriptionItemRepo) Create(ctx context.Context, input subscription.Cr
 			cmd.SetDiscounts(lo.EmptyableToPtr(input.RateCard.AsMeta().Discounts))
 		}
 
-		// Persist unit_config only on a usage-based price (mirrors RateCardMeta.Validate); a stray
-		// config on a flat-fee item is dropped so it stays correctly unconverted.
-		if meta := input.RateCard.AsMeta(); meta.UnitConfig != nil && meta.Price != nil && meta.Price.SupportsUnitConfig() {
-			cmd.SetUnitConfig(meta.UnitConfig)
+		if input.RateCard.AsMeta().UnitConfig != nil {
+			cmd.SetUnitConfig(input.RateCard.AsMeta().UnitConfig)
 		}
 
 		i, err := cmd.Save(ctx)

--- a/openmeter/subscription/repo/subscriptionitemrepo.go
+++ b/openmeter/subscription/repo/subscriptionitemrepo.go
@@ -163,6 +163,12 @@ func (r *subscriptionItemRepo) Create(ctx context.Context, input subscription.Cr
 			cmd.SetDiscounts(lo.EmptyableToPtr(input.RateCard.AsMeta().Discounts))
 		}
 
+		// Persist unit_config only on a usage-based price (mirrors RateCardMeta.Validate); a stray
+		// config on a flat-fee item is dropped so it stays correctly unconverted.
+		if meta := input.RateCard.AsMeta(); meta.UnitConfig != nil && meta.Price != nil && meta.Price.SupportsUnitConfig() {
+			cmd.SetUnitConfig(meta.UnitConfig)
+		}
+
 		i, err := cmd.Save(ctx)
 		if err != nil {
 			return def, err

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -2247,9 +2247,6 @@ func TestCreateFromPlanSnapshotsUnitConfig(t *testing.T) {
 	// - the persisted subscription item retains the unit_config, proving the snapshot survives
 	//   subscription persistence. Without the column the config
 	//   is dropped on write/read and this reloads as nil.
-	// Immutability against later catalog edits is structural: the rate-card columns are written once at
-	// item creation (subscriptionitemrepo.Create) and never re-synced from the plan, so a reload always
-	// returns the creation-time snapshot regardless of subsequent catalog changes.
 	now := testutils.GetRFC3339Time(t, "2021-01-01T00:00:00Z")
 	clock.SetTime(now)
 	defer clock.ResetTime()

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -1078,7 +1078,8 @@ func TestEditCombinations(t *testing.T) {
 			t,
 			deps,
 			subscriptiontestutils.GetExamplePlanInput(t),
-			subscriptiontestutils.BuildAddonForTesting(t,
+			subscriptiontestutils.BuildAddonForTesting(
+				t,
 				productcatalog.EffectivePeriod{
 					EffectiveFrom: &now,
 					EffectiveTo:   nil,
@@ -2235,4 +2236,65 @@ func TestSettlementMode(t *testing.T) {
 		}, creditOnlyPlan)
 		require.ErrorContains(t, err, "validation error: credits are not enabled on this deployment of OpenMeter")
 	})
+}
+
+func TestCreateFromPlanSnapshotsUnitConfig(t *testing.T) {
+	// given:
+	// - a plan whose usage-based rate card carries a unit_config
+	// when:
+	// - a subscription is created from it and reloaded from the database
+	// then:
+	// - the persisted subscription item retains the unit_config, proving the snapshot survives
+	//   subscription persistence. Without the column the config
+	//   is dropped on write/read and this reloads as nil.
+	// Immutability against later catalog edits is structural: the rate-card columns are written once at
+	// item creation (subscriptionitemrepo.Create) and never re-synced from the plan, so a reload always
+	// returns the creation-time snapshot regardless of subsequent catalog changes.
+	now := testutils.GetRFC3339Time(t, "2021-01-01T00:00:00Z")
+	clock.SetTime(now)
+	defer clock.ResetTime()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	require.NotNil(t, dbDeps)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+	deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	unitConfig := &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperationDivide,
+		ConversionFactor: alpacadecimal.NewFromInt(1000),
+		Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+	}
+
+	// ExampleRateCard1 is usage-based with a UnitPrice, which supports unit_config.
+	rc := subscriptiontestutils.ExampleRateCard1
+	rc.UnitConfig = unitConfig
+
+	p := deps.PlanHelper.CreatePlan(t, subscriptiontestutils.BuildTestPlanInput(t).
+		AddPhase(nil, &rc).
+		Build())
+
+	cust := deps.CustomerAdapter.CreateExampleCustomer(t)
+	require.NotNil(t, cust)
+
+	subView, err := deps.WorkflowService.CreateFromPlan(context.Background(), subscriptionworkflow.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{Custom: &now},
+		},
+		CustomerID: cust.ID,
+		Namespace:  subscriptiontestutils.ExampleNamespace,
+	}, p)
+	require.NoError(t, err)
+
+	// Reload from the database — exercises the persistence round-trip through the new column.
+	reloaded, err := deps.SubscriptionService.GetView(context.Background(), subView.Subscription.NamespacedID)
+	require.NoError(t, err)
+
+	items := reloaded.Phases[0].ItemsByKey[subscriptiontestutils.ExampleRateCard1.Key()]
+	require.Len(t, items, 1)
+
+	got := items[0].SubscriptionItem.RateCard.AsMeta().UnitConfig
+	require.NotNil(t, got, "unit_config must survive subscription persistence; nil means it was dropped on write/read")
+	assert.True(t, got.Equal(unitConfig), "reloaded unit_config must equal the authored config, got %+v", got)
 }

--- a/tools/migrate/migrations/20260707142444_om_399_subscription_unit_config.down.sql
+++ b/tools/migrate/migrations/20260707142444_om_399_subscription_unit_config.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "subscription_items" table
+ALTER TABLE "subscription_items" DROP COLUMN "unit_config";

--- a/tools/migrate/migrations/20260707142444_om_399_subscription_unit_config.up.sql
+++ b/tools/migrate/migrations/20260707142444_om_399_subscription_unit_config.up.sql
@@ -1,0 +1,2 @@
+-- modify "subscription_items" table
+ALTER TABLE "subscription_items" ADD COLUMN "unit_config" jsonb NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:YdLAzqPCjFsISWdn33Qynt6ZTrtydM3waZv65CBEJxk=
+h1:hxm6CUxM4F7vwbMJGUB6h92TJI+/N09WwlUe1MytGMM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -224,3 +224,4 @@ h1:YdLAzqPCjFsISWdn33Qynt6ZTrtydM3waZv65CBEJxk=
 20260630181340_add_breakage_record_source_charge_id.up.sql h1:OLPQPKq1S5J941TXL7tHceMSrvMWk5E/nAc3rAnXhZM=
 20260701084156_add_currency_cost_basis_effective_to.up.sql h1:31ASikUUszFmPpArKruD3TeAnTIA7ebqMJdt2DzMH6A=
 20260703084504_applied-unit-config-snapshot.up.sql h1:s8DVZu17GDewYm3YbCQusADdv9fbaiiaD5x0WEp/VrU=
+20260707142444_om_399_subscription_unit_config.up.sql h1:NfIgaPJWptTtGaxyMzwUV/jts/Z6AVvbp3COxEgDOtQ=


### PR DESCRIPTION
Snapshots a rate card's unit_config onto subscription items via a new unit_config column and rejects addon rate cards that carry a divergent unit_config rather than silently dropping it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription items can now store an optional `unit_config`, persisted in the database.
* **Bug Fixes**
  * Rate-card add-on overlays now enforce `unit_config` compatibility during add-on apply and reject mismatches with a 400 validation error.
  * Plan phase and addon rate-card compatibility now also checks `unit_config`.
* **Tests**
  * Added tests covering overlay compatibility, `unit_config` persistence across subscription create+reload, and E2E invoice quantity conversion using `unit_config`.
  * Removed an outdated E2E test that expected `unit_config` plan rejection when a feature flag is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR snapshots rate-card unit configuration onto subscription items. The main changes are:

- Added a nullable subscription item `unit_config` column and generated Ent mappings.
- Persisted and reloaded unit configuration through subscription item storage.
- Rejected addon rate cards when both addon and target carry different unit configs.
- Kept addon restore independent from unit-config validation.
- Added unit-config billing and persistence test coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/subscription/addon/extend.go | Adds unit-config compatibility validation on addon apply and keeps restore free of that check. |
| openmeter/productcatalog/ratecard.go | Adds shared rate-card overlay validation for divergent unit configs. |
| openmeter/subscription/repo/subscriptionitemrepo.go | Stores unit config from rate-card metadata when creating subscription items. |
| openmeter/subscription/repo/mapping.go | Restores persisted unit config onto rate-card metadata when loading subscription items. |
| openmeter/ent/schema/subscription.go | Adds the nullable JSON-backed unit_config field to subscription item schema. |

<sub>Reviews (5): Last reviewed commit: ["test: cover planaddon unit config compat..."](https://github.com/openmeterio/openmeter/commit/7cc8026cdb123e675d1f8d691c76453037dd26ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42647448)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->