### PR TITLE
[DoNotMerge,POC] Add seat upgrade proration correction line

### DIFF
--- a/openmeter/billing/annotations.go
+++ b/openmeter/billing/annotations.go
@@ -1,5 +1,11 @@
 package billing
 
+import (
+	"errors"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
 const (
 	// AnnotationSubscriptionSyncIgnore is used to mark a line or hierarchy as ignored in subscription syncing.
 	// Should be used in case there is a breaking change in the subscription synchronization process, preventing billing
@@ -11,4 +17,33 @@ const (
 	// found line, the sync process will adjust the start of the next line to the end of the previously found line, so that we don't have gaps in the
 	// invoices.
 	AnnotationSubscriptionSyncForceContinuousLines = "billing.subscription.sync.force-continuous-lines"
+
+	// AnnotationInvoiceLineCorrection marks a billing-owned line whose amount reverses part of an immutable invoice line.
+	AnnotationInvoiceLineCorrection = "billing.invoice.line.correction"
+	// AnnotationInvoiceLineCorrectionOfInvoiceID identifies the immutable invoice containing the corrected line.
+	AnnotationInvoiceLineCorrectionOfInvoiceID = "billing.invoice.line.correction.of-invoice-id"
+	// AnnotationInvoiceLineCorrectionOfLineID identifies the immutable invoice line being corrected.
+	AnnotationInvoiceLineCorrectionOfLineID = "billing.invoice.line.correction.of-line-id"
 )
+
+// IsInvoiceLineCorrection reports whether the line has correction semantics. Correction lines keep
+// ordinary prices non-negative and apply the reversing sign during billing-owned line calculation.
+func IsInvoiceLineCorrection(annotations models.Annotations) bool {
+	return annotations.GetBool(AnnotationInvoiceLineCorrection)
+}
+
+func validateInvoiceLineCorrectionAnnotations(annotations models.Annotations) error {
+	if !IsInvoiceLineCorrection(annotations) {
+		return nil
+	}
+
+	if invoiceID, ok := annotations.GetString(AnnotationInvoiceLineCorrectionOfInvoiceID); !ok || invoiceID == "" {
+		return errors.New("correction source invoice id is required")
+	}
+
+	if lineID, ok := annotations.GetString(AnnotationInvoiceLineCorrectionOfLineID); !ok || lineID == "" {
+		return errors.New("correction source line id is required")
+	}
+
+	return nil
+}

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -514,8 +514,99 @@ type reconcileInvoicingStateInput struct {
 	NewAmountAfterProration alpacadecimal.Decimal
 }
 
+type buildFlatFeeCorrectionGatheringLineInput struct {
+	Charge                 flatfee.Charge
+	Run                    flatfee.RealizationRun
+	RetainedServicePeriod  timeutil.ClosedPeriod
+	RetainedProratedAmount alpacadecimal.Decimal
+}
+
+// buildFlatFeeCorrectionGatheringLine creates the customer-facing reversal for the
+// unserved tail of an immutable flat-fee run. The price remains positive; the billing-owned
+// line engine applies the correction sign after rating.
+func buildFlatFeeCorrectionGatheringLine(input buildFlatFeeCorrectionGatheringLineInput) (billing.GatheringLine, error) {
+	if !input.Run.Immutable {
+		return billing.GatheringLine{}, fmt.Errorf("source realization run[%s] must be immutable", input.Run.ID.ID)
+	}
+
+	if input.Run.LineID == nil || *input.Run.LineID == "" {
+		return billing.GatheringLine{}, fmt.Errorf("source realization run[%s] line id is required", input.Run.ID.ID)
+	}
+
+	if input.Run.InvoiceID == nil || *input.Run.InvoiceID == "" {
+		return billing.GatheringLine{}, fmt.Errorf("source realization run[%s] invoice id is required", input.Run.ID.ID)
+	}
+
+	if !input.RetainedServicePeriod.From.Equal(input.Run.ServicePeriod.From) || !input.RetainedServicePeriod.To.Before(input.Run.ServicePeriod.To) {
+		return billing.GatheringLine{}, fmt.Errorf("retained service period must remove a tail from source realization run[%s]", input.Run.ID.ID)
+	}
+
+	currencyCalculator, err := input.Charge.Intent.GetCurrency().Calculator()
+	if err != nil {
+		return billing.GatheringLine{}, fmt.Errorf("getting currency calculator: %w", err)
+	}
+
+	correctionAmount := currencyCalculator.RoundToPrecision(input.Run.AmountAfterProration.Sub(input.RetainedProratedAmount))
+	if !correctionAmount.IsPositive() {
+		return billing.GatheringLine{}, fmt.Errorf("correction amount must be positive")
+	}
+
+	lineIntent := input.Charge.Intent.GetEffectiveIntent()
+	correctionPeriod := timeutil.ClosedPeriod{
+		From: input.RetainedServicePeriod.To,
+		To:   input.Run.ServicePeriod.To,
+	}
+
+	return billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   input.Charge.Namespace,
+				Name:        fmt.Sprintf("%s correction", lineIntent.Name),
+				Description: lineIntent.Description,
+			}),
+			Annotations: models.Annotations{
+				billing.AnnotationInvoiceLineCorrection:            true,
+				billing.AnnotationInvoiceLineCorrectionOfInvoiceID: *input.Run.InvoiceID,
+				billing.AnnotationInvoiceLineCorrectionOfLineID:    *input.Run.LineID,
+				billing.AnnotationSubscriptionSyncIgnore:           true,
+			},
+			ManagedBy:     billing.SystemManagedLine,
+			Engine:        billing.LineEngineTypeInvoice,
+			Currency:      lineIntent.Currency,
+			ServicePeriod: correctionPeriod,
+			InvoiceAt:     lineIntent.InvoiceAt,
+			Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount:      correctionAmount,
+				PaymentTerm: lineIntent.PaymentTerm,
+			})),
+		},
+	}, nil
+}
+
 func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Context, input reconcileInvoicingStateInput) error {
 	currentRun := s.Charge.Realizations.CurrentRun
+
+	if s.InvoiceLineCorrectionsEnabled &&
+		currentRun != nil &&
+		currentRun.Immutable &&
+		input.Op == meta.PatchTypeShrink &&
+		input.NewAmountAfterProration.LessThan(input.OldAmountAfterProration) {
+		s.Charge.Intent = input.Intent
+		s.Charge.State.AmountAfterProration = input.NewAmountAfterProration
+
+		correctionLine, err := buildFlatFeeCorrectionGatheringLine(buildFlatFeeCorrectionGatheringLineInput{
+			Charge:                 s.Charge,
+			Run:                    *currentRun,
+			RetainedServicePeriod:  input.Period,
+			RetainedProratedAmount: input.NewAmountAfterProration,
+		})
+		if err != nil {
+			return fmt.Errorf("creating flat-fee correction line: %w", err)
+		}
+
+		s.AddInvoicePatch(invoiceupdater.NewCreateLinePatch(correctionLine))
+		return nil
+	}
 
 	// TODO(credit-note support): this branch is a temporary fallback for
 	// immutable invoice lines until the line updater can correct them with

--- a/openmeter/billing/charges/flatfee/service/service.go
+++ b/openmeter/billing/charges/flatfee/service/service.go
@@ -82,12 +82,13 @@ func New(config Config) (flatfee.Service, error) {
 }
 
 type service struct {
-	adapter              flatfee.Adapter
-	handler              flatfee.Handler
-	metaAdapter          meta.Adapter
-	locker               *lockr.Locker
-	realizations         *flatfeerealizations.Service
-	creditNotesSupported atomic.Bool
+	adapter                       flatfee.Adapter
+	handler                       flatfee.Handler
+	metaAdapter                   meta.Adapter
+	locker                        *lockr.Locker
+	realizations                  *flatfeerealizations.Service
+	creditNotesSupported          atomic.Bool
+	invoiceLineCorrectionsEnabled atomic.Bool
 }
 
 func (s *service) GetLineEngine() billing.LineEngine {
@@ -106,5 +107,17 @@ func (s *service) SetCreditNotesSupportedByLineUpdater(t *testing.T, supported b
 
 	t.Helper()
 	s.creditNotesSupported.Store(supported)
+	return nil
+}
+
+// SetInvoiceLineCorrectionsEnabled enables the annotation-backed correction-line proof of concept.
+// It is test-only until correction persistence and ledger handling have a production contract.
+func (s *service) SetInvoiceLineCorrectionsEnabled(t *testing.T, enabled bool) error {
+	if t == nil {
+		return errors.New("testing is nil")
+	}
+
+	t.Helper()
+	s.invoiceLineCorrectionsEnabled.Store(enabled)
 	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -22,7 +22,8 @@ type stateMachine struct {
 	Realizations *flatfeerealizations.Service
 	Service      *service
 
-	CreditNotesSupported bool
+	CreditNotesSupported          bool
+	InvoiceLineCorrectionsEnabled bool
 }
 
 type StateMachine = chargestatemachine.StateMachine[flatfee.Charge]
@@ -34,7 +35,8 @@ type StateMachineConfig struct {
 	Realizations *flatfeerealizations.Service
 	Service      *service
 
-	CreditNotesSupported bool
+	CreditNotesSupported          bool
+	InvoiceLineCorrectionsEnabled bool
 }
 
 func (c StateMachineConfig) Validate() error {
@@ -65,10 +67,11 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	}
 
 	out := &stateMachine{
-		Adapter:              config.Adapter,
-		Realizations:         config.Realizations,
-		Service:              config.Service,
-		CreditNotesSupported: config.CreditNotesSupported,
+		Adapter:                       config.Adapter,
+		Realizations:                  config.Realizations,
+		Service:                       config.Service,
+		CreditNotesSupported:          config.CreditNotesSupported,
+		InvoiceLineCorrectionsEnabled: config.InvoiceLineCorrectionsEnabled,
 	}
 
 	machine, err := chargestatemachine.New(chargestatemachine.Config[flatfee.Charge, flatfee.ChargeBase, flatfee.Status]{

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -145,11 +145,12 @@ func mutateBaseIntentPeriodForOverriddenCharge(charge *flatfee.Charge, patch per
 
 func (s *service) getStateMachineConfigForCharge(charge flatfee.Charge) StateMachineConfig {
 	return StateMachineConfig{
-		Charge:               charge,
-		Adapter:              s.adapter,
-		Realizations:         s.realizations,
-		Service:              s,
-		CreditNotesSupported: s.creditNotesSupported.Load(),
+		Charge:                        charge,
+		Adapter:                       s.adapter,
+		Realizations:                  s.realizations,
+		Service:                       s,
+		CreditNotesSupported:          s.creditNotesSupported.Load(),
+		InvoiceLineCorrectionsEnabled: s.invoiceLineCorrectionsEnabled.Load(),
 	}
 }
 

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -490,6 +490,10 @@ func (i GatheringLineBase) Validate() error {
 		}
 	}
 
+	if err := validateInvoiceLineCorrectionAnnotations(i.Annotations); err != nil {
+		errs = append(errs, fmt.Errorf("annotations: %w", err))
+	}
+
 	if i.Subscription != nil {
 		if err := i.Subscription.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("subscription: %w", err))
@@ -516,6 +520,10 @@ func (i GatheringLineBase) Validate() error {
 
 	if i.Price.Type() != productcatalog.FlatPriceType && i.FeatureKey == "" {
 		errs = append(errs, errors.New("feature key is required for non-flat prices"))
+	}
+
+	if IsInvoiceLineCorrection(i.Annotations) && i.Price.Type() != productcatalog.FlatPriceType {
+		errs = append(errs, errors.New("correction lines require a flat price"))
 	}
 
 	return errors.Join(errs...)

--- a/openmeter/billing/lineengine/stdinvoice.go
+++ b/openmeter/billing/lineengine/stdinvoice.go
@@ -74,6 +74,19 @@ func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.Stan
 			return nil, fmt.Errorf("merging generated detailed lines for line[%s]: %w", stdLine.ID, err)
 		}
 
+		if billing.IsInvoiceLineCorrection(stdLine.Annotations) {
+			for idx := range stdLine.DetailedLines {
+				stdLine.DetailedLines[idx].Quantity = stdLine.DetailedLines[idx].Quantity.Neg()
+				stdLine.DetailedLines[idx].Totals = stdLine.DetailedLines[idx].Totals.Neg()
+			}
+
+			if stdLine.UsageBased.Quantity != nil {
+				stdLine.UsageBased.Quantity = lo.ToPtr(stdLine.UsageBased.Quantity.Neg())
+			}
+
+			stdLine.Totals = stdLine.Totals.Neg()
+		}
+
 		if err := stdLine.Validate(); err != nil {
 			return nil, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
 		}

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -125,6 +125,10 @@ func (i StandardLineBase) Validate() error {
 		}
 	}
 
+	if err := validateInvoiceLineCorrectionAnnotations(i.Annotations); err != nil {
+		errs = append(errs, fmt.Errorf("annotations: %w", err))
+	}
+
 	if i.RateCardDiscounts.Percentage != nil {
 		if err := i.RateCardDiscounts.Percentage.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("percentage discounts: %w", err))
@@ -690,7 +694,15 @@ func (i StandardLine) Validate() error {
 		errs = append(errs, err)
 	}
 
-	if err := i.Totals.ValidateTotalNonNegative(); err != nil {
+	if IsInvoiceLineCorrection(i.Annotations) {
+		if i.Totals.Total.IsPositive() {
+			errs = append(errs, errors.New("correction line total must be zero or negative"))
+		}
+
+		if i.UsageBased.Price.Type() != productcatalog.FlatPriceType {
+			errs = append(errs, errors.New("correction lines require a flat price"))
+		}
+	} else if err := i.Totals.ValidateTotalNonNegative(); err != nil {
 		errs = append(errs, fmt.Errorf("totals: %w", err))
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -33,13 +33,23 @@ import (
 	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	addonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
+	addonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	planaddonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
+	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
 	productcatalogsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -55,6 +65,9 @@ type CreditThenInvoiceTestSuite struct {
 
 	BalanceQuerier ledger.BalanceQuerier
 	LedgerResolver *ledgerresolvers.AccountResolver
+	FlatFeeService interface {
+		SetInvoiceLineCorrectionsEnabled(*testing.T, bool) error
+	}
 }
 
 func TestCreditThenInvoiceScenarios(t *testing.T) {
@@ -127,6 +140,9 @@ func (s *CreditThenInvoiceTestSuite) SetupSuite() {
 	s.NoError(err)
 
 	s.Charges = stack.ChargesService
+	s.FlatFeeService = stack.FlatFeeService.(interface {
+		SetInvoiceLineCorrectionsEnabled(*testing.T, bool) error
+	})
 
 	service, err := New(Config{
 		BillingService:          s.BillingService,
@@ -2456,6 +2472,274 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 		s.Equal(billing.ImmutableInvoiceHandlingNotSupportedErrorCode, issue.Code)
 		s.Equal(billing.ComponentName("charges.invoiceupdater"), issue.Component)
 		s.Equal(fmt.Sprintf("lines/%s", approvedInvoice.Lines.OrEmpty()[0].ID), issue.Path)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestSeatUpgradeProrating() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-04-01T00:00:00Z")
+	upgradeAt := s.mustParseTime("2024-04-16T00:00:00Z")
+	periodEnd := s.mustParseTime("2024-05-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+	s.enableProrating()
+	s.NoError(s.FlatFeeService.SetInvoiceLineCorrectionsEnabled(s.T(), true))
+	defer func() {
+		s.NoError(s.FlatFeeService.SetInvoiceLineCorrectionsEnabled(s.T(), false))
+	}()
+
+	var subscriptionView subscription.SubscriptionView
+	var upgradedSubscriptionView subscription.SubscriptionView
+	var seatsAddon *addon.Addon
+	var paidInvoice billing.StandardInvoice
+	var upgradeInvoice billing.StandardInvoice
+
+	s.Run("given a monthly subscription with one paid base seat", func() {
+		// given:
+		// - an allowed-users feature that does not require a meter
+		// - a monthly credit-then-invoice plan with one $10 in-advance flat fee and no feature
+		// - a compatible multi-instance add-on that adds an allowed-users seat for $10
+		// - the subscription has started and its base seat invoice has been paid
+		allowedUsersFeature, err := s.FeatureService.CreateFeature(ctx, feature.CreateFeatureInputs{
+			Namespace: s.Namespace,
+			Name:      "Allowed users",
+			Key:       "allowed-users",
+		})
+		s.NoError(err)
+
+		monthlyCadence := datetime.MustParseDuration(s.T(), "P1M")
+		createdPlan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Seat plan",
+					Key:            "seat-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: monthlyCadence,
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("default", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.FlatFeeRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:  "seat-price",
+									Name: "Base seat",
+									Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+										Amount:      alpacadecimal.NewFromInt(10),
+										PaymentTerm: productcatalog.InAdvancePaymentTerm,
+									}),
+								},
+								BillingCadence: &monthlyCadence,
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		publisher := eventbus.NewMock(s.T())
+		featureResolver, err := featureresolver.New(s.FeatureService)
+		s.NoError(err)
+		addonRepository, err := addonadapter.New(addonadapter.Config{
+			Client: s.DBClient,
+			Logger: slog.Default(),
+		})
+		s.NoError(err)
+		addonService, err := addonservice.New(addonservice.Config{
+			Adapter:         addonRepository,
+			TaxCode:         s.TaxCodeService,
+			Logger:          slog.Default(),
+			Publisher:       publisher,
+			FeatureResolver: featureResolver,
+		})
+		s.NoError(err)
+
+		seatsAddon, err = addonService.CreateAddon(ctx, addon.CreateAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Addon: productcatalog.Addon{
+				AddonMeta: productcatalog.AddonMeta{
+					Name:         "Additional seats",
+					Key:          "additional-seats",
+					Currency:     currency.USD,
+					InstanceType: productcatalog.AddonInstanceTypeMultiple,
+				},
+				RateCards: productcatalog.RateCards{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:  "seat-price",
+							Name: "Additional seat price",
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      alpacadecimal.NewFromInt(10),
+								PaymentTerm: productcatalog.InAdvancePaymentTerm,
+							}),
+						},
+						BillingCadence: &monthlyCadence,
+					},
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:        "allowed-users",
+							Name:       "Allowed users",
+							FeatureKey: lo.ToPtr(allowedUsersFeature.Key),
+							FeatureID:  lo.ToPtr(allowedUsersFeature.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(
+								productcatalog.BooleanEntitlementTemplate{},
+							),
+						},
+						BillingCadence: &monthlyCadence,
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		addonEffectiveFrom := start.Add(-time.Second)
+		seatsAddon, err = addonService.PublishAddon(ctx, addon.PublishAddonInput{
+			NamespacedID: seatsAddon.NamespacedID,
+			EffectivePeriod: productcatalog.EffectivePeriod{
+				EffectiveFrom: &addonEffectiveFrom,
+			},
+		})
+		s.NoError(err)
+
+		planAddonRepository, err := planaddonadapter.New(planaddonadapter.Config{
+			Client: s.DBClient,
+			Logger: slog.Default(),
+		})
+		s.NoError(err)
+		planAddonService, err := planaddonservice.New(planaddonservice.Config{
+			Adapter:   planAddonRepository,
+			Plan:      s.PlanService,
+			Addon:     addonService,
+			Logger:    slog.Default(),
+			Publisher: publisher,
+		})
+		s.NoError(err)
+
+		_, err = planAddonService.CreatePlanAddon(ctx, planaddon.CreatePlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			PlanID:        createdPlan.ID,
+			AddonID:       seatsAddon.ID,
+			FromPlanPhase: "default",
+		})
+		s.NoError(err)
+
+		subscriptionPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, s.Namespace, productcatalogsubscription.PlanRefInput{
+			Key:     createdPlan.Key,
+			Version: lo.ToPtr(createdPlan.Version),
+		})
+		s.NoError(err)
+
+		subscriptionView, err = s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{
+					Custom: &start,
+				},
+				Name: "seat-subscription",
+			},
+			Namespace:  s.Namespace,
+			CustomerID: s.Customer.ID,
+		}, subscriptionPlan)
+		s.NoError(err)
+
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subscriptionView, start))
+		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+			CustomerID: &filter.FilterULID{FilterString: filter.FilterString{Eq: &s.Customer.ID}},
+			Expand:     billing.InvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Require().Len(invoices.Items, 1)
+
+		initialInvoice, err := invoices.Items[0].AsStandardInvoice()
+		s.NoError(err)
+		paidInvoice, err = s.BillingService.ApproveInvoice(ctx, initialInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, paidInvoice.Status)
+		s.Require().Len(paidInvoice.Lines.OrEmpty(), 1)
+		s.Equal(float64(10), paidInvoice.Lines.OrEmpty()[0].Totals.Amount.InexactFloat64())
+	})
+
+	s.Run("when three additional seats are added in the middle of the month", func() {
+		// given:
+		// - the original base seat invoice is already paid
+		// when:
+		// - three instances of the additional-seats add-on are activated halfway through the month
+		// - subscription sync invoices the resulting in-advance flat-fee change
+		clock.FreezeTime(upgradeAt)
+
+		var err error
+		var purchasedAddon subscriptionaddon.SubscriptionAddon
+		upgradedSubscriptionView, purchasedAddon, err = s.SubscriptionWorkflowService.AddAddon(ctx, subscriptionView.Subscription.NamespacedID, subscriptionworkflow.AddAddonWorkflowInput{
+			AddonID:         seatsAddon.ID,
+			InitialQuantity: 3,
+			Timing: subscription.Timing{
+				Custom: &upgradeAt,
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(purchasedAddon.GetInstances(), 1)
+		s.True(purchasedAddon.GetInstances()[0].ActiveFrom.Equal(upgradeAt))
+		s.Require().Len(purchasedAddon.RateCards, 2)
+		s.Require().Len(upgradedSubscriptionView.Phases[0].ItemsByKey["seat-price"], 2)
+		s.Require().Len(upgradedSubscriptionView.Phases[0].ItemsByKey["allowed-users"], 1)
+
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, upgradedSubscriptionView, upgradeAt))
+		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+			CustomerID: &filter.FilterULID{FilterString: filter.FilterString{Eq: &s.Customer.ID}},
+			Expand:     billing.InvoiceExpandAll,
+		})
+		s.NoError(err)
+
+		for _, invoice := range invoices.Items {
+			if invoice.Type() != billing.InvoiceTypeStandard {
+				continue
+			}
+
+			standardInvoice, err := invoice.AsStandardInvoice()
+			s.Require().NoError(err)
+			if standardInvoice.ID != paidInvoice.ID {
+				upgradeInvoice = standardInvoice
+			}
+		}
+
+		s.Require().NotEmpty(upgradeInvoice.ID, "expected the seat upgrade to create an invoice")
+	})
+
+	s.Run("then the upgrade invoice prorates the seats and credits the already paid item", func() {
+		// then:
+		// - the four seats for the remaining half-month are charged as a prorated $20 line
+		// - the unused half of the already-paid $10 base seat is credited as a -$5 line
+		s.DebugDumpInvoice("seat upgrade invoice", upgradeInvoice)
+
+		lines := upgradeInvoice.Lines.OrEmpty()
+		s.Require().Len(lines, 2)
+		proratedSeatsLine, found := lo.Find(lines, func(line *billing.StandardLine) bool {
+			return line.Totals.Amount.Equal(alpacadecimal.NewFromInt(20))
+		})
+		s.Require().True(found, "expected a $20 line for four seats over the remaining half-month")
+		s.Equal(timeutil.ClosedPeriod{From: upgradeAt, To: periodEnd}, proratedSeatsLine.Period)
+
+		correctionLine, found := lo.Find(lines, func(line *billing.StandardLine) bool {
+			return line.Totals.Amount.Equal(alpacadecimal.NewFromInt(-5))
+		})
+		s.Require().True(found, "expected a -$5 line crediting the unused half of the already-paid base seat")
+		s.True(billing.IsInvoiceLineCorrection(correctionLine.Annotations))
+		s.Equal(paidInvoice.ID, correctionLine.Annotations[billing.AnnotationInvoiceLineCorrectionOfInvoiceID])
+		s.Equal(paidInvoice.Lines.OrEmpty()[0].ID, correctionLine.Annotations[billing.AnnotationInvoiceLineCorrectionOfLineID])
+		s.Equal(float64(15), upgradeInvoice.Totals.Amount.InexactFloat64())
 	})
 }
 


