### PR TITLE
docs(quickstart): update examples and worker healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -X POST http://localhost:48888/api/v1/events \
     "specversion": "1.0",
     "type": "request",
     "id": "00001",
-    "time": "2024-01-01T00:00:00.001Z",
+    "time": "2026-07-07T00:00:00.001Z",
     "source": "my-service",
     "subject": "customer-1",
     "data": { "method": "GET", "route": "/api/hello" }

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -33,7 +33,7 @@ curl -X POST http://localhost:48888/api/v1/events \
   "specversion" : "1.0",
   "type": "request",
   "id": "00001",
-  "time": "2023-01-01T00:00:00.001Z",
+  "time": "2026-07-07T00:00:00.001Z",
   "source": "service-0",
   "subject": "customer-1",
   "data": {
@@ -55,7 +55,7 @@ curl -X POST http://localhost:48888/api/v1/events \
   "specversion" : "1.0",
   "type": "request",
   "id": "00002",
-  "time": "2023-01-01T00:00:00.001Z",
+  "time": "2026-07-07T00:00:00.001Z",
   "source": "service-0",
   "subject": "customer-1",
   "data": {
@@ -77,7 +77,7 @@ curl -X POST http://localhost:48888/api/v1/events \
   "specversion" : "1.0",
   "type": "request",
   "id": "00003",
-  "time": "2023-01-02T00:00:00.001Z",
+  "time": "2026-07-08T00:00:00.001Z",
   "source": "service-0",
   "subject": "customer-1",
   "data": {
@@ -103,8 +103,8 @@ curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?windowSize=H
   "data": [
     {
       "value": 2,
-      "windowStart": "2023-01-01T00:00:00Z",
-      "windowEnd": "2023-01-01T01:00:00Z",
+      "windowStart": "2026-07-07T00:00:00Z",
+      "windowEnd": "2026-07-07T01:00:00Z",
       "subject": null,
       "groupBy": {
         "method": "GET",
@@ -113,8 +113,8 @@ curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?windowSize=H
     },
     {
       "value": 1,
-      "windowStart": "2023-01-02T00:00:00Z",
-      "windowEnd": "2023-01-02T01:00:00Z",
+      "windowStart": "2026-07-08T00:00:00Z",
+      "windowEnd": "2026-07-08T01:00:00Z",
       "subject": null,
       "groupBy": {
         "method": "GET",
@@ -136,8 +136,8 @@ curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=cust
   "data": [
     {
       "value": 3,
-      "windowStart": "2023-01-01T00:00:00Z",
-      "windowEnd": "2023-01-02T00:01:00Z",
+      "windowStart": "2026-07-07T00:00:00Z",
+      "windowEnd": "2026-07-08T00:01:00Z",
       "subject": "customer-1",
       "groupBy": {}
     }

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -1,4 +1,10 @@
 # please use port numbers in the 40000 range so that it doesn't conflict with the main dev environment
+x-openmeter-worker-healthcheck: &openmeter-worker-healthcheck
+  test: ["CMD", "wget", "--spider", "http://localhost:10000/healthz"]
+  interval: 5s
+  timeout: 3s
+  retries: 30
+
 services:
   openmeter:
     image: ghcr.io/openmeterio/openmeter:latest
@@ -40,6 +46,7 @@ services:
       - "127.0.0.1:40000:10000"
     volumes:
       - ./config.yaml:/etc/openmeter/config.yaml
+    healthcheck: *openmeter-worker-healthcheck
 
   balance-worker:
     image: ghcr.io/openmeterio/openmeter:latest
@@ -59,6 +66,7 @@ services:
       - "127.0.0.1:40001:10000"
     volumes:
       - ./config.yaml:/etc/openmeter/config.yaml
+    healthcheck: *openmeter-worker-healthcheck
 
   notification-service:
     image: ghcr.io/openmeterio/openmeter:latest
@@ -76,6 +84,7 @@ services:
       - "127.0.0.1:40002:10000"
     volumes:
       - ./config.yaml:/etc/openmeter/config.yaml
+    healthcheck: *openmeter-worker-healthcheck
 
   billing-worker:
     image: ghcr.io/openmeterio/openmeter:latest
@@ -93,6 +102,7 @@ services:
       - "127.0.0.1:40003:10000"
     volumes:
       - ./config.yaml:/etc/openmeter/config.yaml
+    healthcheck: *openmeter-worker-healthcheck
 
   openmeter-jobs:
     image: ghcr.io/openmeterio/openmeter:latest


### PR DESCRIPTION
## What changed

- Update quickstart README event timestamps from stale 2023 examples to realistic 2026 dates.
- Update the root README quickstart event timestamp to match the same 2026 window.
- Add Docker Compose healthchecks for the quickstart worker services that expose telemetry health endpoints: sink, balance, notification, and billing.

## Why

The 2023 examples can be immediately outside Kafka retention during local quickstart validation. Also, the worker containers were running but showed no Docker health status, which made service readiness harder to audit.

## Validation

- `git diff --check`
- `docker compose -f docker-compose.yaml -f docker-compose.debug-ports.yaml config --quiet`
- Recreated the quickstart stack and verified backend plus sink/balance/notification/billing reported `health=healthy`
- Posted three sample events and verified hourly query returned `2` and `1`
- Shut the quickstart stack down after validation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the quickstart examples and worker readiness checks. The main changes are:

- Root README sample event time moved to July 2026.
- Quickstart event and query examples moved to the same July 2026 window.
- Worker services now share a Docker Compose healthcheck for `/healthz`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small documentation cleanup.

- The worker healthchecks match the worker telemetry port and `/healthz` route.
- The quickstart examples can become stale again because the event times are fixed.
- No security issue was found in the changed code.

quickstart/README.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates the root quickstart event timestamp to the July 2026 example window. |
| quickstart/README.md | Updates quickstart event timestamps and expected query windows, but the examples still depend on fixed absolute dates. |
| quickstart/docker-compose.yaml | Adds a shared healthcheck to quickstart worker services that expose telemetry on port 10000. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aquickstart%2FREADME.md%3A36%0A**Fixed%20Dates%20Become%20Stale**%0A%0AThe%20quickstart%20still%20sends%20absolute%20%602026-07-07%2F08%60%20event%20times%20while%20the%20documented%20queries%20omit%20%60from%60%20and%20%60to%60.%20After%20these%20dates%20fall%20outside%20the%20local%20retention%20window%2C%20the%20sample%20ingest%20path%20can%20succeed%20but%20the%20hourly%20query%20can%20return%20missing%20results%20instead%20of%20the%20documented%20%602%60%20and%20%601%60.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4670&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22codex%2Fquickstart-docs-healthchecks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fquickstart-docs-healthchecks%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aquickstart%2FREADME.md%3A36%0A**Fixed%20Dates%20Become%20Stale**%0A%0AThe%20quickstart%20still%20sends%20absolute%20%602026-07-07%2F08%60%20event%20times%20while%20the%20documented%20queries%20omit%20%60from%60%20and%20%60to%60.%20After%20these%20dates%20fall%20outside%20the%20local%20retention%20window%2C%20the%20sample%20ingest%20path%20can%20succeed%20but%20the%20hourly%20query%20can%20return%20missing%20results%20instead%20of%20the%20documented%20%602%60%20and%20%601%60.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4670&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
quickstart/README.md:36
**Fixed Dates Become Stale**

The quickstart still sends absolute `2026-07-07/08` event times while the documented queries omit `from` and `to`. After these dates fall outside the local retention window, the sample ingest path can succeed but the hourly query can return missing results instead of the documented `2` and `1`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(quickstart): update examples and wo..."](https://github.com/openmeterio/openmeter/commit/24f569e31ba08a1034edcf3e1e926af43403018e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42709316)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart example timestamps and sample query results to reflect newer date ranges.
  * Refreshed the Self-Hosted event ingestion example with a current CloudEvents timestamp.

* **Chores**
  * Standardized health checks for worker-related services in the Quickstart environment to use a shared configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->