### PR TITLE
feat: writable unit_config on the v3 add-on API

### DIFF
--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -346,7 +346,101 @@ func ToAPIBillingRateCard(rc productcatalog.RateCard) (apiv3.BillingRateCard, er
 		return result, fmt.Errorf("unsupported rate card type: %s", rc.Type())
 	}
 
+	if meta.UnitConfig != nil {
+		result.UnitConfig = lo.ToPtr(ToAPIBillingUnitConfig(*meta.UnitConfig))
+	} else {
+		unitConfig, err := ToAPIBillingRateCardUnitConfig(meta.Price)
+		if err != nil {
+			return result, fmt.Errorf("failed to convert unit config: %w", err)
+		}
+
+		result.UnitConfig = unitConfig
+	}
+
 	return result, nil
+}
+
+// ToAPIBillingRateCardUnitConfig synthesizes a v3 unit config from a v1 dynamic or package price
+func ToAPIBillingRateCardUnitConfig(p *productcatalog.Price) (*apiv3.BillingUnitConfig, error) {
+	if p == nil {
+		return nil, nil
+	}
+
+	switch p.Type() {
+	case productcatalog.DynamicPriceType:
+		dynamic, err := p.AsDynamic()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read dynamic price: %w", err)
+		}
+
+		return &apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationMultiply,
+			ConversionFactor: dynamic.Multiplier.String(),
+		}, nil
+
+	case productcatalog.PackagePriceType:
+		pkg, err := p.AsPackage()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read package price: %w", err)
+		}
+
+		return &apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationDivide,
+			ConversionFactor: pkg.QuantityPerPackage.String(),
+			Rounding:         lo.ToPtr(apiv3.BillingUnitConfigRoundingModeCeiling),
+		}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// ToAPIBillingUnitConfig maps a stored domain unit config to its API
+// representation. Rounding and Precision are omitted when no rounding is applied,
+// mirroring the domain semantics where both are inert for the "none" mode.
+func ToAPIBillingUnitConfig(uc productcatalog.UnitConfig) apiv3.BillingUnitConfig {
+	out := apiv3.BillingUnitConfig{
+		Operation:        apiv3.BillingUnitConfigOperation(uc.Operation),
+		ConversionFactor: uc.ConversionFactor.String(),
+		DisplayUnit:      uc.DisplayUnit,
+	}
+
+	if !uc.Rounding.IsNone() {
+		out.Rounding = lo.ToPtr(apiv3.BillingUnitConfigRoundingMode(uc.Rounding))
+		out.Precision = lo.ToPtr(uc.Precision)
+	}
+
+	return out
+}
+
+// FromAPIBillingUnitConfig maps the API unit config to the domain type. The enum
+// values are identical across the two layers, so operation and rounding are direct
+// casts; UnitConfig.Validate (run via RateCardMeta.Validate) rejects unknown enum
+// values and a non-positive conversion factor.
+func FromAPIBillingUnitConfig(uc apiv3.BillingUnitConfig) (*productcatalog.UnitConfig, error) {
+	conversionFactor, err := decimal.NewFromString(uc.ConversionFactor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid conversion factor: %w", err)
+	}
+
+	out := &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperation(uc.Operation),
+		ConversionFactor: conversionFactor,
+		DisplayUnit:      uc.DisplayUnit,
+	}
+
+	if uc.Rounding != nil {
+		out.Rounding = productcatalog.UnitConfigRoundingMode(*uc.Rounding)
+	}
+
+	// Precision is inert without rounding; only carry it when rounding is active so
+	// it round-trips consistently with ToAPIBillingUnitConfig, which omits Precision
+	// in the "none" case.
+	if !out.Rounding.IsNone() {
+		out.Precision = lo.FromPtr(uc.Precision)
+	}
+
+	return out, nil
 }
 
 func ToAPIBillingPrice(price productcatalog.Price) (apiv3.BillingPrice, *apiv3.BillingSpendCommitments, *apiv3.BillingPricePaymentTerm, error) {
@@ -414,6 +508,38 @@ func ToAPIBillingPrice(price productcatalog.Price) (apiv3.BillingPrice, *apiv3.B
 			}
 		default:
 			return apiPrice, nil, nil, fmt.Errorf("unsupported tiered price mode: %s", tieredPrice.Mode)
+		}
+
+	case productcatalog.DynamicPriceType:
+		// Dynamic prices are surfaced in v3 as a unit price of amount 1; the
+		// multiplier is carried separately on the rate card's unit config (see
+		// ToAPIBillingRateCardUnitConfig). This lets a v1-authored add-on read back
+		// through the v3 API rather than erroring on an unrepresentable price type.
+		c := price.GetCommitments()
+		commitments = ToAPIBillingSpendCommitments(c.MinimumAmount, c.MaximumAmount)
+
+		if err := apiPrice.FromBillingPriceUnit(apiv3.BillingPriceUnit{
+			Type:   apiv3.BillingPriceUnitTypeUnit,
+			Amount: "1",
+		}); err != nil {
+			return apiPrice, nil, nil, fmt.Errorf("failed to encode unit price for dynamic price: %w", err)
+		}
+
+	case productcatalog.PackagePriceType:
+		// Package prices are surfaced in v3 as a unit price of the per-unit amount;
+		// the package size is carried separately on the rate card's unit config.
+		pkg, err := price.AsPackage()
+		if err != nil {
+			return apiPrice, nil, nil, fmt.Errorf("failed to cast PackagePrice: %w", err)
+		}
+
+		commitments = ToAPIBillingSpendCommitments(pkg.MinimumAmount, pkg.MaximumAmount)
+
+		if err := apiPrice.FromBillingPriceUnit(apiv3.BillingPriceUnit{
+			Type:   apiv3.BillingPriceUnitTypeUnit,
+			Amount: pkg.Amount.String(),
+		}); err != nil {
+			return apiPrice, nil, nil, fmt.Errorf("failed to encode unit price for package price: %w", err)
 		}
 
 	default:
@@ -726,6 +852,21 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 		}
 
 		meta.EntitlementTemplate = tmpl
+	}
+
+	// Set the unit config up front: meta is copied by value into both the flat and
+	// usage-based rate cards below, so it must be populated before the price switch.
+	// We do not branch on price type here; the price-type restriction lives in
+	// RateCardMeta.Validate as a publish-blocking warning, so an invalid combination
+	// (e.g. unit_config on a flat price) is mapped through and surfaces as a
+	// validation issue on the draft rather than being rejected at create/update.
+	if rc.UnitConfig != nil {
+		unitConfig, err := FromAPIBillingUnitConfig(*rc.UnitConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert unit config: %w", err)
+		}
+
+		meta.UnitConfig = unitConfig
 	}
 
 	priceDiscriminator, err := rc.Price.Discriminator()

