### PR TITLE
feat: support usage-based gathering line deletes

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -130,6 +130,7 @@ Patch target rules:
 - Delete patches follow the same target rule: deleting the base layer while an override is active should mark the base intent deleted but leave the effective override-backed charge behavior intact.
 - Charge listing for subscription-sync persisted-state loading must filter on base-intent deletion state, not effective `DeletedAt`; otherwise an active override can hide a subscription-owned base charge that sync still needs to reconcile.
 - Gathering-line upsert patches are target-state patches. `PatchOpUpsertGatheringLineByChargeID` should carry the full rebuilt `billing.GatheringLine` target state, not just period deltas. The invoice updater queries the existing pending gathering line by charge ID and merges the patch target with `WithTargetState(...)` so DB identity and invoice membership stay intact; if no active pending line exists, it creates one through the regular pending-line provisioning path.
+- `PatchShrink` is system-only and always targets the base layer. API/customer-originated period shortening must use a distinct API patch such as `PatchShrinkToRealizedPeriod`, which resolves its target layer through API patch rules and creates or updates the override layer when the base intent is subscription-managed.
 
 ## Usage-Based Invoice Line Mapping
 
@@ -184,13 +185,15 @@ Important rules:
 - invoice-backed charge line engines must map persisted run/realization state back onto returned standard invoice lines after run creation. Do not rely on state-machine methods mutating a standard-line pointer as their public contract.
 - For invoice-backed charge line engines, flat-fee and usage-based should follow the same structural contract: charge state machines emit invoice patches, and line engines consume those patches at the billing boundary. Standard-line delete patches must flow through the same deleted-standard-line cleanup used by `OnMutableStandardLinesDeletedBySystem(...)` so credit corrections, charge-owned detailed-line cleanup, and deleted-run marking stay consistent.
 - Invoice-backed charge API invoice-line edits/deletes are mediated by emitted invoice patches. Standard-line edits use update target-state patches, gathering-line edits use upsert target-state patches, gathering-line delete patches are validated locally, and standard-line delete patches invoke deleted-standard-line cleanup after the state machine detaches the current run. Zero-proration delete patches are currently rejected unless the charge engine explicitly models that delete result.
+- Billing calls `ValidateMutableInvoiceLineEditViaAPI(...)` before `OnMutableInvoiceLinesEditedViaAPI(...)`. The validation hook must not mutate charge or invoice state; it should only validate engine ownership, patch shape, target layer, and preconditions needed to make the later state-machine patch deterministic. Charge mutation and invoice patch consumption belong in `OnMutableInvoiceLinesEditedViaAPI(...)`.
 - API-created invoice-backed charge lines are preallocated and provisionally persisted by billing before charge line-engine dispatch. Charge engines must require the billing-owned line ID, create charge/realization state against that line identity when the charge lifecycle needs it, and return target state merged onto the preallocated line. Do not create a second invoice-line identity inside the charge package for the same customer-facing line.
 - If a charge line engine creates charge intents directly, it must preserve root charges create semantics that would otherwise be bypassed. When an API-created line omits tax config, use the billing edit callback's default tax-code resolver rather than adding a charge-service dependency on tax-code lookup.
 - When a charge line engine creates an intent from an API-created invoice line, use `InvoiceAtAccessor` only for line types that expose invoice-at as customer-facing scheduling input, such as gathering lines. `billing.StandardLine.InvoiceAt` is display-only for rendered gathering lines; standard-line charge create flows should derive intent invoice-at from the charge/payment-term semantics instead of reading that field as scheduling state.
-- Usage-based API invoice-line edit/delete support is currently unimplemented; keep returning `billing.ErrCannotUpdateChargeManagedLine` there until it follows the same patch-mediated contract as flat-fee. Credit-purchase is a separate lifecycle and should not be forced into this flat-fee/usage-based structure.
+- Usage-based API invoice-line support is delete-only for now; creates and updates should still return `billing.ErrCannotUpdateChargeManagedLine`. Standard-line delete is allowed only when the charge has one non-voided realization run, and the line engine must validate the emitted standard-line delete patch, invoke mutable-standard-line realization cleanup, and apply at most one remaining gathering-line delete patch. Gathering-line delete with no non-voided realizations deletes the effective charge through the API delete patch. Gathering-line delete with existing non-voided realizations must use `PatchShrinkToRealizedPeriod`, delete only the remaining gathering tail, preserve existing standard invoice history, explicitly reclassify the latest kept partial run as `RealizationRunTypeFinalRealization` when that run now covers the shortened effective period, and otherwise preserve the charge's current status/state so the existing invoice lifecycle continues to own advancement. This patch carries only the new effective service-period end for validation and must not change invoice-at, billing period, or full service period.
+- For usage-based gathering-line API delete with existing realizations, `PatchShrinkToRealizedPeriod` validation in the usage-based state-machine handler must prove the requested new effective period end equals the latest non-voided realization run's `ServicePeriodTo`. Keep this boundary check with the handler that mutates the charge, not in the line engine's preliminary validation path.
 - for usage-based realization creation, validate at the run-creation boundary (`usagebased/service/run.CreateRatedRunInput.Validate`) that `Charge.State.CurrentRealizationRunID` is nil before creating a new run; keep the line-engine-side early return too so `InvoicePendingLines` fails with the charge-specific validation error at the billing boundary. In both places, key the guard off `CurrentRealizationRunID`, not a specific status prefix such as `partial_invoice`
 - usage-based payment handling is intentionally different from flat-fee and credit-purchase: the usage-based state machine owns realization only, while the usage-based line engine/run service records payment authorization/settlement directly on historical runs and only re-enters the state machine through an aggregate trigger (for example `all_payments_settled`) once all invoiced runs on the charge are settled. Do not apply this rule generically to flat-fee or credit-purchase; those charge types may still keep payment states inside their own state machines.
-- usage-based invoice branches should read in this order: `started -> waiting_for_collection -> processing -> issuing -> completed`, then auto-advance out of the branch. Keep `invoice_issued` as the boundary between `processing` and `issuing`, run `FinalizeInvoiceRun(...)` from the `issuing` state, and let `completed` be the last branch-local status before `next` returns a partial invoice to `active` or moves a final invoice to `active.awaiting_payment_settlement`
+- usage-based invoice branches use the unified `active.realization.*` statuses for both partial and final invoice-backed runs. Keep the branch order as `started -> waiting_for_collection -> processing -> issuing -> completed`, keep `invoice_issued` as the boundary between `processing` and `issuing`, run `FinalizeInvoiceRun(...)` from the `issuing` state, and let `completed` dynamically route to `active` or `active.awaiting_payment_settlement` based on the effective service-period boundary and realization history. Do not reintroduce separate partial/final status branches; legacy `active.partial_invoice.*` and `active.final_realization.*` values are normalized when loading the state machine.
 - when adding or renaming usage-based detailed statuses, remember that `status_detailed` is an Ent enum for `ChargeUsageBased`; run `make generate` so the generated enum validators and migrate schema include the new values before trusting state-machine changes
 - when charge code deletes an empty standard invoice, call billing `DeleteInvoice` with `billing.ChangeSourceSystem`; billing stores that source for audit and dispatches `OnMutableStandardLinesDeletedBySystem(...)` only for non-deleted standard lines so charge engines can clean up line-backed runs without mutating the deleted invoice's visible line history
 
@@ -213,11 +216,11 @@ Usage-based credit-then-invoice extension rules:
 
 - `PatchExtend` must represent a real extension: the new service period end must be after the persisted intent end; full service period and billing period ends may stay unchanged but must not move backwards. Carry the new invoice-at on the patch separately from the service-period end.
 - Do not stretch an in-progress final realization run to cover the extension. There can only be one active run, and stretching the old final run would keep the run open across the extension and delay the standard invoice lifecycle.
