### PR TITLE
feat: default billing invoices to schema level 2

### DIFF
--- a/openmeter/billing/adapter/schemalevel.go
+++ b/openmeter/billing/adapter/schemalevel.go
@@ -15,7 +15,7 @@ var _ billing.SchemaLevelAdapter = (*adapter)(nil)
 
 const (
 	invoiceWriteSchemaLevelID      = "write_schema_level"
-	DefaultInvoiceWriteSchemaLevel = 1
+	DefaultInvoiceWriteSchemaLevel = 2
 )
 
 func (a *adapter) GetInvoiceDefaultSchemaLevel(ctx context.Context) (int, error) {

--- a/openmeter/billing/models/stddetailedline/mixin.go
+++ b/openmeter/billing/models/stddetailedline/mixin.go
@@ -26,8 +26,8 @@ type mixinBase struct {
 
 func (mixinBase) Mixin() []ent.Mixin {
 	return []ent.Mixin{
-		entutils.AnnotationsMixin{},
-		entutils.ResourceMixin{},
+		entutils.AnnotationsMixin{DeprecatedReason: "detailed line annotations are not exposed by the domain model"},
+		entutils.ResourceMixin{MetadataDeprecatedReason: "detailed line metadata is not exposed by the domain model"},
 		totals.Mixin{},
 	}
 }

--- a/openmeter/billing/service/invoiceupdate_test.go
+++ b/openmeter/billing/service/invoiceupdate_test.go
@@ -503,7 +503,7 @@ func TestWithLineEngineInvoiceLineChangesGroupsAPIEditsByEngine(t *testing.T) {
 		StandardInvoiceBase: billing.StandardInvoiceBase{
 			Namespace:   "ns",
 			ID:          "invoice-1",
-			SchemaLevel: 1,
+			SchemaLevel: 2,
 		},
 		Lines: billing.NewStandardInvoiceLines(billing.StandardLines{invoiceLine, chargeLine}),
 	}
@@ -598,7 +598,7 @@ func TestWithLineEngineInvoiceLineChangesPreallocatesCreatedLineID(t *testing.T)
 			Namespace:   "ns",
 			ID:          "invoice-1",
 			Currency:    "USD",
-			SchemaLevel: 1,
+			SchemaLevel: 2,
 		},
 		Lines: billing.NewStandardInvoiceLines(nil),
 	}
@@ -655,7 +655,7 @@ func TestApplyManualInvoiceLineOverridesMarksManualChanges(t *testing.T) {
 			Namespace:   "ns",
 			ID:          "invoice-1",
 			Status:      billing.StandardInvoiceStatusGathering,
-			SchemaLevel: 1,
+			SchemaLevel: 2,
 		},
 		Lines: billing.NewStandardInvoiceLines(billing.StandardLines{originalLine}),
 	}
