### PR TITLE
fix: optimize customer usage attribution lookup

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -512,22 +512,11 @@ func (a *adapter) GetCustomerByUsageAttribution(ctx context.Context, input custo
 		now := clock.Now().UTC()
 
 		query := repo.db.Customer.Query().
-			Where(customerdb.Namespace(input.Namespace)).
 			Where(
-				customerdb.Or(
-					// We lookup the customer by subject key in the subjects table
-					customerdb.HasSubjectsWith(
-						customersubjectsdb.SubjectKey(input.Key),
-						customersubjectsdb.Or(
-							customersubjectsdb.DeletedAtIsNil(),
-							customersubjectsdb.DeletedAtGT(now),
-						),
-					),
-					// Or else we lookup the customer by key in the customers table
-					customerdb.Key(input.Key),
-				),
-			).
-			Where(customerdb.DeletedAtIsNil())
+				customerdb.Namespace(input.Namespace),
+				customerdb.DeletedAtIsNil(),
+				customerMatchesUsageAttributionKey(input.Namespace, input.Key, now),
+			)
 		query = WithSubjects(query, now)
 		if slices.Contains(input.Expands, customer.ExpandSubscriptions) {
 			query = WithActiveSubscriptions(query, now)
@@ -550,6 +539,78 @@ func (a *adapter) GetCustomerByUsageAttribution(ctx context.Context, input custo
 
 		return CustomerFromDBEntity(*customerEntity, input.Expands)
 	})
+}
+
+// customerMatchesUsageAttributionKey resolves a customer key before a subject
+// key while keeping both lookup branches independently indexable. The returned
+// candidate is applied to the outer customer query as:
+//
+//	WHERE customers.id IN (
+//	    SELECT matches.id
+//	    FROM (
+//	        SELECT c.id, 0 AS lookup_priority
+//	        FROM customers AS c
+//	        WHERE c.namespace = $1
+//	          AND c.key = $2
+//	          AND c.deleted_at IS NULL
+//
+//	        UNION ALL
+//
+//	        SELECT c.id, 1 AS lookup_priority
+//	        FROM customer_subjects AS cs
+//	        JOIN customers AS c ON c.id = cs.customer_id
+//	        WHERE cs.namespace = $1
+//	          AND cs.subject_key = $2
+//	          AND (cs.deleted_at IS NULL OR cs.deleted_at > $3)
+//	          AND c.namespace = $1
+//	          AND c.deleted_at IS NULL
+//	    ) AS matches
+//	    ORDER BY matches.lookup_priority
+//	    LIMIT 1
+//	)
+func customerMatchesUsageAttributionKey(namespace, key string, at time.Time) predicate.Customer {
+	return func(s *sql.Selector) {
+		keyCustomerTable := sql.Table(customerdb.Table).As("customer_by_key")
+		customerKeyMatch := sql.Select(keyCustomerTable.C(customerdb.FieldID)).
+			AppendSelectExprAs(sql.Expr("0"), "lookup_priority").
+			From(keyCustomerTable).
+			Where(sql.And(
+				sql.EQ(keyCustomerTable.C(customerdb.FieldNamespace), namespace),
+				sql.EQ(keyCustomerTable.C(customerdb.FieldKey), key),
+				sql.IsNull(keyCustomerTable.C(customerdb.FieldDeletedAt)),
+			))
+
+		customerSubjectsTable := sql.Table(customersubjectsdb.Table).As("customer_subjects")
+		subjectCustomerTable := sql.Table(customerdb.Table).As("customer_by_subject")
+		subjectKeyMatch := sql.Select(subjectCustomerTable.C(customerdb.FieldID)).
+			AppendSelectExprAs(sql.Expr("1"), "lookup_priority").
+			From(customerSubjectsTable).
+			Join(subjectCustomerTable).
+			On(
+				subjectCustomerTable.C(customerdb.FieldID),
+				customerSubjectsTable.C(customersubjectsdb.FieldCustomerID),
+			).
+			Where(sql.And(
+				sql.EQ(customerSubjectsTable.C(customersubjectsdb.FieldNamespace), namespace),
+				sql.EQ(customerSubjectsTable.C(customersubjectsdb.FieldSubjectKey), key),
+				sql.Or(
+					sql.IsNull(customerSubjectsTable.C(customersubjectsdb.FieldDeletedAt)),
+					sql.GT(customerSubjectsTable.C(customersubjectsdb.FieldDeletedAt), at),
+				),
+				sql.EQ(subjectCustomerTable.C(customerdb.FieldNamespace), namespace),
+				sql.IsNull(subjectCustomerTable.C(customerdb.FieldDeletedAt)),
+			))
+
+		candidates := customerKeyMatch.
+			UnionAll(subjectKeyMatch).
+			As("usage_attribution_matches")
+		preferredCustomerID := sql.Select(candidates.C(customerdb.FieldID)).
+			From(candidates).
+			OrderBy(candidates.C("lookup_priority")).
+			Limit(1)
+
+		s.Where(sql.In(s.C(customerdb.FieldID), preferredCustomerID))
+	}
 }
 
 // GetCustomersByUsageAttribution resolves multiple customers by usage attribution keys in a single query.

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -391,6 +391,194 @@ func customerIDs(customers []customer.Customer) []string {
 	})
 }
 