-- If the current final realization run is still backed by a mutable invoice line, the extend flow should update the charge intent, emit an invoice-line delete patch for that mutable standard line, and let the billing invoice updater/line engine delete the invoice line and mark the run deleted. The charge should move back to `active` with `AdvanceAfter` set to the new service-period end so the extended tail can realize later.
-- While a mutable final invoice run is before invoice issuing (`active.final_realization.started`, `active.final_realization.waiting_for_collection`, or `active.final_realization.processing`), billing remains the owner of the ongoing invoice lifecycle. Extension may delete the mutable line, mark the current run deleted, and recreate a gathering line; a direct `AdvanceCharges(...)` before the new service-period end must be a no-op, and the replacement final run should be created by billing when the replacement gathering line is invoiced at the extended end.
-- Once a final invoice run reaches `active.final_realization.issuing` or `active.final_realization.completed`, extend is explicitly rejected by `UnsupportedExtendOperation` because invoice lifecycle callbacks or state-machine advancement still own those states. Subscription sync is expected to retry instead of moving the charge out of those states manually.
-- Extending from `active.awaiting_payment_settlement` is allowed: preserve the invoice line and ledger bookings, reclassify the old final run as partial, move the charge back to `active`, and create only a tail gathering line.
-- If the old final realization has already passed into immutable invoice territory, keep the invoice and ledger untouched. Reclassify the old final run as a partial invoice run and move the charge back to `active`; the extended tail will produce a new final run later. Immutable invoice cleanup should be surfaced as validation warnings by billing rather than reversing ledger bookings.
+- If the current invoice-backed realization run reaches the old effective service-period end and is still backed by a mutable invoice line, the extend flow should update the charge intent, emit an invoice-line delete patch for that mutable standard line, and let the billing invoice updater/line engine delete the invoice line and mark the run deleted. The charge should move back to `active` with `AdvanceAfter` set to the new service-period end so the extended tail can realize later.
+- While an invoice-backed run that reaches the old effective service-period end is before invoice issuing (`active.realization.started`, `active.realization.waiting_for_collection`, or `active.realization.processing`), billing remains the owner of the ongoing invoice lifecycle. Extension may delete the mutable line, mark the current run deleted, and recreate a gathering line; a direct `AdvanceCharges(...)` before the new service-period end must be a no-op, and the replacement final run should be created by billing when the replacement gathering line is invoiced at the extended end.
+- Once an invoice-backed run reaches `active.realization.issuing` or `active.realization.completed`, extend is explicitly rejected by `UnsupportedExtendOperation` because invoice lifecycle callbacks or state-machine advancement still own those states. Subscription sync is expected to retry instead of moving the charge out of those states manually.
+- Extending from `active.awaiting_payment_settlement` is allowed: preserve the invoice line and ledger bookings, reclassify the old terminal run as partial, move the charge back to `active`, and create only a tail gathering line.
+- If the old terminal realization has already passed into immutable invoice territory, keep the invoice and ledger untouched. Reclassify the old final run as a partial invoice run and move the charge back to `active`; the extended tail will produce a new final run later. Immutable invoice cleanup should be surfaced as validation warnings by billing rather than reversing ledger bookings.
 - Pending gathering lines for the charge should be extended in place by charge ID using a full target-state gathering-line patch. The target line's service period must cover only the remaining charge period not already represented by non-voided realization runs; do not rebuild the pending gathering line from the whole effective charge period once prior runs exist. Existing standard invoice lines should only be deleted in the mutable-current-final case above.
 - These rules are intentionally about not blocking the invoice train: extension should not hold a standard invoice lifecycle open while waiting for newly extended usage windows to finish.
 
@@ -226,7 +229,7 @@ Usage-based credit-then-invoice shrink rules:
 - `PatchShrink` must represent a real shrink: the new service period end must be before the persisted intent end and after the persisted service period start. Full service period and billing period ends may stay unchanged or move earlier, but must not move later. Carry the new invoice-at on the patch separately from the service-period end.
 - Shrink is native for usage-based `credit_then_invoice` charges so immutable invoice and ledger history can be preserved. Usage-based `credit_only` shrink remains an emulated delete/create replacement unless that mode explicitly gains native support.
 - Pending gathering lines should be shrunk in place by charge ID using a full target-state gathering-line patch for the remaining unbilled period. This updates the line service period, invoice-at, price/tax/discount state, and subscription billing period through the invoice updater.
-- If the current invoice-backed realization run is still backed by a mutable invoice line (`active.partial_invoice.started`, `active.partial_invoice.waiting_for_collection`, `active.partial_invoice.processing`, `active.final_realization.started`, `active.final_realization.waiting_for_collection`, or `active.final_realization.processing`) and extends past the new service-period end, shrink should delete that mutable standard line and create a replacement gathering line for the shrunk period. Billing's mutable-line deletion hook owns credit correction, run deletion, and moving the charge back to `active`.
+- If the current invoice-backed realization run is still backed by a mutable invoice line (`active.realization.started`, `active.realization.waiting_for_collection`, or `active.realization.processing`) and extends past the new service-period end, shrink should delete that mutable standard line and create a replacement gathering line for the shrunk period. Billing's mutable-line deletion hook owns credit correction, run deletion, and moving the charge back to `active`.
 - In `active.awaiting_payment_settlement` and `final`, shrink is allowed even though the existing final invoice is immutable. Emit the line-delete patch anyway so billing records the immutable-invoice/prorating warning, leave existing invoice and ledger history untouched, move the charge back to `active`, and create a replacement gathering line for the shrunk period using the patch invoice-at.
 - Shrink must reject if a non-deleted run beyond the new service-period end is not invoice-backed. Do not prorate, rewrite immutable invoices, or reverse immutable ledger bookings from the charge state machine.
 - Shrink is explicitly unsupported in issuing/completed invoice states and `deleted`. Subscription sync can retry after billing advances when the invoice lifecycle owns the current state.
@@ -465,10 +468,10 @@ Relevant statuses:
 
 - `created`
 - `active`
-- `active.final_realization.started`
-- `active.final_realization.waiting_for_collection`
-- `active.final_realization.processing`
-- `active.final_realization.completed`
+- `active.realization.started`
+- `active.realization.waiting_for_collection`
+- `active.realization.processing`
+- `active.realization.completed`
 - `final`
 
 High-level transitions:
@@ -476,19 +479,19 @@ High-level transitions:
 1. `created -> active`
    - guarded by `IsInsideServicePeriod()`
    - sets `AdvanceAfter` to service-period start while waiting
-2. `active -> active.final_realization.started`
+2. `active -> active.realization.started`
    - guarded by `IsAfterServicePeriod()`
    - sets `AdvanceAfter` to service-period end while waiting
-3. `active.final_realization.started -> active.final_realization.waiting_for_collection`
+3. `active.realization.started -> active.realization.waiting_for_collection`
    - `StartFinalRealizationRun(...)` creates the realization run
-4. `active.final_realization.waiting_for_collection -> active.final_realization.processing`
+4. `active.realization.waiting_for_collection -> active.realization.processing`
    - guarded by `IsAfterCollectionPeriod(...)`
-5. `active.final_realization.processing -> active.final_realization.completed`
+5. `active.realization.processing -> active.realization.completed`
    - `FinalizeRealizationRun(...)` re-rates usage, computes delta vs initial run totals, then:
      - positive delta → allocates additional credits via `allocateCredits`
      - negative delta → corrects existing allocations via `Realizations.Correct()` with handler callback `OnCreditsOnlyUsageAccruedCorrection`
      - zero delta → no-op
-6. `active.final_realization.completed -> final`
+6. `active.realization.completed -> final`
    - clears `AdvanceAfter`
 
 `AdvanceUntilStateStable(...)` loops until the machine can no longer fire `TriggerNext`.
@@ -520,7 +523,7 @@ Key differences from usage-based credits-only:
 - No collection period, no two-phase realization
 - Amount is computed at creation from `Intent.AmountBeforeProration` and stored in `State.AmountAfterProration`, no meter snapshot or rating
 - No `FeatureMeter` or `CustomerOverride` needed
-- Uses `flatfee.Status` with only top-level states (not sub-statuses like `active.final_realization.*`)
+- Uses `flatfee.Status` with only top-level states for credit-only (not usage-based-style sub-statuses like `active.realization.*`)
 - Persists only `flatfee.ChargeBase`; credit allocations / payment / accrued usage live in `flatfee.Realizations`
 
 Service construction requires a `*lockr.Locker` (same as usage-based).
@@ -576,10 +579,11 @@ Realization runs are the persisted checkpoint for collection progress.
 
 Important rules:
 
-- the first final-realization advance creates a run
+- invoice-backed and credits-only realization steps create runs; final vs partial behavior is represented on `RealizationRun.Type`, not by separate active status branches
 - `StoredAtLT`, `ServicePeriodTo`, and `MeteredQuantity` must be persisted on the run and mapped back into the domain model
 - `CurrentRealizationRunID` points at the active run while waiting/finalizing
 - finalization must clear `CurrentRealizationRunID`
