### PR TITLE
ci: add stale pull request workflow

### DIFF
--- a/.github/workflows/stale-pull-requests.yaml
+++ b/.github/workflows/stale-pull-requests.yaml
@@ -1,0 +1,59 @@
+name: Stale pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Process inactive pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process inactive pull requests
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues are managed separately; this workflow only handles pull requests.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # CONTRIBUTING.md defines 60 days of inactivity as the closure threshold.
+          # Warn at day 45, then allow 15 days for the author to resume work.
+          days-before-pr-stale: 45
+          days-before-pr-close: 15
+          stale-pr-label: stale
+          exempt-pr-labels: keep-open
+          exempt-draft-pr: false
+
+          stale-pr-message: >-
+            This pull request has been inactive for 45 days. Push a commit or
+            leave a comment describing the next step to remove the `stale`
+            label. Maintainers can apply `keep-open` with a concrete reason when
+            longer-lived work is intentional. This pull request will close
+            automatically after another 15 days without activity.
+          close-pr-message: >-
+            This pull request was closed after 60 days of inactivity. Closing
+            does not reject the idea; reopen it when the work is ready to
+            continue.
+
+          remove-pr-stale-when-updated: true
+          ignore-pr-updates: false
+          delete-branch: false
+
+          # Process the least recently updated pull requests first and cap API
+          # writes so one run cannot flood the repository with notifications.
+          operations-per-run: 20
+          sort-by: updated
+          ascending: true
+          enable-statistics: true


### PR DESCRIPTION
## Summary

- run stale pull request processing daily at midnight UTC
- mark pull requests stale after 45 inactive days and close them 15 days later
- keep issues out of scope, preserve branches, and allow explicit `keep-open` exemptions
- process the oldest updates first with a capped number of API writes
- pin `actions/stale` v10.4.0 by full commit SHA

This enforces the existing 60-day inactivity policy in `CONTRIBUTING.md`. The `stale` and `keep-open` repository labels have already been created.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/stale-pull-requests.yaml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated management of inactive pull requests.
  * Pull requests are marked stale after 45 days and closed 15 days later if no further activity occurs.
  * Added configurable exemptions, status updates, notifications, and manual or daily workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automation for inactive pull requests. The main changes are:

- A daily and manually runnable stale pull request workflow.
- `actions/stale` pinned by commit SHA.
- Pull requests marked stale after 45 inactive days and closed 15 days later.
- Issue handling disabled and branch deletion disabled.
- `keep-open` exemptions and a per-run operations cap.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed workflow.
- The timing matches the documented inactivity policy.
- The workflow disables issue handling and preserves branches as described.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/stale-pull-requests.yaml | Adds the scheduled stale pull request workflow with scoped permissions, stale/close timing, exemptions, and API write limits. |

<sub>Reviews (1): Last reviewed commit: ["ci: add stale pull request workflow"](https://github.com/openmeterio/openmeter/commit/0ce2a2db97575933c6e675e9c3813591fd850cce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43797790)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->