### PR TITLE
feat: report overdue billing worker invoices

### DIFF
--- a/app/common/openmeter_billingworker.go
+++ b/app/common/openmeter_billingworker.go
@@ -5,15 +5,22 @@ import (
 	"fmt"
 	"log/slog"
 	"syscall"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/wire"
 	"github.com/oklog/run"
+	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingworker "github.com/openmeterio/openmeter/openmeter/billing/worker"
 	billingworkercollect "github.com/openmeterio/openmeter/openmeter/billing/worker/collect"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics"
+	billingworkermetricsadapter "github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics/adapter"
+	billingworkermetricsservice "github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	watermillkafka "github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/openmeter/watermill/router"
@@ -40,6 +47,8 @@ var BillingWorker = wire.NewSet(
 	NewBillingWorkerOptions,
 	NewBillingWorker,
 	NewBillingCollector,
+	NewBillingWorkerInvoiceMetricsAdapter,
+	NewBillingWorkerInvoiceMetricsService,
 	NewBillingSubscriptionSyncAdapter,
 	NewBillingSubscriptionSyncService,
 	BillingWorkerGroup,
@@ -109,9 +118,34 @@ func NewBillingWorker(workerOptions billingworker.WorkerOptions) (*billingworker
 	return worker, nil
 }
 
+func NewBillingWorkerInvoiceMetricsAdapter(db *entdb.Client, billingAdapter billing.Adapter) (invoicemetrics.Adapter, error) {
+	return billingworkermetricsadapter.New(billingworkermetricsadapter.Config{
+		Client:         db,
+		BillingAdapter: billingAdapter,
+	})
+}
+
+func NewBillingWorkerInvoiceMetricsService(
+	adapter invoicemetrics.Adapter,
+	meter otelmetric.Meter,
+	logger *slog.Logger,
+	billingFsConfig config.BillingFeatureSwitchesConfiguration,
+) (invoicemetrics.Service, error) {
+	return billingworkermetricsservice.New(billingworkermetricsservice.Config{
+		Adapter:            adapter,
+		Meter:              meter,
+		Logger:             logger,
+		ReportInterval:     time.Minute,
+		OverdueThreshold:   10 * time.Minute,
+		QueryTimeout:       30 * time.Second,
+		ExcludedNamespaces: billingFsConfig.NamespaceLockdown,
+	})
+}
+
 func BillingWorkerGroup(
 	ctx context.Context,
 	worker *billingworker.Worker,
+	invoiceMetrics invoicemetrics.Service,
 	telemetryServer TelemetryServer,
 ) run.Group {
 	var group run.Group
@@ -124,6 +158,11 @@ func BillingWorkerGroup(
 	group.Add(
 		func() error { return worker.Run(ctx) },
 		func(err error) { _ = worker.Close() },
+	)
+
+	group.Add(
+		func() error { return invoiceMetrics.Start(ctx) },
+		func(err error) { invoiceMetrics.Stop() },
 	)
 
 	group.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -409,10 +409,32 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	invoicemetricsAdapter, err := common.NewBillingWorkerInvoiceMetricsAdapter(client, adapter)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	invoicemetricsService, err := common.NewBillingWorkerInvoiceMetricsService(invoicemetricsAdapter, meter, logger, billingFeatureSwitchesConfiguration)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	health := common.NewHealthChecker(logger)
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, logger)
 	v4, cleanup8 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
-	group := common.BillingWorkerGroup(ctx, worker, v4)
+	group := common.BillingWorkerGroup(ctx, worker, invoicemetricsService, v4)
 	runner := common.Runner{
 		Group:  group,
 		Logger: logger,

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -76,6 +76,8 @@ type InvoiceAdapter interface {
 type StandardInvoiceAdapter interface {
 	GetStandardInvoiceById(ctx context.Context, input GetStandardInvoiceByIdInput) (StandardInvoice, error)
 	UpdateStandardInvoice(ctx context.Context, input UpdateStandardInvoiceAdapterInput) (StandardInvoice, error)
+	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]StandardInvoice, error)
+	CountStandardInvoicesPendingAdvancement(ctx context.Context, input CountStandardInvoicesPendingAdvancementInput) (int64, error)
 }
 
 type GatheringInvoiceAdapter interface {

--- a/openmeter/billing/adapter/invoice_advancement.go
+++ b/openmeter/billing/adapter/invoice_advancement.go
@@ -1,0 +1,125 @@
+package billingadapter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/sortx"
+)
+
+func invoicePendingAdvancementPredicate(filter billing.InvoicePendingAdvancementFilter) predicate.BillingInvoice {
+	cutoff := filter.AsOf.Add(-filter.MinimumAge)
+
+	// Available actions are cached when an invoice is persisted and do not change
+	// merely because time passes. The scheduled branches detect newly due states;
+	// the cached-action branch remains the fail-safe for other advanceable states.
+	return billinginvoice.And(
+		billinginvoice.StatusNEQ(billing.StandardInvoiceStatusGathering),
+		billinginvoice.Or(
+			// The automatic draft approval period has elapsed.
+			billinginvoice.And(
+				billinginvoice.StatusEQ(billing.StandardInvoiceStatusDraftWaitingAutoApproval),
+				billinginvoice.DraftUntilLTE(cutoff),
+			),
+			// The invoice's quantity collection window has elapsed.
+			billinginvoice.And(
+				billinginvoice.StatusEQ(billing.StandardInvoiceStatusDraftWaitingForCollection),
+				billinginvoice.Or(
+					billinginvoice.CollectionAtLTE(cutoff),
+					billinginvoice.And(
+						billinginvoice.CollectionAtIsNil(),
+						billinginvoice.UpdatedAtLTE(cutoff),
+					),
+				),
+			),
+			// The state machine exposes another immediately advanceable transition;
+			// this is the worker's fail-safe for invoices stuck between stable states.
+			billinginvoice.And(
+				entutils.JSONBKeyExistsInObject(
+					billinginvoice.FieldStatusDetailsCache,
+					"availableActions",
+					string(billing.InvoiceAvailableActionsFilterAdvance),
+				),
+				billinginvoice.UpdatedAtLTE(cutoff),
+			),
+		),
+	)
+}
+
+func (a *adapter) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.StandardInvoice, error) {
+	if err := input.Validate(); err != nil {
+		return nil, billing.ValidationError{Err: err}
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) ([]billing.StandardInvoice, error) {
+		query := tx.db.BillingInvoice.Query().
+			WithBillingInvoiceValidationIssues(func(q *db.BillingInvoiceValidationIssueQuery) {
+				q.Where(billinginvoicevalidationissue.DeletedAtIsNil())
+			}).
+			WithBillingWorkflowConfig(workflowConfigWithTaxCode).
+			Where(
+				billinginvoice.DeletedAtIsNil(),
+				invoicePendingAdvancementPredicate(billing.InvoicePendingAdvancementFilter{
+					AsOf:       input.AsOf,
+					MinimumAge: input.MinimumAge,
+				}),
+			)
+
+		if len(input.Namespaces) > 0 {
+			query.Where(billinginvoice.NamespaceIn(input.Namespaces...))
+		}
+
+		if len(input.IDs) > 0 {
+			query.Where(billinginvoice.IDIn(input.IDs...))
+		}
+
+		query.Order(billinginvoice.ByCreatedAt(entutils.GetOrdering(sortx.OrderDefault)...))
+
+		entities, err := query.All(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list standard invoices pending advancement: %w", err)
+		}
+
+		invoices := make([]billing.StandardInvoice, 0, len(entities))
+		for _, entity := range entities {
+			invoice, err := tx.mapStandardInvoiceFromDB(ctx, entity, billing.StandardInvoiceExpands{})
+			if err != nil {
+				return nil, fmt.Errorf("failed to map standard invoice pending advancement: %w", err)
+			}
+
+			invoices = append(invoices, invoice)
+		}
+
+		return invoices, nil
+	})
+}
+
+func (a *adapter) CountStandardInvoicesPendingAdvancement(ctx context.Context, input billing.CountStandardInvoicesPendingAdvancementInput) (int64, error) {
+	if err := input.Validate(); err != nil {
+		return 0, billing.ValidationError{Err: err}
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (int64, error) {
+		query := tx.db.BillingInvoice.Query().Where(
+			billinginvoice.DeletedAtIsNil(),
+			invoicePendingAdvancementPredicate(input.Filter),
+		)
+
+		if len(input.ExcludedNamespaces) > 0 {
+			query.Where(billinginvoice.NamespaceNotIn(input.ExcludedNamespaces...))
+		}
+
+		count, err := query.Count(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("failed to count standard invoices pending advancement: %w", err)
+		}
+
+		return int64(count), nil
+	})
+}

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -113,6 +113,8 @@ type StandardInvoiceService interface {
 	GetStandardInvoiceById(ctx context.Context, input GetStandardInvoiceByIdInput) (StandardInvoice, error)
 	// ListStandardInvoices lists standard invoices
 	ListStandardInvoices(ctx context.Context, input ListStandardInvoicesInput) (ListStandardInvoicesResponse, error)
+	// ListStandardInvoicesPendingAdvancement lists standard invoices due for automatic advancement.
+	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]StandardInvoice, error)
 	// CreateStandardInvoiceFromGatheringLines creates a standard invoice from the gathering invoice lines.
 	CreateStandardInvoiceFromGatheringLines(ctx context.Context, input CreateStandardInvoiceFromGatheringLinesInput) (*StandardInvoice, error)
 	// RegisterStandardInvoiceHooks registers hooks for standard invoice lifecycle events

