### PR TITLE
fix: repair usage-based deleted invoice runs

### DIFF
--- a/tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.down.sql
+++ b/tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.down.sql
@@ -1,0 +1,1 @@
+-- Data repair migration; intentionally irreversible.

--- a/tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.up.sql
+++ b/tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.up.sql
@@ -1,0 +1,167 @@
+-- Repair usage-based realization runs left live after API-deleting progressively billed standard invoices.
+--
+-- The original API delete path removed the invoice/line but did not dispatch the usage-based
+-- line-engine cleanup for these rows. Restrict the repair to zero-credit runs so no ledger credit
+-- correction is needed:
+-- - partial_invoice runs are only soft-deleted;
+-- - final_realization runs are soft-deleted and the charge is made effectively deleted through
+--   an override intent, leaving the subscription-owned base intent intact for subscription sync;
+-- - gathering lines for deleted charges are soft-deleted so subscription sync does not keep
+--   referencing charges that the repair intentionally tombstones;
+-- - touched gathering invoices are soft-deleted when those line deletions leave no live lines.
+BEGIN;
+
+CREATE TEMPORARY TABLE repair_usagebased_deleted_invoice_runs ON COMMIT DROP AS
+SELECT
+  l.namespace,
+  l.charge_id,
+  r.id AS run_id,
+  r.type AS run_type
+FROM billing_invoice_lines l
+JOIN charge_usage_based_runs r
+  ON r.namespace = l.namespace
+ AND r.charge_id = l.charge_id
+ AND r.line_id = l.id
+JOIN billing_invoices i
+  ON i.namespace = l.namespace
+ AND i.id = l.invoice_id
+WHERE l.charge_id IS NOT NULL
+  AND l.status = 'valid'
+  AND (
+    l.deleted_at IS NOT NULL
+    OR (i.deleted_at IS NOT NULL AND i.status <> 'gathering')
+  )
+  AND r.deleted_at IS NULL
+  AND r.credits_total = 0
+  AND r.type IN ('partial_invoice', 'final_realization');
+
+UPDATE charge_usage_based_runs r
+SET
+  deleted_at = now(),
+  updated_at = now()
+FROM repair_usagebased_deleted_invoice_runs affected
+WHERE r.namespace = affected.namespace
+  AND r.id = affected.run_id;
+
+UPDATE charge_usage_based c
+SET
+  current_realization_run_id = NULL,
+  updated_at = now()
+FROM repair_usagebased_deleted_invoice_runs affected
+WHERE c.namespace = affected.namespace
+  AND c.id = affected.charge_id
+  AND c.current_realization_run_id = affected.run_id;
+
+UPDATE billing_invoice_lines l
+SET
+  deleted_at = now(),
+  updated_at = now()
+FROM (
+  SELECT DISTINCT namespace, charge_id
+  FROM repair_usagebased_deleted_invoice_runs
+  WHERE run_type = 'final_realization'
+) affected,
+billing_invoices i
+WHERE l.namespace = affected.namespace
+  AND l.charge_id = affected.charge_id
+  AND l.deleted_at IS NULL
+  AND l.status = 'valid'
+  AND i.namespace = l.namespace
+  AND i.id = l.invoice_id
+  AND i.status = 'gathering'
+  AND i.deleted_at IS NULL;
+
+UPDATE billing_invoices i
+SET
+  deleted_at = now(),
+  updated_at = now()
+FROM (
+  SELECT DISTINCT l.namespace, l.invoice_id
+  FROM billing_invoice_lines l
+  JOIN repair_usagebased_deleted_invoice_runs affected
+    ON affected.namespace = l.namespace
+   AND affected.charge_id = l.charge_id
+   AND affected.run_type = 'final_realization'
+) touched
+WHERE i.namespace = touched.namespace
+  AND i.id = touched.invoice_id
+  AND i.status = 'gathering'
+  AND i.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM billing_invoice_lines remaining
+    WHERE remaining.namespace = i.namespace
+      AND remaining.invoice_id = i.id
+      AND remaining.deleted_at IS NULL
+  );
+
+INSERT INTO charge_usage_based_overrides (
+  id,
+  namespace,
+  charge_id,
+  name,
+  description,
+  metadata,
+  tax_behavior,
+  tax_code_id,
+  intent_deleted_at,
+  service_period_from,
+  service_period_to,
+  full_service_period_from,
+  full_service_period_to,
+  billing_period_from,
+  billing_period_to,
+  invoice_at,
+  feature_key,
+  price,
+  discounts,
+  unit_config
+)
+SELECT
+  c.id,
+  c.namespace,
+  c.id,
+  c.name,
+  c.description,
+  c.metadata,
+  c.tax_behavior,
+  c.tax_code_id,
+  now(),
+  c.service_period_from,
+  c.service_period_to,
+  c.full_service_period_from,
+  c.full_service_period_to,
+  c.billing_period_from,
+  c.billing_period_to,
+  c.invoice_at,
+  c.feature_key,
+  c.price,
+  c.discounts,
+  c.unit_config
+FROM (
+  SELECT DISTINCT namespace, charge_id
+  FROM repair_usagebased_deleted_invoice_runs
+  WHERE run_type = 'final_realization'
+) affected
+JOIN charge_usage_based c
+  ON c.namespace = affected.namespace
+ AND c.id = affected.charge_id
+ON CONFLICT (charge_id) DO UPDATE
+SET intent_deleted_at = now();
+
+UPDATE charge_usage_based c
+SET
+  deleted_at = now(),
+  updated_at = now(),
+  status = 'deleted',
+  status_detailed = 'deleted'
+FROM (
+  SELECT DISTINCT namespace, charge_id
+  FROM repair_usagebased_deleted_invoice_runs
+  WHERE run_type = 'final_realization'
+) affected
+WHERE c.namespace = affected.namespace
+  AND c.id = affected.charge_id
+  AND c.deleted_at IS NULL;
+
+COMMIT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hxm6CUxM4F7vwbMJGUB6h92TJI+/N09WwlUe1MytGMM=
+h1:QuvnrMCD6JzSpttSUluCLu/s8fX/mas7elUFUCJL+B4=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -225,3 +225,4 @@ h1:hxm6CUxM4F7vwbMJGUB6h92TJI+/N09WwlUe1MytGMM=
 20260701084156_add_currency_cost_basis_effective_to.up.sql h1:31ASikUUszFmPpArKruD3TeAnTIA7ebqMJdt2DzMH6A=
 20260703084504_applied-unit-config-snapshot.up.sql h1:s8DVZu17GDewYm3YbCQusADdv9fbaiiaD5x0WEp/VrU=
 20260707142444_om_399_subscription_unit_config.up.sql h1:NfIgaPJWptTtGaxyMzwUV/jts/Z6AVvbp3COxEgDOtQ=
