### PR TITLE
feat: add bulk invoice schema migration function

### DIFF
--- a/openmeter/billing/adapter/schemamigration.go
+++ b/openmeter/billing/adapter/schemamigration.go
@@ -69,7 +69,7 @@ func (a *adapter) migrateCustomerInvoices(ctx context.Context, customerID custom
 func (a *adapter) migrateSchemaLevel1(ctx context.Context, customerID customer.CustomerID) error {
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
 		// Schema level 1 -> 2 migration is implemented as a DB function (see migrations).
-		rows, err := tx.db.QueryContext(ctx, `SELECT om_func_migrate_customer_invoices_to_schema_level_2($1)`, customerID.ID)
+		rows, err := tx.db.QueryContext(ctx, `SELECT om_func_migrate_customer_invoices_to_schema_level_2_bulk(ARRAY[$1]::TEXT[])`, customerID.ID)
 		if err != nil {
 			return err
 		}

--- a/test/billing/schemamigration_test.go
+++ b/test/billing/schemamigration_test.go
@@ -52,6 +52,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 	var (
 		customerEntity *customer.Customer
 		invoiceID      billing.InvoiceID
+		gatheringID    billing.InvoiceID
 
 		deletedAtSet time.Time
 
@@ -210,6 +211,40 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 		s.GreaterOrEqual(len(lineActive.DetailedLines[0].AmountDiscounts), 1)
 	})
 
+	s.Run("Given a schema level 1 gathering invoice exists", func() {
+		periodStart := time.Now().Add(-time.Hour)
+		periodEnd := time.Now().Add(time.Hour)
+
+		result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+			Customer: customerEntity.GetID(),
+			Currency: currencyx.Code(currency.USD),
+			Lines: []billing.GatheringLine{
+				{
+					GatheringLineBase: billing.GatheringLineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Gathering item",
+						}),
+						ServicePeriod: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+						InvoiceAt:     periodEnd,
+						ManagedBy:     billing.ManuallyManagedLine,
+						Currency:      currencyx.Code(currency.USD),
+						FeatureKey:    featureFlatPerUnit.Key,
+						Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount: alpacadecimal.NewFromFloat(100),
+						})),
+					},
+				},
+			},
+		})
+		s.Require().NoError(err)
+
+		gatheringID = result.Invoice.GetInvoiceID()
+		gatheringInvoice, err := s.DBClient.BillingInvoice.Get(ctx, gatheringID.ID)
+		s.Require().NoError(err)
+		s.Require().Equal(1, gatheringInvoice.SchemaLevel)
+	})
+
 	s.Run("When the write schema level is set to 2 and a lock is obtained on the customer", func() {
 		s.NoError(s.BillingAdapter.SetInvoiceDefaultSchemaLevel(ctx, 2))
 		// Side-effect: migration happens due to the previous line.
@@ -217,6 +252,10 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 	})
 
 	s.Run("Then the invoice is migrated and lines (incl detailed lines) match exactly", func() {
+		gatheringInvoice, err := s.DBClient.BillingInvoice.Get(ctx, gatheringID.ID)
+		s.Require().NoError(err)
+		s.Require().Equal(2, gatheringInvoice.SchemaLevel)
+
 		invoiceAfter, err := s.BillingAdapter.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoiceID,
 			Expand: billing.StandardInvoiceExpands{

--- a/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.down.sql
+++ b/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS om_func_migrate_customer_invoices_to_schema_level_2_bulk(TEXT[]);

--- a/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
+++ b/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
@@ -78,6 +78,9 @@ BEGIN
         i.customer_id = ANY(p_customer_ids)
         AND i.schema_level = 1
         AND i.status <> 'gathering'
+        -- Hard-deleting parent lines previously used ON DELETE SET NULL instead of cascading,
+        -- leaving orphaned legacy detailed lines that cannot be represented in schema level 2.
+        AND l.parent_line_id IS NOT NULL
         AND l.status = 'detailed'
         AND l.type = 'flat_fee'
     ON CONFLICT (id) DO NOTHING;
@@ -125,6 +128,7 @@ BEGIN
         i.customer_id = ANY(p_customer_ids)
         AND i.schema_level = 1
         AND i.status <> 'gathering'
+        AND l.parent_line_id IS NOT NULL
         AND l.status = 'detailed'
         AND l.type = 'flat_fee'
     ON CONFLICT (id) DO NOTHING;

--- a/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
+++ b/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
@@ -1,0 +1,142 @@
+-- Migrates schema-level-1 invoices for an arbitrary set of customers to schema level 2.
+--
+-- Gathering invoice details are intentionally excluded: they are invalid legacy data and are
+-- removed by the preceding gathering-detail cleanup migration.
+CREATE OR REPLACE FUNCTION om_func_migrate_customer_invoices_to_schema_level_2_bulk(p_customer_ids TEXT[])
+RETURNS BIGINT
+AS $$
+DECLARE
+    v_updated_invoices BIGINT;
+BEGIN
+    INSERT INTO billing_standard_invoice_detailed_lines (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        name,
+        description,
+        currency,
+        amount,
+        taxes_total,
+        taxes_inclusive_total,
+        taxes_exclusive_total,
+        charges_total,
+        discounts_total,
+        total,
+        service_period_start,
+        service_period_end,
+        quantity,
+        invoicing_app_external_id,
+        child_unique_reference_id,
+        per_unit_amount,
+        category,
+        payment_term,
+        index,
+        invoice_id,
+        parent_line_id,
+        credits_total,
+        credits_applied
+    )
+    SELECT
+        l.id,
+        l.namespace,
+        l.created_at,
+        l.updated_at,
+        l.deleted_at,
+        l.name,
+        l.description,
+        l.currency,
+        l.amount,
+        l.taxes_total,
+        l.taxes_inclusive_total,
+        l.taxes_exclusive_total,
+        l.charges_total,
+        l.discounts_total,
+        l.total,
+        l.period_start AS service_period_start,
+        l.period_end AS service_period_end,
+        l.quantity,
+        l.invoicing_app_external_id,
+        l.child_unique_reference_id,
+        c.per_unit_amount,
+        c.category,
+        c.payment_term,
+        c.index,
+        l.invoice_id,
+        l.parent_line_id,
+        l.credits_total,
+        l.credits_applied
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_flat_fee_line_configs c
+        ON c.id = l.fee_line_config_id
+        AND c.namespace = l.namespace
+    WHERE
+        i.customer_id = ANY(p_customer_ids)
+        AND i.schema_level = 1
+        AND i.status <> 'gathering'
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO billing_standard_invoice_detailed_line_amount_discounts (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        child_unique_reference_id,
+        description,
+        reason,
+        invoicing_app_external_id,
+        amount,
+        rounding_amount,
+        source_discount,
+        line_id
+    )
+    SELECT
+        d.id,
+        d.namespace,
+        d.created_at,
+        d.updated_at,
+        d.deleted_at,
+        d.child_unique_reference_id,
+        d.description,
+        d.reason,
+        d.invoicing_app_external_id,
+        d.amount,
+        d.rounding_amount,
+        d.source_discount,
+        d.line_id
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_standard_invoice_detailed_lines migrated_l
+        ON migrated_l.id = l.id
+        AND migrated_l.namespace = l.namespace
+    JOIN billing_invoice_line_discounts d
+        ON d.line_id = l.id
+        AND d.namespace = l.namespace
+    WHERE
+        i.customer_id = ANY(p_customer_ids)
+        AND i.schema_level = 1
+        AND i.status <> 'gathering'
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    UPDATE billing_invoices
+    SET schema_level = 2
+    WHERE
+        customer_id = ANY(p_customer_ids)
+        AND schema_level = 1;
+
+    GET DIAGNOSTICS v_updated_invoices = ROW_COUNT;
+
+    RETURN v_updated_invoices;
+END;
+$$ LANGUAGE plpgsql VOLATILE;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sHp6EpaiKRdL9B9trZ/xwvONr0fdPUZGrOmNafRNcYQ=
+h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -237,3 +237,4 @@ h1:sHp6EpaiKRdL9B9trZ/xwvONr0fdPUZGrOmNafRNcYQ=
 20260716150455_cleanup_gathering_invoice_details.up.sql h1:W4u33tHXJy+GfryC8j46bHi2SiQwDk6brBOex/fQ4rw=
 20260716150456_drop_gathering_detail_cleanup_indexes.up.sql h1:IJ6P54dqEy/LFG9hID2T9yBoN29FRTH/iLTSSTkdpDQ=
 20260716152332_rescope-credit-grant-key-to-customer.up.sql h1:gbeATYlchOi0pwaTUFX+nrbLoS0jZbVDMHn8uMTck0c=
+20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:G5G6jYndCh8yx903RzDzVzrStmPDpdNhLiziNBT5ul0=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
+h1:HC/PLv5Sdfxy/ezlvrARXnwdKCcXFYHOtUS1Vx1IQbw=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -237,4 +237,4 @@ h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
 20260716150455_cleanup_gathering_invoice_details.up.sql h1:W4u33tHXJy+GfryC8j46bHi2SiQwDk6brBOex/fQ4rw=
 20260716150456_drop_gathering_detail_cleanup_indexes.up.sql h1:IJ6P54dqEy/LFG9hID2T9yBoN29FRTH/iLTSSTkdpDQ=
 20260716152332_rescope-credit-grant-key-to-customer.up.sql h1:gbeATYlchOi0pwaTUFX+nrbLoS0jZbVDMHn8uMTck0c=
-20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:G5G6jYndCh8yx903RzDzVzrStmPDpdNhLiziNBT5ul0=
+20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:kJCvXyNuRC9FMysGg9c6nesUXsfbkNq/RKfTIwnQzEw=


### PR DESCRIPTION
## Overview

Improve schema-level-2 migration performance by adding a set-based function that accepts an arbitrary array of customer IDs. The billing adapter also uses it with a one-customer array for on-demand migration, while the next stacked migration can upgrade all affected customers in one bulk operation.

## Changes

- Add `om_func_migrate_customer_invoices_to_schema_level_2_bulk(TEXT[])` without modifying the existing scalar function used by older OpenMeter versions.
- Bulk-copy eligible legacy flat-fee detailed lines and amount discounts into the schema-level-2 tables.
- Exclude gathering invoices from detailed-line copying because gathering invoices do not have valid detailed lines.
- Update all schema-level-1 invoices for the supplied customers, including gathering invoices, and return the number updated.
- Use the bulk function from the billing adapter with a one-customer array.
- Extend the schema-migration integration test to assert that gathering invoices are also upgraded to schema level 2.

The set-based implementation avoids repeating the same invoice and detailed-line migration queries customer by customer during the mass backfill. The function is idempotent for copied rows through `ON CONFLICT (id) DO NOTHING`. It does not acquire customer locks; callers remain responsible for locking the customers they migrate.

## Legacy orphan handling

Legacy detailed lines can have a NULL `parent_line_id` when their parent line was hard-deleted: the old foreign key used `ON DELETE SET NULL`, so the detailed row survived. Schema level 2 requires `parent_line_id` and cannot represent these orphans, which otherwise aborts the entire customer migration with a NOT NULL violation.

The bulk function skips these orphaned detailed lines and their discounts. This was observed on a gathering invoice; gathering details remain excluded from copying while the invoice itself still advances to schema level 2. The schema-level-2 foreign key uses `ON DELETE CASCADE`, preventing new data from reaching this orphaned shape.

## Validation

- `nix develop --impure .#ci -c make test-nocache` — 6,154 tests passed, 9 skipped
- `atlas migrate --env local lint --latest 1`
- `atlas migrate validate --env local`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration of legacy invoices to the latest schema level.
  * Ensured gathering invoices and their associated details are migrated correctly.
  * Added safeguards to prevent duplicate invoice detail records during migration.

* **Database**
  * Added bulk migration support to update invoice schema levels for multiple customers in one operation.
  * Added rollback support for the new bulk migration capability.

* **Tests**
  * Expanded schema migration coverage to verify gathering invoices are updated to schema level 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bulk migration of customer invoices to schema level 2. The main changes are:

- Adds a PostgreSQL function that migrates invoices for an array of customer IDs.
- Copies eligible detailed lines and amount discounts with conflict handling.
- Excludes gathering-invoice details while upgrading gathering invoices.
- Uses the bulk function for on-demand single-customer migration.
- Adds integration coverage for gathering-invoice upgrades.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated migration intentionally excludes invalid gathering-invoice details.
- The new test confirms that gathering invoices advance to schema level 2.
- No blocking issue remains in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql | Adds the bulk migration function and handles gathering invoices according to the new schema contract. |
| openmeter/billing/adapter/schemamigration.go | Switches on-demand migration to the bulk function with a one-customer array. |
| test/billing/schemamigration_test.go | Adds coverage confirming that gathering invoices advance to schema level 2. |
| tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.down.sql | Removes the bulk migration function during rollback. |
| tools/migrate/migrations/atlas.sum | Registers the new migration in the Atlas checksum manifest. |

<sub>Reviews (3): Last reviewed commit: ["fix: skip orphaned invoice detail rows"](https://github.com/openmeterio/openmeter/commit/0f786195e3d9a684f92ee946b7b925d80b4a5841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44817074)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->