--- a/openmeter/billing/service/stdinvoice.go
+++ b/openmeter/billing/service/stdinvoice.go
@@ -160,3 +160,16 @@ func (s *Service) ListStandardInvoices(ctx context.Context, input billing.ListSt
 		TotalCount: resp.TotalCount,
 	}, nil
 }
+
+func (s *Service) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.StandardInvoice, error) {
+	if err := input.Validate(); err != nil {
+		return nil, billing.ValidationError{Err: err}
+	}
+
+	invoices, err := s.adapter.ListStandardInvoicesPendingAdvancement(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("listing standard invoices pending advancement: %w", err)
+	}
+
+	return invoices, nil
+}

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -1090,6 +1090,63 @@ var StandardInvoiceExpandAll = StandardInvoiceExpands{
 	// Deleted lines are not expanded by default
 }
 
+// InvoicePendingAdvancementFilter selects invoices that have been eligible for
+// automatic advancement for at least MinimumAge as of AsOf. Scheduled states
+// use their explicit due timestamp; states without one use the invoice's last
+// update as the start of the pending period.
+type InvoicePendingAdvancementFilter struct {
+	AsOf       time.Time
+	MinimumAge time.Duration
+}
+
+var _ models.Validator = (*InvoicePendingAdvancementFilter)(nil)
+
+func (f InvoicePendingAdvancementFilter) Validate() error {
+	var errs []error
+
+	if f.AsOf.IsZero() {
+		errs = append(errs, errors.New("as of is required"))
+	}
+
+	if f.MinimumAge < 0 {
+		errs = append(errs, errors.New("minimum age cannot be negative"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// ListStandardInvoicesPendingAdvancementInput configures retrieval of standard
+// invoices that are due for automatic advancement.
+type ListStandardInvoicesPendingAdvancementInput struct {
+	Namespaces []string
+	IDs        []string
+	AsOf       time.Time
+	MinimumAge time.Duration
+}
+
+var _ models.Validator = (*ListStandardInvoicesPendingAdvancementInput)(nil)
+
+func (i ListStandardInvoicesPendingAdvancementInput) Validate() error {
+	return InvoicePendingAdvancementFilter{
+		AsOf:       i.AsOf,
+		MinimumAge: i.MinimumAge,
+	}.Validate()
+}
+
+// CountStandardInvoicesPendingAdvancementInput configures an aggregate count
+// of advancement candidates while allowing operationally disabled namespaces
+// to be excluded.
+type CountStandardInvoicesPendingAdvancementInput struct {
+	Filter             InvoicePendingAdvancementFilter
+	ExcludedNamespaces []string
+}
+
+var _ models.Validator = (*CountStandardInvoicesPendingAdvancementInput)(nil)
+
+func (i CountStandardInvoicesPendingAdvancementInput) Validate() error {
+	return i.Filter.Validate()
+}
+
 type GetStandardInvoiceByIdInput struct {
 	Invoice InvoiceID
 	Expand  StandardInvoiceExpands

--- a/openmeter/billing/worker/advance/advance.go
+++ b/openmeter/billing/worker/advance/advance.go
@@ -75,71 +75,17 @@ func (a *AutoAdvancer) All(ctx context.Context, namespaces []string, batchSize i
 	return errors.Join(errs...)
 }
 
-// ListInvoicesPendingAutoAdvance lists invoices that are due to be auto-advanced
-func (a *AutoAdvancer) ListInvoicesPendingAutoAdvance(ctx context.Context, namespaces []string, ids []string) ([]billing.StandardInvoice, error) {
-	resp, err := a.invoice.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
-		ExtendedStatuses: []billing.StandardInvoiceStatus{billing.StandardInvoiceStatusDraftWaitingAutoApproval},
-		DraftUntilLTE:    lo.ToPtr(time.Now()),
-		Namespaces:       namespaces,
-		IDs:              ids,
+func (a *AutoAdvancer) ListInvoicesToAdvance(ctx context.Context, namespaces []string, ids []string) ([]billing.StandardInvoice, error) {
+	invoices, err := a.invoice.ListStandardInvoicesPendingAdvancement(ctx, billing.ListStandardInvoicesPendingAdvancementInput{
+		Namespaces: namespaces,
+		IDs:        ids,
+		AsOf:       time.Now(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list invoices pending advancement: %w", err)
 	}
 
-	return resp.Items, nil
-}
-
-// ListInvoicesPendingCollection lists invoices that are due to be collected
-func (a *AutoAdvancer) ListInvoicesPendingCollection(ctx context.Context, namespaces []string, ids []string) ([]billing.StandardInvoice, error) {
-	resp, err := a.invoice.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
-		ExtendedStatuses: []billing.StandardInvoiceStatus{billing.StandardInvoiceStatusDraftWaitingForCollection},
-		CollectionAtLTE:  lo.ToPtr(time.Now()),
-		Namespaces:       namespaces,
-		IDs:              ids,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
-}
-
-// ListStuckInvoicesNeedingAdvance lists invoices that are stuck in some advanceable state (this is a fail-safe mechanism)
-func (a *AutoAdvancer) ListStuckInvoicesNeedingAdvance(ctx context.Context, namespaces []string, ids []string) ([]billing.StandardInvoice, error) {
-	resp, err := a.invoice.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
-		HasAvailableAction: []billing.InvoiceAvailableActionsFilter{billing.InvoiceAvailableActionsFilterAdvance},
-		Namespaces:         namespaces,
-		IDs:                ids,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
-}
-
-func (a *AutoAdvancer) ListInvoicesToAdvance(ctx context.Context, namespace []string, ids []string) ([]billing.StandardInvoice, error) {
-	autoAdvanceInvoices, err := a.ListInvoicesPendingAutoAdvance(ctx, namespace, ids)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list invoices to auto-advance: %w", err)
-	}
-
-	collectingInvoices, err := a.ListInvoicesPendingCollection(ctx, namespace, ids)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list invoices to collect: %w", err)
-	}
-
-	stuckInvoices, err := a.ListStuckInvoicesNeedingAdvance(ctx, namespace, ids)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list invoices that can be advanced: %w", err)
-	}
-
-	allInvoices := append(autoAdvanceInvoices, stuckInvoices...)
-	allInvoices = append(allInvoices, collectingInvoices...)
-	return lo.UniqBy(allInvoices, func(i billing.StandardInvoice) string {
-		return i.ID
-	}), nil
+	return invoices, nil
 }
 
 func (a *AutoAdvancer) AdvanceInvoice(ctx context.Context, id billing.InvoiceID) (billing.StandardInvoice, error) {

--- a/openmeter/billing/worker/invoicemetrics/adapter.go
+++ b/openmeter/billing/worker/invoicemetrics/adapter.go
@@ -1,0 +1,13 @@
+package invoicemetrics
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+type Adapter interface {
+	entutils.TxCreator
+
+	CountOverdueInvoices(ctx context.Context, input CountOverdueInvoicesInput) (OverdueInvoiceCounts, error)
+}

--- a/openmeter/billing/worker/invoicemetrics/adapter/adapter.go
+++ b/openmeter/billing/worker/invoicemetrics/adapter/adapter.go
@@ -11,6 +11,7 @@ import (
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type Config struct {
@@ -19,15 +20,17 @@ type Config struct {
 }
 
 func (c Config) Validate() error {
+	var errs []error
+
 	if c.Client == nil {
-		return errors.New("ent client is required")
+		errs = append(errs, errors.New("ent client is required"))
 	}
 
 	if c.BillingAdapter == nil {
-		return errors.New("billing adapter is required")
+		errs = append(errs, errors.New("billing adapter is required"))
 	}
 
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func New(config Config) (invoicemetrics.Adapter, error) {

--- a/openmeter/billing/worker/invoicemetrics/adapter/adapter.go
+++ b/openmeter/billing/worker/invoicemetrics/adapter/adapter.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+)
+
+type Config struct {
+	Client         *entdb.Client
+	BillingAdapter billing.StandardInvoiceAdapter
+}
+
+func (c Config) Validate() error {
+	if c.Client == nil {
+		return errors.New("ent client is required")
+	}
+
+	if c.BillingAdapter == nil {
+		return errors.New("billing adapter is required")
+	}
+
+	return nil
+}
+
+func New(config Config) (invoicemetrics.Adapter, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &adapter{
+		db:             config.Client,
+		billingAdapter: config.BillingAdapter,
+	}, nil
+}
+
+var _ invoicemetrics.Adapter = (*adapter)(nil)
+
+type adapter struct {
+	db             *entdb.Client
+	billingAdapter billing.StandardInvoiceAdapter
+}
+
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
+		ReadOnly: false,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to hijack transaction: %w", err)
+	}
+
+	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
+}
+
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+	txDB := entdb.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
+
+	return &adapter{
+		db:             txDB.Client(),
+		billingAdapter: a.billingAdapter,
+	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
+}

--- a/openmeter/billing/worker/invoicemetrics/adapter/count.go
+++ b/openmeter/billing/worker/invoicemetrics/adapter/count.go
@@ -1,0 +1,59 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+func (a *adapter) CountOverdueInvoices(ctx context.Context, input invoicemetrics.CountOverdueInvoicesInput) (invoicemetrics.OverdueInvoiceCounts, error) {
+	if err := input.Validate(); err != nil {
+		return invoicemetrics.OverdueInvoiceCounts{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (invoicemetrics.OverdueInvoiceCounts, error) {
+		cutoff := input.AsOf.Add(-input.MinimumAge)
+
+		collectionQuery := tx.db.BillingInvoice.Query().
+			Where(
+				billinginvoice.DeletedAtIsNil(),
+				billinginvoice.StatusEQ(billing.StandardInvoiceStatusGathering),
+				billinginvoice.Or(
+					billinginvoice.CollectionAtLTE(cutoff),
+					billinginvoice.And(
+						billinginvoice.CollectionAtIsNil(),
+						billinginvoice.UpdatedAtLTE(cutoff),
+					),
+				),
+			)
+
+		if len(input.ExcludedNamespaces) > 0 {
+			collectionQuery.Where(billinginvoice.NamespaceNotIn(input.ExcludedNamespaces...))
+		}
+
+		collectionCount, err := collectionQuery.Count(ctx)
+		if err != nil {
+			return invoicemetrics.OverdueInvoiceCounts{}, fmt.Errorf("failed to count invoices overdue for collection: %w", err)
+		}
+
+		advancementCount, err := tx.billingAdapter.CountStandardInvoicesPendingAdvancement(ctx, billing.CountStandardInvoicesPendingAdvancementInput{
+			Filter: billing.InvoicePendingAdvancementFilter{
+				AsOf:       input.AsOf,
+				MinimumAge: input.MinimumAge,
+			},
+			ExcludedNamespaces: input.ExcludedNamespaces,
+		})
+		if err != nil {
+			return invoicemetrics.OverdueInvoiceCounts{}, fmt.Errorf("failed to count invoices overdue for advancement: %w", err)
+		}
+
+		return invoicemetrics.OverdueInvoiceCounts{
+			Collection:  int64(collectionCount),
+			Advancement: advancementCount,
+		}, nil
+	})
+}

--- a/openmeter/billing/worker/invoicemetrics/metrics.go
+++ b/openmeter/billing/worker/invoicemetrics/metrics.go
@@ -1,0 +1,35 @@
+package invoicemetrics
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type OverdueInvoiceCounts struct {
+	Collection  int64
+	Advancement int64
+}
+
+type CountOverdueInvoicesInput struct {
+	AsOf               time.Time
+	MinimumAge         time.Duration
+	ExcludedNamespaces []string
+}
+
+var _ models.Validator = (*CountOverdueInvoicesInput)(nil)
+
+func (i CountOverdueInvoicesInput) Validate() error {
+	var errs []error
+
+	if i.AsOf.IsZero() {
+		errs = append(errs, errors.New("as of is required"))
+	}
+
+	if i.MinimumAge <= 0 {
+		errs = append(errs, errors.New("minimum age must be greater than zero"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}

--- a/openmeter/billing/worker/invoicemetrics/service.go
+++ b/openmeter/billing/worker/invoicemetrics/service.go
@@ -1,0 +1,8 @@
+package invoicemetrics
+
+import "context"
+
+type Service interface {
+	Start(ctx context.Context) error
+	Stop()
+}

--- a/openmeter/billing/worker/invoicemetrics/service/service.go
+++ b/openmeter/billing/worker/invoicemetrics/service/service.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics"
+	"github.com/openmeterio/openmeter/pkg/clock"
+)
+
+const metricName = "openmeter.billing.worker.pending_invoices"
+
+type Config struct {
+	Adapter invoicemetrics.Adapter
+	Meter   metric.Meter
+	Logger  *slog.Logger
+
+	ReportInterval     time.Duration
+	OverdueThreshold   time.Duration
+	QueryTimeout       time.Duration
+	ExcludedNamespaces []string
+}
+
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.Adapter == nil {
+		errs = append(errs, errors.New("adapter is required"))
+	}
+
+	if c.Meter == nil {
+		errs = append(errs, errors.New("meter is required"))
+	}
+
+	if c.Logger == nil {
+		errs = append(errs, errors.New("logger is required"))
+	}
+
+	if c.ReportInterval <= 0 {
+		errs = append(errs, errors.New("report interval must be greater than zero"))
+	}
+
+	if c.OverdueThreshold <= 0 {
+		errs = append(errs, errors.New("overdue threshold must be greater than zero"))
+	}
+
+	if c.QueryTimeout <= 0 {
+		errs = append(errs, errors.New("query timeout must be greater than zero"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func New(config Config) (invoicemetrics.Service, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	pendingInvoices, err := config.Meter.Int64Gauge(
+		metricName,
+		metric.WithDescription("Number of invoices overdue for billing worker processing"),
+		metric.WithUnit("{invoice}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pending invoice gauge: %w", err)
+	}
+
+	return &Service{
+		adapter:            config.Adapter,
+		logger:             config.Logger,
+		pendingInvoices:    pendingInvoices,
+		reportInterval:     config.ReportInterval,
+		overdueThreshold:   config.OverdueThreshold,
+		queryTimeout:       config.QueryTimeout,
+		excludedNamespaces: config.ExcludedNamespaces,
+		stopCh:             make(chan struct{}),
+	}, nil
+}
+
+var _ invoicemetrics.Service = (*Service)(nil)
+
+type Service struct {
+	adapter invoicemetrics.Adapter
+	logger  *slog.Logger
+
+	pendingInvoices metric.Int64Gauge
+
+	reportInterval     time.Duration
+	overdueThreshold   time.Duration
+	queryTimeout       time.Duration
+	excludedNamespaces []string
+
+	started  atomic.Bool
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func (s *Service) Start(ctx context.Context) error {
+	if s.started.Swap(true) {
+		return errors.New("invoice metrics service is already started")
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		select {
+		case <-runCtx.Done():
+		case <-s.stopCh:
+			cancel()
+		}
+	}()
+
+	s.report(runCtx)
+
+	ticker := time.NewTicker(s.reportInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-runCtx.Done():
+			return nil
+		case <-ticker.C:
+			s.report(runCtx)
+		}
+	}
+}
+
+func (s *Service) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+	})
+}
+
+func (s *Service) report(ctx context.Context) {
+	queryCtx, cancel := context.WithTimeout(ctx, s.queryTimeout)
+	defer cancel()
+
+	counts, err := s.adapter.CountOverdueInvoices(queryCtx, invoicemetrics.CountOverdueInvoicesInput{
+		AsOf:               clock.Now(),
+		MinimumAge:         s.overdueThreshold,
+		ExcludedNamespaces: s.excludedNamespaces,
+	})
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to report overdue invoice counts", "error", err)
+
+		return
+	}
+
+	s.pendingInvoices.Record(ctx, counts.Collection, metric.WithAttributes(
+		attribute.String("operation", "collection"),
+	))
+	s.pendingInvoices.Record(ctx, counts.Advancement, metric.WithAttributes(
+		attribute.String("operation", "advancement"),
+	))
+}

--- a/openmeter/billing/worker/invoicemetrics/service/service.go
+++ b/openmeter/billing/worker/invoicemetrics/service/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/invoicemetrics"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const metricName = "openmeter.billing.worker.pending_invoices"
@@ -56,7 +57,7 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("query timeout must be greater than zero"))
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func New(config Config) (invoicemetrics.Service, error) {

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1894,6 +1894,10 @@ func (n NoopBillingService) ListStandardInvoices(ctx context.Context, input bill
 	return billing.ListStandardInvoicesResponse{}, nil
 }
 
+func (n NoopBillingService) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.StandardInvoice, error) {
+	return nil, nil
+}
+
 func (n NoopBillingService) CreateStandardInvoiceFromGatheringLines(ctx context.Context, input billing.CreateStandardInvoiceFromGatheringLinesInput) (*billing.StandardInvoice, error) {
 	return &billing.StandardInvoice{}, nil
 }


### PR DESCRIPTION
## Summary

- add a one-minute billing-worker gauge for invoices overdue for collection or advancement
- centralize automatic advancement candidates behind dedicated standard-invoice list and count operations, including the worker processes
- exclude lockdown namespaces and report collection and advancement independently

## Summary by CodeRabbit

* **New Features**
  * Added automatic invoice advancement tracking for invoices awaiting collection or advancement.
  * Added periodic overdue-invoice metrics, reported separately for collection and advancement.
  * Added lifecycle management so metrics start and stop with the billing worker.

* **Bug Fixes**
  * Consolidated invoice advancement detection into a single, more consistent retrieval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic detection and listing of invoices ready for advancement.
  - Added periodic overdue-invoice metrics for collection and advancement workflows.
  - Metrics now start and stop with the billing worker.
- **Improvements**
  - Streamlined invoice advancement processing through unified eligibility checks.
  - Added filtering by namespace, invoice ID, cutoff time, and minimum invoice age.
- **Bug Fixes**
  - Improved handling of invoices awaiting collection or advancement, including fallback timing cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds overdue invoice reporting to the billing worker. The main changes are:

- A new billing-worker metric for pending invoice counts.
- Separate collection and advancement overdue counts.
- Centralized standard-invoice advancement list and count paths.
- Billing-worker wiring for the new metrics service.
- Namespace lockdown exclusions for invoice metrics.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/common/openmeter_billingworker.go | Wires the new invoice metrics adapter and service into the billing worker. |
| openmeter/billing/adapter/invoice_advancement.go | Adds shared list and count queries for standard invoices pending advancement. |
| openmeter/billing/worker/advance/advance.go | Routes automatic advancement candidate discovery through the shared billing service method. |
| openmeter/billing/worker/invoicemetrics/adapter/count.go | Counts overdue invoices for collection and advancement. |
| openmeter/billing/worker/invoicemetrics/service/service.go | Adds the periodic metrics loop that records overdue invoice counts. |

<sub>Reviews (2): Last reviewed commit: ["fix: validate invoice metrics configurat..."](https://github.com/openmeterio/openmeter/commit/5cf59d795e7de25434944529630f4908258403b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44150009)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->