### PR TITLE
fix: use bare `exists` json tag on v3 FilterString, not `$exists`

### DIFF
--- a/.agents/skills/api-filters/SKILL.md
+++ b/.agents/skills/api-filters/SKILL.md
@@ -91,7 +91,7 @@ Operator constants live in `api/v3/filters/parse.go` as `OpEq`, `OpNeq`, `OpGt`,
 | `FilterLabel`       | `Eq`, `Neq`, `Contains`, `Oeq`, `Ocontains` (label map value predicates)       |
 | `FilterLabels`      | type alias: `map[string]FilterLabel`                                           |
 
-The `Exists` field is serialized under the JSON key `$exists` so it does not collide with a literal `exists` operator in flattened encodings.
+The wire operator for `Exists` is plain `exists` (see `OpExists` in `api/v3/filters/parse.go`), matching its `json:"exists,omitempty"` tag — don't confuse it with the unrelated `$`-prefixed Mongo-style tags used by the v1 API (`api/api.gen.go`).
 
 **Important:** the API-layer types do NOT have `Validate()` methods. Validation (mutual exclusivity, complexity bounds, format checks) happens on the internal `pkg/filter.*` predicates — typically from the service input struct's own `Validate()`, calling `f.Validate()` on each non-nil filter.
 

--- a/.agents/skills/api/rules/aip-160-filtering.md
+++ b/.agents/skills/api/rules/aip-160-filtering.md
@@ -48,11 +48,13 @@ The authoritative operator surface for each Common type is defined in `api/spec/
 
 The Go types in `api/v3/filters/filter.go` deliberately expose a **superset** of operators beyond what the matching OAS `Common.*FieldFilter` advertises, so a single Go struct can back several endpoints with different narrow OAS surfaces:
 
-- `filters.FilterString` adds `gt`/`gte`/`lt`/`lte` and an `$exists` check on top of `Common.StringFieldFilter`'s operators
+- `filters.FilterString` adds `gt`/`gte`/`lt`/`lte` and an `exists` check on top of `Common.StringFieldFilter`'s operators
 - `filters.FilterNumeric` adds `neq` and `oeq`
 - `filters.FilterDateTime` matches its Common type exactly (`eq`/`gt`/`gte`/`lt`/`lte`)
 
-The existence check (`$exists`) and `nexists` are AIP-160 operators, but they are not currently modeled in any `Common.*FieldFilter` `oneOf` shape, so picking e.g. `Common.StringFieldFilter` in TypeSpec does not advertise them. Do not rely on `gt`/`gte`/`lt`/`lte` on string fields as a stable contract — the Common type is the public surface.
+The existence check (`exists`) and `nexists` are AIP-160 operators, but they are not currently modeled in any `Common.*FieldFilter` `oneOf` shape, so picking e.g. `Common.StringFieldFilter` in TypeSpec does not advertise them. Do not rely on `gt`/`gte`/`lt`/`lte` on string fields as a stable contract — the Common type is the public surface.
+
+Note: the v3 `exists` operator is unrelated to the `$`-prefixed Mongo-style tags (`$eq`, `$in`, ...) used by the v1 API (`api/api.gen.go`) — don't conflate the two.
 
 ## Operators
 

--- a/api/v3/filters/filter.go
+++ b/api/v3/filters/filter.go
@@ -80,7 +80,7 @@ type FilterString struct {
 	Ocontains []string `json:"ocontains,omitempty"`
 
 	// Exists requires the field to be present (true) or absent (false).
-	Exists *bool `json:"$exists,omitempty"`
+	Exists *bool `json:"exists,omitempty"`
 }
 
 // FilterULID represents a filter operation on a string field that satisfies ULID format.


### PR DESCRIPTION
## What

Fixes a stray `json:"$exists"` tag on `api/v3/filters.FilterString.Exists`, inconsistent with its sibling fields (`eq`, `neq`, `contains`, ...) which all use bare operator names. Corrects the `api-filters` and `aip-160-filtering` skill docs, which incorrectly described `$exists` as an intentional wire-format collision guard.

## Why

Investigating the `$exists` mention in the skill docs surfaced that it doesn't match any real API operator (the wire operator is plain `exists`, per `OpExists` in `api/v3/filters/parse.go`) and isn't actually serialized anywhere — these structs are never marshaled/unmarshaled. The tag was just an inconsistent leftover, and the docs had rationalized it as deliberate.

## How

- `api/v3/filters/filter.go`: `Exists *bool` tag changed from `` `json:"$exists,omitempty"` `` to `` `json:"exists,omitempty"` ``.
- `.agents/skills/api-filters/SKILL.md` and `.agents/skills/api/rules/aip-160-filtering.md`: corrected the `$exists` explanation to a one-line note pointing at the real `exists` operator, and to distinguish it from the unrelated `$`-prefixed Mongo-style tags used by the v1 API (`api/api.gen.go`).

Verified via `go build`/`go test` (471 tests, `pkg/filter` + `api/v3/filters`) and `make etoe` — no regressions on v1 or v3 filter behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the v3 filter `exists` operator naming across code and docs.

- Changes `FilterString.Exists` to use `json:"exists,omitempty"`.
- Updates API filter skill docs to describe plain `exists`.
- Clarifies that v3 `exists` is separate from v1 `$`-prefixed filter tags.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The v3 parser already uses plain `exists` for the query operator.
- The changed docs now match the code path described by the PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/filters/filter.go | Updates the v3 `FilterString.Exists` JSON tag to match the plain `exists` operator. |
| .agents/skills/api-filters/SKILL.md | Updates filter guidance to describe the v3 `exists` operator accurately. |
| .agents/skills/api/rules/aip-160-filtering.md | Updates AIP-160 filter guidance and separates v3 `exists` from v1 `$` tags. |

<sub>Reviews (1): Last reviewed commit: ["fix: use bare \`exists\` json tag on v3 Fi..."](https://github.com/openmeterio/openmeter/commit/0f9ccfae237fca008446a8a95cdf711004a5edbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43010832)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and aligned the `exists` filter format so API requests use the expected `exists` operator, reducing confusion with the older Mongo-style syntax.

* **Documentation**
  * Improved filtering docs to clearly distinguish `exists` and `nexists` behavior and note the difference between v3 and legacy v1 encoding formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->