### PR TITLE
fix: interim payment errors for progressively billed usage-based items

### DIFF
--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -141,7 +141,6 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
-		Permit(meta.TriggerAllPaymentsSettled, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -956,17 +956,8 @@ func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPayme
 			return fmt.Errorf("refetching flat fee charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		canFire, err := stateMachine.CanFire(ctx, meta.TriggerAllPaymentsSettled)
-		if err != nil {
-			return fmt.Errorf("checking all_payments_settled for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if !canFire {
-			continue
-		}
-
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerAllPaymentsSettled); err != nil {
-			return fmt.Errorf("triggering all_payments_settled for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+			return fmt.Errorf("advancing flat fee charge[%s] after payment settlement: %w", stateMachine.GetCharge().ID, err)
 		}
 	}
 

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -9,7 +9,6 @@ var (
 	TriggerInvoiceCreated      Trigger = "invoice_created"
 	TriggerCollectionCompleted Trigger = "collection_completed"
 	TriggerInvoiceIssued       Trigger = "invoice_issued"
-	TriggerAllPaymentsSettled  Trigger = "all_payments_settled"
 	TriggerLineManualEdit      Trigger = "line_manual_edit"
 	TriggerAttachInvoiceLine   Trigger = "attach_invoice_line"
 )

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -2339,7 +2339,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
 		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
-		s.Equal(usagebased.StatusActiveAwaitingPaymentSettlement, usageBasedCharge.Status)
+		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
 		s.Nil(usageBasedCharge.State.CurrentRealizationRunID)
 		s.Nil(usageBasedCharge.State.AdvanceAfter)
 		s.Len(usageBasedCharge.Realizations, 1)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -156,7 +156,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 	// Payment + final
 
 	s.Configure(usagebased.StatusActiveAwaitingPaymentSettlement).
-		Permit(meta.TriggerAllPaymentsSettled, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
+		Permit(meta.TriggerNext, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))

--- a/openmeter/billing/charges/usagebased/service/payments.go
+++ b/openmeter/billing/charges/usagebased/service/payments.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
@@ -96,26 +95,18 @@ func (e *LineEngine) recordPaymentSettled(ctx context.Context, stateMachine Stat
 		return fmt.Errorf("update realization run: %w", err)
 	}
 
-	if charge.Status != usagebased.StatusActiveAwaitingPaymentSettlement {
-		return nil
-	}
-
-	if !areAllInvoicedRunsSettled(charge) {
-		return nil
-	}
-
 	stateMachineConfig, err := e.service.getStateMachineConfigForPatch(ctx, charge)
 	if err != nil {
 		return fmt.Errorf("get state machine config: %w", err)
 	}
 
-	settlementStateMachine, err := e.service.newStateMachine(stateMachineConfig)
+	advancementStateMachine, err := e.service.newStateMachine(stateMachineConfig)
 	if err != nil {
 		return fmt.Errorf("new state machine: %w", err)
 	}
 
-	if err := settlementStateMachine.FireAndActivate(ctx, meta.TriggerAllPaymentsSettled); err != nil {
-		return fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerAllPaymentsSettled, charge.ID, err)
+	if _, err := advancementStateMachine.AdvanceUntilStateStable(ctx); err != nil {
+		return fmt.Errorf("advancing charge[%s] after payment settlement: %w", charge.ID, err)
 	}
 
 	return nil

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -452,7 +452,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchK
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.True(invoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 1)
 		currentRun := charge.Realizations[0]
 		runID = currentRun.ID
@@ -4082,7 +4082,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchDuringAwaitingPaymentSettlementCreatesReplacementFinalRun() {
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchAfterNoFiatFinalInvoiceCreatesReplacementFinalRun() {
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-immutable")
@@ -4201,7 +4201,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.True(invoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 1)
 		currentRun := charge.Realizations[0]
 		runID = currentRun.ID
@@ -4564,7 +4564,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchDuringAwaitingPaymentSettlementReclassifiesFinalRunAndKeepsLedgerBookings() {
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchAfterNoFiatFinalInvoiceReclassifiesFinalRunAndKeepsLedgerBookings() {
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-immutable")
@@ -4680,7 +4680,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.True(invoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 1)
 		run := charge.Realizations[0]
 		runID = run.ID
@@ -4696,7 +4696,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), immutableLedger.Accrued, "immutable invoice should keep accrued credit booking")
 	})
 
-	s.Run("when the charge is extended during active.awaiting_payment_settlement", func() {
+	s.Run("when the charge is extended after the no-fiat final invoice", func() {
 		// given:
 		// - the original final run is no longer current and the invoice lifecycle callbacks have completed
 		// when:
@@ -4919,7 +4919,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, firstInvoice.Status)
 		s.True(firstInvoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 1)
 		firstRun := charge.Realizations[0]
 		firstRunID = firstRun.ID
@@ -5001,7 +5001,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, secondInvoice.Status)
 		s.True(secondInvoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 2)
 		secondRun := lo.MaxBy(charge.Realizations, func(run usagebased.RealizationRun, latest usagebased.RealizationRun) bool {
 			return run.ServicePeriodTo.After(latest.ServicePeriodTo)
@@ -5125,7 +5125,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, thirdInvoice.Status)
 		s.True(thirdInvoice.StatusDetails.Immutable)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 3)
 		thirdRun, err := charge.Realizations.GetByLineID(thirdLineID.ID)
 		s.NoError(err)
@@ -5286,7 +5286,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchF
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 
-		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveAwaitingPaymentSettlement)
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusFinal)
 		s.Len(charge.Realizations, 1)
 
 		run := charge.Realizations[0]


### PR DESCRIPTION
## Summary
- fix progressively billed usage-based items so:
  - fully credited interim invoices do not remain waiting for fiat payment settlement
  - progressively billed lines with interim payments do not fail due to not being able to tirgger payment
- move charge finalization after payment recording back onto the normal guarded `TriggerNext` advancement path
- remove the dedicated `all_payments_settled` trigger now that flat-fee and usage-based settlement both use normal charge advancement

## Why
Progressively billed usage-based items can produce interim invoice lines that are fully covered by credits and do not require a fiat payment transaction. Those lines were able to leave the charge waiting for payment settlement even though there was no payment to settle, which could surface as payment-processing errors for interim invoices.

The charge state machine already has the correct guarded advancement rules. This change records the line payment state first, then lets the standard advancement loop settle the charge into the correct final state when all invoiced usage is settled or no fiat transaction is required.

## Validation
- `go test -tags=dynamic -count=1 ./openmeter/billing/charges/flatfee/service`
- `go test -tags=dynamic -count=1 ./openmeter/billing/charges/usagebased/service`
- `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 ./openmeter/billing/charges/service -run 'TestInvoicable|TestUsageBased'`
- `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 ./test/credits`
- `make test-nocache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charging flows now progress to the final state more reliably after payments are settled.
  * Invoice and credit-then-invoice scenarios now complete as final instead of lingering in an awaiting-settlement state.

* **Tests**
  * Updated coverage to reflect the new finalization behavior across multiple billing scenarios.
  * Adjusted test case names and expectations to match the updated charge lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates payment settlement for credit-then-invoice charges. The main changes are:

- Replaces the dedicated `all_payments_settled` trigger with guarded `TriggerNext` advancement.
- Finalizes fully credited usage-based invoice runs without waiting for a fiat payment.
- Applies the same normal advancement path to flat-fee payment settlement.
- Updates billing and credit integration tests for the new final charge state.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/payments.go | Records usage-based payment settlement and then resumes normal charge advancement. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Moves awaiting-payment-settlement finalization onto the guarded `TriggerNext` transition. |
| openmeter/billing/charges/flatfee/service/lineengine.go | Uses normal state-machine advancement after flat-fee payment settlement. |
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Removes the dedicated settlement trigger from the flat-fee finalization state. |
| openmeter/billing/charges/meta/triggers.go | Removes the unused `all_payments_settled` trigger constant. |
| openmeter/billing/charges/service/invoicable_test.go | Updates the fully credited usage-based invoice expectation to final. |
| test/credits/credit_then_invoice_test.go | Updates credit-then-invoice integration expectations for no-fiat final invoices. |

<sub>Reviews (2): Last reviewed commit: ["test(billing): expect no-fiat usage char..."](https://github.com/openmeterio/openmeter/commit/b746d1fd742112393c4facc3f1d10839bed0328d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42659512)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->