--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -420,7 +420,7 @@ func ToAPIBillingUnitConfig(uc productcatalog.UnitConfig) apiv3.BillingUnitConfi
 func FromAPIBillingUnitConfig(uc apiv3.BillingUnitConfig) (*productcatalog.UnitConfig, error) {
 	conversionFactor, err := decimal.NewFromString(uc.ConversionFactor)
 	if err != nil {
-		return nil, fmt.Errorf("invalid conversion factor: %w", err)
+		return nil, models.NewGenericValidationError(fmt.Errorf("invalid conversion factor: %w", err))
 	}
 
 	out := &productcatalog.UnitConfig{

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	decimal "github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -198,5 +199,308 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		boolean, err := out.AsBillingRateCardBooleanEntitlement()
 		require.NoError(t, err)
 		assert.Equal(t, "boolean", string(boolean.Type))
+	})
+}
+
+func TestToAPIBillingRateCardUnitConfig(t *testing.T) {
+	t.Run("nil price has no unit config", func(t *testing.T) {
+		result, err := ToAPIBillingRateCardUnitConfig(nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("flat price has no unit config", func(t *testing.T) {
+		p := productcatalog.NewPriceFrom(productcatalog.FlatPrice{Amount: decimal.NewFromFloat(5)})
+
+		result, err := ToAPIBillingRateCardUnitConfig(p)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("unit price has no unit config", func(t *testing.T) {
+		p := productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: decimal.NewFromFloat(0.05)})
+
+		result, err := ToAPIBillingRateCardUnitConfig(p)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("dynamic price produces multiply unit config", func(t *testing.T) {
+		p := productcatalog.NewPriceFrom(productcatalog.DynamicPrice{
+			Multiplier: decimal.NewFromFloat(1.2),
+		})
+
+		result, err := ToAPIBillingRateCardUnitConfig(p)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, apiv3.BillingUnitConfigOperationMultiply, result.Operation)
+		assert.Equal(t, apiv3.Numeric("1.2"), result.ConversionFactor)
+		assert.Nil(t, result.Rounding)
+		assert.Nil(t, result.Precision)
+		assert.Nil(t, result.DisplayUnit)
+	})
+
+	t.Run("package price produces divide unit config with ceiling rounding", func(t *testing.T) {
+		p := productcatalog.NewPriceFrom(productcatalog.PackagePrice{
+			Amount:             decimal.NewFromFloat(10),
+			QuantityPerPackage: decimal.NewFromInt(1000),
+		})
+
+		result, err := ToAPIBillingRateCardUnitConfig(p)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, apiv3.BillingUnitConfigOperationDivide, result.Operation)
+		assert.Equal(t, apiv3.Numeric("1000"), result.ConversionFactor)
+		require.NotNil(t, result.Rounding)
+		assert.Equal(t, apiv3.BillingUnitConfigRoundingModeCeiling, *result.Rounding)
+	})
+}
+
+func TestToAPIBillingRateCard_DynamicAndPackagePrices(t *testing.T) {
+	cadence, err := datetime.ISODurationString("P1M").Parse()
+	require.NoError(t, err)
+
+	t.Run("dynamic price renders as unit price plus multiply unit config and preserves commitments", func(t *testing.T) {
+		minAmt := decimal.NewFromFloat(10)
+		maxAmt := decimal.NewFromFloat(100)
+		price := productcatalog.NewPriceFrom(productcatalog.DynamicPrice{
+			Multiplier: decimal.NewFromFloat(1.2),
+			Commitments: productcatalog.Commitments{
+				MinimumAmount: &minAmt,
+				MaximumAmount: &maxAmt,
+			},
+		})
+
+		rc := &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:   "tokens",
+				Name:  "Tokens",
+				Price: price,
+			},
+			BillingCadence: cadence,
+		}
+
+		result, err := ToAPIBillingRateCard(rc)
+		require.NoError(t, err)
+
+		disc, err := result.Price.Discriminator()
+		require.NoError(t, err)
+		assert.Equal(t, "unit", disc)
+
+		unit, err := result.Price.AsBillingPriceUnit()
+		require.NoError(t, err)
+		assert.Equal(t, apiv3.Numeric("1"), unit.Amount)
+
+		require.NotNil(t, result.UnitConfig)
+		assert.Equal(t, apiv3.BillingUnitConfigOperationMultiply, result.UnitConfig.Operation)
+		assert.Equal(t, apiv3.Numeric("1.2"), result.UnitConfig.ConversionFactor)
+		assert.Nil(t, result.UnitConfig.Rounding)
+
+		require.NotNil(t, result.Commitments)
+		assert.Equal(t, lo.ToPtr(apiv3.Numeric("10")), result.Commitments.MinimumAmount)
+		assert.Equal(t, lo.ToPtr(apiv3.Numeric("100")), result.Commitments.MaximumAmount)
+	})
+
+	t.Run("package price renders as unit price plus divide unit config and preserves commitments", func(t *testing.T) {
+		minAmt := decimal.NewFromFloat(5)
+		price := productcatalog.NewPriceFrom(productcatalog.PackagePrice{
+			Amount:             decimal.NewFromFloat(0.5),
+			QuantityPerPackage: decimal.NewFromInt(1000),
+			Commitments: productcatalog.Commitments{
+				MinimumAmount: &minAmt,
+			},
+		})
+
+		rc := &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:   "api-calls",
+				Name:  "API Calls",
+				Price: price,
+			},
+			BillingCadence: cadence,
+		}
+
+		result, err := ToAPIBillingRateCard(rc)
+		require.NoError(t, err)
+
+		disc, err := result.Price.Discriminator()
+		require.NoError(t, err)
+		assert.Equal(t, "unit", disc)
+
+		unit, err := result.Price.AsBillingPriceUnit()
+		require.NoError(t, err)
+		assert.Equal(t, apiv3.Numeric("0.5"), unit.Amount)
+
+		require.NotNil(t, result.UnitConfig)
+		assert.Equal(t, apiv3.BillingUnitConfigOperationDivide, result.UnitConfig.Operation)
+		assert.Equal(t, apiv3.Numeric("1000"), result.UnitConfig.ConversionFactor)
+		require.NotNil(t, result.UnitConfig.Rounding)
+		assert.Equal(t, apiv3.BillingUnitConfigRoundingModeCeiling, *result.UnitConfig.Rounding)
+
+		require.NotNil(t, result.Commitments)
+		assert.Equal(t, lo.ToPtr(apiv3.Numeric("5")), result.Commitments.MinimumAmount)
+		assert.Nil(t, result.Commitments.MaximumAmount)
+	})
+
+	t.Run("unit price has no unit config on rate card", func(t *testing.T) {
+		price := productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: decimal.NewFromFloat(0.05),
+		})
+
+		rc := &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:   "api-calls",
+				Name:  "API Calls",
+				Price: price,
+			},
+			BillingCadence: cadence,
+		}
+
+		result, err := ToAPIBillingRateCard(rc)
+		require.NoError(t, err)
+		assert.Nil(t, result.UnitConfig)
+	})
+}
+
+func TestUnitConfigMapping(t *testing.T) {
+	t.Run("FromAPI maps all five fields", func(t *testing.T) {
+		uc, err := FromAPIBillingUnitConfig(apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationDivide,
+			ConversionFactor: apiv3.Numeric("1000"),
+			Rounding:         lo.ToPtr(apiv3.BillingUnitConfigRoundingModeCeiling),
+			Precision:        lo.ToPtr(2),
+			DisplayUnit:      lo.ToPtr("K"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.Equal(t, productcatalog.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, float64(1000), uc.ConversionFactor.InexactFloat64())
+		assert.Equal(t, productcatalog.UnitConfigRoundingModeCeiling, uc.Rounding)
+		assert.Equal(t, 2, uc.Precision)
+		assert.Equal(t, "K", lo.FromPtr(uc.DisplayUnit))
+	})
+
+	t.Run("FromAPI defaults rounding to none and precision to zero when omitted", func(t *testing.T) {
+		uc, err := FromAPIBillingUnitConfig(apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationMultiply,
+			ConversionFactor: apiv3.Numeric("1.2"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.True(t, uc.Rounding.IsNone())
+		assert.Equal(t, 0, uc.Precision)
+		assert.Nil(t, uc.DisplayUnit)
+	})
+
+	t.Run("FromAPI drops precision when rounding is omitted, mirroring ToAPI", func(t *testing.T) {
+		// Precision is inert without rounding; carrying it would make From/To
+		// disagree about what is stored across a round-trip.
+		uc, err := FromAPIBillingUnitConfig(apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationMultiply,
+			ConversionFactor: apiv3.Numeric("1.2"),
+			Precision:        lo.ToPtr(3),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.True(t, uc.Rounding.IsNone())
+		assert.Equal(t, 0, uc.Precision)
+	})
+
+	t.Run("FromAPI rejects a non-numeric conversion factor", func(t *testing.T) {
+		_, err := FromAPIBillingUnitConfig(apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationDivide,
+			ConversionFactor: apiv3.Numeric("not-a-number"),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ToAPI omits rounding and precision when rounding is none", func(t *testing.T) {
+		out := ToAPIBillingUnitConfig(productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationMultiply,
+			ConversionFactor: decimal.NewFromFloat(1.2),
+			Precision:        3, // inert without rounding, must not surface
+		})
+		assert.Equal(t, apiv3.BillingUnitConfigOperationMultiply, out.Operation)
+		assert.Equal(t, apiv3.Numeric("1.2"), out.ConversionFactor)
+		assert.Nil(t, out.Rounding)
+		assert.Nil(t, out.Precision)
+	})
+
+	t.Run("round-trips through FromAPI and ToAPI", func(t *testing.T) {
+		in := apiv3.BillingUnitConfig{
+			Operation:        apiv3.BillingUnitConfigOperationDivide,
+			ConversionFactor: apiv3.Numeric("1000"),
+			Rounding:         lo.ToPtr(apiv3.BillingUnitConfigRoundingModeCeiling),
+			Precision:        lo.ToPtr(0),
+			DisplayUnit:      lo.ToPtr("GB"),
+		}
+
+		domain, err := FromAPIBillingUnitConfig(in)
+		require.NoError(t, err)
+
+		assert.Equal(t, in, ToAPIBillingUnitConfig(*domain))
+	})
+
+	t.Run("a stored unit config is surfaced verbatim on read, ahead of v1 synthesis", func(t *testing.T) {
+		cadence, err := datetime.ISODurationString("P1M").Parse()
+		require.NoError(t, err)
+
+		rc := &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:   "storage",
+				Name:  "Storage",
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: decimal.NewFromFloat(0.05)}),
+				UnitConfig: &productcatalog.UnitConfig{
+					Operation:        productcatalog.UnitConfigOperationDivide,
+					ConversionFactor: decimal.NewFromInt(1_000_000_000),
+					Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+					DisplayUnit:      lo.ToPtr("GB"),
+				},
+			},
+			BillingCadence: cadence,
+		}
+
+		result, err := ToAPIBillingRateCard(rc)
+		require.NoError(t, err)
+		require.NotNil(t, result.UnitConfig)
+		assert.Equal(t, apiv3.BillingUnitConfigOperationDivide, result.UnitConfig.Operation)
+		assert.Equal(t, apiv3.Numeric("1000000000"), result.UnitConfig.ConversionFactor)
+		require.NotNil(t, result.UnitConfig.Rounding)
+		assert.Equal(t, apiv3.BillingUnitConfigRoundingModeCeiling, *result.UnitConfig.Rounding)
+		assert.Equal(t, lo.ToPtr("GB"), result.UnitConfig.DisplayUnit)
+	})
+
+	t.Run("FromAPIBillingRateCard propagates unit_config into the rate card meta", func(t *testing.T) {
+		// Guards the authoring wiring directly: a unit_config on an apiv3.BillingRateCard
+		// must survive into meta.UnitConfig. Without this, dropping the propagation in
+		// FromAPIBillingRateCard would still leave the helper round-trip tests green.
+		var price apiv3.BillingPrice
+		require.NoError(t, price.FromBillingPriceUnit(apiv3.BillingPriceUnit{Amount: "0.05", Type: "unit"}))
+
+		bc := apiv3.ISO8601Duration("P1M")
+		rc := apiv3.BillingRateCard{
+			Key:            "storage",
+			Name:           "Storage",
+			Price:          price,
+			BillingCadence: &bc,
+			UnitConfig: &apiv3.BillingUnitConfig{
+				Operation:        apiv3.BillingUnitConfigOperationDivide,
+				ConversionFactor: apiv3.Numeric("1000000000"),
+				Rounding:         lo.ToPtr(apiv3.BillingUnitConfigRoundingModeCeiling),
+				Precision:        lo.ToPtr(0),
+				DisplayUnit:      lo.ToPtr("GB"),
+			},
+		}
+
+		result, err := FromAPIBillingRateCard(rc)
+		require.NoError(t, err)
+
+		uc := result.AsMeta().UnitConfig
+		require.NotNil(t, uc)
+		assert.Equal(t, productcatalog.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, float64(1_000_000_000), uc.ConversionFactor.InexactFloat64())
+		assert.Equal(t, productcatalog.UnitConfigRoundingModeCeiling, uc.Rounding)
+		assert.Equal(t, 0, uc.Precision)
+		assert.Equal(t, lo.ToPtr("GB"), uc.DisplayUnit)
 	})
 }

--- a/api/v3/handlers/addons/create.go
+++ b/api/v3/handlers/addons/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type (
@@ -25,6 +26,14 @@ func (h *handler) CreateAddon() CreateAddonHandler {
 			body := apiv3.CreateAddonRequest{}
 			if err := request.ParseBody(r, &body); err != nil {
 				return CreateAddonRequest{}, err
+			}
+
+			if !h.unitConfigEnabled {
+				for _, rc := range body.RateCards {
+					if rc.UnitConfig != nil {
+						return CreateAddonRequest{}, models.NewGenericValidationError(fmt.Errorf("unit_config is not enabled on this deployment of OpenMeter"))
+					}
+				}
 			}
 
 			ns, err := h.resolveNamespace(ctx)

--- a/api/v3/handlers/addons/create.go
+++ b/api/v3/handlers/addons/create.go
@@ -28,6 +28,7 @@ func (h *handler) CreateAddon() CreateAddonHandler {
 				return CreateAddonRequest{}, err
 			}
 
+			// NOTE: We gate the addon authoring behind this config flag. It is applied for both create and update and will be removed when unit config is feature complete.
 			if !h.unitConfigEnabled {
 				for _, rc := range body.RateCards {
 					if rc.UnitConfig != nil {

--- a/api/v3/handlers/addons/handler.go
+++ b/api/v3/handlers/addons/handler.go
@@ -18,19 +18,22 @@ type Handler interface {
 }
 
 type handler struct {
-	resolveNamespace func(ctx context.Context) (string, error)
-	service          addon.Service
-	options          []httptransport.HandlerOption
+	resolveNamespace  func(ctx context.Context) (string, error)
+	service           addon.Service
+	unitConfigEnabled bool
+	options           []httptransport.HandlerOption
 }
 
 func New(
 	resolveNamespace func(ctx context.Context) (string, error),
 	service addon.Service,
+	unitConfigEnabled bool,
 	options ...httptransport.HandlerOption,
 ) Handler {
 	return &handler{
-		resolveNamespace: resolveNamespace,
-		service:          service,
-		options:          options,
+		resolveNamespace:  resolveNamespace,
+		service:           service,
+		unitConfigEnabled: unitConfigEnabled,
+		options:           options,
 	}
 }

--- a/api/v3/handlers/addons/update.go
+++ b/api/v3/handlers/addons/update.go
@@ -29,6 +29,7 @@ func (h *handler) UpdateAddon() UpdateAddonHandler {
 				return UpdateAddonRequest{}, err
 			}
 
+			// NOTE: We gate the addon authoring behind this config flag. It is applied for both create and update and will be removed when unit config is feature complete.
 			if !h.unitConfigEnabled {
 				for _, rc := range body.RateCards {
 					if rc.UnitConfig != nil {

--- a/api/v3/handlers/addons/update.go
+++ b/api/v3/handlers/addons/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type (
@@ -26,6 +27,14 @@ func (h *handler) UpdateAddon() UpdateAddonHandler {
 			body := apiv3.UpsertAddonRequest{}
 			if err := request.ParseBody(r, &body); err != nil {
 				return UpdateAddonRequest{}, err
+			}
+
+			if !h.unitConfigEnabled {
+				for _, rc := range body.RateCards {
+					if rc.UnitConfig != nil {
+						return UpdateAddonRequest{}, models.NewGenericValidationError(fmt.Errorf("unit_config is not enabled on this deployment of OpenMeter"))
+					}
+				}
 			}
 
 			ns, err := h.resolveNamespace(ctx)

--- a/api/v3/server/server.go
+++ b/api/v3/server/server.go
@@ -303,7 +303,7 @@ func NewServer(config *Config) (*Server, error) {
 		return ns, nil
 	}
 
-	addonHandler := addonshandler.New(resolveNamespace, config.AddonService, httptransport.WithErrorHandler(config.ErrorHandler))
+	addonHandler := addonshandler.New(resolveNamespace, config.AddonService, config.UnitConfig.Enabled, httptransport.WithErrorHandler(config.ErrorHandler))
 	appsHandler := appshandler.New(resolveNamespace, config.AppService, config.BillingService, config.StripeService, httptransport.WithErrorHandler(config.ErrorHandler))
 	eventsHandler := eventshandler.New(resolveNamespace, config.IngestService, config.MeterEventService, httptransport.WithErrorHandler(config.ErrorHandler))
 	customersHandler := customershandler.New(resolveNamespace, config.CustomerService, httptransport.WithErrorHandler(config.ErrorHandler))

--- a/e2e/addons_unitconfig_v3_test.go
+++ b/e2e/addons_unitconfig_v3_test.go
@@ -1,0 +1,305 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/openmeterio/openmeter/api/client/go"
+	v3sdk "github.com/openmeterio/openmeter/api/v3/client"
+)
+
+// newMeteredFeature creates a SUM meter and a feature backed by it, returning
+// the feature. Unit/usage-based rate cards require a feature, and the rate card
+// key must equal the feature key on the v3 authoring path.
+func newMeteredFeature(t *testing.T, c *v3Client) v3sdk.Feature {
+	t.Helper()
+
+	meterKey := uniqueKey("uc_meter")
+
+	m, err := c.Meters.Create(t.Context(), v3sdk.CreateMeterRequest{
+		Key:           meterKey,
+		Name:          "Test Meter " + meterKey,
+		Aggregation:   v3sdk.MeterAggregationSum,
+		EventType:     uniqueKey("uc_event"),
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, m)
+	require.NotEmpty(t, m.ID)
+
+	featureKey := uniqueKey("uc_feat")
+
+	f, err := c.Features.Create(t.Context(), v3sdk.CreateFeatureRequest{
+		Key:   featureKey,
+		Name:  "Test Feature " + featureKey,
+		Meter: &v3sdk.FeatureMeterReferenceInput{ID: m.ID},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, f)
+	require.NotEmpty(t, f.ID)
+
+	return *f
+}
+
+// TestV3AddonUnitConfigAuthoring proves the v3 add-on rate card API can author,
+// read back, and update a unit_config — the plan/add-on parity this ticket adds.
+// Mirrors the Hurl round-trip (author → read → update → read) at the SDK layer.
+func TestV3AddonUnitConfigAuthoring(t *testing.T) {
+	c := newV3Client(t)
+	f := newMeteredFeature(t, c)
+
+	// Author: a unit-priced rate card carrying a full unit_config (bill GB:
+	// divide bytes by 1e9, round up, label "GB").
+	rc := validUnitRateCard(f)
+	rc.UnitConfig = &v3sdk.UnitConfig{
+		Operation:        v3sdk.UnitConfigOperationDivide,
+		ConversionFactor: "1000000000",
+		Rounding:         lo.ToPtr(v3sdk.UnitConfigRoundingModeCeiling),
+		Precision:        lo.ToPtr(int64(0)),
+		DisplayUnit:      lo.ToPtr("GB"),
+	}
+
+	body := validAddonRequest("uc_authoring")
+	body.RateCards = []v3sdk.RateCardInput{rc}
+
+	var addonID string
+
+	t.Run("create surfaces the unit_config", func(t *testing.T) {
+		addon, err := c.Addons.Create(t.Context(), body)
+		c.requireStatus(http.StatusCreated, err)
+		require.NotNil(t, addon)
+		require.Len(t, addon.RateCards, 1)
+
+		uc := addon.RateCards[0].UnitConfig
+		require.NotNil(t, uc, "unit_config dropped on create")
+		assert.Equal(t, v3sdk.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, v3sdk.Numeric("1000000000"), uc.ConversionFactor)
+		require.NotNil(t, uc.Rounding)
+		assert.Equal(t, v3sdk.UnitConfigRoundingModeCeiling, *uc.Rounding)
+		assert.EqualValues(t, 0, lo.FromPtr(uc.Precision))
+		assert.Equal(t, "GB", lo.FromPtr(uc.DisplayUnit))
+
+		addonID = addon.ID
+	})
+
+	t.Run("get round-trips the stored unit_config verbatim", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+
+		addon, err := c.Addons.Get(t.Context(), addonID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, addon)
+		require.Len(t, addon.RateCards, 1)
+
+		uc := addon.RateCards[0].UnitConfig
+		require.NotNil(t, uc)
+		assert.Equal(t, v3sdk.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, v3sdk.Numeric("1000000000"), uc.ConversionFactor)
+		require.NotNil(t, uc.Rounding)
+		assert.Equal(t, v3sdk.UnitConfigRoundingModeCeiling, *uc.Rounding)
+		require.NotNil(t, uc.Precision)
+		assert.EqualValues(t, 0, *uc.Precision)
+		require.NotNil(t, uc.DisplayUnit)
+		assert.Equal(t, "GB", *uc.DisplayUnit)
+	})
+
+	t.Run("update rewrites the unit_config", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+
+		updated := validUnitRateCard(f)
+		updated.UnitConfig = &v3sdk.UnitConfig{
+			Operation:        v3sdk.UnitConfigOperationMultiply,
+			ConversionFactor: "1000000",
+			Rounding:         lo.ToPtr(v3sdk.UnitConfigRoundingModeHalfUp),
+			Precision:        lo.ToPtr(int64(2)),
+			DisplayUnit:      lo.ToPtr("M"),
+		}
+
+		addon, err := c.Addons.Update(t.Context(), addonID, v3sdk.UpsertAddonRequest{
+			Name:         body.Name,
+			InstanceType: body.InstanceType,
+			RateCards:    []v3sdk.RateCardInput{updated},
+		})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, addon)
+		require.Len(t, addon.RateCards, 1)
+
+		uc := addon.RateCards[0].UnitConfig
+		require.NotNil(t, uc)
+		assert.Equal(t, v3sdk.UnitConfigOperationMultiply, uc.Operation)
+		assert.Equal(t, v3sdk.Numeric("1000000"), uc.ConversionFactor)
+		require.NotNil(t, uc.Rounding)
+		assert.Equal(t, v3sdk.UnitConfigRoundingModeHalfUp, *uc.Rounding)
+		assert.EqualValues(t, 2, lo.FromPtr(uc.Precision))
+		assert.Equal(t, "M", lo.FromPtr(uc.DisplayUnit))
+	})
+
+	t.Run("get reflects the updated unit_config", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+
+		addon, err := c.Addons.Get(t.Context(), addonID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, addon)
+		require.Len(t, addon.RateCards, 1)
+
+		uc := addon.RateCards[0].UnitConfig
+		require.NotNil(t, uc)
+		assert.Equal(t, v3sdk.UnitConfigOperationMultiply, uc.Operation)
+		assert.Equal(t, v3sdk.Numeric("1000000"), uc.ConversionFactor)
+		require.NotNil(t, uc.Rounding)
+		assert.Equal(t, v3sdk.UnitConfigRoundingModeHalfUp, *uc.Rounding)
+		require.NotNil(t, uc.Precision)
+		assert.EqualValues(t, 2, *uc.Precision)
+		require.NotNil(t, uc.DisplayUnit)
+		assert.Equal(t, "M", *uc.DisplayUnit)
+	})
+}
+
+// TestV3AddonV1PriceReadFallback proves the v1→v3 read fallback for add-ons: v3
+// cannot author a package/dynamic price, so an add-on only carries one when
+// authored through the v1 API. Reading such an add-on through the v3 API must
+// render the price as a unit price paired with a synthesized unit_config that
+// describes the conversion v1 applied implicitly — exactly as the v3 plan API
+// already does. Two versions: package and dynamic.
+func TestV3AddonV1PriceReadFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		// buildPrice returns the v1 usage-based price under test.
+		buildPrice func(t *testing.T) api.RateCardUsageBasedPrice
+		// expected v3-rendered unit price amount + synthesized unit_config.
+		wantUnitAmount       string
+		wantOperation        v3sdk.UnitConfigOperation
+		wantConversionFactor v3sdk.Numeric
+		wantRounding         *v3sdk.UnitConfigRoundingMode
+	}{
+		{
+			name: "package price renders as unit + divide unit_config",
+			buildPrice: func(t *testing.T) api.RateCardUsageBasedPrice {
+				var p api.RateCardUsageBasedPrice
+				require.NoError(t, p.FromPackagePriceWithCommitments(api.PackagePriceWithCommitments{
+					Type:               api.PackagePriceWithCommitmentsTypePackage,
+					Amount:             "10",
+					QuantityPerPackage: "1000",
+				}))
+				return p
+			},
+			wantUnitAmount:       "10",
+			wantOperation:        v3sdk.UnitConfigOperationDivide,
+			wantConversionFactor: "1000",
+			wantRounding:         lo.ToPtr(v3sdk.UnitConfigRoundingModeCeiling),
+		},
+		{
+			name: "dynamic price renders as unit 1 + multiply unit_config",
+			buildPrice: func(t *testing.T) api.RateCardUsageBasedPrice {
+				var p api.RateCardUsageBasedPrice
+				require.NoError(t, p.FromDynamicPriceWithCommitments(api.DynamicPriceWithCommitments{
+					Type:       api.DynamicPriceWithCommitmentsTypeDynamic,
+					Multiplier: lo.ToPtr(api.Numeric("1.2")),
+				}))
+				return p
+			},
+			wantUnitAmount:       "1",
+			wantOperation:        v3sdk.UnitConfigOperationMultiply,
+			wantConversionFactor: "1.2",
+			wantRounding:         nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newV3Client(t)
+			v1 := initClient(t)
+
+			f := newMeteredFeature(t, c)
+
+			// Author the add-on through the v1 API (camelCase; unions built via
+			// FromX constructors). The package/dynamic price is v1's native shape;
+			// no unit_config is stored.
+			price := tc.buildPrice(t)
+
+			var rc api.RateCard
+			require.NoError(t, rc.FromRateCardUsageBased(api.RateCardUsageBased{
+				Type:           api.RateCardUsageBasedTypeUsageBased,
+				Key:            f.Key,
+				Name:           "v1 fallback rc",
+				FeatureKey:     &f.Key,
+				BillingCadence: "P1M",
+				Price:          &price,
+			}))
+
+			createResp, err := v1.CreateAddonWithResponse(t.Context(), api.AddonCreate{
+				Name:         "v1-fallback-addon " + f.Key,
+				Key:          uniqueKey("v1_fallback"),
+				Currency:     "USD",
+				InstanceType: api.AddonInstanceTypeSingle,
+				RateCards:    []api.RateCard{rc},
+			})
+			require.NoError(t, err)
+			require.Equal(t, http.StatusCreated, createResp.StatusCode(), "v1 create body: %s", string(createResp.Body))
+			require.NotNil(t, createResp.JSON201)
+			addonID := createResp.JSON201.Id
+			require.NotEmpty(t, addonID)
+
+			// Read the SAME add-on through the v3 API: the fallback must project the
+			// v1 price to a unit price + synthesized unit_config.
+			addon, err := c.Addons.Get(t.Context(), addonID)
+			c.requireStatus(http.StatusOK, err)
+			require.NotNil(t, addon)
+			require.Len(t, addon.RateCards, 1)
+
+			gotRC := addon.RateCards[0]
+
+			unitPrice, err := gotRC.Price.AsPriceUnit()
+			require.NoError(t, err, "v1 %s price should read back as a v3 unit price", tc.name)
+			assert.Equal(t, tc.wantUnitAmount, unitPrice.Amount)
+
+			uc := gotRC.UnitConfig
+			require.NotNil(t, uc, "v1 price did not synthesize a unit_config on v3 read")
+			assert.Equal(t, tc.wantOperation, uc.Operation)
+			assert.Equal(t, tc.wantConversionFactor, uc.ConversionFactor)
+			assert.Equal(t, tc.wantRounding, uc.Rounding)
+		})
+	}
+}
+
+// TestV3AddonUnitConfigRejectedByV1Read proves the OM-409 guard that add-on
+// unit_config authoring unblocks: once an add-on can carry a stored unit_config
+// (v3 authoring, above), the v1 add-on read surface — which cannot represent it
+// — must reject it. Author + publish a unit_config add-on via v3, then GET it
+// through the v1 API and expect a 400 unit_config_not_representable.
+func TestV3AddonUnitConfigRejectedByV1Read(t *testing.T) {
+	c := newV3Client(t)
+	v1 := initClient(t)
+
+	f := newMeteredFeature(t, c)
+
+	rc := validUnitRateCard(f)
+	rc.UnitConfig = &v3sdk.UnitConfig{
+		Operation:        v3sdk.UnitConfigOperationDivide,
+		ConversionFactor: "1000000000",
+		Rounding:         lo.ToPtr(v3sdk.UnitConfigRoundingModeCeiling),
+		DisplayUnit:      lo.ToPtr("GB"),
+	}
+
+	body := validAddonRequest("uc_v1_reject")
+	body.RateCards = []v3sdk.RateCardInput{rc}
+
+	addon, err := c.Addons.Create(t.Context(), body)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, addon)
+
+	// A unit price is usage-based, so the unit_config price-type rule is satisfied
+	// and publish succeeds — putting the add-on into active state for the v1 GET.
+	published, err := c.Addons.Publish(t.Context(), addon.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, published)
+
+	resp, err := v1.GetAddonWithResponse(t.Context(), addon.ID, &api.GetAddonParams{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode(),
+		"v1 add-on GET of a unit_config add-on must be rejected; body: %s", string(resp.Body))
+	assert.Contains(t, string(resp.Body), "unit_config_not_representable")
+}

--- a/e2e/addons_unitconfig_v3_test.go
+++ b/e2e/addons_unitconfig_v3_test.go
@@ -265,11 +265,10 @@ func TestV3AddonV1PriceReadFallback(t *testing.T) {
 	}
 }
 
-// TestV3AddonUnitConfigRejectedByV1Read proves the OM-409 guard that add-on
-// unit_config authoring unblocks: once an add-on can carry a stored unit_config
-// (v3 authoring, above), the v1 add-on read surface — which cannot represent it
-// — must reject it. Author + publish a unit_config add-on via v3, then GET it
-// through the v1 API and expect a 400 unit_config_not_representable.
+// TestV3AddonUnitConfigRejectedByV1Read proves that once an add-on carries a
+// stored unit_config (v3 authoring, above), the v1 read surface — which can't
+// represent it — rejects it. Author + publish via v3, then GET via v1 and
+// expect a 400 unit_config_not_representable.
 func TestV3AddonUnitConfigRejectedByV1Read(t *testing.T) {
 	c := newV3Client(t)
 	v1 := initClient(t)

--- a/openmeter/subscription/addon/extend.go
+++ b/openmeter/subscription/addon/extend.go
@@ -48,7 +48,10 @@ func (a SubscriptionAddonRateCard) Apply(target productcatalog.RateCard, annotat
 		if aMeta.Price != nil {
 			switch {
 			case tMeta.Price == nil:
+				// UnitConfig travels with Price here: it's meaningless without the price
+				// it converts, and the target has none of its own to preserve.
 				m.Price = aMeta.Price
+				m.UnitConfig = aMeta.UnitConfig
 			case tMeta.Price.Type() == productcatalog.FlatPriceType:
 				tFlat, _ := tMeta.Price.AsFlat()
 				aFlat, _ := aMeta.Price.AsFlat()
@@ -155,7 +158,9 @@ func (a SubscriptionAddonRateCard) Restore(target productcatalog.RateCard, annot
 					PaymentTerm: tFlat.PaymentTerm,
 				})
 			case instanceType == productcatalog.AddonInstanceTypeSingle:
+				// Clear UnitConfig with Price: it can't outlive the price it converts.
 				m.Price = nil
+				m.UnitConfig = nil
 			default:
 				return m, fmt.Errorf("not supported price type: %s", tMeta.Price.Type())
 			}

--- a/openmeter/subscription/addon/extend_test.go
+++ b/openmeter/subscription/addon/extend_test.go
@@ -463,6 +463,39 @@ func TestExtendApply(t *testing.T) {
 		require.Equal(t, 200.0, *me.IssueAfterReset)
 	})
 
+	t.Run("Should propagate addon UnitConfig to target when target has no price", func(t *testing.T) {
+		meta := someMeta.Clone()
+		meta.Price = productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		})
+		meta.UnitConfig = &productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationDivide,
+			ConversionFactor: alpacadecimal.NewFromInt(1_000_000_000),
+			Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+		}
+
+		rc := getTestAddonRateCard(&productcatalog.UsageBasedRateCard{
+			RateCardMeta:   meta.Clone(),
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		})
+
+		targetMeta := meta.Clone()
+		targetMeta.Price = nil
+		targetMeta.UnitConfig = nil
+
+		target := &productcatalog.UsageBasedRateCard{
+			RateCardMeta:   targetMeta,
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		}
+
+		err := rc.Apply(target, models.Annotations{})
+
+		require.NoError(t, err)
+		require.NotNil(t, target.AsMeta().UnitConfig, "addon's UnitConfig must travel with its Price onto a previously priceless target")
+		require.Equal(t, productcatalog.UnitConfigOperationDivide, target.AsMeta().UnitConfig.Operation)
+		require.Equal(t, alpacadecimal.NewFromInt(1_000_000_000).InexactFloat64(), target.AsMeta().UnitConfig.ConversionFactor.InexactFloat64())
+	})
+
 	t.Run("Should add Usage Discounts from UsageBasedRateCard to target with UnitPrice", func(t *testing.T) {
 		meta := someMeta.Clone()
 		meta.Price = nil
@@ -800,6 +833,35 @@ func TestExtendRestore(t *testing.T) {
 		me, err := target.AsMeta().EntitlementTemplate.AsMetered()
 		require.NoError(t, err)
 		require.Equal(t, 0.0, *me.IssueAfterReset)
+	})
+
+	t.Run("Should clear UnitConfig when restoring a single-instance addon's price to nil", func(t *testing.T) {
+		meta := someMeta.Clone()
+		meta.EntitlementTemplate = nil
+		meta.Price = productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		})
+		meta.UnitConfig = &productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationDivide,
+			ConversionFactor: alpacadecimal.NewFromInt(1_000_000_000),
+			Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+		}
+
+		rc := getTestAddonRateCard(&productcatalog.UsageBasedRateCard{
+			RateCardMeta:   meta.Clone(),
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		})
+
+		target := &productcatalog.UsageBasedRateCard{
+			RateCardMeta:   meta.Clone(),
+			BillingCadence: datetime.MustParseDuration(t, "P1M"),
+		}
+
+		err := rc.Restore(target, models.Annotations{}, productcatalog.AddonInstanceTypeSingle)
+
+		require.NoError(t, err)
+		require.Nil(t, target.AsMeta().Price)
+		require.Nil(t, target.AsMeta().UnitConfig, "tearing down the addon's price must also clear the UnitConfig it carried in, or the target is left with a UnitConfig and no price to convert")
 	})
 
 	t.Run("Should error if trying to restore Usage Discount when one is not present on target", func(t *testing.T) {

--- a/openmeter/subscription/addon/http/get.go
+++ b/openmeter/subscription/addon/http/get.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -49,6 +50,10 @@ func (h *handler) GetSubscriptionAddon() GetSubscriptionAddonHandler {
 			view, err := h.SubscriptionService.GetView(ctx, req.SubscriptionID)
 			if err != nil {
 				return GetSubscriptionAddonResponse{}, err
+			}
+
+			if res.Addon.AsProductCatalogAddon().HasUnitConfig() {
+				return GetSubscriptionAddonResponse{}, productcatalog.ErrUnitConfigNotRepresentable
 			}
 
 			return MapSubscriptionAddonToResponse(view, *res)

--- a/openmeter/subscription/addon/http/list.go
+++ b/openmeter/subscription/addon/http/list.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -53,6 +54,10 @@ func (h *handler) ListSubscriptionAddons() ListSubscriptionAddonsHandler {
 			}
 
 			return slicesx.MapWithErr(res.Items, func(item subscriptionaddon.SubscriptionAddon) (api.SubscriptionAddon, error) {
+				if item.Addon.AsProductCatalogAddon().HasUnitConfig() {
+					return api.SubscriptionAddon{}, productcatalog.ErrUnitConfigNotRepresentable
+				}
+
 				return MapSubscriptionAddonToResponse(view, item)
 			})
 		},

--- a/openmeter/subscription/addon/http/list.go
+++ b/openmeter/subscription/addon/http/list.go
@@ -53,6 +53,9 @@ func (h *handler) ListSubscriptionAddons() ListSubscriptionAddonsHandler {
 				return nil, err
 			}
 
+			// Deliberately fails the whole list, not just the unrepresentable item: this is
+			// an actual-state surface (what the customer is billed for), which rejects,
+			// unlike catalog-list endpoints such as ListAddons, which omit instead.
 			return slicesx.MapWithErr(res.Items, func(item subscriptionaddon.SubscriptionAddon) (api.SubscriptionAddon, error) {
 				if item.Addon.AsProductCatalogAddon().HasUnitConfig() {
 					return api.SubscriptionAddon{}, productcatalog.ErrUnitConfigNotRepresentable

--- a/openmeter/subscription/addon/http/update.go
+++ b/openmeter/subscription/addon/http/update.go
@@ -69,13 +69,10 @@ func (h *handler) UpdateSubscriptionAddon() UpdateSubscriptionAddonHandler {
 			}, nil
 		},
 		func(ctx context.Context, request UpdateSubscriptionAddonRequest) (UpdateSubscriptionAddonResponse, error) {
-			// v1 cannot represent a unit_config add-on. Reject BEFORE the quantity
-			// change so a request we are going to reject never persists a mutation.
-			// We guard here in the v1 handler, not inside ChangeAddonQuantity: that is
-			// a domain workflow (shared with the create path) whose result IS
-			// representable in v3, so the "v1-only" restriction belongs on the v1 read
-			// surface. Guard the served add-on only, never the subscription's plan
-			// (per OM-399).
+			// Reject before the quantity change so a rejected request never persists a
+			// mutation. Guarded here, not in ChangeAddonQuantity, since that workflow's
+			// result is representable in v3; only the v1 surface needs the restriction.
+			// Checks the served add-on only, never the subscription's plan.
 			served, err := h.SubscriptionAddonService.Get(ctx, subscriptionaddon.GetSubscriptionAddonInput{
 				NamespacedID: request.WorkflowInput.SubscriptionAddonID,
 			})

--- a/openmeter/subscription/addon/http/update.go
+++ b/openmeter/subscription/addon/http/update.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 
 	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	subscriptionhttp "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/http"
+	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -67,6 +69,24 @@ func (h *handler) UpdateSubscriptionAddon() UpdateSubscriptionAddonHandler {
 			}, nil
 		},
 		func(ctx context.Context, request UpdateSubscriptionAddonRequest) (UpdateSubscriptionAddonResponse, error) {
+			// v1 cannot represent a unit_config add-on. Reject BEFORE the quantity
+			// change so a request we are going to reject never persists a mutation.
+			// We guard here in the v1 handler, not inside ChangeAddonQuantity: that is
+			// a domain workflow (shared with the create path) whose result IS
+			// representable in v3, so the "v1-only" restriction belongs on the v1 read
+			// surface. Guard the served add-on only, never the subscription's plan
+			// (per OM-399).
+			served, err := h.SubscriptionAddonService.Get(ctx, subscriptionaddon.GetSubscriptionAddonInput{
+				NamespacedID: request.WorkflowInput.SubscriptionAddonID,
+			})
+			if err != nil {
+				return UpdateSubscriptionAddonResponse{}, err
+			}
+
+			if served.Addon.AsProductCatalogAddon().HasUnitConfig() {
+				return UpdateSubscriptionAddonResponse{}, productcatalog.ErrUnitConfigNotRepresentable
+			}
+
 			view, addon, err := h.SubscriptionWorkflowService.ChangeAddonQuantity(ctx, request.SubscriptionID, request.WorkflowInput)
 			if err != nil {
 				return UpdateSubscriptionAddonResponse{}, err


### PR DESCRIPTION
## What

Makes `unit_config` writable and readable on the v3 **add-on** rate card API, closing the last plan/add-on parity gap. Mirrors the v3 plan converter (OM-396): a unit-priced add-on rate card can now author a full `unit_config` (operation, conversion factor, rounding, precision, display unit) and read it back verbatim. Also mirrors the plan **v1→v3 read fallback** — a v1-authored add-on with a dynamic/package price now reads through v3 as a `unit` price paired with a synthesized `unit_config`, instead of erroring. Gated behind `unitConfig.enabled`; **no TypeSpec, schema, or migration change** — the field and the shared persistence column already existed.

## Why

`unit_config` was fully supported on v3 plans and in the domain/persistence layer for **both** plans and add-ons (shared `RateCardMeta` mixin + shared Ent column, OM-393/395), but the v3 add-on HTTP converters were never wired — so **no API could author a `unit_config` onto an add-on** (v3 dropped it on write; v1 add-on authoring is closed by design). The asymmetry surfaced during OM-409. A second, pre-existing gap: the add-on read path errored on v1 dynamic/package prices where the plan path projects them to `unit` + `unit_config` — so the read-side fallback was unreachable for add-ons. Landing authoring also makes the OM-409 v1 read/mutation guards (previously latent because an add-on could never carry `unit_config`) reachable and testable.

## How

- **Write** — add the `unit_config` mapping to the add-on `FromAPIBillingRateCard`, set up front before the price-type switch (`meta` is copied by value into both rate-card variants), mirroring the plan converter. The three `unit_config` helpers are duplicated into the addons package (the whole converter is already duplicated between plans/addons; kept self-contained over cross-package coupling).
- **Read** — add the `unit_config` mapping to the add-on `ToAPIBillingRateCard` with the same stored-else-v1-fallback plans use (prefer a stored config; else synthesize from a v1 dynamic/package price).
- **Read fallback price mapping** — add `dynamic`/`package` cases to the add-on `ToAPIBillingPrice` (dynamic → `unit "1"`, package → `unit` per-unit amount, commitments preserved) so the read no longer errors on those price types and the fallback is actually reachable — true plan/add-on read parity.
- **Flag gate** — new `unitConfigEnabled` field + ctor param on the addon handler, create/update reject guards over the flat `body.RateCards`, threaded from the router DI (mirroring plans). Off → v3 add-on writes reject `unit_config` as today; byte-identical read fallback for v1-authored add-ons.
- **Boundary validation** — reuse the shared `RateCardMeta.Validate` / `Price.SupportsUnitConfig` (requires a usage-based price; rejects both `unit_config` + package/dynamic). Both rate-card kinds share the type, so the rules fire on the add-on path automatically.
- **OM-409 guards unblocked** — verified the latent v1 add-on GET and plan-add-on GET/LIST rejects fire; added the add-on-side `HasUnitConfig()` reject to v1 sub-add-on `get`/`list`/`update` on the **served** add-on (never `view.Spec`, per OM-399). Guarding follows the OM-409 rule: catalog surfaces omit (plan LIST), actual-state and single-resource surfaces reject.
- **Tests** — converter round-trip unit tests; Go e2e (authoring round-trip, the v1→v3 fallback for both package and dynamic, and the OM-409 v1-read reject) verified green against the live stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v3 add-on `unit_config` support, including correct v1↔v3 billing conversions for dynamic and package pricing and automatic `unit_config` synthesis when derived from v1.

* **Bug Fixes**
  * Enforced the unit-config deployment flag: add-on create/update now reject requests containing `unit_config` when disabled.
  * Subscription add-on get/list/update now fail when `unit_config` can’t be represented in the subscription API.
  * Subscription add-on apply/restore now keeps or clears `unit_config` in sync with price changes.

* **Tests**
  * Added unit and end-to-end coverage for conversion, mapping/rounding rules, round-trips, and rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `unit_config` support to the v3 add-on API. The main changes are:

- Maps stored unit configuration on add-on writes and reads.
- Converts legacy dynamic and package prices into v3 unit prices with synthesized configuration.
- Gates add-on authoring behind the deployment feature flag.
- Rejects unrepresentable add-ons on legacy subscription surfaces.
- Keeps unit configuration aligned with prices during add-on apply and restore flows.
- Adds converter, lifecycle, and end-to-end coverage.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The representability check returns before the quantity mutation runs.
- No blocking issue was found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/handlers/addons/convert.go | Maps add-on unit configuration and converts legacy dynamic and package prices for v3 reads. |
| api/v3/handlers/addons/create.go | Rejects unit configuration during add-on creation when the feature is disabled. |
| api/v3/handlers/addons/update.go | Rejects unit configuration during add-on updates when the feature is disabled. |
| openmeter/subscription/addon/extend.go | Copies and clears unit configuration together with its associated price. |
| openmeter/subscription/addon/http/update.go | Checks representability before invoking the quantity-change workflow. |

<sub>Reviews (4): Last reviewed commit: ["fix: propagate addon unit\_config on subs..."](https://github.com/openmeterio/openmeter/commit/ed7806b8b4f293570c29c5065ab04c85539161fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44583977)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->