### PR TITLE
ci: use Go 1.26 for CodeQL build

### DIFF
--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -48,8 +48,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version-file: go.mod
+          go-version: "1.26.4"
           cache: true
+          cache-dependency-path: |
+            go.sum
+            collector/go.sum
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2


### PR DESCRIPTION
## Summary
- install Go 1.26.4 in the CodeQL Go workflow so the non-PR full build can compile the collector module
- include both root and collector go.sum files in setup-go's cache key

## Root Cause
The non-PR CodeQL Go workflow installs Go from the root go.mod, which is currently 1.25.6, then runs `make build GO_BUILD_FLAGS=`. That aggregate build includes `build-benthos-collector`, but `collector/go.mod` requires Go 1.26.4 and the job runs with `GOTOOLCHAIN=local`, so the collector build fails before CodeQL analysis.

## Validation
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go CodeQL workflow to use a fixed Go version and improved dependency caching for faster, more consistent CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Go CodeQL workflow for the collector build. The main changes are:

- Pins `actions/setup-go` to Go 1.26.4.
- Keeps Go module caching enabled.
- Adds both root and collector `go.sum` files to the cache key.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql-go.yaml | Updates the CodeQL Go setup step to use Go 1.26.4 and include both module sum files in setup-go caching. |

<sub>Reviews (1): Last reviewed commit: ["ci: use collector Go version for CodeQL ..."](https://github.com/openmeterio/openmeter/commit/736000d175a31e67c247a906c80be6daa2ae3e39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43099422)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->