### PR TITLE
docs(test-skill): update TestEnv pattern for cached pre-migrated DB

### DIFF
--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -50,9 +50,17 @@ From `openmeter/testutils/`:
 
 | Utility | Usage |
 |---------|-------|
-| `testutils.InitPostgresDB(t)` | Provisions fresh Postgres DB per test; skips if `POSTGRES_HOST` not set |
+| `testutils.InitPostgresDB(t, state)` | Provisions a fresh Postgres DB per test from a cached, pre-migrated template; skips if `POSTGRES_HOST` not set |
 | `testutils.NewDiscardLogger(t)` | Silent logger for tests |
 | `testutils.NewLogger(t)` | Default slog logger for tests |
+
+`InitPostgresDB` takes a `testutils.PostgresDBState` selecting how the template DB is migrated. The template is cached and cloned per test, so the returned DB is **already migrated** — do not run schema migration yourself in `NewTestEnv` or tests:
+
+| State | Meaning |
+|-------|---------|
+| `PostgresDBStateEmpty` | No schema; empty database |
+| `PostgresDBStateEntMigrated` | Schema created from the Ent client (`Schema.Create`); use this for service/adapter tests |
+| `PostgresDBStateAtlasMigrated` | Schema built by replaying Atlas migrations; use when a test must exercise real migration output |
 
 From `openmeter/watermill/eventbus/`:
 
@@ -91,13 +99,6 @@ type TestEnv struct {
     close   sync.Once
 }
 
-func (e *TestEnv) DBSchemaMigrate(t *testing.T) {
-    t.Helper()
-    require.NotNilf(t, e.db, "database must be initialized")
-    err := e.db.EntDriver.Client().Schema.Create(t.Context())
-    require.NoErrorf(t, err, "schema migration must not fail")
-}
-
 func (e *TestEnv) Close(t *testing.T) {
     t.Helper()
     e.close.Do(func() {
@@ -122,8 +123,8 @@ func NewTestEnv(t *testing.T) *TestEnv {
 
     logger := testutils.NewDiscardLogger(t)
 
-    // Init database
-    db := testutils.InitPostgresDB(t)
+    // Init database (returns an already-migrated DB cloned from a cached template)
+    db := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
     client := db.EntDriver.Client()
 
     // Init event publisher
@@ -159,7 +160,6 @@ func NewTestEnv(t *testing.T) *TestEnv {
 func TestCreate<Resource>(t *testing.T) {
     env := testutils.NewTestEnv(t)
     t.Cleanup(func() { env.Close(t) })
-    env.DBSchemaMigrate(t)
 
     ns := testutils.NewTestNamespace(t) // generates a random ULID namespace
 
@@ -253,7 +253,6 @@ type <Domain>Suite struct {
 
 func (s *<Domain>Suite) SetupSuite() {
     s.env = testutils.NewTestEnv(s.T())
-    s.env.DBSchemaMigrate(s.T())
 }
 
 func (s *<Domain>Suite) TearDownSuite() {

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -50,11 +50,11 @@ From `openmeter/testutils/`:
 
 | Utility | Usage |
 |---------|-------|
-| `testutils.InitPostgresDB(t, state)` | Provisions a fresh Postgres DB per test from a cached, pre-migrated template; skips if `POSTGRES_HOST` not set |
+| `testutils.InitPostgresDB(t, state)` | Provisions a fresh Postgres DB per test, cloned from a cached template in the requested `state`; skips if `POSTGRES_HOST` not set |
 | `testutils.NewDiscardLogger(t)` | Silent logger for tests |
 | `testutils.NewLogger(t)` | Default slog logger for tests |
 
-`InitPostgresDB` takes a `testutils.PostgresDBState` selecting how the template DB is migrated. The template is cached and cloned per test, so the returned DB is **already migrated** — do not run schema migration yourself in `NewTestEnv` or tests:
+`InitPostgresDB` takes a `testutils.PostgresDBState` selecting how the template DB is prepared, then clones it per test. The `EntMigrated` and `AtlasMigrated` states return an **already-migrated** DB, so do not run schema migration yourself in `NewTestEnv` or tests; `Empty` intentionally returns a schemaless DB:
 
 | State | Meaning |
 |-------|---------|


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the test-writing guide with the new database initialization API.
  * Clarified database setup options, including pre-migrated, migration-replayed, and empty databases.
  * Updated examples to use automatic schema initialization and removed obsolete migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the test-writing guide for cached database templates. The main changes are:

- Documents the state-aware `InitPostgresDB` API.
- Explains empty, Ent-migrated, and Atlas-migrated database states.
- Removes redundant schema migration calls from the `TestEnv` examples.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The documented API and database states match the implementation.
- The pre-migrated states make the removed migration calls redundant.
- No blocking issues were found in the changed documentation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .agents/skills/test/SKILL.md | Updates database test setup guidance to match the state-aware initialization API and pre-migrated templates. |

<sub>Reviews (4): Last reviewed commit: ["docs(test-skill): clarify InitPostgresDB..."](https://github.com/openmeterio/openmeter/commit/3e8110249781ec8d24df19834f5e96bbf9e04a53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44788202)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->