@@ -889,7 +889,7 @@ func standardInvoicePairForTaxConfigDiffTest(beforeTaxConfig, afterTaxConfig *bi
 		StandardInvoiceBase: billing.StandardInvoiceBase{
 			Namespace:   "ns",
 			ID:          "invoice-1",
-			SchemaLevel: 1,
+			SchemaLevel: 2,
 			Workflow: billing.InvoiceWorkflow{
 				Config: billing.WorkflowConfig{
 					Invoicing: billing.InvoicingConfig{

--- a/openmeter/ent/db/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline.go
@@ -49,10 +49,14 @@ type BillingStandardInvoiceDetailedLine struct {
 	// CreditsApplied holds the value of the "credits_applied" field.
 	CreditsApplied *creditsapplied.CreditsApplied `json:"credits_applied,omitempty"`
 	// Annotations holds the value of the "annotations" field.
+	//
+	// Deprecated: Field "annotations" was marked as deprecated in the schema.
 	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Metadata holds the value of the "metadata" field.
+	//
+	// Deprecated: Field "metadata" was marked as deprecated in the schema.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
@@ -120,9 +120,7 @@ var Columns = []string{
 	FieldPaymentTerm,
 	FieldIndex,
 	FieldCreditsApplied,
-	FieldAnnotations,
 	FieldNamespace,
-	FieldMetadata,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldDeletedAt,
@@ -144,6 +142,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldAnnotations, FieldMetadata} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/chargeflatfeerundetailedline.go
+++ b/openmeter/ent/db/chargeflatfeerundetailedline.go
@@ -48,10 +48,14 @@ type ChargeFlatFeeRunDetailedLine struct {
 	// CreditsApplied holds the value of the "credits_applied" field.
 	CreditsApplied *creditsapplied.CreditsApplied `json:"credits_applied,omitempty"`
 	// Annotations holds the value of the "annotations" field.
+	//
+	// Deprecated: Field "annotations" was marked as deprecated in the schema.
 	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Metadata holds the value of the "metadata" field.
+	//
+	// Deprecated: Field "metadata" was marked as deprecated in the schema.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/openmeter/ent/db/chargeflatfeerundetailedline/chargeflatfeerundetailedline.go
+++ b/openmeter/ent/db/chargeflatfeerundetailedline/chargeflatfeerundetailedline.go
@@ -102,9 +102,7 @@ var Columns = []string{
 	FieldPaymentTerm,
 	FieldIndex,
 	FieldCreditsApplied,
-	FieldAnnotations,
 	FieldNamespace,
-	FieldMetadata,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldDeletedAt,
@@ -126,6 +124,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldAnnotations, FieldMetadata} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline.go
@@ -49,10 +49,14 @@ type ChargeUsageBasedRunDetailedLine struct {
 	// CreditsApplied holds the value of the "credits_applied" field.
 	CreditsApplied *creditsapplied.CreditsApplied `json:"credits_applied,omitempty"`
 	// Annotations holds the value of the "annotations" field.
+	//
+	// Deprecated: Field "annotations" was marked as deprecated in the schema.
 	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Metadata holds the value of the "metadata" field.
+	//
+	// Deprecated: Field "metadata" was marked as deprecated in the schema.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
@@ -124,9 +124,7 @@ var Columns = []string{
 	FieldPaymentTerm,
 	FieldIndex,
 	FieldCreditsApplied,
-	FieldAnnotations,
 	FieldNamespace,
-	FieldMetadata,
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldDeletedAt,
@@ -150,6 +148,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldAnnotations, FieldMetadata} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -643,7 +643,7 @@ var (
 		{Name: "period_end", Type: field.TypeTime, Nullable: true},
 		{Name: "collection_at", Type: field.TypeTime, Nullable: true},
 		{Name: "payment_processing_entered_at", Type: field.TypeTime, Nullable: true},
-		{Name: "schema_level", Type: field.TypeInt, Default: 1},
+		{Name: "schema_level", Type: field.TypeInt, Default: 2},
 		{Name: "tax_app_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "invoicing_app_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "payment_app_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -1129,7 +1129,7 @@ func (BillingInvoice) Fields() []ent.Field {
 			Nillable(),
 
 		// The schema level for writing invoice data (until invoice migrations are complete).
-		field.Int("schema_level").Default(1),
+		field.Int("schema_level").Default(2),
 	}
 }
 

--- a/pkg/framework/entutils/mixins.go
+++ b/pkg/framework/entutils/mixins.go
@@ -52,13 +52,14 @@ func (UniqueResourceMixin) Indexes() []ent.Index {
 // ResourceMixin adds common fields
 type ResourceMixin struct {
 	mixin.Schema
+	MetadataDeprecatedReason string
 }
 
-func (ResourceMixin) Fields() []ent.Field {
+func (m ResourceMixin) Fields() []ent.Field {
 	var fields []ent.Field
 	fields = append(fields, IDMixin{}.Fields()...)
 	fields = append(fields, NamespaceMixin{}.Fields()...)
-	fields = append(fields, MetadataMixin{}.Fields()...)
+	fields = append(fields, MetadataMixin{DeprecatedReason: m.MetadataDeprecatedReason}.Fields()...)
 	fields = append(fields, TimeMixin{}.Fields()...)
 	fields = append(fields,
 		field.String("name"),
@@ -158,33 +159,41 @@ type NamespaceMixinCreator[T any] interface {
 // MetadataMixin adds metadata to the schema
 type MetadataMixin struct {
 	mixin.Schema
+	DeprecatedReason string
 }
 
 // Fields of the IDMixin.
-func (MetadataMixin) Fields() []ent.Field {
-	return []ent.Field{
-		field.JSON("metadata", map[string]string{}).
-			Optional().
-			SchemaType(map[string]string{
-				dialect.Postgres: "jsonb",
-			}),
+func (m MetadataMixin) Fields() []ent.Field {
+	metadata := field.JSON("metadata", map[string]string{}).
+		Optional().
+		SchemaType(map[string]string{
+			dialect.Postgres: "jsonb",
+		})
+	if m.DeprecatedReason != "" {
+		metadata.Deprecated(m.DeprecatedReason)
 	}
+
+	return []ent.Field{metadata}
 }
 
 // AnnotationsMixin adds annotations to the schema
 type AnnotationsMixin struct {
 	mixin.Schema
+	DeprecatedReason string
 }
 
 // Fields of the IDMixin.
-func (AnnotationsMixin) Fields() []ent.Field {
-	return []ent.Field{
-		field.JSON("annotations", models.Annotations{}).
-			Optional().
-			SchemaType(map[string]string{
-				dialect.Postgres: "jsonb",
-			}),
+func (m AnnotationsMixin) Fields() []ent.Field {
+	annotations := field.JSON("annotations", models.Annotations{}).
+		Optional().
+		SchemaType(map[string]string{
+			dialect.Postgres: "jsonb",
+		})
+	if m.DeprecatedReason != "" {
+		annotations.Deprecated(m.DeprecatedReason)
 	}
+
+	return []ent.Field{annotations}
 }
 
 func (AnnotationsMixin) Indexes() []ent.Index {

--- a/test/billing/schemamigration_test.go
+++ b/test/billing/schemamigration_test.go
@@ -174,6 +174,16 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 
 		invoiceID = invoices[0].GetInvoiceID()
 
+		updatedDetailedLines, err := s.DBClient.BillingInvoiceLine.Update().
+			Where(billinginvoiceline.Namespace(namespace)).
+			Where(billinginvoiceline.InvoiceID(invoiceID.ID)).
+			Where(billinginvoiceline.StatusEQ(billing.InvoiceLineStatusDetailed)).
+			SetAnnotations(models.Annotations{"deprecated": true}).
+			SetMetadata(map[string]string{"deprecated": "true"}).
+			Save(ctx)
+		s.Require().NoError(err)
+		s.Require().Equal(2, updatedDetailedLines)
+
 		// Delete all detailed lines under the chosen parent by directly updating the schema-level-1 representation (billing_invoice_lines).
 		deletedAtSet = clock.Now()
 		n, err := s.markAllDetailedChildrenDeleted(ctx, namespace, invoiceID.ID, lineNameDeletedDetailed, deletedAtSet)
@@ -235,12 +245,16 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 		s.Equal(beforeActive, afterActive)
 
 		// Detailed lines copied (2 input lines => 2 detailed fee lines; one is deleted).
-		detailedLineCount, err := s.DBClient.BillingStandardInvoiceDetailedLine.Query().
+		migratedDetailedLines, err := s.DBClient.BillingStandardInvoiceDetailedLine.Query().
 			Where(billingstandardinvoicedetailedline.Namespace(namespace)).
 			Where(billingstandardinvoicedetailedline.InvoiceID(invoiceID.ID)).
-			Count(ctx)
+			All(ctx)
 		s.Require().NoError(err)
-		s.Require().Equal(2, detailedLineCount)
+		s.Require().Len(migratedDetailedLines, 2)
+		for _, detailedLine := range migratedDetailedLines {
+			s.Empty(detailedLine.Annotations)
+			s.Empty(detailedLine.Metadata)
+		}
 
 		// Deleted detailed line is copied (find by deleted_at we set).
 		deletedCopiedCount, err := s.DBClient.BillingStandardInvoiceDetailedLine.Query().

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -242,6 +242,7 @@ func (s *BaseSuite) setupSuite(opts SetupSuiteOptions) {
 	})
 	require.NoError(t, err)
 	s.BillingAdapter = billingAdapter
+	require.NoError(t, billingAdapter.SetInvoiceDefaultSchemaLevel(t.Context(), billingadapter.DefaultInvoiceWriteSchemaLevel))
 
 	billingSequenceAdapter, err := billingsequenceadapter.New(billingsequenceadapter.Config{
 		Client: dbClient,

--- a/tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.down.sql
+++ b/tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.down.sql
@@ -1,0 +1,145 @@
+-- reverse: modify "billing_invoices" table
+ALTER TABLE "billing_invoices" ALTER COLUMN "schema_level" SET DEFAULT 1;
+
+INSERT INTO "billing_invoice_write_schema_levels" ("id", "schema_level")
+VALUES ('write_schema_level', 1)
+ON CONFLICT ("id") DO UPDATE
+SET "schema_level" = EXCLUDED."schema_level";
+
+CREATE OR REPLACE FUNCTION om_func_migrate_customer_invoices_to_schema_level_2(p_customer_id TEXT)
+RETURNS BIGINT
+AS $$
+DECLARE
+    v_updated_invoices BIGINT;
+BEGIN
+    INSERT INTO billing_standard_invoice_detailed_lines (
+        id,
+        annotations,
+        namespace,
+        metadata,
+        created_at,
+        updated_at,
+        deleted_at,
+        name,
+        description,
+        currency,
+        amount,
+        taxes_total,
+        taxes_inclusive_total,
+        taxes_exclusive_total,
+        charges_total,
+        discounts_total,
+        total,
+        service_period_start,
+        service_period_end,
+        quantity,
+        invoicing_app_external_id,
+        child_unique_reference_id,
+        per_unit_amount,
+        category,
+        payment_term,
+        index,
+        invoice_id,
+        parent_line_id,
+        credits_total,
+        credits_applied
+    )
+    SELECT
+        l.id,
+        l.annotations,
+        l.namespace,
+        l.metadata,
+        l.created_at,
+        l.updated_at,
+        l.deleted_at,
+        l.name,
+        l.description,
+        l.currency,
+        l.amount,
+        l.taxes_total,
+        l.taxes_inclusive_total,
+        l.taxes_exclusive_total,
+        l.charges_total,
+        l.discounts_total,
+        l.total,
+        l.period_start AS service_period_start,
+        l.period_end AS service_period_end,
+        l.quantity,
+        l.invoicing_app_external_id,
+        l.child_unique_reference_id,
+        c.per_unit_amount,
+        c.category,
+        c.payment_term,
+        c.index,
+        l.invoice_id,
+        l.parent_line_id,
+        l.credits_total,
+        l.credits_applied
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_flat_fee_line_configs c
+        ON c.id = l.fee_line_config_id
+        AND c.namespace = l.namespace
+    WHERE
+        i.customer_id = p_customer_id
+        AND i.schema_level = 1
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO billing_standard_invoice_detailed_line_amount_discounts (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        child_unique_reference_id,
+        description,
+        reason,
+        invoicing_app_external_id,
+        amount,
+        rounding_amount,
+        source_discount,
+        line_id
+    )
+    SELECT
+        d.id,
+        d.namespace,
+        d.created_at,
+        d.updated_at,
+        d.deleted_at,
+        d.child_unique_reference_id,
+        d.description,
+        d.reason,
+        d.invoicing_app_external_id,
+        d.amount,
+        d.rounding_amount,
+        d.source_discount,
+        d.line_id
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_line_discounts d
+        ON d.line_id = l.id
+        AND d.namespace = l.namespace
+    WHERE
+        i.customer_id = p_customer_id
+        AND i.schema_level = 1
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    UPDATE billing_invoices
+    SET schema_level = 2
+    WHERE
+        customer_id = p_customer_id
+        AND schema_level = 1;
+
+    GET DIAGNOSTICS v_updated_invoices = ROW_COUNT;
+
+    RETURN v_updated_invoices;
+END;
+$$ LANGUAGE plpgsql VOLATILE;

--- a/tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.up.sql
+++ b/tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.up.sql
@@ -1,0 +1,141 @@
+-- modify "billing_invoices" table
+ALTER TABLE "billing_invoices" ALTER COLUMN "schema_level" SET DEFAULT 2;
+
+INSERT INTO "billing_invoice_write_schema_levels" ("id", "schema_level")
+VALUES ('write_schema_level', 2)
+ON CONFLICT ("id") DO UPDATE
+SET "schema_level" = EXCLUDED."schema_level";
+
+CREATE OR REPLACE FUNCTION om_func_migrate_customer_invoices_to_schema_level_2(p_customer_id TEXT)
+RETURNS BIGINT
+AS $$
+DECLARE
+    v_updated_invoices BIGINT;
+BEGIN
+    INSERT INTO billing_standard_invoice_detailed_lines (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        name,
+        description,
+        currency,
+        amount,
+        taxes_total,
+        taxes_inclusive_total,
+        taxes_exclusive_total,
+        charges_total,
+        discounts_total,
+        total,
+        service_period_start,
+        service_period_end,
+        quantity,
+        invoicing_app_external_id,
+        child_unique_reference_id,
+        per_unit_amount,
+        category,
+        payment_term,
+        index,
+        invoice_id,
+        parent_line_id,
+        credits_total,
+        credits_applied
+    )
+    SELECT
+        l.id,
+        l.namespace,
+        l.created_at,
+        l.updated_at,
+        l.deleted_at,
+        l.name,
+        l.description,
+        l.currency,
+        l.amount,
+        l.taxes_total,
+        l.taxes_inclusive_total,
+        l.taxes_exclusive_total,
+        l.charges_total,
+        l.discounts_total,
+        l.total,
+        l.period_start AS service_period_start,
+        l.period_end AS service_period_end,
+        l.quantity,
+        l.invoicing_app_external_id,
+        l.child_unique_reference_id,
+        c.per_unit_amount,
+        c.category,
+        c.payment_term,
+        c.index,
+        l.invoice_id,
+        l.parent_line_id,
+        l.credits_total,
+        l.credits_applied
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_flat_fee_line_configs c
+        ON c.id = l.fee_line_config_id
+        AND c.namespace = l.namespace
+    WHERE
+        i.customer_id = p_customer_id
+        AND i.schema_level = 1
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO billing_standard_invoice_detailed_line_amount_discounts (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        child_unique_reference_id,
+        description,
+        reason,
+        invoicing_app_external_id,
+        amount,
+        rounding_amount,
+        source_discount,
+        line_id
+    )
+    SELECT
+        d.id,
+        d.namespace,
+        d.created_at,
+        d.updated_at,
+        d.deleted_at,
+        d.child_unique_reference_id,
+        d.description,
+        d.reason,
+        d.invoicing_app_external_id,
+        d.amount,
+        d.rounding_amount,
+        d.source_discount,
+        d.line_id
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_line_discounts d
+        ON d.line_id = l.id
+        AND d.namespace = l.namespace
+    WHERE
+        i.customer_id = p_customer_id
+        AND i.schema_level = 1
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    UPDATE billing_invoices
+    SET schema_level = 2
+    WHERE
+        customer_id = p_customer_id
+        AND schema_level = 1;
+
+    GET DIAGNOSTICS v_updated_invoices = ROW_COUNT;
+
+    RETURN v_updated_invoices;
+END;
+$$ LANGUAGE plpgsql VOLATILE;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:dYcsKJwoTpQcsxSs+06+R73lsXc+cAa5+rW89lgBizo=
+h1:q2q3y5w5ZGJ22djQeI+8x1yz6exFby1c4ZYDpzRkpxA=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -229,3 +229,4 @@ h1:dYcsKJwoTpQcsxSs+06+R73lsXc+cAa5+rW89lgBizo=
 20260709134422_add_ledger_internal_fks.up.sql h1:JE6z1+A8Vg64F0hwyr3RnoLXu/BdFKf3JD6wLJM9LG0=
 20260709134500_add_credit_purchase_voided_at.up.sql h1:+LXY/WI+kvHKOCh4VQXdswI7O+PPnqHKk/o7snTxlxk=
 20260709134600_add_ledger_credit_void_records.up.sql h1:o5C0cNz9b50BMgQcn1lp3BtlBYx8ETeOs2m8Ck6OiXc=
+20260714140423_set_billing_invoice_schema_level_2.up.sql h1:4SzI0XyP9hXBxwdeTNEf2r55KY6vDRUgkbaZAK8rwWA=


### PR DESCRIPTION
## Summary

- default newly written billing invoices to schema level 2 in application and Ent configuration
- add one Atlas migration that updates the database defaults without eagerly migrating existing invoices
- replace the lazy customer invoice migration function so deprecated detailed-line annotations and metadata are not copied
- retain the unused detailed-line columns while marking them deprecated in Ent

## Impact

New invoices use the schema-level-2 representation by default. Existing schema-level-1 invoices remain untouched until the existing customer-lock migration trigger runs.

The migration updates both the `billing_invoices.schema_level` default and the singleton write-schema-level record. Its function replacement preserves the current lazy migration behavior and discount copying, while leaving deprecated annotations and metadata behind.

## Validation

- `make test-nocache`
- focused billing, charge adapter, schema migration, and migration up/down tests
- focused `go vet` for billing and billing tests
- Atlas schema diff, migration lint, and checksum validation

Atlas reports only the existing column-alignment warning for migration `20260709134600`; the new migration has no diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New invoices now use schema level 2 by default.
  - Added migration support to upgrade existing invoices and preserve eligible detailed invoice data.

- **Bug Fixes**
  - Deprecated detailed-line annotations and metadata are now clearly identified and removed during migration.

- **Tests**
  - Updated invoice processing and migration coverage for schema level 2 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves billing invoices to schema level 2 by default. The main changes are:

- Application and Ent defaults now write new invoices at schema level 2.
- A migration updates the database default and singleton write-schema-level row.
- The lazy invoice migration stops copying deprecated detailed-line annotations and metadata.
- Ent generated code reflects the deprecated detailed-line fields.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after tightening one migration test.

- The runtime default and database migration paths are consistent.
- The lazy migration update matches the intended deprecated-field behavior.
- One test can miss copied deprecated column values because the query no longer selects them.

test/billing/schemamigration_test.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/adapter/schemalevel.go | Changes the application fallback invoice write schema level from 1 to 2. |
| openmeter/ent/schema/billing.go | Changes the Ent invoice schema-level default to 2. |
| pkg/framework/entutils/mixins.go | Adds optional deprecation support for metadata and annotations mixins. |
| tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.up.sql | Updates schema-level defaults and replaces the lazy migration function. |
| tools/migrate/migrations/20260714140423_set_billing_invoice_schema_level_2.down.sql | Restores schema-level defaults and the previous lazy migration function. |
| test/billing/schemamigration_test.go | Adds migration coverage for deprecated detailed-line fields, but the query does not select those fields. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fbilling%2Fschemamigration_test.go%3A249-253%0A**Deprecated%20Columns%20Stay%20Unchecked**%0A%0AThis%20query%20uses%20the%20default%20Ent%20column%20list%2C%20but%20the%20same%20PR%20marks%20%60annotations%60%20and%20%60metadata%60%20deprecated%2C%20so%20those%20columns%20are%20no%20longer%20selected%20by%20default.%20If%20the%20SQL%20function%20accidentally%20copies%20those%20values%2C%20this%20test%20still%20reads%20empty%20struct%20fields%20and%20passes%20without%20proving%20the%20database%20columns%20were%20cleared.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4709&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fbilling-invoice-schema-level-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbilling-invoice-schema-level-2%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Fbilling%2Fschemamigration_test.go%3A249-253%0A**Deprecated%20Columns%20Stay%20Unchecked**%0A%0AThis%20query%20uses%20the%20default%20Ent%20column%20list%2C%20but%20the%20same%20PR%20marks%20%60annotations%60%20and%20%60metadata%60%20deprecated%2C%20so%20those%20columns%20are%20no%20longer%20selected%20by%20default.%20If%20the%20SQL%20function%20accidentally%20copies%20those%20values%2C%20this%20test%20still%20reads%20empty%20struct%20fields%20and%20passes%20without%20proving%20the%20database%20columns%20were%20cleared.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4709&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/billing/schemamigration_test.go:249-253
**Deprecated Columns Stay Unchecked**

This query uses the default Ent column list, but the same PR marks `annotations` and `metadata` deprecated, so those columns are no longer selected by default. If the SQL function accidentally copies those values, this test still reads empty struct fields and passes without proving the database columns were cleared.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: default billing invoices to schema..."](https://github.com/openmeterio/openmeter/commit/9f2a634f29ed10557d2e17ebfa52ea18f066380c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44149532)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->