### PR TITLE
chore: drop invoice schema migration functions

### DIFF
--- a/openmeter/billing/adapter/schemamigration.go
+++ b/openmeter/billing/adapter/schemamigration.go
@@ -69,7 +69,7 @@ func (a *adapter) migrateCustomerInvoices(ctx context.Context, customerID custom
 func (a *adapter) migrateSchemaLevel1(ctx context.Context, customerID customer.CustomerID) error {
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
 		// Schema level 1 -> 2 migration is implemented as a DB function (see migrations).
-		rows, err := tx.db.QueryContext(ctx, `SELECT om_func_migrate_customer_invoices_to_schema_level_2($1)`, customerID.ID)
+		rows, err := tx.db.QueryContext(ctx, `SELECT om_func_migrate_customer_invoices_to_schema_level_2_bulk(ARRAY[$1]::TEXT[])`, customerID.ID)
 		if err != nil {
 			return err
 		}

--- a/test/billing/schemamigration_test.go
+++ b/test/billing/schemamigration_test.go
@@ -52,6 +52,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 	var (
 		customerEntity *customer.Customer
 		invoiceID      billing.InvoiceID
+		gatheringID    billing.InvoiceID
 
 		deletedAtSet time.Time
 
@@ -210,6 +211,40 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 		s.GreaterOrEqual(len(lineActive.DetailedLines[0].AmountDiscounts), 1)
 	})
 
+	s.Run("Given a schema level 1 gathering invoice exists", func() {
+		periodStart := time.Now().Add(-time.Hour)
+		periodEnd := time.Now().Add(time.Hour)
+
+		result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+			Customer: customerEntity.GetID(),
+			Currency: currencyx.Code(currency.USD),
+			Lines: []billing.GatheringLine{
+				{
+					GatheringLineBase: billing.GatheringLineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Gathering item",
+						}),
+						ServicePeriod: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+						InvoiceAt:     periodEnd,
+						ManagedBy:     billing.ManuallyManagedLine,
+						Currency:      currencyx.Code(currency.USD),
+						FeatureKey:    featureFlatPerUnit.Key,
+						Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount: alpacadecimal.NewFromFloat(100),
+						})),
+					},
+				},
+			},
+		})
+		s.Require().NoError(err)
+
+		gatheringID = result.Invoice.GetInvoiceID()
+		gatheringInvoice, err := s.DBClient.BillingInvoice.Get(ctx, gatheringID.ID)
+		s.Require().NoError(err)
+		s.Require().Equal(1, gatheringInvoice.SchemaLevel)
+	})
+
 	s.Run("When the write schema level is set to 2 and a lock is obtained on the customer", func() {
 		s.NoError(s.BillingAdapter.SetInvoiceDefaultSchemaLevel(ctx, 2))
 		// Side-effect: migration happens due to the previous line.
@@ -217,6 +252,10 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 	})
 
 	s.Run("Then the invoice is migrated and lines (incl detailed lines) match exactly", func() {
+		gatheringInvoice, err := s.DBClient.BillingInvoice.Get(ctx, gatheringID.ID)
+		s.Require().NoError(err)
+		s.Require().Equal(2, gatheringInvoice.SchemaLevel)
+
 		invoiceAfter, err := s.BillingAdapter.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoiceID,
 			Expand: billing.StandardInvoiceExpands{

--- a/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.down.sql
+++ b/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS om_func_migrate_customer_invoices_to_schema_level_2_bulk(TEXT[]);

--- a/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
+++ b/tools/migrate/migrations/20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql
@@ -1,0 +1,142 @@
+-- Migrates schema-level-1 invoices for an arbitrary set of customers to schema level 2.
+--
+-- Gathering invoice details are intentionally excluded: they are invalid legacy data and are
+-- removed by the preceding gathering-detail cleanup migration.
+CREATE OR REPLACE FUNCTION om_func_migrate_customer_invoices_to_schema_level_2_bulk(p_customer_ids TEXT[])
+RETURNS BIGINT
+AS $$
+DECLARE
+    v_updated_invoices BIGINT;
+BEGIN
+    INSERT INTO billing_standard_invoice_detailed_lines (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        name,
+        description,
+        currency,
+        amount,
+        taxes_total,
+        taxes_inclusive_total,
+        taxes_exclusive_total,
+        charges_total,
+        discounts_total,
+        total,
+        service_period_start,
+        service_period_end,
+        quantity,
+        invoicing_app_external_id,
+        child_unique_reference_id,
+        per_unit_amount,
+        category,
+        payment_term,
+        index,
+        invoice_id,
+        parent_line_id,
+        credits_total,
+        credits_applied
+    )
+    SELECT
+        l.id,
+        l.namespace,
+        l.created_at,
+        l.updated_at,
+        l.deleted_at,
+        l.name,
+        l.description,
+        l.currency,
+        l.amount,
+        l.taxes_total,
+        l.taxes_inclusive_total,
+        l.taxes_exclusive_total,
+        l.charges_total,
+        l.discounts_total,
+        l.total,
+        l.period_start AS service_period_start,
+        l.period_end AS service_period_end,
+        l.quantity,
+        l.invoicing_app_external_id,
+        l.child_unique_reference_id,
+        c.per_unit_amount,
+        c.category,
+        c.payment_term,
+        c.index,
+        l.invoice_id,
+        l.parent_line_id,
+        l.credits_total,
+        l.credits_applied
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_invoice_flat_fee_line_configs c
+        ON c.id = l.fee_line_config_id
+        AND c.namespace = l.namespace
+    WHERE
+        i.customer_id = ANY(p_customer_ids)
+        AND i.schema_level = 1
+        AND i.status <> 'gathering'
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO billing_standard_invoice_detailed_line_amount_discounts (
+        id,
+        namespace,
+        created_at,
+        updated_at,
+        deleted_at,
+        child_unique_reference_id,
+        description,
+        reason,
+        invoicing_app_external_id,
+        amount,
+        rounding_amount,
+        source_discount,
+        line_id
+    )
+    SELECT
+        d.id,
+        d.namespace,
+        d.created_at,
+        d.updated_at,
+        d.deleted_at,
+        d.child_unique_reference_id,
+        d.description,
+        d.reason,
+        d.invoicing_app_external_id,
+        d.amount,
+        d.rounding_amount,
+        d.source_discount,
+        d.line_id
+    FROM billing_invoices i
+    JOIN billing_invoice_lines l
+        ON l.invoice_id = i.id
+        AND l.namespace = i.namespace
+    JOIN billing_standard_invoice_detailed_lines migrated_l
+        ON migrated_l.id = l.id
+        AND migrated_l.namespace = l.namespace
+    JOIN billing_invoice_line_discounts d
+        ON d.line_id = l.id
+        AND d.namespace = l.namespace
+    WHERE
+        i.customer_id = ANY(p_customer_ids)
+        AND i.schema_level = 1
+        AND i.status <> 'gathering'
+        AND l.status = 'detailed'
+        AND l.type = 'flat_fee'
+    ON CONFLICT (id) DO NOTHING;
+
+    UPDATE billing_invoices
+    SET schema_level = 2
+    WHERE
+        customer_id = ANY(p_customer_ids)
+        AND schema_level = 1;
+
+    GET DIAGNOSTICS v_updated_invoices = ROW_COUNT;
+
+    RETURN v_updated_invoices;
+END;
+$$ LANGUAGE plpgsql VOLATILE;

--- a/tools/migrate/migrations/20260717062142_migrate_invoices_to_schema_level_2.down.sql
+++ b/tools/migrate/migrations/20260717062142_migrate_invoices_to_schema_level_2.down.sql
@@ -1,0 +1,1 @@
+-- Migrated invoice data cannot be safely restored to schema level 1.

--- a/tools/migrate/migrations/20260717062142_migrate_invoices_to_schema_level_2.up.sql
+++ b/tools/migrate/migrations/20260717062142_migrate_invoices_to_schema_level_2.up.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- Prevent invoice writes while existing customers are migrated to schema level 2.
+SELECT *
+FROM billing_customer_locks
+FOR UPDATE;
+
+CREATE TEMPORARY TABLE om_tmp_billing_schema_level_2_affected_customers (
+    customer_id TEXT PRIMARY KEY
+) ON COMMIT DROP;
+
+INSERT INTO om_tmp_billing_schema_level_2_affected_customers (customer_id)
+SELECT DISTINCT l.customer_id::TEXT
+FROM billing_customer_locks l
+JOIN billing_invoices i
+    ON i.namespace = l.namespace
+    AND i.customer_id = l.customer_id
+WHERE i.schema_level = 1;
+
+SELECT om_func_migrate_customer_invoices_to_schema_level_2_bulk(
+    ARRAY(
+        SELECT customer_id
+        FROM om_tmp_billing_schema_level_2_affected_customers
+    )
+);
+
+COMMIT;

--- a/tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.down.sql
+++ b/tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.down.sql
@@ -1,0 +1,1 @@
+-- The completed invoice schema migration helpers are intentionally not recreated on rollback.

--- a/tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.up.sql
+++ b/tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.up.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS om_func_migrate_customer_invoices_to_schema_level_2_bulk(TEXT[]);
+DROP FUNCTION IF EXISTS om_func_migrate_customer_invoices_to_schema_level_2(TEXT);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sHp6EpaiKRdL9B9trZ/xwvONr0fdPUZGrOmNafRNcYQ=
+h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -237,3 +237,4 @@ h1:sHp6EpaiKRdL9B9trZ/xwvONr0fdPUZGrOmNafRNcYQ=
 20260716150455_cleanup_gathering_invoice_details.up.sql h1:W4u33tHXJy+GfryC8j46bHi2SiQwDk6brBOex/fQ4rw=
 20260716150456_drop_gathering_detail_cleanup_indexes.up.sql h1:IJ6P54dqEy/LFG9hID2T9yBoN29FRTH/iLTSSTkdpDQ=
 20260716152332_rescope-credit-grant-key-to-customer.up.sql h1:gbeATYlchOi0pwaTUFX+nrbLoS0jZbVDMHn8uMTck0c=
+20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:G5G6jYndCh8yx903RzDzVzrStmPDpdNhLiziNBT5ul0=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
+h1:PLpYnThNR2qZYbg5mpj8/fGEVJRzW+N2B3soS58IHtg=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -238,3 +238,4 @@ h1:ACEAs9ku7RQcRBVm3VP14IhdgxZ8ByODYwzo0ebdwrc=
 20260716150456_drop_gathering_detail_cleanup_indexes.up.sql h1:IJ6P54dqEy/LFG9hID2T9yBoN29FRTH/iLTSSTkdpDQ=
 20260716152332_rescope-credit-grant-key-to-customer.up.sql h1:gbeATYlchOi0pwaTUFX+nrbLoS0jZbVDMHn8uMTck0c=
 20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:G5G6jYndCh8yx903RzDzVzrStmPDpdNhLiziNBT5ul0=
+20260717062142_migrate_invoices_to_schema_level_2.up.sql h1:aFCoJPJyKCHMoDBZlvtcjaRgHLsXpH5woF2J4/8VG3U=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PLpYnThNR2qZYbg5mpj8/fGEVJRzW+N2B3soS58IHtg=
+h1:mHsx5lyYbVcb5ZqGxTwRMJQSkbjaeb/Cw8jByjr32X8=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -239,3 +239,4 @@ h1:PLpYnThNR2qZYbg5mpj8/fGEVJRzW+N2B3soS58IHtg=
 20260716152332_rescope-credit-grant-key-to-customer.up.sql h1:gbeATYlchOi0pwaTUFX+nrbLoS0jZbVDMHn8uMTck0c=
 20260717060208_add_bulk_invoice_schema_level_2_migration_function.up.sql h1:G5G6jYndCh8yx903RzDzVzrStmPDpdNhLiziNBT5ul0=
 20260717062142_migrate_invoices_to_schema_level_2.up.sql h1:aFCoJPJyKCHMoDBZlvtcjaRgHLsXpH5woF2J4/8VG3U=
+20260717062143_drop_invoice_schema_migration_functions.up.sql h1:RiYc9FHVckXFhliha5mGmBvUZm5PvocnHC5GTH5Cxwc=


### PR DESCRIPTION
## Overview

Drop the temporary invoice schema migration helper functions after the bulk schema-level-2 backfill has completed.

> [!NOTE]
> This PR is intentionally just a collection of cleanups to be merged later. Keep it open until the bulk backfill has been deployed and older OpenMeter versions that still call the scalar function are no longer in use.

This PR is stacked on top of #4729.

## Changes

- Drop `om_func_migrate_customer_invoices_to_schema_level_2(TEXT)`.
- Drop `om_func_migrate_customer_invoices_to_schema_level_2_bulk(TEXT[])`.
- Do not recreate the completed migration helpers on rollback.

## Validation

- `atlas migrate --env local lint --latest 1`
- `atlas migrate validate --env local`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the completed invoice schema migration helpers. The main changes are:

- Drops the scalar invoice migration function.
- Drops the bulk invoice migration function.
- Leaves both functions absent on rollback.
- Registers the migration in the Atlas checksum.

<h3>Confidence Score: 4/5</h3>

The function-removal migration can break invoice processing while scalar or bulk callers remain deployable.

- Older instances can call the dropped scalar helper during a rolling deployment.
- The current invoice-lock path can call the dropped bulk helper for remaining schema-level-1 invoices.
- The Atlas checksum and comment-only down migration follow repository conventions.

tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.up.sql

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.up.sql | Drops both helpers while deployed application versions can still call them. |
| tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.down.sql | Intentionally keeps the helper functions removed during rollback. |
| tools/migrate/migrations/atlas.sum | Adds the new up migration using the repository's normal checksum convention. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fmigrate%2Fmigrations%2F20260717062143_drop_invoice_schema_migration_functions.up.sql%3A1-2%0A**Function%20Drops%20Break%20Active%20Callers**%0A%0ADuring%20a%20rolling%20deployment%2C%20an%20older%20instance%20can%20still%20call%20the%20scalar%20helper%20after%20this%20migration%20drops%20it.%20The%20current%20invoice-lock%20path%20can%20likewise%20call%20the%20bulk%20helper%20when%20it%20encounters%20a%20schema-level-1%20invoice%2C%20so%20either%20state%20produces%20a%20PostgreSQL%20%60function%20does%20not%20exist%60%20error%20and%20blocks%20invoice%20processing.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4732&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fdrop-invoice-schema-migration-functions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fdrop-invoice-schema-migration-functions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atools%2Fmigrate%2Fmigrations%2F20260717062143_drop_invoice_schema_migration_functions.up.sql%3A1-2%0A**Function%20Drops%20Break%20Active%20Callers**%0A%0ADuring%20a%20rolling%20deployment%2C%20an%20older%20instance%20can%20still%20call%20the%20scalar%20helper%20after%20this%20migration%20drops%20it.%20The%20current%20invoice-lock%20path%20can%20likewise%20call%20the%20bulk%20helper%20when%20it%20encounters%20a%20schema-level-1%20invoice%2C%20so%20either%20state%20produces%20a%20PostgreSQL%20%60function%20does%20not%20exist%60%20error%20and%20blocks%20invoice%20processing.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4732&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tools/migrate/migrations/20260717062143_drop_invoice_schema_migration_functions.up.sql:1-2
**Function Drops Break Active Callers**

During a rolling deployment, an older instance can still call the scalar helper after this migration drops it. The current invoice-lock path can likewise call the bulk helper when it encounters a schema-level-1 invoice, so either state produces a PostgreSQL `function does not exist` error and blocks invoice processing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: drop invoice schema migration fun..."](https://github.com/openmeterio/openmeter/commit/5d6b68ad80e906cd77a16e2803e5370e6149705a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45002099)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->