### PR TITLE
fix(api): v3 TypeScript sdk datetime validation

### DIFF
--- a/api/spec/packages/aip-client-javascript/src/models/schemas.ts
+++ b/api/spec/packages/aip-client-javascript/src/models/schemas.ts
@@ -6809,7 +6809,7 @@ export const ulidWire = z
 
 export const dateTimeWire = z
   .string()
-  .datetime()
+  .datetime({ offset: true })
 
   .describe(
     '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.',

--- a/api/spec/packages/aip-client-javascript/tests/validation.spec.ts
+++ b/api/spec/packages/aip-client-javascript/tests/validation.spec.ts
@@ -295,3 +295,79 @@ describe('nullable cursor response validation', () => {
     expect(result.value?.meta.page.previous).toBe(42)
   })
 })
+
+// RFC 3339 permits a numeric UTC offset, not just `Z`, and the API emits them.
+describe('strict validation accepts RFC 3339 numeric UTC offsets', () => {
+  it('accepts meter query rows whose from/to carry a numeric offset', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: '2024-01-01T00:00:00+02:00',
+            to: '2024-01-02T00:00:00-07:00',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.error).toBeUndefined()
+    expect(result.ok).toBe(true)
+    expect(result.value?.data[0]?.value).toBe('10')
+    // the offset is a real instant, not a UTC wall-clock reading
+    expect(result.value?.data[0]?.from?.toISOString()).toBe(
+      '2023-12-31T22:00:00.000Z',
+    )
+    expect(result.value?.data[0]?.to?.toISOString()).toBe(
+      '2024-01-02T07:00:00.000Z',
+    )
+  })
+
+  it('still accepts a plain Z timestamp', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: '2024-01-01T00:00:00Z',
+            to: '2024-01-02T00:00:00Z',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.data[0]?.from?.toISOString()).toBe(
+      '2024-01-01T00:00:00.000Z',
+    )
+  })
+
+  it('still rejects a genuinely malformed timestamp', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: 'not-a-timestamp',
+            to: '2024-01-02T00:00:00Z',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(ValidationError)
+  })
+})

--- a/api/spec/packages/typespec-typescript/src/zodBaseSchema.tsx
+++ b/api/spec/packages/typespec-typescript/src/zodBaseSchema.tsx
@@ -216,10 +216,16 @@ function scalarBaseType($: Typekit, type: Scalar) {
  * pass types them `z.date()` (the SDK surface takes and returns `Date`; the
  * runtime wire mapper converts at the request/response boundary), while the
  * wire pass keeps the RFC 3339 string the JSON payload actually carries.
+ *
+ * `offset: true` because RFC 3339 permits a numeric UTC offset, not just `Z`,
+ * and the API emits them; zod's default rejects everything but `Z`.
  */
 function dateTimeBaseType() {
   if (useWireMode()) {
-    return zodMemberExpr(callPart('string'), callPart('datetime'))
+    return zodMemberExpr(
+      callPart('string'),
+      callPart('datetime', '{ offset: true }'),
+    )
   }
   return zodMemberExpr(callPart('date'))
 }

--- a/api/spec/packages/typespec-typescript/templates/tests/validation.spec.ts
+++ b/api/spec/packages/typespec-typescript/templates/tests/validation.spec.ts
@@ -293,3 +293,79 @@ describe('nullable cursor response validation', () => {
     expect(result.value?.meta.page.previous).toBe(42)
   })
 })
+
+// RFC 3339 permits a numeric UTC offset, not just `Z`, and the API emits them.
+describe('strict validation accepts RFC 3339 numeric UTC offsets', () => {
+  it('accepts meter query rows whose from/to carry a numeric offset', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: '2024-01-01T00:00:00+02:00',
+            to: '2024-01-02T00:00:00-07:00',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.error).toBeUndefined()
+    expect(result.ok).toBe(true)
+    expect(result.value?.data[0]?.value).toBe('10')
+    // the offset is a real instant, not a UTC wall-clock reading
+    expect(result.value?.data[0]?.from?.toISOString()).toBe(
+      '2023-12-31T22:00:00.000Z',
+    )
+    expect(result.value?.data[0]?.to?.toISOString()).toBe(
+      '2024-01-02T07:00:00.000Z',
+    )
+  })
+
+  it('still accepts a plain Z timestamp', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: '2024-01-01T00:00:00Z',
+            to: '2024-01-02T00:00:00Z',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.data[0]?.from?.toISOString()).toBe(
+      '2024-01-01T00:00:00.000Z',
+    )
+  })
+
+  it('still rejects a genuinely malformed timestamp', async () => {
+    fetchMock.route(
+      '*',
+      json({
+        data: [
+          {
+            value: '10',
+            from: 'not-a-timestamp',
+            to: '2024-01-02T00:00:00Z',
+            dimensions: { subject: 'customer-1' },
+          },
+        ],
+      }),
+    )
+
+    const result = await funcs.queryMeter(client(true), { meterId, body: {} })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(ValidationError)
+  })
+})


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamp validation now accepts RFC 3339 values with numeric UTC offsets, such as `+02:00` and `-07:00`.
  * Timestamps continue to support standard `Z` notation and are correctly converted to their corresponding instants.
  * Malformed timestamp values are rejected with validation errors.

* **Tests**
  * Added coverage for offset-based, standard, and invalid timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows RFC 3339 numeric offsets in the TypeScript SDK’s strict datetime validation. The main changes are:

- Emits `datetime({ offset: true })` for wire schemas.
- Regenerates the JavaScript client schema.
- Tests numeric offsets, `Z` timestamps, malformed input, and `Date` conversion.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The generated schema matches the emitter output.
- The configured Zod version supports the option, and the strict validation path converts offsets to the correct instant.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/spec/packages/typespec-typescript/src/zodBaseSchema.tsx | Updates wire-mode datetime generation to accept RFC 3339 numeric offsets while keeping the public `Date` schema unchanged. |
| api/spec/packages/aip-client-javascript/src/models/schemas.ts | Regenerates `dateTimeWire` with the offset-enabled Zod datetime option. |
| api/spec/packages/typespec-typescript/templates/tests/validation.spec.ts | Adds source conformance tests for offset timestamps, `Z`, malformed values, and instant conversion. |
| api/spec/packages/aip-client-javascript/tests/validation.spec.ts | Mirrors the template tests in the generated SDK test suite. |

<sub>Reviews (1): Last reviewed commit: ["fix(api): v3 TypeScript sdk datetime val..."](https://github.com/openmeterio/openmeter/commit/f8688d5f8f29193a68e70bc54791e7ce134f3759) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44817318)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->