+20260709132435_repair_usagebased_deleted_invoice_runs.up.sql h1:4Wo2RUrKLTkYqOqrRyXku75I04OEuycJfJbDqEo3kfI=

--- a/tools/migrate/repair_usagebased_deleted_invoice_runs_test.go
+++ b/tools/migrate/repair_usagebased_deleted_invoice_runs_test.go
@@ -1,0 +1,544 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepairUsageBasedDeletedInvoiceRunsMigration(t *testing.T) {
+	up := readMigration(t, "20260709132435_repair_usagebased_deleted_invoice_runs.up.sql")
+	require.Contains(t, up, "CREATE TEMPORARY TABLE repair_usagebased_deleted_invoice_runs")
+	require.Contains(t, up, "BEGIN;")
+	require.Contains(t, up, "COMMIT;")
+	require.NotContains(t, up, "c.intent_deleted_at = now()")
+	require.NotContains(t, up, "om_func_generate_ulid()")
+
+	namespace := "default"
+	now := time.Date(2026, 7, 3, 15, 40, 11, 0, time.UTC)
+	deletedAt := now.Add(time.Hour)
+
+	customerID := ulid.Make().String()
+	taxCodeID := ulid.Make().String()
+	featureID := ulid.Make().String()
+	workflowID := ulid.Make().String()
+	profileID := ulid.Make().String()
+	taxAppID := ulid.Make().String()
+	invoicingAppID := ulid.Make().String()
+	paymentAppID := ulid.Make().String()
+	gatheringInvoiceID := ulid.Make().String()
+	gatheringWorkflowID := ulid.Make().String()
+	emptyGatheringCustomerID := ulid.Make().String()
+	emptyGatheringInvoiceID := ulid.Make().String()
+	emptyGatheringWorkflowID := ulid.Make().String()
+
+	cases := []repairUsageBasedDeletedInvoiceRunsCase{
+		{
+			name:              "partial zero credit line deleted",
+			runType:           "partial_invoice",
+			creditsTotal:      "0",
+			invoiceStatus:     "paid",
+			lineDeletedAt:     &deletedAt,
+			wantRunDeleted:    true,
+			wantChargeDeleted: false,
+			wantOverride:      false,
+		},
+		{
+			name:              "final zero credit invoice deleted",
+			runType:           "final_realization",
+			creditsTotal:      "0",
+			invoiceStatus:     "deleted",
+			invoiceDeletedAt:  &deletedAt,
+			wantRunDeleted:    true,
+			wantChargeDeleted: true,
+			wantOverride:      true,
+		},
+		{
+			name:                        "final zero credit invoice deleted deletes empty gathering invoice",
+			customerID:                  emptyGatheringCustomerID,
+			gatheringInvoiceID:          emptyGatheringInvoiceID,
+			runType:                     "final_realization",
+			creditsTotal:                "0",
+			invoiceStatus:               "deleted",
+			invoiceDeletedAt:            &deletedAt,
+			wantRunDeleted:              true,
+			wantChargeDeleted:           true,
+			wantGatheringInvoiceDeleted: true,
+			wantOverride:                true,
+		},
+		{
+			name:                 "final zero credit existing override",
+			runType:              "final_realization",
+			creditsTotal:         "0",
+			invoiceStatus:        "deleted",
+			invoiceDeletedAt:     &deletedAt,
+			existingOverrideName: "existing override",
+			wantRunDeleted:       true,
+			wantChargeDeleted:    true,
+			wantOverride:         true,
+		},
+		{
+			name:              "final nonzero credit ignored",
+			runType:           "final_realization",
+			creditsTotal:      "1",
+			invoiceStatus:     "deleted",
+			invoiceDeletedAt:  &deletedAt,
+			wantRunDeleted:    false,
+			wantChargeDeleted: false,
+			wantOverride:      false,
+		},
+		{
+			name:              "deleted gathering invoice ignored",
+			runType:           "final_realization",
+			creditsTotal:      "0",
+			invoiceStatus:     "gathering",
+			invoiceDeletedAt:  &deletedAt,
+			wantRunDeleted:    false,
+			wantChargeDeleted: false,
+			wantOverride:      false,
+		},
+		{
+			name:              "active invoice and line ignored",
+			runType:           "partial_invoice",
+			creditsTotal:      "0",
+			invoiceStatus:     "paid",
+			wantRunDeleted:    false,
+			wantChargeDeleted: false,
+			wantOverride:      false,
+		},
+	}
+
+	runner{
+		stops: stops{
+			{
+				version:   20260703084504,
+				direction: directionUp,
+				action: func(t *testing.T, db *sql.DB) {
+					seedRepairUsageBasedDeletedInvoiceRunsBase(t, db, repairUsageBasedDeletedInvoiceRunsBase{
+						namespace:                namespace,
+						now:                      now,
+						customerID:               customerID,
+						taxCodeID:                taxCodeID,
+						featureID:                featureID,
+						workflowID:               workflowID,
+						profileID:                profileID,
+						taxAppID:                 taxAppID,
+						invoicingAppID:           invoicingAppID,
+						paymentAppID:             paymentAppID,
+						gatheringInvoiceID:       gatheringInvoiceID,
+						gatheringWorkflowID:      gatheringWorkflowID,
+						emptyGatheringCustomerID: emptyGatheringCustomerID,
+						emptyGatheringInvoiceID:  emptyGatheringInvoiceID,
+						emptyGatheringWorkflowID: emptyGatheringWorkflowID,
+					})
+
+					for idx := range cases {
+						if cases[idx].customerID == "" {
+							cases[idx].customerID = customerID
+						}
+						if cases[idx].gatheringInvoiceID == "" {
+							cases[idx].gatheringInvoiceID = gatheringInvoiceID
+						}
+						cases[idx].chargeID = ulid.Make().String()
+						cases[idx].invoiceID = ulid.Make().String()
+						cases[idx].invoiceWorkflowID = ulid.Make().String()
+						cases[idx].lineID = ulid.Make().String()
+						cases[idx].gatheringLineID = ulid.Make().String()
+						cases[idx].runID = ulid.Make().String()
+
+						seedRepairUsageBasedDeletedInvoiceRunCase(t, db, namespace, now, taxCodeID, featureID, profileID, taxAppID, invoicingAppID, paymentAppID, cases[idx])
+					}
+				},
+			},
+			{
+				version:   20260709132435,
+				direction: directionUp,
+				action: func(t *testing.T, db *sql.DB) {
+					for _, tc := range cases {
+						t.Run(tc.name, func(t *testing.T) {
+							assertRepairUsageBasedDeletedInvoiceRunCase(t, db, tc)
+						})
+					}
+				},
+			},
+		},
+	}.Test(t)
+}
+
+type repairUsageBasedDeletedInvoiceRunsBase struct {
+	namespace                string
+	now                      time.Time
+	customerID               string
+	taxCodeID                string
+	featureID                string
+	workflowID               string
+	profileID                string
+	taxAppID                 string
+	invoicingAppID           string
+	paymentAppID             string
+	gatheringInvoiceID       string
+	gatheringWorkflowID      string
+	emptyGatheringCustomerID string
+	emptyGatheringInvoiceID  string
+	emptyGatheringWorkflowID string
+}
+
+type repairUsageBasedDeletedInvoiceRunsCase struct {
+	name                        string
+	customerID                  string
+	chargeID                    string
+	invoiceID                   string
+	invoiceWorkflowID           string
+	lineID                      string
+	gatheringInvoiceID          string
+	gatheringLineID             string
+	runID                       string
+	runType                     string
+	creditsTotal                string
+	invoiceStatus               string
+	invoiceDeletedAt            *time.Time
+	lineDeletedAt               *time.Time
+	existingOverrideName        string
+	wantRunDeleted              bool
+	wantChargeDeleted           bool
+	wantGatheringInvoiceDeleted bool
+	wantOverride                bool
+}
+
+func seedRepairUsageBasedDeletedInvoiceRunsBase(t *testing.T, db *sql.DB, input repairUsageBasedDeletedInvoiceRunsBase) {
+	t.Helper()
+
+	_, err := db.Exec(`
+		INSERT INTO customers (
+			id, namespace, metadata, created_at, updated_at, key, name, currency
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'customer', 'Customer', 'EUR'
+		)
+	`, input.customerID, input.namespace, input.now)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO customers (
+			id, namespace, metadata, created_at, updated_at, key, name, currency
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'empty-gathering-customer', 'Empty gathering customer', 'EUR'
+		)
+	`, input.emptyGatheringCustomerID, input.namespace, input.now)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO tax_codes (
+			id, namespace, metadata, created_at, updated_at, name, key
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Tax code', 'tax-code'
+		)
+	`, input.taxCodeID, input.namespace, input.now)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO features (
+			id, namespace, metadata, created_at, updated_at, name, key
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Feature', 'feature'
+		)
+	`, input.featureID, input.namespace, input.now)
+	require.NoError(t, err)
+
+	for _, app := range []struct {
+		id      string
+		appType string
+		name    string
+	}{
+		{id: input.taxAppID, appType: "tax", name: "Tax app"},
+		{id: input.invoicingAppID, appType: "invoicing", name: "Invoicing app"},
+		{id: input.paymentAppID, appType: "payment", name: "Payment app"},
+	} {
+		_, err = db.Exec(`
+			INSERT INTO apps (
+				id, namespace, metadata, created_at, updated_at, name, description, type, status
+			) VALUES (
+				$1, $2, '{}'::jsonb, $3, $3, $4, '', $5, 'ready'
+			)
+		`, app.id, input.namespace, input.now, app.name, app.appType)
+		require.NoError(t, err)
+	}
+
+	seedRepairUsageBasedDeletedInvoiceRunsWorkflowConfig(t, db, input.namespace, input.now, input.workflowID)
+	seedRepairUsageBasedDeletedInvoiceRunsWorkflowConfig(t, db, input.namespace, input.now, input.gatheringWorkflowID)
+	seedRepairUsageBasedDeletedInvoiceRunsWorkflowConfig(t, db, input.namespace, input.now, input.emptyGatheringWorkflowID)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_profiles (
+			id, namespace, metadata, created_at, updated_at, name, tax_app_id, invoicing_app_id,
+			payment_app_id, workflow_config_id, "default", supplier_name
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Profile', $4, $5, $6, $7, false, 'Supplier'
+		)
+	`, input.profileID, input.namespace, input.now, input.taxAppID, input.invoicingAppID, input.paymentAppID, input.workflowID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_invoices (
+			id, namespace, metadata, created_at, updated_at, supplier_name,
+			customer_name, number, type, customer_id, source_billing_profile_id, currency,
+			status, workflow_config_id, tax_app_id, invoicing_app_id, payment_app_id,
+			amount, taxes_total, taxes_inclusive_total, taxes_exclusive_total, charges_total,
+			discounts_total, credits_total, total
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Supplier',
+			'Customer', $4, 'gathering', $5, $6, 'EUR',
+			'gathering', $7, $8, $9, $10,
+			0, 0, 0, 0, 0,
+			0, 0, 0
+		)
+	`, input.gatheringInvoiceID, input.namespace, input.now, "GATHERING-"+input.gatheringInvoiceID, input.customerID, input.profileID, input.gatheringWorkflowID, input.taxAppID, input.invoicingAppID, input.paymentAppID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_invoices (
+			id, namespace, metadata, created_at, updated_at, supplier_name,
+			customer_name, number, type, customer_id, source_billing_profile_id, currency,
+			status, workflow_config_id, tax_app_id, invoicing_app_id, payment_app_id,
+			amount, taxes_total, taxes_inclusive_total, taxes_exclusive_total, charges_total,
+			discounts_total, credits_total, total
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Supplier',
+			'Empty gathering customer', $4, 'gathering', $5, $6, 'EUR',
+			'gathering', $7, $8, $9, $10,
+			0, 0, 0, 0, 0,
+			0, 0, 0
+		)
+	`, input.emptyGatheringInvoiceID, input.namespace, input.now, "GATHERING-"+input.emptyGatheringInvoiceID, input.emptyGatheringCustomerID, input.profileID, input.emptyGatheringWorkflowID, input.taxAppID, input.invoicingAppID, input.paymentAppID)
+	require.NoError(t, err)
+}
+
+func seedRepairUsageBasedDeletedInvoiceRunsWorkflowConfig(t *testing.T, db *sql.DB, namespace string, now time.Time, workflowID string) {
+	t.Helper()
+
+	_, err := db.Exec(`
+		INSERT INTO billing_workflow_configs (
+			id, namespace, created_at, updated_at, collection_alignment, line_collection_period,
+			invoice_auto_advance, invoice_draft_period, invoice_due_after, invoice_collection_method,
+			invoice_progressive_billing, subscription_end_proration_mode, tax_enabled, tax_enforced
+		) VALUES (
+			$1, $2, $3, $3, 'subscription', 'P1D', true, 'P1D', 'P1D', 'charge_automatically',
+			true, 'bill_actual_period', true, false
+		)
+	`, workflowID, namespace, now)
+	require.NoError(t, err)
+}
+
+func seedRepairUsageBasedDeletedInvoiceRunCase(
+	t *testing.T,
+	db *sql.DB,
+	namespace string,
+	now time.Time,
+	taxCodeID string,
+	featureID string,
+	profileID string,
+	taxAppID string,
+	invoicingAppID string,
+	paymentAppID string,
+	tc repairUsageBasedDeletedInvoiceRunsCase,
+) {
+	t.Helper()
+
+	seedRepairUsageBasedDeletedInvoiceRunsWorkflowConfig(t, db, namespace, now, tc.invoiceWorkflowID)
+
+	_, err := db.Exec(`
+		INSERT INTO charge_usage_based (
+			id, namespace, invoice_at, settlement_mode, discounts, feature_key, price,
+			service_period_from, service_period_to, billing_period_from, billing_period_to,
+			full_service_period_from, full_service_period_to, unique_reference_id, currency,
+			managed_by, annotations, metadata, created_at, updated_at, name, status,
+			status_detailed, customer_id, tax_code_id, feature_id, rating_engine,
+			current_realization_run_id
+		) VALUES (
+			$1, $2, $3, 'credit_then_invoice', '{}'::jsonb, 'feature', '{"type":"unit","amount":"1"}'::jsonb,
+			$3, $4, $3, $4, $3, $5, $6, 'EUR',
+			'subscription', '{}'::jsonb, '{}'::jsonb, $3, $3, $7, 'active',
+			'active', $8, $9, $10, 'delta',
+			NULL
+		)
+	`, tc.chargeID, namespace, now, now.Add(time.Hour), now.Add(24*time.Hour), "repair-"+tc.chargeID, "Charge "+tc.name, tc.customerID, taxCodeID, featureID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO charges (
+			id, namespace, created_at, type, charge_usage_based_id
+		) VALUES (
+			$1, $2, $3, 'usage_based', $1
+		)
+	`, tc.chargeID, namespace, now)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_invoices (
+			id, namespace, metadata, created_at, updated_at, deleted_at, supplier_name,
+			customer_name, number, type, customer_id, source_billing_profile_id, currency,
+			status, workflow_config_id, tax_app_id, invoicing_app_id, payment_app_id,
+			amount, taxes_total, taxes_inclusive_total, taxes_exclusive_total, charges_total,
+			discounts_total, credits_total, total
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, $4, 'Supplier',
+			'Customer', $5, 'standard', $6, $7, 'EUR',
+			$8, $9, $10, $11, $12,
+			0, 0, 0, 0, 0,
+			0, 0, 0
+		)
+	`, tc.invoiceID, namespace, now, tc.invoiceDeletedAt, "INV-"+tc.invoiceID, tc.customerID, profileID, tc.invoiceStatus, tc.invoiceWorkflowID, taxAppID, invoicingAppID, paymentAppID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_invoice_lines (
+			id, namespace, metadata, created_at, updated_at, deleted_at, name,
+			period_start, period_end, invoice_at, type, status, currency, invoice_id,
+			managed_by, amount, taxes_total, taxes_inclusive_total, taxes_exclusive_total,
+			charges_total, discounts_total, credits_total, total, charge_id, engine,
+			tax_code_id
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, $4, $5,
+			$3, $6, $3, 'usage_based', 'valid', 'EUR', $7,
+			'subscription', 0, 0, 0, 0,
+			0, 0, 0, 0, $8, 'charge_usagebased',
+			$9
+		)
+	`, tc.lineID, namespace, now, tc.lineDeletedAt, "Line "+tc.name, now.Add(time.Hour), tc.invoiceID, tc.chargeID, taxCodeID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO billing_invoice_lines (
+			id, namespace, metadata, created_at, updated_at, name,
+			period_start, period_end, invoice_at, type, status, currency, invoice_id,
+			managed_by, amount, taxes_total, taxes_inclusive_total, taxes_exclusive_total,
+			charges_total, discounts_total, credits_total, total, charge_id, engine,
+			tax_code_id
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, $4,
+			$3, $5, $3, 'usage_based', 'valid', 'EUR', $6,
+			'subscription', 0, 0, 0, 0,
+			0, 0, 0, 0, $7, 'charge_usagebased',
+			$8
+		)
+	`, tc.gatheringLineID, namespace, now, "Gathering line "+tc.name, now.Add(24*time.Hour), tc.gatheringInvoiceID, tc.chargeID, taxCodeID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO charge_usage_based_runs (
+			id, namespace, created_at, updated_at, type, initial_type, stored_at_lt,
+			service_period_to, detailed_lines_present, line_id, invoice_id, metered_quantity,
+			no_fiat_transaction_required, charge_id, feature_id, amount, taxes_total,
+			taxes_inclusive_total, taxes_exclusive_total, charges_total, discounts_total,
+			credits_total, total
+		) VALUES (
+			$1, $2, $3, $3, $4, $4, $6,
+			$6, false, $7, $8, 0,
+			true, $9, $10, 0, 0,
+			0, 0, 0, 0,
+			$5, 0
+		)
+	`, tc.runID, namespace, now, tc.runType, tc.creditsTotal, now.Add(time.Hour), tc.lineID, tc.invoiceID, tc.chargeID, featureID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		UPDATE charge_usage_based
+		SET current_realization_run_id = $1
+		WHERE id = $2
+	`, tc.runID, tc.chargeID)
+	require.NoError(t, err)
+
+	if tc.existingOverrideName != "" {
+		_, err = db.Exec(`
+			INSERT INTO charge_usage_based_overrides (
+				id, namespace, charge_id, name, metadata, service_period_from, service_period_to,
+				full_service_period_from, full_service_period_to, billing_period_from, billing_period_to,
+				invoice_at, feature_key, price, discounts
+			) VALUES (
+				$1, $2, $3, $4, '{}'::jsonb, $5, $6,
+				$5, $7, $5, $6,
+				$5, 'feature', '{"type":"unit","amount":"2"}'::jsonb, '{}'::jsonb
+			)
+		`, ulid.Make().String(), namespace, tc.chargeID, tc.existingOverrideName, now, now.Add(time.Hour), now.Add(24*time.Hour))
+		require.NoError(t, err)
+	}
+}
+
+func assertRepairUsageBasedDeletedInvoiceRunCase(t *testing.T, db *sql.DB, tc repairUsageBasedDeletedInvoiceRunsCase) {
+	t.Helper()
+
+	var runDeletedAt sql.NullTime
+	err := db.QueryRow(`
+		SELECT deleted_at
+		FROM charge_usage_based_runs
+		WHERE id = $1
+	`, tc.runID).Scan(&runDeletedAt)
+	require.NoError(t, err)
+	require.Equal(t, tc.wantRunDeleted, runDeletedAt.Valid)
+
+	var chargeDeletedAt sql.NullTime
+	var baseIntentDeletedAt sql.NullTime
+	var currentRunID sql.NullString
+	var chargeStatus string
+	var chargeDetailedStatus string
+	err = db.QueryRow(`
+		SELECT deleted_at, intent_deleted_at, current_realization_run_id, status, status_detailed
+		FROM charge_usage_based
+		WHERE id = $1
+	`, tc.chargeID).Scan(&chargeDeletedAt, &baseIntentDeletedAt, &currentRunID, &chargeStatus, &chargeDetailedStatus)
+	require.NoError(t, err)
+	require.Equal(t, tc.wantChargeDeleted, chargeDeletedAt.Valid)
+	require.False(t, baseIntentDeletedAt.Valid, "base/system intent must stay visible for subscription sync")
+	require.Equal(t, !tc.wantRunDeleted, currentRunID.Valid)
+	if !tc.wantRunDeleted {
+		require.Equal(t, tc.runID, currentRunID.String)
+	}
+	if tc.wantChargeDeleted {
+		require.Equal(t, "deleted", chargeStatus)
+		require.Equal(t, "deleted", chargeDetailedStatus)
+	} else {
+		require.Equal(t, "active", chargeStatus)
+		require.Equal(t, "active", chargeDetailedStatus)
+	}
+
+	var gatheringLineDeletedAt sql.NullTime
+	err = db.QueryRow(`
+		SELECT deleted_at
+		FROM billing_invoice_lines
+		WHERE id = $1
+	`, tc.gatheringLineID).Scan(&gatheringLineDeletedAt)
+	require.NoError(t, err)
+	require.Equal(t, tc.wantChargeDeleted, gatheringLineDeletedAt.Valid)
+
+	var gatheringInvoiceDeletedAt sql.NullTime
+	err = db.QueryRow(`
+		SELECT deleted_at
+		FROM billing_invoices
+		WHERE id = $1
+	`, tc.gatheringInvoiceID).Scan(&gatheringInvoiceDeletedAt)
+	require.NoError(t, err)
+	require.Equal(t, tc.wantGatheringInvoiceDeleted, gatheringInvoiceDeletedAt.Valid)
+
+	var overrideName sql.NullString
+	var overrideIntentDeletedAt sql.NullTime
+	err = db.QueryRow(`
+		SELECT name, intent_deleted_at
+		FROM charge_usage_based_overrides
+		WHERE charge_id = $1
+	`, tc.chargeID).Scan(&overrideName, &overrideIntentDeletedAt)
+	if !tc.wantOverride {
+		require.ErrorIs(t, err, sql.ErrNoRows)
+		return
+	}
+
+	require.NoError(t, err)
+	require.True(t, overrideIntentDeletedAt.Valid)
+	require.True(t, overrideName.Valid)
+	if tc.existingOverrideName != "" {
+		require.Equal(t, tc.existingOverrideName, overrideName.String)
+	} else {
+		require.Equal(t, "Charge "+tc.name, overrideName.String)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Soft delete charges that are belonging to deleted standard invoices. This corrects any inconsistencies before the usagebased delete was implemented.

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a corrective database migration to repair “usage-based realization runs” that could incorrectly remain active after related invoices were deleted.
  * Improved consistency of related billing records by properly marking affected runs, invoice lines, and gathering invoices as deleted and clearing stale references.
* **Tests**
  * Added migration coverage to validate expected repair behavior across multiple invoice/run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a data repair for usage-based runs left active after invoice deletion. The main changes are:

- New irreversible migration for affected zero-credit usage-based runs.
- Cleanup of repaired runs, gathering lines, and empty gathering invoices.
- Override tombstones for final realization charges.
- Migration test coverage for repaired and ignored cases.

<h3>Confidence Score: 4/5</h3>

This is close, but the repair can still leave affected charges out of normal billing advancement.

- The migration preserves the base intent field, but still marks the base charge row deleted.
- Billing advancement paths can filter that row out before future usage-based runs are created.
- The affected charges can stop billing after the repair runs.

tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.up.sql

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.up.sql | Adds the repair migration, but the final base charge update can still hide repaired charges from normal billing advancement. |
| tools/migrate/repair_usagebased_deleted_invoice_runs_test.go | Adds migration coverage for affected runs, ignored runs, override handling, and gathering cleanup. |
| tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.down.sql | Documents the data repair as intentionally irreversible. |
| tools/migrate/migrations/atlas.sum | Updates the migration checksum for the new repair migration. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fmigrate%2Fmigrations%2F20260709132435_repair_usagebased_deleted_invoice_runs.up.sql%3A152-165%0A**Base%20Charge%20Still%20Hidden**%0A%0AThis%20update%20keeps%20%60intent_deleted_at%60%20unset%20on%20the%20base%20row%2C%20but%20it%20still%20sets%20%60charge_usage_based.deleted_at%60%20and%20%60status%20%3D%20'deleted'%60.%20Subscription%20sync%20can%20use%20the%20base-intent%20filter%20to%20see%20the%20row%2C%20but%20the%20normal%20billing%20advancement%20discovery%20path%20filters%20out%20deleted%20rows%20and%20deleted%20statuses.%20After%20the%20migration%20repairs%20a%20final%20realization%20charge%2C%20future%20advancement%20can%20skip%20that%20charge%20and%20stop%20creating%20new%20usage-based%20runs%20or%20invoices%20for%20it%2C%20even%20though%20the%20subscription-owned%20base%20intent%20is%20meant%20to%20remain%20visible.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4673&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Frepair-api-deleted-invoice-lines%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frepair-api-deleted-invoice-lines%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fmigrate%2Fmigrations%2F20260709132435_repair_usagebased_deleted_invoice_runs.up.sql%3A152-165%0A**Base%20Charge%20Still%20Hidden**%0A%0AThis%20update%20keeps%20%60intent_deleted_at%60%20unset%20on%20the%20base%20row%2C%20but%20it%20still%20sets%20%60charge_usage_based.deleted_at%60%20and%20%60status%20%3D%20'deleted'%60.%20Subscription%20sync%20can%20use%20the%20base-intent%20filter%20to%20see%20the%20row%2C%20but%20the%20normal%20billing%20advancement%20discovery%20path%20filters%20out%20deleted%20rows%20and%20deleted%20statuses.%20After%20the%20migration%20repairs%20a%20final%20realization%20charge%2C%20future%20advancement%20can%20skip%20that%20charge%20and%20stop%20creating%20new%20usage-based%20runs%20or%20invoices%20for%20it%2C%20even%20though%20the%20subscription-owned%20base%20intent%20is%20meant%20to%20remain%20visible.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4673&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/migrate/migrations/20260709132435_repair_usagebased_deleted_invoice_runs.up.sql:152-165
**Base Charge Still Hidden**

This update keeps `intent_deleted_at` unset on the base row, but it still sets `charge_usage_based.deleted_at` and `status = 'deleted'`. Subscription sync can use the base-intent filter to see the row, but the normal billing advancement discovery path filters out deleted rows and deleted statuses. After the migration repairs a final realization charge, future advancement can skip that charge and stop creating new usage-based runs or invoices for it, even though the subscription-owned base intent is meant to remain visible.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: cover usage-based deleted invoice ..."](https://github.com/openmeterio/openmeter/commit/e4542f325a6655358291c9f32be7d20c40a21939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42990014)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->