### PR TITLE
refactor: move billing sequence service

### DIFF
--- a/app/common/app.go
+++ b/app/common/app.go
@@ -96,8 +96,8 @@ func NewAppSandboxFactory(
 	billing BillingRegistry,
 ) (*appsandbox.Factory, error) {
 	factory, err := appsandbox.NewFactory(appsandbox.Config{
-		AppService:     appService,
-		BillingService: billing.Billing,
+		AppService:      appService,
+		SequenceService: billing.Sequence,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize app sandbox factory: %w", err)
@@ -146,7 +146,7 @@ func NewAppCustomInvoicingService(logger *slog.Logger, db *entdb.Client, appsCon
 	_, err = appcustominvoicing.NewFactory(appcustominvoicing.FactoryConfig{
 		AppService:             appService,
 		CustomInvoicingService: service,
-		BillingService:         billingRegistry.Billing,
+		SequenceService:        billingRegistry.Sequence,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create appcustominvoicing factory: %w", err)

--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -17,6 +17,9 @@ import (
 	chargesworkeradvance "github.com/openmeterio/openmeter/openmeter/billing/charges/worker/advance"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	billingsequence "github.com/openmeterio/openmeter/openmeter/billing/sequence"
+	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
 	billingcustomer "github.com/openmeterio/openmeter/openmeter/billing/validators/customer"
 	billingsubscription "github.com/openmeterio/openmeter/openmeter/billing/validators/subscription"
@@ -44,8 +47,9 @@ import (
 // BillingRegistry bundles the billing and charges services. External callers that need
 // billing or charges should depend on BillingRegistry rather than individual services.
 type BillingRegistry struct {
-	Billing billing.Service
-	Charges *ChargesRegistry
+	Billing  billing.Service
+	Sequence billingsequence.Service
+	Charges  *ChargesRegistry
 }
 
 func (r BillingRegistry) ChargesServiceOrNil() charges.Service {
@@ -85,6 +89,21 @@ func BillingAdapter(
 	})
 }
 
+func NewBillingSequenceService(
+	logger *slog.Logger,
+	db *entdb.Client,
+) (billingsequence.Service, error) {
+	adapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
+		Client: db,
+		Logger: logger.With("subsystem", "billing.sequence"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return billingsequenceservice.New(adapter), nil
+}
+
 // newBillingService creates the billing service and registers validators/hooks.
 // Downstream consumers should use BillingRegistry.
 func newBillingService(
@@ -92,6 +111,7 @@ func newBillingService(
 	appService app.Service,
 	billingAdapter billing.Adapter,
 	billingRatingService rating.Service,
+	sequenceService billingsequence.Service,
 	customerService customer.Service,
 	featureConnector feature.FeatureConnector,
 	meterService meter.Service,
@@ -106,6 +126,7 @@ func newBillingService(
 ) (billing.Service, error) {
 	service, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
+		SequenceService:              sequenceService,
 		RatingService:                billingRatingService,
 		AppService:                   appService,
 		CustomerService:              customerService,
@@ -152,11 +173,17 @@ func NewBillingRegistry(
 	breakageService ledgerbreakage.Service,
 	featureGate *featuregate.FeatureGateChecker,
 ) (BillingRegistry, error) {
+	sequenceService, err := NewBillingSequenceService(logger, db)
+	if err != nil {
+		return BillingRegistry{}, err
+	}
+
 	billingService, err := newBillingService(
 		logger,
 		appService,
 		billingAdapter,
 		billingRatingService,
+		sequenceService,
 		customerService,
 		featureConnector,
 		meterService,
@@ -200,8 +227,9 @@ func NewBillingRegistry(
 	}
 
 	billingRegistry := BillingRegistry{
-		Billing: billingService,
-		Charges: chargesRegistry,
+		Billing:  billingService,
+		Sequence: sequenceService,
+		Charges:  chargesRegistry,
 	}
 
 	// Hook registration

--- a/openmeter/app/custominvoicing/app.go
+++ b/openmeter/app/custominvoicing/app.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
 )
@@ -16,7 +17,7 @@ var (
 	_ billing.InvoicingAppAsyncSyncer = (*App)(nil)
 )
 
-var DefaultInvoiceSequenceNumber = billing.SequenceDefinition{
+var DefaultInvoiceSequenceNumber = sequence.Definition{
 	Prefix:         "INV",
 	SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 	Scope:          "invoices/custom-invoicing",
@@ -57,7 +58,7 @@ type App struct {
 	Meta
 
 	customInvoicingService Service
-	billingService         billing.Service
+	sequenceService        sequence.Service
 }
 
 func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
@@ -108,9 +109,9 @@ func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.Standa
 	// If we are done with the hook work, let's make sure that the invoice has a non-draft invoice number
 	if canAdvance {
 		// If the invoice still has a draft invoice number, let's generate a non-draft one
-		if billing.DraftInvoiceSequenceNumber.PrefixMatches(invoice.Number) {
-			invoiceNumber, err := a.billingService.GenerateInvoiceSequenceNumber(ctx,
-				billing.SequenceGenerationInput{
+		if sequence.DraftInvoiceSequenceNumber.PrefixMatches(invoice.Number) {
+			invoiceNumber, err := a.sequenceService.GenerateInvoiceSequenceNumber(ctx,
+				sequence.GenerationInput{
 					Namespace:    invoice.Namespace,
 					CustomerName: invoice.Customer.Name,
 					Currency:     invoice.Currency,

--- a/openmeter/app/custominvoicing/factory.go
+++ b/openmeter/app/custominvoicing/factory.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
-	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 )
 
 var (
@@ -48,13 +48,13 @@ var (
 type Factory struct {
 	appService             app.Service
 	customInvoicingService Service
-	billingService         billing.Service
+	sequenceService        sequence.Service
 }
 
 type FactoryConfig struct {
 	AppService             app.Service
 	CustomInvoicingService Service
-	BillingService         billing.Service
+	SequenceService        sequence.Service
 }
 
 func (c FactoryConfig) Validate() error {
@@ -66,8 +66,8 @@ func (c FactoryConfig) Validate() error {
 		return fmt.Errorf("custom invoicing service is required")
 	}
 
-	if c.BillingService == nil {
-		return fmt.Errorf("billing service is required")
+	if c.SequenceService == nil {
+		return fmt.Errorf("sequence service is required")
 	}
 
 	return nil
@@ -81,7 +81,7 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 	fact := &Factory{
 		appService:             config.AppService,
 		customInvoicingService: config.CustomInvoicingService,
-		billingService:         config.BillingService,
+		sequenceService:        config.SequenceService,
 	}
 
 	err := config.AppService.RegisterMarketplaceListing(app.RegistryItem{
@@ -108,7 +108,7 @@ func (f *Factory) NewApp(ctx context.Context, appBase app.AppBase) (app.App, err
 			Configuration: cfg,
 		},
 		customInvoicingService: f.customInvoicingService,
-		billingService:         f.billingService,
+		sequenceService:        f.sequenceService,
 	}, nil
 }
 

--- a/openmeter/app/sandbox/app.go
+++ b/openmeter/app/sandbox/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -29,7 +30,7 @@ var (
 	_ billing.InvoicingAppPostAdvanceHook = (*App)(nil)
 	_ app.CustomerData                    = (*CustomerData)(nil)
 
-	InvoiceSequenceNumber = billing.SequenceDefinition{
+	InvoiceSequenceNumber = sequence.Definition{
 		Prefix:         "OM-SANDBOX",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/app/sandbox",
@@ -51,7 +52,7 @@ func (m *Meta) FromEventAppData(event app.EventApp) error {
 type App struct {
 	Meta
 
-	billingService billing.Service
+	sequenceService sequence.Service
 }
 
 func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
@@ -87,9 +88,9 @@ func (a App) UpsertStandardInvoice(ctx context.Context, invoice billing.Standard
 }
 
 func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
-	invoiceNumber, err := a.billingService.GenerateInvoiceSequenceNumber(
+	invoiceNumber, err := a.sequenceService.GenerateInvoiceSequenceNumber(
 		ctx,
-		billing.SequenceGenerationInput{
+		sequence.GenerationInput{
 			Namespace:    invoice.Namespace,
 			CustomerName: invoice.Customer.Name,
 			Currency:     invoice.Currency,
@@ -165,13 +166,13 @@ func (c CustomerData) Validate() error {
 }
 
 type Factory struct {
-	appService     app.Service
-	billingService billing.Service
+	appService      app.Service
+	sequenceService sequence.Service
 }
 
 type Config struct {
-	AppService     app.Service
-	BillingService billing.Service
+	AppService      app.Service
+	SequenceService sequence.Service
 }
 
 func (c Config) Validate() error {
@@ -179,8 +180,8 @@ func (c Config) Validate() error {
 		return fmt.Errorf("app service is required")
 	}
 
-	if c.BillingService == nil {
-		return fmt.Errorf("billing service is required")
+	if c.SequenceService == nil {
+		return fmt.Errorf("sequence service is required")
 	}
 
 	return nil
@@ -192,8 +193,8 @@ func NewFactory(config Config) (*Factory, error) {
 	}
 
 	fact := &Factory{
-		appService:     config.AppService,
-		billingService: config.BillingService,
+		appService:      config.AppService,
+		sequenceService: config.SequenceService,
 	}
 
 	err := config.AppService.RegisterMarketplaceListing(app.RegistryItem{
@@ -213,7 +214,7 @@ func (a *Factory) NewApp(_ context.Context, appBase app.AppBase) (app.App, error
 		Meta: Meta{
 			AppBase: appBase,
 		},
-		billingService: a.billingService,
+		sequenceService: a.sequenceService,
 	}, nil
 }
 

--- a/openmeter/app/sandbox/mock.go
+++ b/openmeter/app/sandbox/mock.go
@@ -236,8 +236,8 @@ func NewMockableFactory(_ *testing.T, config Config, opts ...mockConfigOption) (
 
 	fact := &MockableFactory{
 		Factory: &Factory{
-			appService:     config.AppService,
-			billingService: config.BillingService,
+			appService:      config.AppService,
+			sequenceService: config.SequenceService,
 		},
 	}
 

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -3,8 +3,6 @@ package billing
 import (
 	"context"
 
-	"github.com/alpacahq/alpacadecimal"
-
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
@@ -19,7 +17,6 @@ type Adapter interface {
 	InvoiceAdapter
 	GatheringInvoiceAdapter
 	StandardInvoiceAdapter
-	SequenceAdapter
 	InvoiceAppAdapter
 	CustomerSynchronizationAdapter
 	SchemaLevelAdapter
@@ -97,10 +94,6 @@ type InvoiceSplitLineGroupAdapter interface {
 	DeleteSplitLineGroup(ctx context.Context, input DeleteSplitLineGroupInput) error
 	GetSplitLineGroup(ctx context.Context, input GetSplitLineGroupInput) (SplitLineHierarchy, error)
 	GetSplitLineGroupHeaders(ctx context.Context, input GetSplitLineGroupHeadersInput) (SplitLineGroupHeaders, error)
-}
-
-type SequenceAdapter interface {
-	NextSequenceNumber(ctx context.Context, input NextSequenceNumberInput) (alpacadecimal.Decimal, error)
 }
 
 type InvoiceAppAdapter interface {

--- a/openmeter/billing/sequence/adapter.go
+++ b/openmeter/billing/sequence/adapter.go
@@ -1,0 +1,15 @@
+package sequence
+
+import (
+	"context"
+
+	"github.com/alpacahq/alpacadecimal"
+
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+type Adapter interface {
+	entutils.TxCreator
+
+	NextSequenceNumber(ctx context.Context, input NextSequenceNumberInput) (alpacadecimal.Decimal, error)
+}

--- a/openmeter/billing/sequence/adapter/adapter.go
+++ b/openmeter/billing/sequence/adapter/adapter.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+)
+
+type Config struct {
+	Client *entdb.Client
+	Logger *slog.Logger
+}
+
+func (c Config) Validate() error {
+	if c.Client == nil {
+		return errors.New("ent client is required")
+	}
+
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+func New(config Config) (sequence.Adapter, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &adapter{
+		db:     config.Client,
+		logger: config.Logger,
+	}, nil
+}
+
+var _ sequence.Adapter = (*adapter)(nil)
+
+type adapter struct {
+	db     *entdb.Client
+	logger *slog.Logger
+}
+
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
+		ReadOnly: false,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to hijack transaction: %w", err)
+	}
+
+	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
+}
+
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+	txDb := entdb.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
+
+	return &adapter{
+		db:     txDb.Client(),
+		logger: a.logger,
+	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
+}

--- a/openmeter/billing/sequence/adapter/seq.go
+++ b/openmeter/billing/sequence/adapter/seq.go
@@ -1,19 +1,17 @@
-package billingadapter
+package adapter
 
 import (
 	"context"
 
 	"github.com/alpacahq/alpacadecimal"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingsequencenumbers"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
-var _ billing.SequenceAdapter = (*adapter)(nil)
-
-func (a *adapter) NextSequenceNumber(ctx context.Context, input billing.NextSequenceNumberInput) (alpacadecimal.Decimal, error) {
+func (a *adapter) NextSequenceNumber(ctx context.Context, input sequence.NextSequenceNumberInput) (alpacadecimal.Decimal, error) {
 	if err := input.Validate(); err != nil {
 		return alpacadecimal.Zero, err
 	}

--- a/openmeter/billing/sequence/sequence.go
+++ b/openmeter/billing/sequence/sequence.go
@@ -1,4 +1,4 @@
-package billing
+package sequence
 
 import (
 	"fmt"
@@ -24,13 +24,13 @@ func (n NextSequenceNumberInput) Validate() error {
 	return nil
 }
 
-type SequenceDefinition struct {
+type Definition struct {
 	Prefix         string
 	SuffixTemplate string
 	Scope          string
 }
 
-func (d SequenceDefinition) Validate() error {
+func (d Definition) Validate() error {
 	if d.Prefix == "" {
 		return fmt.Errorf("prefix is required")
 	}
@@ -46,30 +46,30 @@ func (d SequenceDefinition) Validate() error {
 	return nil
 }
 
-func (d SequenceDefinition) PrefixMatches(s string) bool {
+func (d Definition) PrefixMatches(s string) bool {
 	return strings.HasPrefix(s, d.Prefix+"-")
 }
 
 var (
-	GatheringInvoiceSequenceNumber = SequenceDefinition{
+	GatheringInvoiceSequenceNumber = Definition{
 		Prefix:         "GATHER",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.Currency}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/gathering",
 	}
-	DraftInvoiceSequenceNumber = SequenceDefinition{
+	DraftInvoiceSequenceNumber = Definition{
 		Prefix:         "DRAFT",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/draft",
 	}
 )
 
-type SequenceGenerationInput struct {
+type GenerationInput struct {
 	Namespace    string
 	CustomerName string
 	Currency     currencyx.Code
 }
 
-func (i SequenceGenerationInput) Validate() error {
+func (i GenerationInput) Validate() error {
 	if i.CustomerName == "" {
 		return fmt.Errorf("customer name is required")
 	}

--- a/openmeter/billing/sequence/service.go
+++ b/openmeter/billing/sequence/service.go
@@ -1,0 +1,7 @@
+package sequence
+
+import "context"
+
+type Service interface {
+	GenerateInvoiceSequenceNumber(ctx context.Context, in GenerationInput, def Definition) (string, error)
+}

--- a/openmeter/billing/sequence/service/service.go
+++ b/openmeter/billing/sequence/service/service.go
@@ -1,4 +1,4 @@
-package billingservice
+package service
 
 import (
 	"bytes"
@@ -9,9 +9,21 @@ import (
 
 	"github.com/gosimple/unidecode"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
+
+type Service struct {
+	adapter sequence.Adapter
+}
+
+var _ sequence.Service = (*Service)(nil)
+
+func New(adapter sequence.Adapter) *Service {
+	return &Service{
+		adapter: adapter,
+	}
+}
 
 type sequenceInput struct {
 	CustomerPrefix     string
@@ -19,7 +31,7 @@ type sequenceInput struct {
 	NextSequenceNumber string
 }
 
-func (s *Service) GenerateInvoiceSequenceNumber(ctx context.Context, in billing.SequenceGenerationInput, def billing.SequenceDefinition) (string, error) {
+func (s *Service) GenerateInvoiceSequenceNumber(ctx context.Context, in sequence.GenerationInput, def sequence.Definition) (string, error) {
 	if err := in.Validate(); err != nil {
 		return "", err
 	}
@@ -28,7 +40,7 @@ func (s *Service) GenerateInvoiceSequenceNumber(ctx context.Context, in billing.
 		return "", err
 	}
 
-	nextSequenceNumber, err := s.adapter.NextSequenceNumber(ctx, billing.NextSequenceNumberInput{
+	nextSequenceNumber, err := s.adapter.NextSequenceNumber(ctx, sequence.NextSequenceNumberInput{
 		Namespace: in.Namespace,
 		Scope:     def.Scope,
 	})

--- a/openmeter/billing/sequence/service/service_test.go
+++ b/openmeter/billing/sequence/service/service_test.go
@@ -1,4 +1,4 @@
-package billingservice
+package service
 
 import (
 	"testing"

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -17,7 +17,6 @@ type Service interface {
 	InvoiceService
 	GatheringInvoiceService
 	StandardInvoiceService
-	SequenceService
 	LockableService
 
 	InvoiceAppService
@@ -129,10 +128,6 @@ type GatheringInvoiceService interface {
 	UpdateGatheringInvoice(ctx context.Context, input UpdateGatheringInvoiceInput) (GatheringInvoice, error)
 	DeleteGatheringInvoice(ctx context.Context, input DeleteInvoiceInput) (GatheringInvoice, error)
 	RecalculateGatheringInvoices(ctx context.Context, input RecalculateGatheringInvoicesInput) error
-}
-
-type SequenceService interface {
-	GenerateInvoiceSequenceNumber(ctx context.Context, in SequenceGenerationInput, def SequenceDefinition) (string, error)
 }
 
 type InvoiceAppService interface {

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -677,13 +678,13 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 		return nil, fmt.Errorf("fetching customer profile: %w", err)
 	}
 
-	invoiceNumber, err := s.GenerateInvoiceSequenceNumber(ctx,
-		billing.SequenceGenerationInput{
+	invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(ctx,
+		sequence.GenerationInput{
 			Namespace:    in.Customer.Namespace,
 			CustomerName: profile.Customer.Name,
 			Currency:     in.Currency,
 		},
-		billing.DraftInvoiceSequenceNumber,
+		sequence.DraftInvoiceSequenceNumber,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("generating invoice number: %w", err)

--- a/openmeter/billing/service/service.go
+++ b/openmeter/billing/service/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billinglineengine "github.com/openmeterio/openmeter/openmeter/billing/lineengine"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -25,6 +26,7 @@ var _ billing.Service = (*Service)(nil)
 
 type Service struct {
 	adapter            billing.Adapter
+	sequenceService    sequence.Service
 	customerService    customer.Service
 	appService         app.Service
 	taxCodeService     taxcode.Service
@@ -47,6 +49,7 @@ type Service struct {
 
 type Config struct {
 	Adapter                      billing.Adapter
+	SequenceService              sequence.Service
 	CustomerService              customer.Service
 	AppService                   app.Service
 	TaxCodeService               taxcode.Service
@@ -64,6 +67,10 @@ type Config struct {
 func (c Config) Validate() error {
 	if c.Adapter == nil {
 		return errors.New("adapter cannot be null")
+	}
+
+	if c.SequenceService == nil {
+		return errors.New("sequence service cannot be null")
 	}
 
 	if c.CustomerService == nil {
@@ -120,6 +127,7 @@ func New(config Config) (*Service, error) {
 
 	svc := &Service{
 		adapter:                      config.Adapter,
+		sequenceService:              config.SequenceService,
 		customerService:              config.CustomerService,
 		appService:                   config.AppService,
 		taxCodeService:               config.TaxCodeService,

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -192,13 +193,13 @@ func (s *Service) upsertGatheringInvoiceForCurrency(ctx context.Context, currenc
 	}
 
 	if len(pendingInvoiceList.Items) == 0 {
-		invoiceNumber, err := s.GenerateInvoiceSequenceNumber(ctx,
-			billing.SequenceGenerationInput{
+		invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(ctx,
+			sequence.GenerationInput{
 				Namespace:    customerProfile.Customer.Namespace,
 				CustomerName: customerProfile.Customer.Name,
 				Currency:     currency,
 			},
-			billing.GatheringInvoiceSequenceNumber)
+			sequence.GatheringInvoiceSequenceNumber)
 		if err != nil {
 			return nil, fmt.Errorf("generating invoice sequence number: %w", err)
 		}

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1970,11 +1970,6 @@ func (n NoopBillingService) GetGatheringInvoiceById(ctx context.Context, input b
 	return billing.GatheringInvoice{}, nil
 }
 
-// SequenceService methods
-func (n NoopBillingService) GenerateInvoiceSequenceNumber(ctx context.Context, in billing.SequenceGenerationInput, def billing.SequenceDefinition) (string, error) {
-	return "", nil
-}
-
 // InvoiceAppService methods
 func (n NoopBillingService) TriggerInvoice(ctx context.Context, input billing.InvoiceTriggerServiceInput) error {
 	return nil

--- a/test/app/testenv.go
+++ b/test/app/testenv.go
@@ -18,6 +18,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
@@ -274,6 +276,14 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 	})
 	require.NoError(t, err)
 
+	billingSequenceAdapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
+		Client: in.DBClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+
 	// Enable unitConfig rating across the shared test env so the suite validates
 	// there is no regression from the flag being on (config-less lines must rate
 	// identically). Lines that carry a unit_config are exercised by the dedicated
@@ -282,6 +292,7 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 
 	return billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
+		SequenceService:              billingSequenceService,
 		RatingService:                billingRatingService,
 		CustomerService:              in.CustomerService,
 		AppService:                   in.AppService,

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -32,6 +32,9 @@ import (
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	billingsequence "github.com/openmeterio/openmeter/openmeter/billing/sequence"
+	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
@@ -71,6 +74,7 @@ type BaseSuite struct {
 
 	BillingAdapter    billing.Adapter
 	BillingService    billing.Service
+	SequenceService   billingsequence.Service
 	InvoiceCalculator *invoicecalc.MockableInvoiceCalculator
 
 	FeatureService         feature.FeatureConnector
@@ -238,8 +242,18 @@ func (s *BaseSuite) setupSuite(opts SetupSuiteOptions) {
 	require.NoError(t, err)
 	s.BillingAdapter = billingAdapter
 
+	billingSequenceAdapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
+		Client: dbClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+	s.SequenceService = billingSequenceService
+
 	billingService, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
+		SequenceService:              billingSequenceService,
 		RatingService:                billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
 		CustomerService:              s.CustomerService,
 		AppService:                   s.AppService,
@@ -263,8 +277,8 @@ func (s *BaseSuite) setupSuite(opts SetupSuiteOptions) {
 
 	// OpenMeter sandbox (registration as side-effect)
 	sandboxApp, err := appsandbox.NewMockableFactory(t, appsandbox.Config{
-		AppService:     appService,
-		BillingService: s.BillingService,
+		AppService:      appService,
+		SequenceService: billingSequenceService,
 	})
 	require.NoError(t, err)
 
@@ -760,7 +774,7 @@ func (s *BaseSuite) SetupCustomInvoicingApp() appcustominvoicing.Service {
 	_, err = appcustominvoicing.NewFactory(appcustominvoicing.FactoryConfig{
 		AppService:             s.AppService,
 		CustomInvoicingService: svc,
-		BillingService:         s.BillingService,
+		SequenceService:        s.SequenceService,
 	})
 	s.NoError(err, "failed to create custom invoicing factory")
 

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -18,6 +18,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
@@ -405,8 +407,19 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		return nil, fmt.Errorf("failed to create billing adapter: %w", err)
 	}
 
+	billingSequenceAdapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
+		Client: dbDeps.DBClient,
+		Logger: logger.WithGroup("billing.sequence"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create billing sequence adapter: %w", err)
+	}
+
+	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+
 	billingService, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
+		SequenceService:              billingSequenceService,
 		RatingService:                billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
 		CustomerService:              customerService,
 		AppService:                   appService,
@@ -425,8 +438,8 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 
 	// Set up app sandbox listing
 	_, err = appsandbox.NewMockableFactory(t, appsandbox.Config{
-		AppService:     appService,
-		BillingService: billingService,
+		AppService:      appService,
+		SequenceService: billingSequenceService,
 	})
 	require.NoError(t, err)
 

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
@@ -85,6 +87,14 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 	})
 	require.NoError(t, err)
 
+	billingSequenceAdapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
+		Client: deps.DBDeps.DBClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+
 	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
 		Client: deps.DBDeps.DBClient,
 		Logger: slog.Default(),
@@ -99,6 +109,7 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 
 	billingService, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
+		SequenceService:              billingSequenceService,
 		RatingService:                billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
 		CustomerService:              deps.CustomerService,
 		AppService:                   appService,
@@ -136,8 +147,8 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 
 	// OpenMeter sandbox (registration as side-effect)
 	_, err = appsandbox.NewMockableFactory(t, appsandbox.Config{
-		AppService:     appService,
-		BillingService: billingService,
+		AppService:      appService,
+		SequenceService: billingSequenceService,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

- Move billing sequence types, service, and adapter into `openmeter/billing/sequence` using the service/adapter package pattern.
- Remove the old `billing/seq.go` compatibility facade and update callers to depend on the sequence package directly.
- Wire the sequence service through common app/billing setup, sandbox/custom invoicing apps, and test harnesses.

## Validation

- `go test -tags=dynamic ./openmeter/billing/sequence/... ./openmeter/billing/service/... ./openmeter/app/sandbox/... ./openmeter/app/custominvoicing/... ./app/common/... ./test/app/... ./test/billing/... ./test/customer/... ./test/subscription/...`
- `go vet -tags=dynamic ./openmeter/billing/sequence/... ./openmeter/billing/service/... ./openmeter/app/sandbox/... ./openmeter/app/custominvoicing/... ./app/common/... ./test/app/... ./test/billing/... ./test/customer/... ./test/subscription/...`
- `go test -tags=dynamic ./cmd/server ./cmd/billing-worker ./cmd/jobs/internal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated invoice sequence management for generating draft and gathering invoice numbers.
  * Invoice numbering is now available through a focused sequence service across billing, sandbox, and custom invoicing workflows.
* **Bug Fixes**
  * Improved invoice finalization and creation flows by consistently using the dedicated sequence generation process.
* **Refactor**
  * Separated invoice sequence handling from the broader billing service for clearer service responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves billing sequence generation into its own package. The main changes are:

- Adds a dedicated sequence service and adapter under `openmeter/billing/sequence`.
- Removes sequence generation from the broader billing service and adapter interfaces.
- Updates billing, sandbox, custom invoicing, and test wiring to inject `sequence.Service` directly.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/common/billing.go | Creates and stores the dedicated sequence service in the shared billing registry. |
| openmeter/billing/sequence/service/service.go | Moves invoice sequence number rendering into the new sequence service. |
| openmeter/billing/sequence/adapter/adapter.go | Adds the sequence adapter wrapper and transaction support. |
| openmeter/app/sandbox/app.go | Updates sandbox invoice numbering to use the injected sequence service. |
| openmeter/app/custominvoicing/factory.go | Updates custom invoicing factory validation and app construction for the sequence service. |

<sub>Reviews (2): Last reviewed commit: ["refactor: move billing sequence service"](https://github.com/openmeterio/openmeter/commit/331767738ce83fbc27a197af0ed773f932b7a78c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43006922)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->