### PR TITLE
chore: bump version of service deps in docker compose

### DIFF
--- a/docker-compose.base.yaml
+++ b/docker-compose.base.yaml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: confluentinc/cp-kafka:8.0.3@sha256:db5eac24a1d15a1689fa89642ef97a7e3bc4f55ad5159a07b213c4dc7d0114e3
+    image: confluentinc/cp-kafka:8.2.2@sha256:8e01c0305844d6c05bfb8e86479f5f363bb6a53497625395943a9da780de67ce
     environment:
       CLUSTER_ID: ca497efe-9f82-4b84-890b-d9969a9a2e1c
       KAFKA_BROKER_ID: 0
@@ -39,7 +39,7 @@ services:
       retries: 30
 
   clickhouse:
-    image: clickhouse/clickhouse-server:25.12.3-alpine@sha256:74da41cd61db84f652c6364fd30d59e19b7276d34f7c82515f5f0e70d6f325da
+    image: clickhouse/clickhouse-server:26.4-distroless@sha256:cac600869f9e0abc00af3aff60855009326b30acf76702f239ff3459c78208db
     environment:
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: default
@@ -56,7 +56,7 @@ services:
       retries: 30
 
   ch-ui:
-    image: ghcr.io/caioricciuti/ch-ui:1.6.4@sha256:556926565654c7d7177f4b92788f5b42a98b14f3652815b1d94db4711dc48f5b
+    image: ghcr.io/caioricciuti/ch-ui:v2.5.3@sha256:d31f4d4ac8ec010eac1f1e46af060032e39b8f31435a5b578efc245cf8b8d1de
     profiles:
       - dev
     depends_on:
@@ -70,7 +70,7 @@ services:
   # Deduplication
   # docker compose --profile redis up
   redis:
-    image: redis:7.4.7@sha256:c6e4a82ce60b829a72a21cc4ad4c1c274fa6962eb0d6ac698e8157cbc3fe16a4
+    image: redis:8.8.0-alpine3.23@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
     command:
       [
         "redis-server",
@@ -90,7 +90,7 @@ services:
   # Development
   # docker compose --profile dev up
   kafka-ui:
-    image: ghcr.io/kafbat/kafka-ui:328aedb
+    image: ghcr.io/kafbat/kafka-ui:v1.5.0@sha256:7cda86a33344160309fdb65146332e4da65db81a945614f2fe32e210803f6fd1
     depends_on:
       - kafka
     environment:
@@ -107,7 +107,7 @@ services:
   # Credit
   # docker compose --profile postgres up
   postgres:
-    image: postgres:14.20-alpine3.23@sha256:14f02666642586a64d6fae8ef42d479fd76456a77c73ae8a626b8fe323b76d22
+    image: postgres:14.23-alpine3.24@sha256:f1341c01408dc7278e9d365ed4f860cd3f87dd16b4464ac326fc0f422083a579
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
@@ -125,7 +125,7 @@ services:
       retries: 30
 
   svix:
-    image: svix/svix-server:v1.84.1@sha256:35dc9d4884073272e55f8e2f60a7a37983e535b7e7994db56a99c87cdf9b1a59
+    image: svix/svix-server:v1.96@sha256:cd3a1c68b65c4ed32552eaaedea6cf323122428db73c43438a832b314e8e0ac8
     environment:
       WAIT_FOR: "true" # We want to wait for the default services
       SVIX_REDIS_DSN: "redis://redis:6379"


### PR DESCRIPTION
## Overview

Bump version of service deps in docker compose.

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service container images to newer pinned versions for improved reliability and consistency across the development environment.
  * Refreshed images for Kafka, ClickHouse, Redis, PostgreSQL, Svix, and related management interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps Docker Compose service dependency images. The main changes are:

- Kafka moves from `confluentinc/cp-kafka:8.0.3` to `8.2.2`.
- ClickHouse moves from an Alpine image to `26.4-distroless`.
- ch-ui, Redis, kafka-ui, Postgres, and Svix get newer pinned images.

<h3>Confidence Score: 4/5</h3>

The compose dependency stack can get stuck waiting for ClickHouse health.

- The ClickHouse image now uses a distroless variant.
- The existing healthcheck still depends on `wget`, which is not available there.
- Other image bumps did not show a concrete changed-code break from the context already inspected.

docker-compose.base.yaml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker-compose.base.yaml | Updates pinned compose dependency images; the ClickHouse distroless image conflicts with the current healthcheck command. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocker-compose.base.yaml%3A42%0A**Distroless%20Healthcheck%20Missing%20Wget**%0A%0AWhen%20the%20ClickHouse%20service%20uses%20the%20new%20distroless%20image%2C%20the%20existing%20%60wget%20--spider%60%20healthcheck%20cannot%20run%20because%20that%20image%20does%20not%20include%20%60wget%60.%20Compose%20marks%20ClickHouse%20unhealthy%2C%20so%20services%20that%20wait%20for%20a%20healthy%20ClickHouse%20dependency%20can%20stay%20blocked%20even%20though%20the%20database%20process%20is%20running.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4683&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22chore%2Fbump-compose%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fbump-compose%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocker-compose.base.yaml%3A42%0A**Distroless%20Healthcheck%20Missing%20Wget**%0A%0AWhen%20the%20ClickHouse%20service%20uses%20the%20new%20distroless%20image%2C%20the%20existing%20%60wget%20--spider%60%20healthcheck%20cannot%20run%20because%20that%20image%20does%20not%20include%20%60wget%60.%20Compose%20marks%20ClickHouse%20unhealthy%2C%20so%20services%20that%20wait%20for%20a%20healthy%20ClickHouse%20dependency%20can%20stay%20blocked%20even%20though%20the%20database%20process%20is%20running.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4683&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docker-compose.base.yaml:42
**Distroless Healthcheck Missing Wget**

When the ClickHouse service uses the new distroless image, the existing `wget --spider` healthcheck cannot run because that image does not include `wget`. Compose marks ClickHouse unhealthy, so services that wait for a healthy ClickHouse dependency can stay blocked even though the database process is running.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump version of service deps in d..."](https://github.com/openmeterio/openmeter/commit/269aee98e9b339f6050ee3d1e3d61385be29dad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43285315)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->