+- use `RealizationRuns.WithoutVoidedBillingHistory().Latest()` when a state-machine handler needs the last effective realized boundary; do not hand-roll max-by-service-period selection at call sites
 
 Persistence gotcha:
 

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -16,10 +16,11 @@ import (
 type PatchType string
 
 const (
-	PatchTypeExtend         PatchType = "extend"
-	PatchTypeShrink         PatchType = "shrink"
-	PatchTypeDelete         PatchType = "delete"
-	PatchTypeLineManualEdit PatchType = "line_manual_edit"
+	PatchTypeExtend                 PatchType = "extend"
+	PatchTypeShrink                 PatchType = "shrink"
+	PatchTypeDelete                 PatchType = "delete"
+	PatchTypeLineManualEdit         PatchType = "line_manual_edit"
+	PatchTypeShrinkToRealizedPeriod PatchType = "shrink_to_realized_period"
 )
 
 type ChangeTarget string

--- a/openmeter/billing/charges/meta/patch_target_test.go
+++ b/openmeter/billing/charges/meta/patch_target_test.go
@@ -169,3 +169,59 @@ func TestLineManualEditPatchValidateRejectsSystemChange(t *testing.T) {
 
 	require.Error(t, patch.Validate())
 }
+
+func TestShrinkToRealizedPeriodPatchGetTargetLayer(t *testing.T) {
+	tests := []struct {
+		name   string
+		intent layeredIntentReaderForTest
+		want   ChangeTarget
+	}{
+		{
+			name: "manual base without override targets base",
+			intent: layeredIntentReaderForTest{
+				baseManagedBy: billing.ManuallyManagedLine,
+			},
+			want: ChangeTargetBase,
+		},
+		{
+			name: "manual base with override targets override",
+			intent: layeredIntentReaderForTest{
+				baseManagedBy: billing.ManuallyManagedLine,
+				hasOverride:   true,
+			},
+			want: ChangeTargetOverride,
+		},
+		{
+			name: "subscription base targets override",
+			intent: layeredIntentReaderForTest{
+				baseManagedBy: billing.SubscriptionManagedLine,
+			},
+			want: ChangeTargetOverride,
+		},
+	}
+
+	patch := PatchShrinkToRealizedPeriod{changeSource: billing.ChangeSourceAPIRequest}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := patch.GetTargetLayer(tt.intent)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestShrinkToRealizedPeriodPatchGetTargetLayerRejectsMissingIntent(t *testing.T) {
+	patch := PatchShrinkToRealizedPeriod{changeSource: billing.ChangeSourceAPIRequest}
+
+	_, err := patch.GetTargetLayer(nil)
+
+	require.ErrorContains(t, err, "intent is required")
+}
+
+func TestShrinkToRealizedPeriodPatchValidateRejectsSystemChange(t *testing.T) {
+	patch := PatchShrinkToRealizedPeriod{changeSource: billing.ChangeSourceSystem}
+
+	require.Error(t, patch.Validate())
+}

--- a/openmeter/billing/charges/meta/patchshrinktorealizedperiod.go
+++ b/openmeter/billing/charges/meta/patchshrinktorealizedperiod.go
@@ -1,0 +1,103 @@
+package meta
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/qmuntal/stateless"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var _ Patch = (*PatchShrinkToRealizedPeriod)(nil)
+
+type PatchShrinkToRealizedPeriod struct {
+	changeSource        billing.ChangeSource
+	newServicePeriodEnd time.Time
+}
+
+type NewPatchShrinkToRealizedPeriodInput struct {
+	ChangeSource        billing.ChangeSource
+	NewServicePeriodEnd time.Time
+}
+
+func (i NewPatchShrinkToRealizedPeriodInput) Validate() error {
+	var errs []error
+
+	if err := i.ChangeSource.Require(billing.ChangeSourceAPIRequest); err != nil {
+		errs = append(errs, fmt.Errorf("change source: %w", err))
+	}
+
+	if i.NewServicePeriodEnd.IsZero() {
+		errs = append(errs, fmt.Errorf("new service period end is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func NewPatchShrinkToRealizedPeriod(input NewPatchShrinkToRealizedPeriodInput) (PatchShrinkToRealizedPeriod, error) {
+	if err := input.Validate(); err != nil {
+		return PatchShrinkToRealizedPeriod{}, err
+	}
+
+	patch := PatchShrinkToRealizedPeriod{
+		changeSource:        input.ChangeSource,
+		newServicePeriodEnd: NormalizeTimestamp(input.NewServicePeriodEnd),
+	}
+	if err := patch.Validate(); err != nil {
+		return PatchShrinkToRealizedPeriod{}, err
+	}
+
+	return patch, nil
+}
+
+func (p PatchShrinkToRealizedPeriod) GetChangeSource() billing.ChangeSource {
+	return p.changeSource
+}
+
+func (p PatchShrinkToRealizedPeriod) GetTargetLayer(intent LayeredIntentReader) (ChangeTarget, error) {
+	if err := p.GetChangeSource().Require(billing.ChangeSourceAPIRequest); err != nil {
+		return "", fmt.Errorf("change source: %w", err)
+	}
+
+	return apiPatchTargetLayer(intent)
+}
+
+func (p PatchShrinkToRealizedPeriod) GetNewServicePeriodEnd() time.Time {
+	return p.newServicePeriodEnd
+}
+
+func (p PatchShrinkToRealizedPeriod) Op() PatchType {
+	return PatchTypeShrinkToRealizedPeriod
+}
+
+func (p PatchShrinkToRealizedPeriod) Trigger() stateless.Trigger {
+	return TriggerShrinkToRealizedPeriod
+}
+
+func (p PatchShrinkToRealizedPeriod) Validate() error {
+	return NewPatchShrinkToRealizedPeriodInput{
+		ChangeSource:        p.GetChangeSource(),
+		NewServicePeriodEnd: p.GetNewServicePeriodEnd(),
+	}.Validate()
+}
+
+func (p PatchShrinkToRealizedPeriod) ValidateWith(intent IntentMutableFields) error {
+	var errs []error
+
+	if err := p.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if !p.GetNewServicePeriodEnd().Before(intent.ServicePeriod.To) {
+		errs = append(errs, fmt.Errorf("new service period end must be less than existing service period to"))
+	}
+
+	if !p.GetNewServicePeriodEnd().After(intent.ServicePeriod.From) {
+		errs = append(errs, fmt.Errorf("new service period end must be greater than existing service period from"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -5,10 +5,11 @@ import "github.com/qmuntal/stateless"
 type Trigger = stateless.Trigger
 
 var (
-	TriggerNext                Trigger = "next"
-	TriggerInvoiceCreated      Trigger = "invoice_created"
-	TriggerCollectionCompleted Trigger = "collection_completed"
-	TriggerInvoiceIssued       Trigger = "invoice_issued"
-	TriggerLineManualEdit      Trigger = "line_manual_edit"
-	TriggerAttachInvoiceLine   Trigger = "attach_invoice_line"
+	TriggerNext                   Trigger = "next"
+	TriggerInvoiceCreated         Trigger = "invoice_created"
+	TriggerCollectionCompleted    Trigger = "collection_completed"
+	TriggerInvoiceIssued          Trigger = "invoice_issued"
+	TriggerLineManualEdit         Trigger = "line_manual_edit"
+	TriggerShrinkToRealizedPeriod Trigger = "shrink_to_realized_period"
+	TriggerAttachInvoiceLine      Trigger = "attach_invoice_line"
 )

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -127,8 +127,9 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 	}
 
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
-		if err := charge.Intent.MutateEffective(func(intentMutableFields *usagebased.IntentMutableFields) {
+		if err := charge.Intent.MutateEffective(func(intentMutableFields *usagebased.IntentMutableFields) error {
 			intentMutableFields.IntentDeletedAt = lo.ToPtr(clock.Now())
+			return nil
 		}); err != nil {
 			return err
 		}

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
@@ -110,8 +110,9 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride()
 		},
 	}
 
-	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields *usagebased.IntentMutableFields) {
+	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields *usagebased.IntentMutableFields) error {
 		fields.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
+		return nil
 	}))
 	override := usagebased.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
@@ -281,8 +282,9 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUnitConfigRoundTrip() {
 	s.True(fetched.Intent.GetBaseIntent().UnitConfig.Equal(newTestUnitConfig(1000, "K")))
 
 	// base update→read: the base unit_config is mutable (lives alongside price)
-	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) {
+	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) error {
 		f.UnitConfig = newTestUnitConfig(1000000, "M")
+		return nil
 	}))
 	updated, err := s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
 	s.Require().NoError(err)
@@ -293,8 +295,9 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUnitConfigRoundTrip() {
 	s.True(fetched.Intent.GetBaseIntent().UnitConfig.Equal(newTestUnitConfig(1000000, "M")))
 
 	// base clear→read
-	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) {
+	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) error {
 		f.UnitConfig = nil
+		return nil
 	}))
 	updated, err = s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
 	s.Require().NoError(err)

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -479,7 +479,7 @@ func (i OverridableIntent) GetDeletedAt() *time.Time {
 	return i.baseLayer.IntentDeletedAt
 }
 
-func (i *OverridableIntent) MutateEffective(editFn func(*IntentMutableFields)) error {
+func (i *OverridableIntent) MutateEffective(editFn func(*IntentMutableFields) error) error {
 	target := meta.ChangeTargetBase
 	if i.overrideLayer != nil {
 		target = meta.ChangeTargetOverride
@@ -493,7 +493,7 @@ func (i *OverridableIntent) MutateEffective(editFn func(*IntentMutableFields)) e
 // The callback always receives a non-nil pointer to a cloned mutable-field value.
 // The clone is written back only after it normalizes and validates, so validation
 // errors do not partially mutate the intent.
-func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(*IntentMutableFields)) error {
+func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(*IntentMutableFields) error) error {
 	var targetFields IntentMutableFields
 	switch target {
 	case meta.ChangeTargetBase:
@@ -506,7 +506,9 @@ func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(*Intent
 		targetFields = i.overrideLayer.Clone()
 	}
 
-	editFn(&targetFields)
+	if err := editFn(&targetFields); err != nil {
+		return err
+	}
 
 	normalizedFields := targetFields.Normalized()
 

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -427,9 +427,9 @@ func (r RealizationRuns) WithoutVoidedBillingHistory() RealizationRuns {
 	})
 }
 
-// Latest returns the run that advanced farthest through the service period.
-// Ties are broken by creation time so callers get the newest run for the same
-// service-period boundary.
+// Latest returns the run with the latest service-period end. Ties are
+// resolved by creation time so callers get the newest run for the same realized
+// boundary. Filtering voided history is a caller decision.
 func (r RealizationRuns) Latest() (RealizationRun, bool) {
 	if len(r) == 0 {
 		return RealizationRun{}, false

--- a/openmeter/billing/charges/usagebased/realizationrun_test.go
+++ b/openmeter/billing/charges/usagebased/realizationrun_test.go
@@ -198,6 +198,58 @@ func TestRealizationRuns_SumSkipsVoidedBillingHistory(t *testing.T) {
 	require.Equal(t, float64(7), RealizationRuns{deletedRun, invalidRun, effectiveRun}.Sum().Total.InexactFloat64())
 }
 
+func TestRealizationRuns_Latest(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("empty", func(t *testing.T) {
+		_, ok := RealizationRuns{}.Latest()
+
+		require.False(t, ok)
+	})
+
+	t.Run("latest service period end", func(t *testing.T) {
+		run, ok := RealizationRuns{
+			newRealizationRunForBillingMeteredQuantityTest(
+				"run-1",
+				RealizationRunTypePartialInvoice,
+				periodStart.Add(24*time.Hour),
+				1,
+			),
+			newRealizationRunForBillingMeteredQuantityTest(
+				"run-2",
+				RealizationRunTypePartialInvoice,
+				periodStart.Add(48*time.Hour),
+				1,
+			),
+		}.Latest()
+
+		require.True(t, ok)
+		require.Equal(t, "run-2", run.ID.ID)
+	})
+
+	t.Run("latest created at wins same service period end", func(t *testing.T) {
+		periodEnd := periodStart.Add(24 * time.Hour)
+		older := newRealizationRunForBillingMeteredQuantityTest(
+			"older",
+			RealizationRunTypePartialInvoice,
+			periodEnd,
+			1,
+		)
+		newer := newRealizationRunForBillingMeteredQuantityTest(
+			"newer",
+			RealizationRunTypePartialInvoice,
+			periodEnd,
+			1,
+		)
+		newer.CreatedAt = older.CreatedAt.Add(time.Hour)
+
+		run, ok := RealizationRuns{newer, older}.Latest()
+
+		require.True(t, ok)
+		require.Equal(t, "newer", run.ID.ID)
+	})
+}
+
 func TestRealizationRuns_GetByLineID(t *testing.T) {
 	lineID := "line-1"
 	otherLineID := "line-2"

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -75,6 +75,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
@@ -83,12 +84,18 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 
 	s.Configure(usagebased.StatusActive).
 		Permit(
+			meta.TriggerNext,
+			usagebased.StatusActiveAwaitingPaymentSettlement,
+			statelessx.BoolFn(s.HasTerminalInvoicedRealizationWithoutCurrentRun),
+		).
+		Permit(
 			meta.TriggerInvoiceCreated,
 			usagebased.StatusActiveRealizationStarted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
 		OnActive(
 			statelessx.AllOf(
 				s.SyncFeatureIDFromFeatureMeter,
@@ -106,6 +113,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
 		OnEntry(statelessx.WithParameters(s.StartInvoiceRun))
 
 	s.Configure(usagebased.StatusActiveRealizationWaitingForCollection).
@@ -116,6 +124,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
 		OnActive(s.AdvanceAfterCollectionPeriodEnd)
 
 	s.Configure(usagebased.StatusActiveRealizationProcessing).
@@ -126,6 +135,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
 		OnActive(
 			s.SnapshotInvoiceUsage,
 		)
@@ -140,6 +150,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// Subscription sync can retry after billing advances the charge.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.UnsupportedShrinkToRealizedPeriodOperation)).
 		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
 
 	s.Configure(usagebased.StatusActiveRealizationCompleted).
@@ -151,7 +162,12 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// Extend is rejected because this branch still has its own next
 		// transition to payment settlement. Subscription sync can retry.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
+		// Invoice-issued callbacks have already finalized the run in the
+		// issuing state. A gathering-line API delete may now shorten the
+		// effective period to that completed run, and the next transition still
+		// owns routing the charge to active or payment settlement.
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
 
 	// Payment + final
 
@@ -159,15 +175,18 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		Permit(meta.TriggerNext, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
 
 	s.Configure(usagebased.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
 
 	s.Configure(usagebased.StatusDeleted).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.UnsupportedShrinkToRealizedPeriodOperation))
 }
 
 func (s *CreditThenInvoiceStateMachine) resolveStateAfterRealizationCompleted(_ context.Context, _ ...any) (stateless.State, error) {
@@ -186,6 +205,35 @@ func (s *CreditThenInvoiceStateMachine) resolveStateAfterRealizationCompleted(_ 
 	return usagebased.StatusActive, nil
 }
 
+// HasTerminalInvoicedRealizationWithoutCurrentRun lets the active state discover
+// a completed invoice-backed realization after manual period changes. Normally
+// the realization branch moves to settlement when it creates the final run; API
+// gathering-line deletes can instead make an existing paid partial run become
+// final while the charge is already back in active.
+func (s *CreditThenInvoiceStateMachine) HasTerminalInvoicedRealizationWithoutCurrentRun() bool {
+	if s.Charge.State.CurrentRealizationRunID != nil {
+		return false
+	}
+
+	latestRun, ok := s.Charge.Realizations.WithoutVoidedBillingHistory().Latest()
+	if !ok {
+		return false
+	}
+
+	if latestRun.Type != usagebased.RealizationRunTypeFinalRealization {
+		return false
+	}
+
+	if latestRun.InvoiceUsage == nil {
+		return false
+	}
+
+	return isFinalRunInPeriod(s.Charge, timeutil.ClosedPeriod{
+		From: s.Charge.Intent.GetEffectiveServicePeriod().From,
+		To:   latestRun.ServicePeriodTo,
+	})
+}
+
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
 	deletedAt := lo.ToPtr(clock.Now())
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
@@ -193,8 +241,9 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 		return fmt.Errorf("getting patch target layer: %w", err)
 	}
 
-	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) {
+	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) error {
 		fields.IntentDeletedAt = deletedAt
+		return nil
 	}); err != nil {
 		return fmt.Errorf("deleting intent: %w", err)
 	}
@@ -245,7 +294,7 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
-	patchResult, err := s.applyPeriodPatch(patch)
+	patchResult, err := s.applyPeriodPatch(ctx, patch)
 	if err != nil {
 		return err
 	}
@@ -319,8 +368,8 @@ func remainingGatheringLinePeriod(charge usagebased.Charge) timeutil.ClosedPerio
 	return period.Truncate(streaming.MinimumWindowSizeDuration)
 }
 
-func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch meta.PatchShrink) error {
-	patchResult, err := s.applyPeriodPatch(patch)
+func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch meta.PatchShrink) error {
+	patchResult, err := s.applyPeriodPatch(ctx, patch)
 	if err != nil {
 		return err
 	}
@@ -336,33 +385,92 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch me
 	return nil
 }
 
+func (s *CreditThenInvoiceStateMachine) ShrinkToRealizedPeriod(ctx context.Context, patch meta.PatchShrinkToRealizedPeriod) error {
+	target, err := patch.GetTargetLayer(s.Charge.Intent)
+	if err != nil {
+		return fmt.Errorf("getting patch target layer: %w", err)
+	}
+
+	nonVoidedRuns := s.Charge.Realizations.WithoutVoidedBillingHistory()
+	latestRun, ok := nonVoidedRuns.Latest()
+	if !ok {
+		return fmt.Errorf("cannot shrink usage-based charge %s to realized period without realization runs: %w", s.Charge.ID, billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
+	}
+	newServicePeriodTo := meta.NormalizeTimestamp(patch.GetNewServicePeriodEnd())
+	latestRunServicePeriodTo := meta.NormalizeTimestamp(latestRun.ServicePeriodTo)
+
+	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) error {
+		if err := patch.ValidateWith(fields.IntentMutableFields); err != nil {
+			return fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+		}
+
+		if !newServicePeriodTo.Equal(latestRunServicePeriodTo) {
+			return fmt.Errorf(
+				"cannot shrink usage-based charge %s to %s because latest realization run %s ends at %s: %w",
+				s.Charge.ID,
+				newServicePeriodTo,
+				latestRun.ID.ID,
+				latestRunServicePeriodTo,
+				billing.ErrCannotEditProgressivelyBilledUsageBasedLine,
+			)
+		}
+
+		fields.ServicePeriod.To = patch.GetNewServicePeriodEnd()
+		return nil
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent: %w", target, err)
+	}
+
+	if target == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing invoice/run state remains owned by the override layer.
+		return nil
+	}
+
+	if latestRun.Type == usagebased.RealizationRunTypePartialInvoice {
+		updatedRunBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+			ID:   latestRun.ID,
+			Type: mo.Some(usagebased.RealizationRunTypeFinalRealization),
+		})
+		if err != nil {
+			return fmt.Errorf("updating realization run[%s] type: %w", latestRun.ID.ID, err)
+		}
+
+		latestRun.RealizationRunBase = updatedRunBase
+		if err := s.Charge.Realizations.SetRealizationRun(latestRun); err != nil {
+			return fmt.Errorf("updating in-memory realization run[%s]: %w", latestRun.ID.ID, err)
+		}
+	}
+
+	s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
+
+	return nil
+}
+
 type creditThenInvoiceApplyPeriodPatchResult struct {
 	ShouldReconcile  bool
 	OldServicePeriod timeutil.ClosedPeriod
 }
 
-func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (creditThenInvoiceApplyPeriodPatchResult, error) {
+func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(ctx context.Context, patch periodPatch) (creditThenInvoiceApplyPeriodPatchResult, error) {
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
 		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("getting patch target layer: %w", err)
 	}
 
-	targetIntent, err := s.Charge.Intent.GetIntentForTarget(target)
-	if err != nil {
-		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", target, err)
-	}
+	var oldServicePeriod timeutil.ClosedPeriod
 
-	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
-		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
-	}
+	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) error {
+		if err := patch.ValidateWith(fields.IntentMutableFields); err != nil {
+			return fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+		}
 
-	oldServicePeriod := meta.NormalizeClosedPeriod(targetIntent.IntentMutableFields.ServicePeriod)
-
-	if err := s.Charge.Intent.Mutate(target, func(fields *usagebased.IntentMutableFields) {
+		oldServicePeriod = meta.NormalizeClosedPeriod(fields.ServicePeriod)
 		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
 		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return nil
 	}); err != nil {
 		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", target, err)
 	}
@@ -388,6 +496,12 @@ func (s *CreditThenInvoiceStateMachine) UnsupportedExtendOperation(_ context.Con
 func (s *CreditThenInvoiceStateMachine) UnsupportedShrinkOperation(_ context.Context, _ meta.PatchShrink) error {
 	return models.NewGenericPreConditionFailedError(
 		fmt.Errorf("cannot shrink usage-based charge in status %s; retry after billing advances", s.Charge.Status),
+	)
+}
+
+func (s *CreditThenInvoiceStateMachine) UnsupportedShrinkToRealizedPeriodOperation(_ context.Context, _ meta.PatchShrinkToRealizedPeriod) error {
+	return models.NewGenericPreConditionFailedError(
+		fmt.Errorf("cannot shrink usage-based charge to realized period in status %s; retry after billing advances", s.Charge.Status),
 	)
 }
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -301,6 +301,138 @@ func TestShrinkChargeMovesToFinalWhenKeptRunCoversNewEndAndSettlementIsComplete(
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }
 
+func TestShrinkToRealizedPeriodFinalizesKeptPartialRunAndPreservesChargeState(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	}
+	newServicePeriodTo := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	currentRunID := "run-1"
+	currentAdvanceAfter := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	charge := usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "charge-id",
+			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
+			Status: usagebased.StatusActive,
+			State: usagebased.State{
+				AdvanceAfter: &currentAdvanceAfter,
+			},
+		},
+		Realizations: usagebased.RealizationRuns{
+			newUsageBasedRunForShrinkTest(currentRunID, usagebased.RealizationRunTypePartialInvoice, newServicePeriodTo),
+		},
+	}
+	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, charge)
+	machine.Adapter = newCreditThenInvoiceStateMachineAdapter(charge)
+
+	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, newServicePeriodTo))
+	require.NoError(t, err)
+
+	charge = machine.GetCharge()
+	require.Equal(t, usagebased.StatusActive, charge.Status)
+	require.Nil(t, charge.State.CurrentRealizationRunID)
+	require.Equal(t, currentAdvanceAfter, *charge.State.AdvanceAfter)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetBaseIntent().ServicePeriod.To)
+	require.True(t, charge.Intent.HasOverrideLayer())
+	require.Equal(t, newServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveIntent().FullServicePeriod.To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveIntent().BillingPeriod.To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveInvoiceAt())
+
+	run, err := charge.Realizations.GetByID(currentRunID)
+	require.NoError(t, err)
+	require.Equal(t, usagebased.RealizationRunTypeFinalRealization, run.Type)
+	require.Equal(t, usagebased.RealizationRunTypePartialInvoice, run.InitialType)
+
+	patches := machine.InvoicePatches()
+	require.Len(t, patches, 1)
+	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
+}
+
+func TestShrinkToRealizedPeriodRejectsPeriodNotCoveredByLatest(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	}
+	firstRunEnd := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	latestRunEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "charge-id",
+			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
+			Status: usagebased.StatusActive,
+		},
+		Realizations: usagebased.RealizationRuns{
+			newUsageBasedRunForShrinkTest("run-1", usagebased.RealizationRunTypePartialInvoice, firstRunEnd),
+			newUsageBasedRunForShrinkTest("run-2", usagebased.RealizationRunTypePartialInvoice, latestRunEnd),
+		},
+	})
+
+	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, firstRunEnd))
+
+	require.ErrorContains(t, err, billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
+}
+
+func TestShrinkToRealizedPeriodFinalizesCurrentPartialRunAndPreservesChargeState(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	}
+	currentRunID := "run-1"
+	currentAdvanceAfter := time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)
+	newServicePeriodTo := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	charge := usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "charge-id",
+			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
+			Status: usagebased.StatusActiveRealizationProcessing,
+			State: usagebased.State{
+				CurrentRealizationRunID: &currentRunID,
+				AdvanceAfter:            &currentAdvanceAfter,
+			},
+		},
+		Realizations: usagebased.RealizationRuns{
+			newUsageBasedRunForShrinkTest(currentRunID, usagebased.RealizationRunTypePartialInvoice, newServicePeriodTo),
+		},
+	}
+	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, charge)
+	machine.Adapter = newCreditThenInvoiceStateMachineAdapter(charge)
+
+	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, newServicePeriodTo))
+	require.NoError(t, err)
+
+	charge = machine.GetCharge()
+	require.Equal(t, usagebased.StatusActiveRealizationProcessing, charge.Status)
+	require.Equal(t, currentRunID, *charge.State.CurrentRealizationRunID)
+	require.Equal(t, currentAdvanceAfter, *charge.State.AdvanceAfter)
+	require.True(t, charge.Intent.HasOverrideLayer())
+	require.Equal(t, newServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveIntent().FullServicePeriod.To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveIntent().BillingPeriod.To)
+	require.Equal(t, servicePeriod.To, charge.Intent.GetEffectiveInvoiceAt())
+
+	run, err := charge.Realizations.GetByID(currentRunID)
+	require.NoError(t, err)
+	require.Equal(t, usagebased.RealizationRunTypeFinalRealization, run.Type)
+	require.Equal(t, usagebased.RealizationRunTypePartialInvoice, run.InitialType)
+
+	patches := machine.InvoicePatches()
+	require.Len(t, patches, 1)
+	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
+}
+
 func newCreditThenInvoiceStateMachineForTest(t *testing.T, status usagebased.Status) *CreditThenInvoiceStateMachine {
 	t.Helper()
 
@@ -392,6 +524,42 @@ func newCreditThenInvoiceStateMachineWithChargeForTest(t *testing.T, charge usag
 	return out
 }
 
+type creditThenInvoiceStateMachineAdapter struct {
+	usagebased.Adapter
+
+	runs map[string]usagebased.RealizationRunBase
+}
+
+func newCreditThenInvoiceStateMachineAdapter(charge usagebased.Charge) *creditThenInvoiceStateMachineAdapter {
+	runs := make(map[string]usagebased.RealizationRunBase, len(charge.Realizations))
+	for _, run := range charge.Realizations {
+		runs[run.ID.ID] = run.RealizationRunBase
+	}
+
+	return &creditThenInvoiceStateMachineAdapter{
+		runs: runs,
+	}
+}
+
+func (a *creditThenInvoiceStateMachineAdapter) CreateChargeOverride(_ context.Context, charge usagebased.ChargeBase, override usagebased.IntentMutableFields) (usagebased.ChargeBase, error) {
+	charge.Intent = usagebased.NewOverridableIntent(charge.Intent.GetBaseIntent(), &override)
+	return charge, nil
+}
+
+func (a *creditThenInvoiceStateMachineAdapter) UpdateRealizationRun(_ context.Context, input usagebased.UpdateRealizationRunInput) (usagebased.RealizationRunBase, error) {
+	run, ok := a.runs[input.ID.ID]
+	if !ok {
+		return usagebased.RealizationRunBase{}, nil
+	}
+
+	if input.Type.IsPresent() {
+		run.Type = input.Type.OrEmpty()
+	}
+
+	a.runs[input.ID.ID] = run
+	return run, nil
+}
+
 func newUsageBasedRunForShrinkTest(id string, typ usagebased.RealizationRunType, servicePeriodTo time.Time) usagebased.RealizationRun {
 	return usagebased.RealizationRun{
 		RealizationRunBase: usagebased.RealizationRunBase{
@@ -421,6 +589,18 @@ func mustNewPatchShrink(t *testing.T, newServicePeriodTo time.Time) meta.PatchSh
 		NewFullServicePeriodTo: newServicePeriodTo,
 		NewBillingPeriodTo:     newServicePeriodTo,
 		NewInvoiceAt:           newServicePeriodTo,
+	})
+	require.NoError(t, err)
+
+	return patch
+}
+
+func mustNewPatchShrinkToRealizedPeriod(t *testing.T, newServicePeriodTo time.Time) meta.PatchShrinkToRealizedPeriod {
+	t.Helper()
+
+	patch, err := meta.NewPatchShrinkToRealizedPeriod(meta.NewPatchShrinkToRealizedPeriodInput{
+		ChangeSource:        billing.ChangeSourceAPIRequest,
+		NewServicePeriodEnd: newServicePeriodTo,
 	})
 	require.NoError(t, err)
 

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -136,8 +136,9 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.P
 		return fmt.Errorf("getting patch target layer: %w", err)
 	}
 
-	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) {
+	if err := s.mutateIntentLayer(ctx, target, func(fields *usagebased.IntentMutableFields) error {
 		fields.IntentDeletedAt = deletedAt
+		return nil
 	}); err != nil {
 		return fmt.Errorf("deleting intent: %w", err)
 	}
@@ -218,20 +219,16 @@ func (s *CreditsOnlyStateMachine) applyPeriodPatch(patch periodPatch) (creditsOn
 		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("getting patch target layer: %w", err)
 	}
 
-	targetIntent, err := s.Charge.Intent.GetIntentForTarget(target)
-	if err != nil {
-		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", target, err)
-	}
+	if err := s.Charge.Intent.Mutate(target, func(fields *usagebased.IntentMutableFields) error {
+		if err := patch.ValidateWith(fields.IntentMutableFields); err != nil {
+			return fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+		}
 
-	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
-		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
-	}
-
-	if err := s.Charge.Intent.Mutate(target, func(fields *usagebased.IntentMutableFields) {
 		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
 		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return nil
 	}); err != nil {
 		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", target, err)
 	}

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -403,18 +403,7 @@ func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoic
 	nonVoidedRuns := charge.Realizations.WithoutVoidedBillingHistory()
 	switch line.AsInvoiceLine().Type() {
 	case billing.InvoiceLineTypeGathering:
-		if len(nonVoidedRuns) > 0 {
-			// TODO: Treat deleting the remaining gathering tail after prior
-			// usage-based realizations as a service-period shortening instead
-			// of deleting the whole charge and touching already-realized
-			// invoice history.
-			return usagebased.Charge{}, fmt.Errorf("usage based gathering line[%s] cannot be deleted with existing realization runs: %w",
-				line.GetID(),
-				billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
-		}
-
-		// TODO: implement
-		return usagebased.Charge{}, billing.ErrCannotUpdateChargeManagedLine
+		// No pre-validation is required, deletion is supported regardless of the charge state.
 	case billing.InvoiceLineTypeStandard:
 		if len(nonVoidedRuns) > 1 {
 			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with multiple realization runs: %w",
@@ -445,6 +434,51 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 	}
 
 	switch line.AsInvoiceLine().Type() {
+	case billing.InvoiceLineTypeGathering:
+		nonVoidedRuns := charge.Realizations.WithoutVoidedBillingHistory()
+		var patch meta.Patch
+		if len(nonVoidedRuns) > 0 {
+			lineServicePeriod := line.GetServicePeriod()
+			shrinkToRealizedPeriodPatch, err := meta.NewPatchShrinkToRealizedPeriod(meta.NewPatchShrinkToRealizedPeriodInput{
+				ChangeSource:        billing.ChangeSourceAPIRequest,
+				NewServicePeriodEnd: lineServicePeriod.From,
+			})
+			if err != nil {
+				return fmt.Errorf("creating usage based charge[%s] API shrink to realized period patch: %w", charge.ID, err)
+			}
+
+			patch = shrinkToRealizedPeriodPatch
+		} else {
+			deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				ChangeSource: billing.ChangeSourceAPIRequest,
+				Policy:       meta.RefundAsCreditsDeletePolicy,
+			})
+			if err != nil {
+				return fmt.Errorf("creating usage based charge[%s] API delete patch: %w", charge.ID, err)
+			}
+
+			patch = deletePatch
+		}
+
+		_, patches, err := e.applyChargePatchForInvoiceLineEditViaAPI(ctx, charge, patch)
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: applying %s patch for charge[%s]: %w", line.GetID(), patch.Op(), charge.ID, err)
+		}
+
+		// The edited gathering invoice already deletes this line. The charge
+		// state machine must still agree by emitting the same pending-line
+		// deletion, which proves the API edit persisted the matching charge
+		// intent change instead of leaving charge state behind.
+		gatheringPatch, err := patches.RequireSingularGatheringLinePatchForCharge(*chargeID)
+		if err != nil {
+			return fmt.Errorf("line[%s]: validating gathering-line API delete patch target: %w", line.GetID(), err)
+		}
+
+		if gatheringPatch.Op() != invoiceupdater.PatchOpDeleteGatheringLineByChargeID {
+			return fmt.Errorf("line[%s]: expected gathering-line delete patch, got %s", line.GetID(), gatheringPatch.Op())
+		}
+
+		return nil
 	case billing.InvoiceLineTypeStandard:
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -397,13 +397,14 @@ func TestGetTotalsForUsageMinimumCommitment(t *testing.T) {
 			require.NoError(t, err)
 
 			charge := newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{})
-			err = charge.Intent.MutateEffective(func(fields *usagebased.IntentMutableFields) {
+			err = charge.Intent.MutateEffective(func(fields *usagebased.IntentMutableFields) error {
 				fields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 					Amount: alpacadecimal.NewFromInt(3),
 					Commitments: productcatalog.Commitments{
 						MinimumAmount: lo.ToPtr(alpacadecimal.NewFromInt(100)),
 					},
 				})
+				return nil
 			})
 			require.NoError(t, err)
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -128,7 +128,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 
 // mutateIntentLayer mutates the requested intent layer, creating a new override
 // layer first when the target is override and the charge has no override yet.
-func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*usagebased.IntentMutableFields)) error {
+func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*usagebased.IntentMutableFields) error) error {
 	switch target {
 	case meta.ChangeTargetBase:
 		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editFn); err != nil {
@@ -144,7 +144,10 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 		}
 
 		overrideFields := s.Charge.Intent.GetEffectiveIntent().IntentMutableFields
-		editFn(&overrideFields)
+		if err := editFn(&overrideFields); err != nil {
+			return err
+		}
+
 		overrideFields = overrideFields.Normalized()
 		if err := overrideFields.Validate(); err != nil {
 			return fmt.Errorf("validating override intent: %w", err)

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -3937,6 +3937,130 @@ func (s *CreditThenInvoiceTestSuite) TestGatheringManualDeleteSync() {
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 }
 
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringManualDeleteWithoutRealizations() {
+	ctx := s.T().Context()
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
+
+	var subsView subscription.SubscriptionView
+	var gatheringInvoice billing.GatheringInvoice
+	var deletedLine billing.GatheringLine
+
+	s.Run("create gathering line without realizations", func() {
+		// given:
+		// - subscription sync owns a usage-based charge base intent
+		// - the initial sync creates one charge-backed gathering line
+		// - no realization run has been created for the charge
+		subsView = s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(5),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+		gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+		s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+		s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+	})
+
+	s.Run("delete gathering line through API", func() {
+		// when:
+		// - the user deletes the gathering line through the invoice API
+		_, err := s.BillingService.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
+			Invoice:      gatheringInvoice.GetInvoiceID(),
+			ChangeSource: billing.ChangeSourceAPIRequest,
+			EditFn: func(invoice *billing.GatheringInvoice) error {
+				lines := invoice.Lines.OrEmpty()
+				s.Require().Len(lines, 1)
+				line := &lines[0]
+
+				line.DeletedAt = lo.ToPtr(clock.Now())
+
+				clonedLine, err := line.Clone()
+				s.NoError(err)
+				deletedLine = clonedLine
+				return nil
+			},
+			IncludeDeletedLines: true,
+		})
+		s.NoError(err)
+	})
+
+	s.Run("assert charge is manually deleted", func() {
+		// then:
+		// - the API delete is persisted as a deleted override intent
+		// - the gathering line is deleted without creating realization history
+		editedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+			Invoice: gatheringInvoice.GetInvoiceID(),
+			Expand: billing.GatheringInvoiceExpands{
+				billing.GatheringInvoiceExpandLines,
+				billing.GatheringInvoiceExpandDeletedLines,
+			},
+		})
+		s.NoError(err)
+		s.DebugDumpInvoice("deleted invoice", editedInvoice)
+
+		invoiceLine, found := lo.Find(editedInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+			return line.ID == deletedLine.ID
+		})
+		s.True(found, "deleted line should be found")
+		s.NotNil(invoiceLine.DeletedAt)
+		s.Equal(billing.ManuallyManagedLine, invoiceLine.ManagedBy)
+
+		chargeAfterDelete := s.mustGetUsageBasedChargeForInvoiceLine(ctx, deletedLine.AsGenericLine())
+		s.Equal(usagebased.StatusDeleted, chargeAfterDelete.Status)
+		s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+		s.Nil(chargeAfterDelete.Intent.GetBaseIntent().IntentDeletedAt)
+		overrideIntent, err := chargeAfterDelete.Intent.GetIntentForTarget(chargesmeta.ChangeTargetOverride)
+		s.NoError(err)
+		s.NotNil(overrideIntent.IntentDeletedAt)
+
+		chargeWithRealizations := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargeAfterDelete.GetChargeID(), chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDeletedRealizations,
+		})
+		s.Empty(chargeWithRealizations.Realizations)
+	})
+
+	s.Run("subscription sync does not recreate deleted line", func() {
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	})
+}
+
 func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualEditSync() {
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -6920,6 +7044,374 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedProgressiveStandardInvoiceDel
 	deletedRun, err := chargeAfterInvoiceDelete.Realizations.GetByLineID(draftLine.ID)
 	s.NoError(err)
 	s.NotNil(deletedRun.DeletedAt)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedProgressiveGatheringLineManualDeleteShrinksCharge() {
+	ctx := s.T().Context()
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
+
+	var subsView subscription.SubscriptionView
+	var progressiveInvoice billing.StandardInvoice
+	var progressiveLine *billing.StandardLine
+	var chargeID chargesmeta.ChargeID
+	var gatheringInvoice billing.GatheringInvoice
+	var remainingLine billing.GatheringLine
+	var deletedLine billing.GatheringLine
+
+	s.Run("create progressive usage-based subscription", func() {
+		// given:
+		// - progressive billing is enabled
+		// - visible usage exists before the progressive invoice cutoff
+		// - subscription sync owns a credit-then-invoice usage-based charge
+		s.enableProgressiveBilling()
+
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-12T09:30:00Z"))
+
+		subsView = s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(10),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		clock.FreezeTime(clock.Now().Add(time.Minute))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	})
+
+	s.Run("create paid progressive invoice and remaining gathering tail", func() {
+		// given:
+		// - a progressive standard invoice is created for the first part of the period
+		// - the invoice is advanced and paid
+		// then:
+		// - a remaining gathering invoice line exists for the unbilled tail
+		clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
+		draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: s.Customer.GetID(),
+			AsOf:     lo.ToPtr(s.mustParseTime("2024-01-15T00:00:00Z")),
+		})
+		s.NoError(err)
+		s.Require().Len(draftInvoices, 1)
+
+		progressiveInvoice = draftInvoices[0]
+		s.Require().Len(progressiveInvoice.Lines.OrEmpty(), 1)
+		progressiveLine = progressiveInvoice.Lines.OrEmpty()[0]
+		s.Require().NotNil(progressiveLine.ChargeID)
+		chargeID = chargesmeta.ChargeID{
+			Namespace: progressiveLine.Namespace,
+			ID:        *progressiveLine.ChargeID,
+		}
+		s.Require().NotNil(progressiveInvoice.CollectionAt)
+
+		clock.FreezeTime(progressiveInvoice.CollectionAt.Add(time.Minute))
+		progressiveInvoice, err = s.BillingService.AdvanceInvoice(ctx, progressiveInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, progressiveInvoice.Status)
+
+		progressiveInvoice, err = s.BillingService.ApproveInvoice(ctx, progressiveInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, progressiveInvoice.Status)
+
+		gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+		s.populateChildIDsFromParents(&gatheringInvoice)
+		s.DebugDumpInvoice("gathering invoice before manual delete", gatheringInvoice)
+
+		var found bool
+		remainingLine, found = lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+			return line.ChargeID != nil && *line.ChargeID == chargeID.ID
+		})
+		s.Require().True(found, "remaining gathering line should exist before manual delete")
+		s.Equal(progressiveLine.GetServicePeriod().To, remainingLine.ServicePeriod.From)
+	})
+
+	s.Run("delete remaining gathering line through API", func() {
+		// when:
+		// - the user deletes the remaining gathering line through the invoice API
+		_, err := s.BillingService.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
+			Invoice:      gatheringInvoice.GetInvoiceID(),
+			ChangeSource: billing.ChangeSourceAPIRequest,
+			EditFn: func(invoice *billing.GatheringInvoice) error {
+				lines := invoice.Lines.OrEmpty()
+				for idx := range lines {
+					if lines[idx].ID != remainingLine.ID {
+						continue
+					}
+
+					lines[idx].DeletedAt = lo.ToPtr(clock.Now())
+
+					clonedLine, err := lines[idx].Clone()
+					s.NoError(err)
+					deletedLine = clonedLine
+
+					return nil
+				}
+
+				return fmt.Errorf("remaining gathering line not found")
+			},
+			IncludeDeletedLines: true,
+		})
+		s.NoError(err)
+	})
+
+	s.Run("assert charge was shrunk to realized period", func() {
+		// then:
+		// - the standard invoice history remains intact
+		// - the charge effective period is manually shortened to the deleted line's start
+		// - the kept partial realization becomes the final realization
+		editedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+			Invoice: gatheringInvoice.GetInvoiceID(),
+			Expand: billing.GatheringInvoiceExpands{
+				billing.GatheringInvoiceExpandLines,
+				billing.GatheringInvoiceExpandDeletedLines,
+			},
+		})
+		s.NoError(err)
+		s.DebugDumpInvoice("gathering invoice after manual delete", editedInvoice)
+		editedLine, found := lo.Find(editedInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+			return line.ID == deletedLine.ID
+		})
+		s.True(found, "deleted gathering line should be present when deleted lines are expanded")
+		s.NotNil(editedLine.DeletedAt)
+		s.Equal(billing.ManuallyManagedLine, editedLine.ManagedBy)
+
+		refetchedStandardInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: progressiveInvoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, refetchedStandardInvoice.Status)
+		s.Require().Len(refetchedStandardInvoice.Lines.OrEmpty(), 1)
+		s.Equal(progressiveLine.ID, refetchedStandardInvoice.Lines.OrEmpty()[0].ID)
+
+		chargeAfterDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargeID, chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDeletedRealizations,
+		})
+		s.Equal(usagebased.StatusActive, chargeAfterDelete.Status)
+		s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+		s.Equal(s.mustParseTime("2024-02-01T00:00:00Z"), chargeAfterDelete.Intent.GetBaseIntent().ServicePeriod.To)
+		s.Equal(deletedLine.ServicePeriod.From, chargeAfterDelete.Intent.GetEffectiveServicePeriod().To)
+		s.Require().Len(chargeAfterDelete.Realizations.WithoutVoidedBillingHistory(), 1)
+		keptRun := chargeAfterDelete.Realizations.WithoutVoidedBillingHistory()[0]
+		s.Equal(usagebased.RealizationRunTypeFinalRealization, keptRun.Type)
+		s.Equal(usagebased.RealizationRunTypePartialInvoice, keptRun.InitialType)
+		s.Nil(keptRun.DeletedAt)
+	})
+
+	s.Run("subscription sync does not recreate deleted tail", func() {
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedProgressiveGatheringInvoiceManualDeleteFinalizesCharge() {
+	ctx := s.T().Context()
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
+
+	var subsView subscription.SubscriptionView
+	var progressiveInvoice billing.StandardInvoice
+	var progressiveLine *billing.StandardLine
+	var chargeID chargesmeta.ChargeID
+	var gatheringInvoice billing.GatheringInvoice
+	var remainingLine billing.GatheringLine
+
+	s.Run("create progressive usage-based subscription", func() {
+		// given:
+		// - progressive billing is enabled
+		// - visible usage exists before the progressive invoice cutoff
+		// - subscription sync owns a credit-then-invoice usage-based charge
+		s.enableProgressiveBilling()
+
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-12T09:30:00Z"))
+
+		subsView = s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(10),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		clock.FreezeTime(clock.Now().Add(time.Minute))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	})
+
+	s.Run("create paid progressive invoice and remaining gathering tail", func() {
+		// given:
+		// - a progressive standard invoice is created for the first part of the period
+		// - the invoice is advanced and paid
+		// then:
+		// - one remaining gathering invoice line exists for the unbilled tail
+		clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
+		draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: s.Customer.GetID(),
+			AsOf:     lo.ToPtr(s.mustParseTime("2024-01-15T00:00:00Z")),
+		})
+		s.NoError(err)
+		s.Require().Len(draftInvoices, 1)
+
+		progressiveInvoice = draftInvoices[0]
+		s.Require().Len(progressiveInvoice.Lines.OrEmpty(), 1)
+		progressiveLine = progressiveInvoice.Lines.OrEmpty()[0]
+		s.Require().NotNil(progressiveLine.ChargeID)
+		chargeID = chargesmeta.ChargeID{
+			Namespace: progressiveLine.Namespace,
+			ID:        *progressiveLine.ChargeID,
+		}
+		s.Require().NotNil(progressiveInvoice.CollectionAt)
+
+		clock.FreezeTime(progressiveInvoice.CollectionAt.Add(time.Minute))
+		progressiveInvoice, err = s.BillingService.AdvanceInvoice(ctx, progressiveInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, progressiveInvoice.Status)
+
+		progressiveInvoice, err = s.BillingService.ApproveInvoice(ctx, progressiveInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, progressiveInvoice.Status)
+
+		gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+		s.populateChildIDsFromParents(&gatheringInvoice)
+		s.DebugDumpInvoice("gathering invoice before manual delete", gatheringInvoice)
+		s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+		var found bool
+		remainingLine, found = lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+			return line.ChargeID != nil && *line.ChargeID == chargeID.ID
+		})
+		s.Require().True(found, "remaining gathering line should exist before manual delete")
+		s.Equal(progressiveLine.GetServicePeriod().To, remainingLine.ServicePeriod.From)
+	})
+
+	s.Run("delete gathering invoice and schedule charge advancement", func() {
+		// when:
+		// - the user deletes the remaining gathering invoice through the invoice API
+		// then:
+		// - the paid standard invoice history remains intact
+		// - the charge effective period is manually shortened to the deleted tail start
+		// - the kept partial realization becomes the final realization
+		// - the charge remains active but is scheduled for immediate advancement from the shrunk boundary
+		deletedInvoice, err := s.BillingService.DeleteGatheringInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        gatheringInvoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceAPIRequest,
+		})
+		s.NoError(err)
+		s.NotNil(deletedInvoice.DeletedAt)
+
+		refetchedStandardInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: progressiveInvoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, refetchedStandardInvoice.Status)
+		s.Require().Len(refetchedStandardInvoice.Lines.OrEmpty(), 1)
+		s.Equal(progressiveLine.ID, refetchedStandardInvoice.Lines.OrEmpty()[0].ID)
+
+		chargeAfterDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargeID, chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDeletedRealizations,
+		})
+		s.Equal(usagebased.StatusActive, chargeAfterDelete.Status)
+		s.Require().NotNil(chargeAfterDelete.State.AdvanceAfter)
+		s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+		s.Equal(s.mustParseTime("2024-02-01T00:00:00Z"), chargeAfterDelete.Intent.GetBaseIntent().ServicePeriod.To)
+		s.Equal(remainingLine.ServicePeriod.From, chargeAfterDelete.Intent.GetEffectiveServicePeriod().To)
+		s.True(chargeAfterDelete.Intent.GetEffectiveServicePeriod().To.Equal(*chargeAfterDelete.State.AdvanceAfter))
+		s.Require().Len(chargeAfterDelete.Realizations.WithoutVoidedBillingHistory(), 1)
+		keptRun := chargeAfterDelete.Realizations.WithoutVoidedBillingHistory()[0]
+		s.Equal(usagebased.RealizationRunTypeFinalRealization, keptRun.Type)
+		s.Equal(usagebased.RealizationRunTypePartialInvoice, keptRun.InitialType)
+		s.Nil(keptRun.DeletedAt)
+	})
+
+	s.Run("advance charge to final", func() {
+		// when:
+		// - the charge worker advances the active charge after the shrunk boundary
+		// then:
+		// - the already-paid final realization lets the charge reach final
+		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: s.Customer.GetID(),
+		})
+		s.NoError(err)
+
+		chargeAfterAdvance := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargeID, chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDeletedRealizations,
+		})
+		s.Equal(usagebased.StatusFinal, chargeAfterAdvance.Status)
+	})
+
+	s.Run("subscription sync does not recreate deleted tail", func() {
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	})
 }
 
 func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {


### PR DESCRIPTION
## Summary

Add a usage-based shrink-to-realized-period patch for manual gathering line deletion.

Rules:
- Deleting a gathering line belonging to a charge without any realization is treated as an override on the charge with the intent to delete the charge.
- Deleteing a gathering line with a charge having realizations is treated as the service period is intended to be only covering the already billed items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “shrink to realized period” operation for charge service periods, including new trigger support and validation of intent timing.
  * Enhanced credit-then-invoice and usage-based credit-only flows to recognize and apply shrink-to-realized transitions.

* **Bug Fixes**
  * Improved invoice line and charge edit lifecycle so validation runs before mutation and validation is non-mutating.
  * Fixed manual deletion behavior for gathering invoice lines to shrink charges or delete as appropriate while preserving billing history.

* **Tests / Docs**
  * Added coverage for shrink behavior, gathering deletions, and realization selection; clarified `RealizationRuns.Latest()` semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds usage-based gathering-line delete handling. The main changes are:

- A new shrink-to-realized-period patch and trigger.
- Gathering-line deletes mapped to charge delete or realized-period shrink.
- Usage-based state-machine updates for preserving realized invoice history.
- Intent mutation callbacks updated to return validation errors.

<h3>Confidence Score: 4/5</h3>

This is close, but the validation gap should be fixed before merging.

- Gathering-line delete validation can still pass edits that the mutation path rejects.
- The failure happens after the billing edit has moved past its preflight check.
- The new shrink-to-realized-period state-machine path otherwise has focused checks for realized-run boundaries.

openmeter/billing/charges/usagebased/service/lineengine.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/lineengine.go | Adds usage-based gathering-line delete handling, but the validation hook still accepts edits that the mutation path can reject. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Adds shrink-to-realized-period state-machine handling for realized usage history. |
| openmeter/billing/charges/meta/patchshrinktorealizedperiod.go | Introduces the API-only shrink-to-realized-period patch type. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Fservice%2Flineengine.go%3A405-406%0A**Validation%20Still%20Bypassed**%0A%0AThis%20branch%20still%20accepts%20gathering-line%20deletes%20that%20the%20mutation%20path%20can%20reject.%20When%20the%20charge%20has%20existing%20realizations%2C%20the%20later%20callback%20fires%20%60ShrinkToRealizedPeriod%60%2C%20which%20rejects%20unsupported%20states%20such%20as%20%60active.realization.issuing%60%20and%20%60deleted%60%2C%20and%20also%20rejects%20when%20the%20deleted%20gathering%20line%20starts%20somewhere%20other%20than%20the%20latest%20non-voided%20run%20boundary.%20With%20no%20realizations%2C%20an%20already-deleted%20charge%20also%20cannot%20fire%20the%20delete%20trigger.%20Billing%20runs%20this%20validation%20before%20applying%20the%20edit%2C%20so%20callers%20can%20still%20pass%20the%20edit%20check%20and%20fail%20only%20during%20%60OnMutableInvoiceLinesEditedViaAPI%60.%20The%20validation%20hook%20needs%20to%20reject%20the%20same%20unsupported%20states%20and%20known%20boundary%20mismatches%20before%20mutation%20starts.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fgathering-line-delete%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgathering-line-delete%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Fservice%2Flineengine.go%3A405-406%0A**Validation%20Still%20Bypassed**%0A%0AThis%20branch%20still%20accepts%20gathering-line%20deletes%20that%20the%20mutation%20path%20can%20reject.%20When%20the%20charge%20has%20existing%20realizations%2C%20the%20later%20callback%20fires%20%60ShrinkToRealizedPeriod%60%2C%20which%20rejects%20unsupported%20states%20such%20as%20%60active.realization.issuing%60%20and%20%60deleted%60%2C%20and%20also%20rejects%20when%20the%20deleted%20gathering%20line%20starts%20somewhere%20other%20than%20the%20latest%20non-voided%20run%20boundary.%20With%20no%20realizations%2C%20an%20already-deleted%20charge%20also%20cannot%20fire%20the%20delete%20trigger.%20Billing%20runs%20this%20validation%20before%20applying%20the%20edit%2C%20so%20callers%20can%20still%20pass%20the%20edit%20check%20and%20fail%20only%20during%20%60OnMutableInvoiceLinesEditedViaAPI%60.%20The%20validation%20hook%20needs%20to%20reject%20the%20same%20unsupported%20states%20and%20known%20boundary%20mismatches%20before%20mutation%20starts.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
openmeter/billing/charges/usagebased/service/lineengine.go:405-406
**Validation Still Bypassed**

This branch still accepts gathering-line deletes that the mutation path can reject. When the charge has existing realizations, the later callback fires `ShrinkToRealizedPeriod`, which rejects unsupported states such as `active.realization.issuing` and `deleted`, and also rejects when the deleted gathering line starts somewhere other than the latest non-voided run boundary. With no realizations, an already-deleted charge also cannot fire the delete trigger. Billing runs this validation before applying the edit, so callers can still pass the edit check and fail only during `OnMutableInvoiceLinesEditedViaAPI`. The validation hook needs to reject the same unsupported states and known boundary mismatches before mutation starts.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(billing): support usage-based gathe..."](https://github.com/openmeterio/openmeter/commit/ee00c8ef294ed8afab902ed21c4592b0d9f12e07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42653504)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->