### PR TITLE
chore(test): format Go test output with gotestsum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ SVIX_JWT_SECRET = DUMMY_JWT_SECRET
 GO_BUILD_FLAGS = -tags=dynamic
 GO_TEST_PACKAGE_PARALLELISM ?= 128
 GO_TEST_FLAGS = -p ${GO_TEST_PACKAGE_PARALLELISM} -parallel 16 ${GO_BUILD_FLAGS}
+GOTESTSUM_FLAGS ?= --format pkgname-and-test-fails --hide-summary=skipped
+GO_TEST = gotestsum ${GOTESTSUM_FLAGS} --
 GO_LINT_PATH ?= ./...
 
 .PHONY: up
@@ -231,25 +233,25 @@ etoe-slow: ## Run e2e tests with slow tests enabled
 test: ## Run tests
 	$(call print-target)
 	PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres postgres -c "SELECT version();" || (echo "!!! Postgres is not running. Please start it with 'docker compose up -d postgres' !!!" && false)
-	POSTGRES_HOST=127.0.0.1 go test ${GO_TEST_FLAGS} ./...
+	POSTGRES_HOST=127.0.0.1 ${GO_TEST} ${GO_TEST_FLAGS} ./...
 
 .PHONY: test-nocache
 test-nocache: ## Run tests without cache
 	$(call print-target)
 	PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres postgres -c "SELECT version();" || (echo "!!! Postgres is not running. Please start it with 'docker compose up -d postgres' !!!" && false)
-	POSTGRES_HOST=127.0.0.1 go test ${GO_TEST_FLAGS} -count=1 ./...
+	POSTGRES_HOST=127.0.0.1 ${GO_TEST} ${GO_TEST_FLAGS} -count=1 ./...
 
 .PHONY: test-all
 test-all: ## Run tests with svix dependencies, bypassing the test cache
 	$(call print-target)
 	docker compose up -d postgres svix redis
 	./tools/wait-for-compose.sh postgres svix redis
-	SVIX_HOST="localhost" SVIX_JWT_SECRET="$(SVIX_JWT_SECRET)" go test ${GO_TEST_FLAGS} -count=1 ./...
+	SVIX_HOST="localhost" SVIX_JWT_SECRET="$(SVIX_JWT_SECRET)" ${GO_TEST} ${GO_TEST_FLAGS} -count=1 ./...
 
 .PHONY: test-go-sdk
 test-go-sdk: ## Build, vet, and test the v3 Go SDK module (api/v3/client)
 	$(call print-target)
-	cd api/v3/client && go build ./... && go vet ./... && go test ./...
+	cd api/v3/client && go build ./... && go vet ./... && ${GO_TEST} ./...
 
 .PHONY: lint
 lint: lint-go lint-api-spec lint-openapi lint-helm ## Run linters

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GO_BUILD_FLAGS = -tags=dynamic
 GO_TEST_PACKAGE_PARALLELISM ?= 128
 GO_TEST_FLAGS = -p ${GO_TEST_PACKAGE_PARALLELISM} -parallel 16 ${GO_BUILD_FLAGS}
 GOTESTSUM_FLAGS ?= --format pkgname-and-test-fails --hide-summary=skipped
-GO_TEST = gotestsum ${GOTESTSUM_FLAGS} --
 GO_LINT_PATH ?= ./...
 
 .PHONY: up
@@ -233,25 +232,25 @@ etoe-slow: ## Run e2e tests with slow tests enabled
 test: ## Run tests
 	$(call print-target)
 	PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres postgres -c "SELECT version();" || (echo "!!! Postgres is not running. Please start it with 'docker compose up -d postgres' !!!" && false)