+func TestGetCustomerByUsageAttribution(t *testing.T) {
+	t.Run("MatchByCustomerKey", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+
+		got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "cust-key",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, id, got.ID)
+		require.NotNil(t, got.UsageAttribution)
+		assert.Equal(t, []string{"subj-1"}, got.UsageAttribution.SubjectKeys)
+	})
+
+	t.Run("MatchBySubjectKey", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1", "subj-2")
+
+		got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "subj-2",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, id, got.ID)
+		require.NotNil(t, got.UsageAttribution)
+		assert.Equal(t, []string{"subj-1", "subj-2"}, got.UsageAttribution.SubjectKeys)
+	})
+
+	t.Run("CustomerKeyTakesPriorityOverAnotherCustomerSubjectKey", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		customerKeyID := env.seedCustomerWithKey(ns, "shared-key", "customer-key-subject")
+		_ = env.seedCustomerWithKey(ns, "subject-owner", "shared-key")
+
+		got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "shared-key",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, customerKeyID, got.ID, "a direct customer-key match must take priority over a subject-key match")
+	})
+
+	t.Run("CustomerMatchedByOwnKeyAndSubjectKeyReturnedOnce", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "shared-key", "shared-key")
+
+		got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "shared-key",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, id, got.ID)
+	})
+
+	t.Run("SoftDeletedCustomerExcluded", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+		_ = freezeTime(t, time.Now())
+
+		require.NoError(t, env.adapter.DeleteCustomer(t.Context(), customer.DeleteCustomerInput{
+			Namespace: ns,
+			ID:        id,
+		}))
+
+		for _, key := range []string{"cust-key", "subj-1"} {
+			_, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+				Namespace: ns,
+				Key:       key,
+			})
+			require.Error(t, err)
+			assert.True(t, models.IsGenericNotFoundError(err))
+		}
+	})
+
+	t.Run("SubjectDeletedInPastExcluded", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+		now := freezeTime(t, time.Now())
+
+		_, err := env.db.CustomerSubjects.Update().
+			Where(
+				customersubjectsdb.Namespace(ns),
+				customersubjectsdb.CustomerID(id),
+				customersubjectsdb.SubjectKey("subj-1"),
+			).
+			SetDeletedAt(now.Add(-time.Minute)).
+			Save(t.Context())
+		require.NoError(t, err)
+
+		_, err = env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "subj-1",
+		})
+		require.Error(t, err)
+		assert.True(t, models.IsGenericNotFoundError(err))
+	})
+
+	t.Run("SubjectDeletedAtLookupTimeExcluded", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+		now := freezeTime(t, time.Now())
+
+		_, err := env.db.CustomerSubjects.Update().
+			Where(
+				customersubjectsdb.Namespace(ns),
+				customersubjectsdb.CustomerID(id),
+				customersubjectsdb.SubjectKey("subj-1"),
+			).
+			SetDeletedAt(now).
+			Save(t.Context())
+		require.NoError(t, err)
+
+		_, err = env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "subj-1",
+		})
+		require.Error(t, err)
+		assert.True(t, models.IsGenericNotFoundError(err))
+	})
+
+	t.Run("SubjectDeletedInFutureIncluded", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+		now := freezeTime(t, time.Now())
+
+		_, err := env.db.CustomerSubjects.Update().
+			Where(
+				customersubjectsdb.Namespace(ns),
+				customersubjectsdb.CustomerID(id),
+				customersubjectsdb.SubjectKey("subj-1"),
+			).
+			SetDeletedAt(now.Add(time.Minute)).
+			Save(t.Context())
+		require.NoError(t, err)
+
+		got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "subj-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, id, got.ID)
+	})
+
+	t.Run("NamespaceIsolation", func(t *testing.T) {
+		env := newTestEnv(t)
+		nsA := ulid.Make().String()
+		nsB := ulid.Make().String()
+		idA := env.seedCustomerWithKey(nsA, "shared-customer-key", "shared-subject-key")
+		_ = env.seedCustomerWithKey(nsB, "shared-customer-key", "shared-subject-key")
+
+		for _, key := range []string{"shared-customer-key", "shared-subject-key"} {
+			got, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+				Namespace: nsA,
+				Key:       key,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, idA, got.ID)
+		}
+	})
+
+	t.Run("UnknownKeyReturnsNotFound", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		_ = env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+
+		_, err := env.adapter.GetCustomerByUsageAttribution(t.Context(), customer.GetCustomerByUsageAttributionInput{
+			Namespace: ns,
+			Key:       "missing",
+		})
+		require.Error(t, err)
+		assert.True(t, models.IsGenericNotFoundError(err))
+	})
+}
+
 func TestGetCustomersByUsageAttribution(t *testing.T) {
 	t.Run("MatchByCustomerKey", func(t *testing.T) {
 		env := newTestEnv(t)

--- a/openmeter/customer/adapter/customer_usage_attribution_benchmark_test.go
+++ b/openmeter/customer/adapter/customer_usage_attribution_benchmark_test.go
@@ -1,0 +1,182 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	customerdb "github.com/openmeterio/openmeter/openmeter/ent/db/customer"
+	customersubjectsdb "github.com/openmeterio/openmeter/openmeter/ent/db/customersubjects"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+const (
+	defaultUsageAttributionBenchmarkCustomers = 100_000
+	usageAttributionBenchmarkSizeEnv          = "CUSTOMER_USAGE_ATTRIBUTION_BENCH_CUSTOMERS"
+)
+
+// BenchmarkCustomerUsageAttributionLookup compares the cross-table OR with the
+// UNION ALL candidate-ID lookup. Seeding is outside the timed sections. Set
+// CUSTOMER_USAGE_ATTRIBUTION_BENCH_CUSTOMERS to change the namespace size from
+// the default 100,000 customers.
+func BenchmarkCustomerUsageAttributionLookup(b *testing.B) {
+	b.StopTimer()
+
+	db := testutils.InitPostgresDB(b)
+	b.Cleanup(func() { db.Close(b) })
+
+	client := db.EntDriver.Client()
+	if err := client.Schema.Create(b.Context()); err != nil {
+		b.Fatalf("create database schema: %v", err)
+	}
+
+	customerCount := usageAttributionBenchmarkCustomerCount(b)
+	namespace := "customer-usage-attribution-benchmark"
+	seedUsageAttributionBenchmark(b, client, namespace, customerCount)
+
+	targetCustomerID := fmt.Sprintf("%026d", customerCount)
+	now := time.Now().UTC()
+
+	lookups := []struct {
+		name string
+		key  string
+	}{
+		{
+			name: "customer_key",
+			key:  fmt.Sprintf("customer-%d", customerCount),
+		},
+		{
+			name: "subject_key",
+			key:  fmt.Sprintf("subject-%d", customerCount),
+		},
+	}
+
+	for _, lookup := range lookups {
+		b.Run(lookup.name, func(b *testing.B) {
+			variants := []struct {
+				name  string
+				query func(context.Context) (string, error)
+			}{
+				{
+					name: "cross_table_or",
+					query: func(ctx context.Context) (string, error) {
+						return client.Customer.Query().
+							Where(
+								customerdb.Namespace(namespace),
+								customerdb.Or(
+									customerdb.HasSubjectsWith(
+										customersubjectsdb.SubjectKey(lookup.key),
+										customersubjectsdb.Or(
+											customersubjectsdb.DeletedAtIsNil(),
+											customersubjectsdb.DeletedAtGT(now),
+										),
+									),
+									customerdb.Key(lookup.key),
+								),
+								customerdb.DeletedAtIsNil(),
+							).
+							FirstID(ctx)
+					},
+				},
+				{
+					name: "union_all",
+					query: func(ctx context.Context) (string, error) {
+						return client.Customer.Query().
+							Where(
+								customerdb.Namespace(namespace),
+								customerdb.DeletedAtIsNil(),
+								customerMatchesUsageAttributionKey(namespace, lookup.key, now),
+							).
+							FirstID(ctx)
+					},
+				},
+			}
+
+			for _, variant := range variants {
+				b.Run(variant.name, func(b *testing.B) {
+					customerID, err := variant.query(b.Context())
+					if err != nil {
+						b.Fatalf("warm up lookup: %v", err)
+					}
+					if customerID != targetCustomerID {
+						b.Fatalf("warm up lookup returned customer %q, expected %q", customerID, targetCustomerID)
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						customerID, err = variant.query(b.Context())
+						if err != nil {
+							b.Fatalf("lookup customer: %v", err)
+						}
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(customerCount), "customers")
+
+					if customerID != targetCustomerID {
+						b.Fatalf("lookup returned customer %q, expected %q", customerID, targetCustomerID)
+					}
+				})
+			}
+		})
+	}
+}
+
+func usageAttributionBenchmarkCustomerCount(b *testing.B) int {
+	b.Helper()
+
+	value := os.Getenv(usageAttributionBenchmarkSizeEnv)
+	if value == "" {
+		return defaultUsageAttributionBenchmarkCustomers
+	}
+
+	count, err := strconv.Atoi(value)
+	if err != nil || count < 1 {
+		b.Fatalf("%s must be a positive integer, got %q", usageAttributionBenchmarkSizeEnv, value)
+	}
+
+	return count
+}
+
+func seedUsageAttributionBenchmark(b *testing.B, client *entdb.Client, namespace string, customerCount int) {
+	b.Helper()
+
+	_, err := client.ExecContext(b.Context(), `
+		INSERT INTO customers (id, namespace, created_at, updated_at, name, key)
+		SELECT
+			lpad(customer_number::text, 26, '0'),
+			$1,
+			now(),
+			now(),
+			'customer-' || customer_number,
+			'customer-' || customer_number
+		FROM generate_series(1, $2) AS customer_number
+	`, namespace, customerCount)
+	if err != nil {
+		b.Fatalf("seed customers: %v", err)
+	}
+
+	_, err = client.ExecContext(b.Context(), `
+		INSERT INTO customer_subjects (namespace, subject_key, created_at, customer_id)
+		SELECT
+			$1,
+			'subject-' || customer_number,
+			now(),
+			lpad(customer_number::text, 26, '0')
+		FROM generate_series(1, $2) AS customer_number
+	`, namespace, customerCount)
+	if err != nil {
+		b.Fatalf("seed customer subjects: %v", err)
+	}
+
+	if _, err = client.ExecContext(b.Context(), "ANALYZE customers"); err != nil {
+		b.Fatalf("analyze customers: %v", err)
+	}
+	if _, err = client.ExecContext(b.Context(), "ANALYZE customer_subjects"); err != nil {
+		b.Fatalf("analyze customer subjects: %v", err)
+	}
+}

--- a/openmeter/testutils/pg_driver.go
+++ b/openmeter/testutils/pg_driver.go
@@ -57,7 +57,7 @@ type TestDB struct {
 	URL       string
 }
 
-func (d *TestDB) Close(t *testing.T) {
+func (d *TestDB) Close(t testing.TB) {
 	if err := d.EntDriver.Close(); err != nil {
 		t.Errorf("failed to close Ent driver: %v", err)
 	}
@@ -101,7 +101,7 @@ func WithDriverOptions(opts []pgdriver.Option) Option {
 	})
 }
 
-func InitPostgresDB(t *testing.T, opts ...Option) *TestDB {
+func InitPostgresDB(t testing.TB, opts ...Option) *TestDB {
 	t.Helper()
 
 	port := os.Getenv("POSTGRES_PORT")
@@ -132,6 +132,7 @@ func InitPostgresDB(t *testing.T, opts ...Option) *TestDB {
 	dbConf := pgtestdb.Custom(t, o.config, o.migrator)
 	if dbConf == nil {
 		t.Fatalf("failed to get db config")
+		return nil
 	}
 
 	postgresDriver, err := pgdriver.NewPostgresDriver(


### PR DESCRIPTION
## Summary

- replace the cross-table `OR` in `GetCustomerByUsageAttribution` with two independently indexable lookup branches combined with `UNION ALL`
- prefer a direct customer-key match over a subject-key match deterministically
- preserve namespace isolation and existing customer/subject soft-deletion semantics
- add focused adapter coverage and a synthetic PostgreSQL benchmark for both lookup routes

## Why

On large customer namespaces, subject-key customer resolution regressed from sub-second behavior to roughly 2-4 seconds per lookup. The old predicate combines a customer-key condition with a correlated subject lookup using a cross-table `OR`. PostgreSQL can respond by scanning the customer namespace and applying the two alternatives as a filter, even though each lookup is independently indexed.

This lookup is used by entitlement and event-resolution paths, so the per-lookup delay can cascade into API timeouts and worker failures. The new query selects one candidate customer ID through indexed branches, then lets the existing Ent query load that customer normally.

## Query plans

Representative local plans below use a synthetic namespace with 100,000 customers and one subject per customer.

### Cross-table OR

```text
Limit (actual rows=1 loops=1)
  -> Seq Scan on customers c (actual rows=1 loops=1)
       Filter: (... ((hashed SubPlan 2) OR (key = 'subject-100000')))
       Rows Removed by Filter: 99999
       SubPlan 2
         -> Index Scan using customer_subjects_subject_key on customer_subjects cs
              Index Cond: (subject_key = 'subject-100000')
Planning Time: 0.745 ms
Execution Time: 28.936 ms
```

The subject lookup uses its index, but the cross-table `OR` still leaves PostgreSQL scanning and filtering the customer namespace.

### UNION ALL candidate lookup

```text
Limit (actual rows=1 loops=1)
  -> Nested Loop (actual rows=1 loops=1)
       -> Limit (actual rows=1 loops=1)
            -> Append (actual rows=1 loops=1)
                 -> Index Scan using customer_namespace_key_active on customers by_key
                      Index Cond: ((namespace = 'benchmark') AND (key = 'subject-100000'))
                 -> Nested Loop (actual rows=1 loops=1)
                      -> Index Scan using customer_subjects_subject_key on customer_subjects cs
                           Index Cond: (subject_key = 'subject-100000')
                      -> Index Scan using customers_pkey on customers by_subject
                           Index Cond: (id = cs.customer_id)
       -> Index Scan using customers_pkey on customers c
            Index Cond: (id = by_key.id)
Planning Time: 0.798 ms
Execution Time: 0.199 ms
```

Both alternatives enter through their existing indexes and the outer customer fetch uses the selected primary key.

## Benchmark

Synthetic local benchmark, 100,000 customers, median of three runs with ten timed iterations per case:

```shell
POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/customer/adapter \
  -run '^$' \
  -bench '^BenchmarkCustomerUsageAttributionLookup$' \
  -benchtime=10x \
  -count=3 \
  -benchmem
```

| Lookup route | Cross-table OR | UNION ALL | Improvement |
|---|---:|---:|---:|
| Customer key | 35.70 ms/op | 3.19 ms/op | 11.2x |
| Subject key | 24.46 ms/op | 0.95 ms/op | 25.7x |

## Correctness coverage

- customer-key and subject-key matches
- deterministic customer-key precedence when a key also identifies another customer's subject
- customer matching through both its own key and subject key
- namespace isolation
- deleted-customer exclusion
- subject deletion before, exactly at, and after the lookup timestamp
- unchanged not-found behavior

## Validation

- `make test`
- `nix develop --impure .#ci -c make lint-go-fast`
- `go test -tags=dynamic ./openmeter/customer/adapter -count=1`
- synthetic benchmark above

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR speeds up customer usage attribution lookup. The main changes are:

- Replaces the cross-table customer/subject `OR` with a `UNION ALL` candidate lookup.
- Gives direct customer-key matches deterministic priority over subject-key matches.
- Adds adapter tests for lookup precedence, namespace isolation, and soft-deletion timing.
- Adds a PostgreSQL benchmark and lets the shared DB test helper accept benchmark handles.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the helper dependency signature.

- The customer lookup keeps the existing namespace and soft-delete behavior.
- The new precedence behavior is covered by direct adapter tests.
- The only follow-up is confirming the PostgreSQL test helper still matches the external helper API.

openmeter/testutils/pg_driver.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/customer/adapter/customer.go | Reworks the single-key usage attribution lookup into an indexed candidate-ID subquery while keeping namespace and soft-delete filters. |
| openmeter/customer/adapter/customer_test.go | Adds focused coverage for direct-key lookup, subject-key lookup, precedence, namespace isolation, deleted customers, deleted subjects, and not-found behavior. |
| openmeter/customer/adapter/customer_usage_attribution_benchmark_test.go | Adds a PostgreSQL-backed benchmark comparing the old cross-table query with the new candidate lookup. |
| openmeter/testutils/pg_driver.go | Generalizes the PostgreSQL test DB helper to `testing.TB` so it can be called from benchmarks. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Ftestutils%2Fpg_driver.go%3A132%0A**Helper%20Type%20May%20Not%20Match**%0A%0A%60InitPostgresDB%60%20now%20passes%20a%20%60testing.TB%60%20interface%20into%20%60pgtestdb.Custom%60.%20If%20that%20dependency's%20%60Custom%60%20function%20is%20typed%20to%20%60*testing.T%60%2C%20every%20package%20that%20imports%20this%20helper%20will%20fail%20to%20compile%20even%20when%20only%20normal%20tests%20call%20it%3B%20the%20benchmark%20support%20needs%20a%20helper%20path%20that%20matches%20the%20dependency's%20accepted%20test%20type.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fcustomer-usage-attribution-benchmark%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcustomer-usage-attribution-benchmark%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Ftestutils%2Fpg_driver.go%3A132%0A**Helper%20Type%20May%20Not%20Match**%0A%0A%60InitPostgresDB%60%20now%20passes%20a%20%60testing.TB%60%20interface%20into%20%60pgtestdb.Custom%60.%20If%20that%20dependency's%20%60Custom%60%20function%20is%20typed%20to%20%60*testing.T%60%2C%20every%20package%20that%20imports%20this%20helper%20will%20fail%20to%20compile%20even%20when%20only%20normal%20tests%20call%20it%3B%20the%20benchmark%20support%20needs%20a%20helper%20path%20that%20matches%20the%20dependency's%20accepted%20test%20type.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4684&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
openmeter/testutils/pg_driver.go:132
**Helper Type May Not Match**

`InitPostgresDB` now passes a `testing.TB` interface into `pgtestdb.Custom`. If that dependency's `Custom` function is typed to `*testing.T`, every package that imports this helper will fail to compile even when only normal tests call it; the benchmark support needs a helper path that matches the dependency's accepted test type.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimize customer usage attribution..."](https://github.com/openmeterio/openmeter/commit/ba602ae5a29d9f2f2af8b2cc39041313fd1d9a0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43288268)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved customer lookup accuracy when usage attribution keys match both customer and subject records.
  * Correctly prioritizes direct customer-key matches and prevents duplicate or cross-namespace results.
  * Handles deleted customers and time-based subject deletion rules correctly.

* **Performance**
  * Optimized usage attribution lookups for faster results at scale.

* **Tests**
  * Added comprehensive coverage and performance benchmarks for customer lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->