### PR TITLE
fix(billing): avoid long-lived invoice sequence locks

### DIFF
--- a/.agents/skills/service/SKILL.md
+++ b/.agents/skills/service/SKILL.md
@@ -175,6 +175,19 @@ func (s *service) Delete<Resource>(ctx context.Context, input <domain>.Delete<Re
 }
 ```
 
+`transaction.RunInNewTransaction()` is exceptional because it deliberately
+breaks atomicity with any transaction already carried by the caller. Do not
+introduce a new call without explicit confirmation from a human developer or
+reviewer. Before requesting confirmation:
+
+- Document why caller rollback must not undo the operation
+- Verify the operation does not depend on the caller's uncommitted writes
+- Verify it cannot wait on locks held by the caller's transaction
+- Assess the additional database connection demand under concurrency
+
+Prefer `transaction.Run()` unless the domain explicitly requires the independent
+commit semantics and these risks have been reviewed.
+
 Reference: `openmeter/llmcost/service/service.go`, `openmeter/customer/service/customer.go`
 
 ### Service Hooks Pattern

--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/google/wire"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
@@ -92,6 +93,7 @@ func BillingAdapter(
 func NewBillingSequenceService(
 	logger *slog.Logger,
 	db *entdb.Client,
+	metricMeter otelmetric.Meter,
 ) (billingsequence.Service, error) {
 	adapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
 		Client: db,
@@ -101,7 +103,10 @@ func NewBillingSequenceService(
 		return nil, err
 	}
 
-	return billingsequenceservice.New(adapter), nil
+	return billingsequenceservice.New(billingsequenceservice.Config{
+		Adapter: adapter,
+		Meter:   metricMeter,
+	})
 }
 
 // newBillingService creates the billing service and registers validators/hooks.
@@ -156,6 +161,7 @@ func NewBillingRegistry(
 	customerService customer.Service,
 	featureConnector feature.FeatureConnector,
 	meterService meter.Service,
+	metricMeter otelmetric.Meter,
 	streamingConnector streaming.Connector,
 	eventPublisher eventbus.Publisher,
 	billingConfig config.BillingConfiguration,
@@ -173,7 +179,7 @@ func NewBillingRegistry(
 	breakageService ledgerbreakage.Service,
 	featureGate *featuregate.FeatureGateChecker,
 ) (BillingRegistry, error) {
-	sequenceService, err := NewBillingSequenceService(logger, db)
+	sequenceService, err := NewBillingSequenceService(logger, db, metricMeter)
 	if err != nil {
 		return BillingRegistry{}, err
 	}

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -353,7 +353,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, meter, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -362,7 +362,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, meter, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -357,7 +357,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, appService, billingAdapter, ratingService, customerService, featureConnector, service, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, appService, billingAdapter, ratingService, customerService, featureConnector, service, meter, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/openmeter/app/custominvoicing/app.go
+++ b/openmeter/app/custominvoicing/app.go
@@ -21,6 +21,7 @@ var DefaultInvoiceSequenceNumber = sequence.Definition{
 	Prefix:         "INV",
 	SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 	Scope:          "invoices/custom-invoicing",
+	CommitMode:     sequence.CommitModeWithCaller,
 }
 
 type Configuration struct {

--- a/openmeter/app/sandbox/app.go
+++ b/openmeter/app/sandbox/app.go
@@ -34,6 +34,7 @@ var (
 		Prefix:         "OM-SANDBOX",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/app/sandbox",
+		CommitMode:     sequence.CommitModeWithCaller,
 	}
 )
 

--- a/openmeter/billing/sequence/adapter/seq.go
+++ b/openmeter/billing/sequence/adapter/seq.go
@@ -2,11 +2,13 @@ package adapter
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	entsql "entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
-	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingsequencenumbers"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
@@ -17,50 +19,55 @@ func (a *adapter) NextSequenceNumber(ctx context.Context, input sequence.NextSeq
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (alpacadecimal.Decimal, error) {
-		existingRecord, err := tx.db.BillingSequenceNumbers.Query().
-			Where(
-				billingsequencenumbers.Namespace(input.Namespace),
-				billingsequencenumbers.Scope(input.Scope),
+		one := alpacadecimal.NewFromInt(1)
+
+		// Equivalent PostgreSQL:
+		// INSERT INTO billing_sequence_numbers (namespace, scope, last)
+		// VALUES ($1, $2, 1)
+		// ON CONFLICT (namespace, scope)
+		// DO UPDATE SET last = billing_sequence_numbers.last + 1
+		// RETURNING last;
+		insert := entsql.Dialect(tx.db.GetConfig().Driver.Dialect()).
+			Insert(billingsequencenumbers.Table).
+			Columns(
+				billingsequencenumbers.FieldNamespace,
+				billingsequencenumbers.FieldScope,
+				billingsequencenumbers.FieldLast,
 			).
-			ForUpdate().
-			First(ctx)
+			Values(input.Namespace, input.Scope, one).
+			OnConflict(
+				entsql.ConflictColumns(
+					billingsequencenumbers.FieldNamespace,
+					billingsequencenumbers.FieldScope,
+				),
+				entsql.ResolveWith(func(update *entsql.UpdateSet) {
+					update.Add(billingsequencenumbers.FieldLast, one)
+				}),
+			).
+			Returning(billingsequencenumbers.FieldLast)
+
+		query, args, err := insert.QueryErr()
 		if err != nil {
-			if !entdb.IsNotFound(err) {
-				return alpacadecimal.Zero, err
-			}
-
-			err := tx.db.BillingSequenceNumbers.Create().
-				SetNamespace(input.Namespace).
-				SetScope(input.Scope).
-				SetLast(alpacadecimal.NewFromInt(0)).
-				OnConflict().
-				DoNothing().
-				Exec(ctx)
-			if err != nil {
-				return alpacadecimal.Zero, err
-			}
-
-			existingRecord, err = tx.db.BillingSequenceNumbers.Query().
-				Where(
-					billingsequencenumbers.Namespace(input.Namespace),
-					billingsequencenumbers.Scope(input.Scope),
-				).
-				ForUpdate().
-				First(ctx)
-			if err != nil {
-				return alpacadecimal.Zero, err
-			}
+			return alpacadecimal.Zero, fmt.Errorf("failed to build sequence allocation query: %w", err)
 		}
 
-		next := existingRecord.Last.Add(alpacadecimal.NewFromInt(1))
-		err = tx.db.BillingSequenceNumbers.Update().
-			SetLast(next).
-			Where(
-				billingsequencenumbers.Namespace(input.Namespace),
-				billingsequencenumbers.Scope(input.Scope),
-			).Exec(ctx)
+		rows, err := tx.db.QueryContext(ctx, query, args...)
 		if err != nil {
-			return alpacadecimal.Zero, err
+			return alpacadecimal.Zero, fmt.Errorf("failed to allocate sequence number: %w", err)
+		}
+		defer rows.Close()
+
+		if !rows.Next() {
+			if err := rows.Err(); err != nil {
+				return alpacadecimal.Zero, fmt.Errorf("failed to read allocated sequence number: %w", err)
+			}
+
+			return alpacadecimal.Zero, errors.New("sequence allocation returned no value")
+		}
+
+		var next alpacadecimal.Decimal
+		if err := rows.Scan(&next); err != nil {
+			return alpacadecimal.Zero, fmt.Errorf("failed to scan allocated sequence number: %w", err)
 		}
 
 		return next, nil

--- a/openmeter/billing/sequence/sequence.go
+++ b/openmeter/billing/sequence/sequence.go
@@ -2,6 +2,7 @@ package sequence
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -28,6 +29,7 @@ type Definition struct {
 	Prefix         string
 	SuffixTemplate string
 	Scope          string
+	CommitMode     CommitMode
 }
 
 func (d Definition) Validate() error {
@@ -43,6 +45,10 @@ func (d Definition) Validate() error {
 		return fmt.Errorf("scope is required")
 	}
 
+	if err := d.CommitMode.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -50,16 +56,42 @@ func (d Definition) PrefixMatches(s string) bool {
 	return strings.HasPrefix(s, d.Prefix+"-")
 }
 
+// CommitMode controls when a sequence allocation is committed. WithCaller
+// allows the number to be reused if the caller rolls back; Independent retains
+// the allocation despite caller rollback, which can create gaps.
+type CommitMode string
+
+const (
+	CommitModeWithCaller  CommitMode = "with_caller"
+	CommitModeIndependent CommitMode = "independent"
+)
+
+func (m CommitMode) Validate() error {
+	if m == "" {
+		return fmt.Errorf("commit mode is required")
+	}
+
+	if !slices.Contains([]CommitMode{CommitModeWithCaller, CommitModeIndependent}, m) {
+		return fmt.Errorf("commit mode is invalid: %s", m)
+	}
+
+	return nil
+}
+
 var (
 	GatheringInvoiceSequenceNumber = Definition{
 		Prefix:         "GATHER",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.Currency}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/gathering",
+		CommitMode:     CommitModeIndependent,
 	}
 	DraftInvoiceSequenceNumber = Definition{
 		Prefix:         "DRAFT",
 		SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
 		Scope:          "invoices/draft",
+		// Draft numbers are temporary and replaced by the invoicing app's final
+		// invoice number, so gaps from retained allocations are acceptable.
+		CommitMode: CommitModeIndependent,
 	}
 )
 

--- a/openmeter/billing/sequence/sequence_test.go
+++ b/openmeter/billing/sequence/sequence_test.go
@@ -1,0 +1,68 @@
+package sequence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitModeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    CommitMode
+		wantErr string
+	}{
+		{
+			name: "with caller",
+			mode: CommitModeWithCaller,
+		},
+		{
+			name: "independent",
+			mode: CommitModeIndependent,
+		},
+		{
+			name:    "missing",
+			wantErr: "commit mode is required",
+		},
+		{
+			name:    "invalid",
+			mode:    CommitMode("invalid"),
+			wantErr: "commit mode is invalid: invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mode.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestDefinitionValidateRequiresCommitMode(t *testing.T) {
+	def := Definition{
+		Prefix:         "INV",
+		SuffixTemplate: "{{.NextSequenceNumber}}",
+		Scope:          "invoices/test",
+	}
+
+	err := def.Validate()
+	require.EqualError(t, err, "commit mode is required")
+}
+
+func TestDefinitionValidateRejectsInvalidCommitMode(t *testing.T) {
+	def := Definition{
+		Prefix:         "INV",
+		SuffixTemplate: "{{.NextSequenceNumber}}",
+		Scope:          "invoices/test",
+		CommitMode:     CommitMode("invalid"),
+	}
+
+	err := def.Validate()
+	require.EqualError(t, err, "commit mode is invalid: invalid")
+}

--- a/openmeter/billing/sequence/service/service.go
+++ b/openmeter/billing/sequence/service/service.go
@@ -3,26 +3,67 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template" // nosemgrep
+	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/gosimple/unidecode"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
 type Service struct {
-	adapter sequence.Adapter
+	adapter            sequence.Adapter
+	allocationDuration metric.Float64Histogram
 }
 
 var _ sequence.Service = (*Service)(nil)
 
-func New(adapter sequence.Adapter) *Service {
-	return &Service{
-		adapter: adapter,
+type Config struct {
+	Adapter sequence.Adapter
+	Meter   metric.Meter
+}
+
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.Adapter == nil {
+		errs = append(errs, errors.New("adapter is required"))
 	}
+
+	if c.Meter == nil {
+		errs = append(errs, errors.New("meter is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func New(config Config) (*Service, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	allocationDuration, err := config.Meter.Float64Histogram(
+		"openmeter.billing.sequence.allocation.duration",
+		metric.WithDescription("Time spent allocating a billing sequence number"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create allocation duration histogram: %w", err)
+	}
+
+	return &Service{
+		adapter:            config.Adapter,
+		allocationDuration: allocationDuration,
+	}, nil
 }
 
 type sequenceInput struct {
@@ -40,7 +81,7 @@ func (s *Service) GenerateInvoiceSequenceNumber(ctx context.Context, in sequence
 		return "", err
 	}
 
-	nextSequenceNumber, err := s.adapter.NextSequenceNumber(ctx, sequence.NextSequenceNumberInput{
+	nextSequenceNumber, err := s.nextSequenceNumber(ctx, def.CommitMode, sequence.NextSequenceNumberInput{
 		Namespace: in.Namespace,
 		Scope:     def.Scope,
 	})
@@ -66,6 +107,30 @@ func (s *Service) GenerateInvoiceSequenceNumber(ctx context.Context, in sequence
 	}
 
 	return fmt.Sprintf("%s-%s", def.Prefix, out.String()), nil
+}
+
+func (s *Service) nextSequenceNumber(ctx context.Context, commitMode sequence.CommitMode, input sequence.NextSequenceNumberInput) (alpacadecimal.Decimal, error) {
+	startedAt := time.Now()
+	defer func() {
+		s.allocationDuration.Record(ctx, time.Since(startedAt).Seconds(), metric.WithAttributes(
+			attribute.String("scope", input.Scope),
+			attribute.String("commit_mode", string(commitMode)),
+		))
+	}()
+
+	switch commitMode {
+	case sequence.CommitModeWithCaller:
+		return s.adapter.NextSequenceNumber(ctx, input)
+	case sequence.CommitModeIndependent:
+		// Avoid holding the namespace-and-scope sequence lock for the caller's full
+		// transaction. This favors concurrency over contiguous invoice numbering,
+		// so rolled-back callers can leave gaps.
+		return transaction.RunInNewTransaction(ctx, s.adapter, func(ctx context.Context) (alpacadecimal.Decimal, error) {
+			return s.adapter.NextSequenceNumber(ctx, input)
+		})
+	default:
+		return alpacadecimal.Zero, fmt.Errorf("commit mode is invalid: %s", commitMode)
+	}
 }
 
 func getCustomerPrefix(name string) string {

--- a/openmeter/billing/sequence/service/service_test.go
+++ b/openmeter/billing/sequence/service/service_test.go
@@ -1,9 +1,23 @@
 package service
 
 import (
+	"context"
+	"errors"
+	"strconv"
 	"testing"
 
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
+	sequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
 func TestCustomerPrefix(t *testing.T) {
@@ -18,4 +32,207 @@ func TestCustomerPrefix(t *testing.T) {
 	require.Equal(t, "LIHO", getCustomerPrefix("Líb Hosted"))
 	require.Equal(t, "ABOR", getCustomerPrefix("Ábel Őri"))
 	require.Equal(t, "PETU", getCustomerPrefix("Péter Túri"))
+}
+
+type SequenceServiceSuite struct {
+	suite.Suite
+
+	testDB  *testutils.TestDB
+	adapter sequence.Adapter
+	service sequence.Service
+}
+
+func (s *SequenceServiceSuite) SetupSuite() {
+	s.testDB = testutils.InitPostgresDB(s.T())
+
+	dbClient := db.NewClient(db.Driver(s.testDB.EntDriver.Driver()))
+	s.Require().NoError(dbClient.Schema.Create(s.T().Context()))
+
+	adapter, err := sequenceadapter.New(sequenceadapter.Config{
+		Client: dbClient,
+		Logger: testutils.NewDiscardLogger(s.T()),
+	})
+	s.Require().NoError(err)
+	s.adapter = adapter
+
+	service, err := New(Config{
+		Adapter: adapter,
+		Meter:   metricnoop.NewMeterProvider().Meter("test"),
+	})
+	s.Require().NoError(err)
+	s.service = service
+}
+
+func (s *SequenceServiceSuite) TearDownSuite() {
+	if s.testDB != nil {
+		s.testDB.Close(s.T())
+	}
+}
+
+func (s *SequenceServiceSuite) TestAllocationAfterCallerRollback() {
+	// given:
+	// - both commit modes backed by the real sequence adapter
+	// when:
+	// - two allocations occur before the caller transaction rolls back
+	// then:
+	// - caller-bound allocations are released and independent allocations remain
+	tests := []struct {
+		name       string
+		commitMode sequence.CommitMode
+		wantNext   string
+	}{
+		{
+			name:       "with caller",
+			commitMode: sequence.CommitModeWithCaller,
+			wantNext:   "INV-ACIN-1",
+		},
+		{
+			name:       "independent",
+			commitMode: sequence.CommitModeIndependent,
+			wantNext:   "INV-ACIN-3",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			namespace := ulid.Make().String()
+			callerRollback := errors.New("roll back caller transaction")
+
+			allocated := make([]string, 0, 2)
+			_, err := transaction.Run(s.T().Context(), s.adapter, func(ctx context.Context) (struct{}, error) {
+				for range 2 {
+					next, err := s.generateInvoiceNumber(ctx, namespace, tt.commitMode)
+					if err != nil {
+						return struct{}{}, err
+					}
+
+					allocated = append(allocated, next)
+				}
+
+				return struct{}{}, callerRollback
+			})
+			s.Require().ErrorIs(err, callerRollback)
+			s.Equal([]string{"INV-ACIN-1", "INV-ACIN-2"}, allocated)
+
+			next, err := s.generateInvoiceNumber(s.T().Context(), namespace, tt.commitMode)
+			s.Require().NoError(err)
+			s.Equal(tt.wantNext, next)
+		})
+	}
+}
+
+func (s *SequenceServiceSuite) TestAllocationAfterCallerCommit() {
+	// given:
+	// - both commit modes backed by the real sequence adapter
+	// when:
+	// - two allocations occur before the caller transaction commits
+	// then:
+	// - both modes retain the allocations and continue from the third number
+	for _, commitMode := range []sequence.CommitMode{
+		sequence.CommitModeWithCaller,
+		sequence.CommitModeIndependent,
+	} {
+		s.Run(string(commitMode), func() {
+			namespace := ulid.Make().String()
+
+			allocated, err := transaction.Run(s.T().Context(), s.adapter, func(ctx context.Context) ([]string, error) {
+				result := make([]string, 0, 2)
+				for range 2 {
+					next, err := s.generateInvoiceNumber(ctx, namespace, commitMode)
+					if err != nil {
+						return nil, err
+					}
+
+					result = append(result, next)
+				}
+
+				return result, nil
+			})
+			s.Require().NoError(err)
+			s.Equal([]string{"INV-ACIN-1", "INV-ACIN-2"}, allocated)
+
+			next, err := s.generateInvoiceNumber(s.T().Context(), namespace, commitMode)
+			s.Require().NoError(err)
+			s.Equal("INV-ACIN-3", next)
+		})
+	}
+}
+
+func (s *SequenceServiceSuite) TestConcurrentAllocationsAreUnique() {
+	// given:
+	// - both commit modes backed by the real sequence adapter
+	// - one sequence scope with no existing allocation row
+	// when:
+	// - concurrent callers allocate numbers through the sequence service
+	// then:
+	// - every number from 1 through allocationCount is returned exactly once
+	const allocationCount = 20
+
+	type allocationResult struct {
+		next string
+		err  error
+	}
+
+	for _, commitMode := range []sequence.CommitMode{
+		sequence.CommitModeWithCaller,
+		sequence.CommitModeIndependent,
+	} {
+		s.Run(string(commitMode), func() {
+			namespace := ulid.Make().String()
+			ctx := s.T().Context()
+			results := make(chan allocationResult, allocationCount)
+
+			for range allocationCount {
+				go func() {
+					var next string
+					var err error
+
+					if commitMode == sequence.CommitModeWithCaller {
+						next, err = transaction.Run(ctx, s.adapter, func(ctx context.Context) (string, error) {
+							return s.generateInvoiceNumber(ctx, namespace, commitMode)
+						})
+					} else {
+						next, err = s.generateInvoiceNumber(ctx, namespace, commitMode)
+					}
+
+					results <- allocationResult{next: next, err: err}
+				}()
+			}
+
+			allocated := make([]string, 0, allocationCount)
+			for range allocationCount {
+				select {
+				case <-ctx.Done():
+					s.T().Fatalf("test context canceled before allocations completed: %v", ctx.Err())
+				case result := <-results:
+					s.Require().NoError(result.err)
+					allocated = append(allocated, result.next)
+				}
+			}
+
+			s.Require().Len(lo.Uniq(allocated), allocationCount)
+
+			expected := lo.Map(lo.RangeFrom(1, allocationCount), func(id int, _ int) string {
+				return "INV-ACIN-" + strconv.Itoa(id)
+			})
+			s.ElementsMatch(expected, allocated)
+		})
+	}
+}
+
+func (s *SequenceServiceSuite) generateInvoiceNumber(ctx context.Context, namespace string, commitMode sequence.CommitMode) (string, error) {
+	return s.service.GenerateInvoiceSequenceNumber(ctx, sequence.GenerationInput{
+		Namespace:    namespace,
+		CustomerName: "Acme Inc",
+		Currency:     currencyx.Code("USD"),
+	}, sequence.Definition{
+		Prefix:         "INV",
+		SuffixTemplate: "{{.CustomerPrefix}}-{{.NextSequenceNumber}}",
+		Scope:          "invoices/test",
+		CommitMode:     commitMode,
+	})
+}
+
+func TestSequenceServiceSuite(t *testing.T) {
+	suite.Run(t, new(SequenceServiceSuite))
 }

--- a/pkg/framework/transaction/context.go
+++ b/pkg/framework/transaction/context.go
@@ -16,6 +16,10 @@ func GetDriverFromContext(ctx context.Context) (Driver, error) {
 	return tx, nil
 }
 
+func withDriver(ctx context.Context, tx Driver) context.Context {
+	return context.WithValue(ctx, contextKey, tx)
+}
+
 type DriverNotFoundError struct{}
 
 func (e *DriverNotFoundError) Error() string {

--- a/pkg/framework/transaction/context_test.go
+++ b/pkg/framework/transaction/context_test.go
@@ -1,0 +1,60 @@
+package transaction
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testContextKey struct{}
+
+func TestRunInNewTransactionShadowsParentTransaction(t *testing.T) {
+	parent := context.WithValue(t.Context(), testContextKey{}, "kept")
+	parent, err := SetDriverOnContext(parent, noopDriver{})
+	require.NoError(t, err)
+
+	createdDriver := &noopDriver{}
+	creator := &noopCreator{driver: createdDriver}
+
+	_, err = RunInNewTransaction(parent, creator, func(ctx context.Context) (interface{}, error) {
+		require.Equal(t, "kept", ctx.Value(testContextKey{}))
+
+		driver, err := GetDriverFromContext(ctx)
+		require.NoError(t, err)
+		require.Same(t, createdDriver, driver)
+
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.True(t, creator.called)
+
+	driver, err := GetDriverFromContext(parent)
+	require.NoError(t, err)
+	require.NotEqual(t, createdDriver, driver)
+}
+
+type noopDriver struct{}
+
+func (noopDriver) Commit() error {
+	return nil
+}
+
+func (noopDriver) Rollback() error {
+	return nil
+}
+
+func (noopDriver) SavePoint() error {
+	return nil
+}
+
+type noopCreator struct {
+	called bool
+	driver Driver
+}
+
+func (n *noopCreator) Tx(ctx context.Context) (context.Context, Driver, error) {
+	n.called = true
+
+	return ctx, n.driver, nil
+}

--- a/pkg/framework/transaction/transaction.go
+++ b/pkg/framework/transaction/transaction.go
@@ -49,6 +49,34 @@ func Run[R any](ctx context.Context, creator Creator, cb func(ctx context.Contex
 	})
 }
 
+// RunInNewTransaction starts and commits a transaction independently of any
+// transaction in ctx. For Ent-backed adapters, it acquires a separate database
+// connection and shadows the caller's transaction in the callback.
+//
+// WARNING: The callback's writes are not atomic with the caller. They remain
+// committed if the caller later rolls back, and the callback cannot observe the
+// caller's uncommitted writes. Calling this while the caller holds locks needed
+// by the callback can deadlock. Concurrent use can also exhaust the connection
+// pool because an operation may hold one connection while acquiring another.
+//
+// Use only when the domain explicitly requires a durable side effect outside
+// the caller's transaction and the visibility, locking, and connection-pool
+// risks have been reviewed.
+func RunInNewTransaction[R any](ctx context.Context, creator Creator, cb func(ctx context.Context) (R, error)) (R, error) {
+	var def R
+
+	ctx, tx, err := creator.Tx(ctx)
+	if err != nil {
+		return def, fmt.Errorf("failed to start transaction: %w", err)
+	}
+
+	ctx = withDriver(ctx, tx)
+
+	return manage(ctx, tx, func(ctx context.Context, tx Driver) (R, error) {
+		return cb(ctx)
+	})
+}
+
 // Returns the current transaction from the context or creates a new one
 func getTx(ctx context.Context, creator Creator) (context.Context, Driver, error) {
 	if tx, err := GetDriverFromContext(ctx); err == nil {

--- a/test/app/testenv.go
+++ b/test/app/testenv.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
@@ -282,7 +283,11 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 	})
 	require.NoError(t, err)
 
-	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+	billingSequenceService, err := billingsequenceservice.New(billingsequenceservice.Config{
+		Adapter: billingSequenceAdapter,
+		Meter:   metricnoop.NewMeterProvider().Meter("test"),
+	})
+	require.NoError(t, err)
 
 	// Enable unitConfig rating across the shared test env so the suite validates
 	// there is no regression from the flag being on (config-less lines must rate

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/app/config"
@@ -248,7 +249,11 @@ func (s *BaseSuite) setupSuite(opts SetupSuiteOptions) {
 	})
 	require.NoError(t, err)
 
-	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+	billingSequenceService, err := billingsequenceservice.New(billingsequenceservice.Config{
+		Adapter: billingSequenceAdapter,
+		Meter:   metricnoop.NewMeterProvider().Meter("test"),
+	})
+	require.NoError(t, err)
 	s.SequenceService = billingSequenceService
 
 	billingService, err := billingservice.New(billingservice.Config{

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/app/config"
@@ -415,7 +416,13 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		return nil, fmt.Errorf("failed to create billing sequence adapter: %w", err)
 	}
 
-	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+	billingSequenceService, err := billingsequenceservice.New(billingsequenceservice.Config{
+		Adapter: billingSequenceAdapter,
+		Meter:   metricnoop.NewMeterProvider().Meter("test"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create billing sequence service: %w", err)
+	}
 
 	billingService, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
@@ -93,7 +94,11 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 	})
 	require.NoError(t, err)
 
-	billingSequenceService := billingsequenceservice.New(billingSequenceAdapter)
+	billingSequenceService, err := billingsequenceservice.New(billingsequenceservice.Config{
+		Adapter: billingSequenceAdapter,
+		Meter:   metricnoop.NewMeterProvider().Meter("test"),
+	})
+	require.NoError(t, err)
 
 	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
 		Client: deps.DBDeps.DBClient,


### PR DESCRIPTION
## Summary

- Add an explicit commit mode to billing sequence definitions so allocations can either follow the caller transaction or commit independently.
- Allocate sequence values with one atomic PostgreSQL upsert and keep gathering/draft allocations independent while custom-invoicing and sandbox allocations remain caller-bound.
- Add allocation latency metrics, transaction safety documentation, and service-level coverage for rollback, commit, and concurrent uniqueness behavior.

## Why

Previously, sequence allocation participated in the surrounding invoice transaction. The sequence row for a namespace and scope could therefore remain locked for the full invoice operation, serializing otherwise independent invoice work.

Independent allocation keeps contention limited to the allocation itself. The deliberate tradeoff is that invoice numbers are not guaranteed to be contiguous: a caller rollback can leave a gap, but an allocated number is not reused.

This is a follow-up to #4676.

## Transaction considerations

`transaction.RunInNewTransaction` is intentionally exceptional. For Ent-backed adapters it starts a separate transaction on another pooled database connection. The callback cannot observe caller-uncommitted writes, and concurrent callers can add connection-pool pressure. The sequence callback only uses in-memory inputs and touches the sequence table, so it does not depend on caller-held customer or invoice locks.

A local OpenMeter Cloud dual-schema harness verified caller commit/rollback behavior and concurrent uniqueness using Cloud's shared Cloud/OpenMeter Ent driver. It also confirmed the additional pooled-connection requirement.

## Validation

- `nix develop --impure .#ci -c make lint`
- `nix develop --impure .#ci -c make test-nocache`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes billing sequence allocation to reduce long-lived invoice sequence locks. The main changes are:

- Adds explicit commit modes for billing sequence definitions.
- Moves gathering and draft invoice number allocation into independent transactions.
- Replaces sequence allocation with one atomic PostgreSQL upsert.
- Adds allocation duration metrics and updates DI wiring.
- Adds tests for rollback, commit, and concurrent allocation behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The highest-risk transaction and allocation paths have targeted coverage for rollback, commit, and concurrent uniqueness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/sequence/adapter/seq.go | Replaces the sequence row lock/read/update flow with an atomic upsert that returns the allocated number. |
| openmeter/billing/sequence/service/service.go | Adds commit-mode dispatch, allocation metrics, and constructor validation for the sequence service. |
| pkg/framework/transaction/transaction.go | Adds a helper for starting a transaction that shadows any transaction already on the caller context. |
| openmeter/billing/sequence/sequence.go | Adds required sequence commit modes and sets the built-in gathering and draft definitions to independent allocation. |
| app/common/billing.go | Threads the metric meter into billing sequence service construction and billing registry wiring. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Generate invoice sequence number] --> B[Validate sequence definition]
    B --> C{Commit mode}
    C -->|with_caller| D[Allocate in caller transaction]
    C -->|independent| E[Start independent transaction]
    E --> F[Allocate sequence number]
    D --> G[Atomic upsert returns next value]
    F --> G
    G --> H[Render invoice number]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Generate invoice sequence number] --> B[Validate sequence definition]
    B --> C{Commit mode}
    C -->|with_caller| D[Allocate in caller transaction]
    C -->|independent| E[Start independent transaction]
    E --> F[Allocate sequence number]
    D --> G[Atomic upsert returns next value]
    F --> G
    G --> H[Render invoice number]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): allocate invoice sequences..."](https://github.com/openmeterio/openmeter/commit/9d3748738bebf145b4b753537e4f88d1c411ac01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43256138)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sequence commit modes for caller-bound or independent commits.
  * Added independent transaction support for sequence allocation.
  * Added OpenTelemetry metrics for tracking allocation duration.

* **Bug Fixes**
  * Improved concurrent sequence allocation to ensure unique numbers.
  * Preserved expected sequence behavior across transaction commits and rollbacks.

* **Tests**
  * Added coverage for commit modes, rollback behavior, concurrency, and transaction isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->