-	POSTGRES_HOST=127.0.0.1 ${GO_TEST} ${GO_TEST_FLAGS} ./...
+	POSTGRES_HOST=127.0.0.1 gotestsum $(GOTESTSUM_FLAGS) -- $(GO_TEST_FLAGS) ./...
 
 .PHONY: test-nocache
 test-nocache: ## Run tests without cache
 	$(call print-target)
 	PGPASSWORD=postgres psql -h 127.0.0.1 -U postgres postgres -c "SELECT version();" || (echo "!!! Postgres is not running. Please start it with 'docker compose up -d postgres' !!!" && false)
-	POSTGRES_HOST=127.0.0.1 ${GO_TEST} ${GO_TEST_FLAGS} -count=1 ./...
+	POSTGRES_HOST=127.0.0.1 gotestsum $(GOTESTSUM_FLAGS) -- $(GO_TEST_FLAGS) -count=1 ./...
 
 .PHONY: test-all
 test-all: ## Run tests with svix dependencies, bypassing the test cache
 	$(call print-target)
 	docker compose up -d postgres svix redis
 	./tools/wait-for-compose.sh postgres svix redis
-	SVIX_HOST="localhost" SVIX_JWT_SECRET="$(SVIX_JWT_SECRET)" ${GO_TEST} ${GO_TEST_FLAGS} -count=1 ./...
+	SVIX_HOST="localhost" SVIX_JWT_SECRET="$(SVIX_JWT_SECRET)" gotestsum $(GOTESTSUM_FLAGS) -- $(GO_TEST_FLAGS) -count=1 ./...
 
 .PHONY: test-go-sdk
 test-go-sdk: ## Build, vet, and test the v3 Go SDK module (api/v3/client)
 	$(call print-target)
-	cd api/v3/client && go build ./... && go vet ./... && ${GO_TEST} ./...
+	cd api/v3/client && go build ./... && go vet ./... && gotestsum $(GOTESTSUM_FLAGS) -- ./...
 
 .PHONY: lint
 lint: lint-go lint-api-spec lint-openapi lint-helm ## Run linters

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
 
               golangci-lint
               goreleaser
+              gotestsum
               air
 
               curl


### PR DESCRIPTION
## What changed

- add `gotestsum` to the pinned Nix development and CI toolchain
- route the root `test`, `test-nocache`, `test-all`, and `test-go-sdk` targets through `gotestsum`, with formatter flags configurable via `GOTESTSUM_FLAGS`
- use compact package results, failed-test details, and a final test-count/timing summary
- keep expanded skipped-test details hidden while retaining the skipped count

## Why

The raw `go test` output lists package results but does not provide a useful run summary or at-a-glance statistics. `gotestsum` improves local and CI readability without introducing coverage reports or XML artifacts.

## Impact

Test behavior is unchanged: existing package/test parallelism, the `dynamic` build tag, no-cache flag, environment variables, and package selections are passed through to `go test`. Specialized e2e and quickstart commands remain unchanged.

## Validation

- `nix develop --impure .#ci -c make test-go-sdk` — 55 tests passed
- focused root run through the configured formatter — 296 tests passed
- `nixpkgs-fmt --check flake.nix`
- `git diff --check`
- pre-commit `nixpkgs-fmt` and commitizen hooks

Full DB-backed `make test-nocache` was not run locally because Docker was unavailable; CI provisions the required dependencies before invoking that target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test output for greater clarity and easier identification of failures.
  * Standardized test execution across regular, uncached, full-suite, and SDK test commands.
  * Skipped-test summaries are now hidden by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR formats Go test output with `gotestsum`. The main changes are:

- Routes four root test targets through `gotestsum`.
- Adds configurable formatter and summary flags.
- Adds `gotestsum` to the Nix development and CI toolchain.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Makefile | Routes the root and Go SDK test targets through `gotestsum` while retaining their target-specific arguments. |
| flake.nix | Adds `gotestsum` to the shared Nix development and CI package set. |

<sub>Reviews (2): Last reviewed commit: ["refactor(test): simplify gotestsum invoc..."](https://github.com/openmeterio/openmeter/commit/df9b250f9ef3c8959e1e467698fbc0f4c091d332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44465686)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->