### PR DESCRIPTION
## Summary

- add an annotation-backed standard invoice correction-line proof of concept
- emit a `-$5` billing-owned correction when an immutable flat-fee charge is shrunk after the original line was paid
- keep ordinary flat prices non-negative and apply the correction sign in the billing line engine
- cover a mid-month three-seat upgrade that produces a `+$20` replacement line and a `-$5` correction line on one `$15` invoice

## Why

This explores whether seat upgrades can be prorated without mutating the original paid invoice. The original `$10` line remains immutable, while the upgrade invoice references it through correction annotations and offsets the unused half of the billing period.

## POC limitations

- correction behavior is explicitly test-gated
- correction references are annotations rather than typed persisted relationships
- ledger correction or reversal is intentionally a no-op
- the implementation only covers an immutable flat-fee tail shrink
- this is not intended for merge in its current form

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -count=1 -tags=dynamic -run TestCreditThenInvoiceScenarios/TestSeatUpgradeProrating ./openmeter/billing/worker/subscriptionsync/service`
- `POSTGRES_HOST=127.0.0.1 go test -count=1 -tags=dynamic -run TestInvoicableCharges/TestFlatFeeCreditThenInvoiceImmutableProration ./openmeter/billing/charges/service`
- `go test -count=1 -tags=dynamic ./openmeter/billing/lineengine`
- `go vet -tags=dynamic ./openmeter/billing/lineengine ./openmeter/billing/charges/flatfee/service ./openmeter/billing/worker/subscriptionsync/service`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a proof-of-concept correction line for flat-fee seat upgrade proration. The main changes are:

- New invoice-line correction annotations and validation.
- A flat-fee correction gathering line for immutable shrink cases.
- Line-engine sign inversion for annotated correction lines.
- Test-only flag plumbing and a seat-upgrade subscription sync test.

<h3>Confidence Score: 4/5</h3>

The correction path can create repeated credits and accepts the correction marker without enforcing billing ownership.

- Retried or repeated shrink processing can reuse the same immutable run.
- Correction annotations can turn an annotated line negative without a system-managed check.
- Detailed correction totals now carry negative fields that some downstream paths may reject.

openmeter/billing/charges/flatfee/service/creditheninvoice.go; openmeter/billing/gatheringinvoice.go; openmeter/billing/lineengine/stdinvoice.go

<details open><summary><h3>Security Review</h3></summary>

Correction annotations currently behave like a privileged billing sign switch. If user-managed invoice paths can preserve these annotations, they can create negative invoice lines without the billing-owned correction flow.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/annotations.go | Adds correction annotation constants and source-reference validation. |
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Creates correction lines for immutable flat-fee shrink cases, but leaves the same realization run eligible for repeated corrections. |
| openmeter/billing/charges/flatfee/service/service.go | Adds a test-only flag setter for invoice-line corrections. |
| openmeter/billing/charges/flatfee/service/statemachine.go | Carries the correction flag through state machine configuration. |
| openmeter/billing/charges/flatfee/service/triggers.go | Loads the correction flag when constructing charge state machines. |
| openmeter/billing/gatheringinvoice.go | Validates correction annotations on gathering lines, but does not enforce system ownership. |
| openmeter/billing/lineengine/stdinvoice.go | Negates correction line amounts after rating, including detailed-line totals. |
| openmeter/billing/stdinvoiceline.go | Allows negative totals for annotated correction lines while keeping ordinary line totals non-negative. |
| openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go | Adds a subscription sync scenario for a mid-period seat upgrade with a correction line. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Immutable paid flat-fee run is shrunk] --> B{Correction flag enabled}
  B -->|yes| C[Create correction gathering line]
  C --> D[Add create-line invoice patch]
  D --> E[Return with CurrentRun still attached]
  E --> F[Retry or later shrink sees same immutable run]
  F --> C
  C --> G[Line engine negates annotated line totals]
  G --> H[Invoice total is reduced]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Immutable paid flat-fee run is shrunk] --> B{Correction flag enabled}
  B -->|yes| C[Create correction gathering line]
  C --> D[Add create-line invoice patch]
  D --> E[Return with CurrentRun still attached]
  E --> F[Retry or later shrink sees same immutable run]
  F --> C
  C --> G[Line engine negates annotated line totals]
  G --> H[Invoice total is reduced]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aopenmeter%2Fbilling%2Fcharges%2Fflatfee%2Fservice%2Fcreditheninvoice.go%3A607-608%0A**Current%20Run%20Stays%20Correctable**%0A%0AWhen%20this%20branch%20creates%20a%20correction%20line%2C%20it%20returns%20without%20detaching%20or%20otherwise%20marking%20%60s.Charge.Realizations.CurrentRun%60%20as%20corrected.%20A%20retry%20or%20second%20shrink%20can%20reach%20the%20same%20immutable%20run%20again%20and%20create%20another%20correction%20for%20the%20same%20paid%20source%20line%2C%20while%20the%20ignored%20system%20line%20will%20not%20be%20reconciled%20away%20later.%0A%0A%23%23%23%20Issue%202%20of%203%0Aopenmeter%2Fbilling%2Fgatheringinvoice.go%3A522-527%0A**Correction%20Annotation%20Lacks%20Ownership**%0A%0AThe%20validation%20accepts%20correction%20annotations%20based%20only%20on%20source%20IDs%20and%20flat%20price%2C%20but%20the%20line%20engine%20negates%20any%20annotated%20line%20later.%20If%20an%20API%20or%20manual%20gathering-line%20path%20can%20pass%20annotations%20through%2C%20a%20non-system%20line%20can%20become%20a%20negative%20invoice%20line%20and%20reduce%20invoice%20totals%20without%20going%20through%20the%20billing-owned%20correction%20path.%0A%0A%23%23%23%20Issue%203%20of%203%0Aopenmeter%2Fbilling%2Flineengine%2Fstdinvoice.go%3A77-81%0A**Detailed%20Totals%20Become%20Negative**%0A%0AThis%20branch%20negates%20every%20detailed-line%20total%20after%20rating%2C%20but%20the%20standard%20validation%20exception%20only%20checks%20the%20parent%20line%20total.%20Any%20later%20path%20that%20validates%20or%20exports%20detailed%20totals%20with%20the%20existing%20non-negative%20%60Totals.Validate%28%29%60%20contract%20can%20reject%20the%20correction%20invoice%20or%20fail%20external%20sync%20because%20%60Amount%60%2C%20%60ChargesTotal%60%2C%20and%20related%20fields%20are%20now%20negative.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fseat-proration-correction-poc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fseat-proration-correction-poc%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aopenmeter%2Fbilling%2Fcharges%2Fflatfee%2Fservice%2Fcreditheninvoice.go%3A607-608%0A**Current%20Run%20Stays%20Correctable**%0A%0AWhen%20this%20branch%20creates%20a%20correction%20line%2C%20it%20returns%20without%20detaching%20or%20otherwise%20marking%20%60s.Charge.Realizations.CurrentRun%60%20as%20corrected.%20A%20retry%20or%20second%20shrink%20can%20reach%20the%20same%20immutable%20run%20again%20and%20create%20another%20correction%20for%20the%20same%20paid%20source%20line%2C%20while%20the%20ignored%20system%20line%20will%20not%20be%20reconciled%20away%20later.%0A%0A%23%23%23%20Issue%202%20of%203%0Aopenmeter%2Fbilling%2Fgatheringinvoice.go%3A522-527%0A**Correction%20Annotation%20Lacks%20Ownership**%0A%0AThe%20validation%20accepts%20correction%20annotations%20based%20only%20on%20source%20IDs%20and%20flat%20price%2C%20but%20the%20line%20engine%20negates%20any%20annotated%20line%20later.%20If%20an%20API%20or%20manual%20gathering-line%20path%20can%20pass%20annotations%20through%2C%20a%20non-system%20line%20can%20become%20a%20negative%20invoice%20line%20and%20reduce%20invoice%20totals%20without%20going%20through%20the%20billing-owned%20correction%20path.%0A%0A%23%23%23%20Issue%203%20of%203%0Aopenmeter%2Fbilling%2Flineengine%2Fstdinvoice.go%3A77-81%0A**Detailed%20Totals%20Become%20Negative**%0A%0AThis%20branch%20negates%20every%20detailed-line%20total%20after%20rating%2C%20but%20the%20standard%20validation%20exception%20only%20checks%20the%20parent%20line%20total.%20Any%20later%20path%20that%20validates%20or%20exports%20detailed%20totals%20with%20the%20existing%20non-negative%20%60Totals.Validate%28%29%60%20contract%20can%20reject%20the%20correction%20invoice%20or%20fail%20external%20sync%20because%20%60Amount%60%2C%20%60ChargesTotal%60%2C%20and%20related%20fields%20are%20now%20negative.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4685&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
openmeter/billing/charges/flatfee/service/creditheninvoice.go:607-608
**Current Run Stays Correctable**

When this branch creates a correction line, it returns without detaching or otherwise marking `s.Charge.Realizations.CurrentRun` as corrected. A retry or second shrink can reach the same immutable run again and create another correction for the same paid source line, while the ignored system line will not be reconciled away later.

### Issue 2 of 3
openmeter/billing/gatheringinvoice.go:522-527
**Correction Annotation Lacks Ownership**

The validation accepts correction annotations based only on source IDs and flat price, but the line engine negates any annotated line later. If an API or manual gathering-line path can pass annotations through, a non-system line can become a negative invoice line and reduce invoice totals without going through the billing-owned correction path.

### Issue 3 of 3
openmeter/billing/lineengine/stdinvoice.go:77-81
**Detailed Totals Become Negative**

This branch negates every detailed-line total after rating, but the standard validation exception only checks the parent line total. Any later path that validates or exports detailed totals with the existing non-negative `Totals.Validate()` contract can reject the correction invoice or fail external sync because `Amount`, `ChargesTotal`, and related fields are now negative.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add seat proration correction line"](https://github.com/openmeterio/openmeter/commit/464d71cdc979c48332c1262a871f7d8f92c86f8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43295474)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->