### PR TITLE
fix(spec): makefile

### DIFF
--- a/api/spec/Makefile
+++ b/api/spec/Makefile
@@ -16,7 +16,7 @@ generate: ## Generate OpenAPI spec
 	# Prefix addon operationIds with `product-catalog-` for the v3 MeteringAndBilling output
 	@FILE="packages/aip/output/definitions/metering-and-billing/v3/openapi.MeteringAndBilling.yaml"; \
 	for op in list-addons create-addon update-addon get-addon delete-addon archive-addon publish-addon; do \
-		new_op="$${op/-addon/-product-catalog-addon}"; \
+		new_op="$$(printf '%s' "$$op" | sed 's/-addon/-product-catalog-addon/')"; \
 		OLD_OP="$$op" NEW_OP="$$new_op" yq -i '(.paths[][] | select(.operationId == strenv(OLD_OP)) | .operationId) = strenv(NEW_OP)' "$$FILE"; \
 	done
 	# Strip Go codegen vendor extensions from the v3 MeteringAndBilling output


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API specification generation to apply consistent operation naming for product catalog addon endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the API spec generation Makefile more portable.

- Replaces bash-only string substitution in `api/spec/Makefile`.
- Uses `printf` and `sed` to rewrite addon operation IDs.
- Keeps the same first-match replacement behavior for the listed operations.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new substitution is portable under the default make shell.
- The operation ID rewrite stays equivalent for the current addon operations.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/spec/Makefile | Updates the `generate` target to use a POSIX-compatible operationId substitution. |

<sub>Reviews (1): Last reviewed commit: ["fix(spec): makefile"](https://github.com/openmeterio/openmeter/commit/d0213943ffeb789185d8cc0269a7e678c1a0e5a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44077819)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->