### PR TITLE
docs: send numeric event values as strings in quickstart

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -39,11 +39,15 @@ curl -X POST http://localhost:48888/api/v1/events \
   "data": {
     "method": "GET",
     "route": "/hello",
-    "duration_ms": 10
+    "duration_ms": "10"
   }
 }
 '
 ```
+
+Note that numeric values where precision matters are sent as JSON strings
+(`"duration_ms": "10"`) so they are parsed without floating-point precision
+loss.
 
 Note how ID is different:
 
@@ -61,7 +65,7 @@ curl -X POST http://localhost:48888/api/v1/events \
   "data": {
     "method": "GET",
     "route": "/hello",
-    "duration_ms": 20
+    "duration_ms": "20"
   }
 }
 '
@@ -83,7 +87,7 @@ curl -X POST http://localhost:48888/api/v1/events \
   "data": {
     "method": "GET",
     "route": "/hello",
-    "duration_ms": 30
+    "duration_ms": "30"
   }
 }
 '


### PR DESCRIPTION
## Overview

The quickstart README's curl examples send `duration_ms` as a JSON number (`"duration_ms": 10`), while the quickstart test (`quickstart/quickstart_test.go`) and the docs best-practices guidance both use string-quoted numbers to preserve precision.

This quotes the three `duration_ms` values in `quickstart/README.md` and adds a one-line note explaining the convention: numeric values where precision matters should be sent as JSON strings so they are parsed without floating-point precision loss.

## Notes for reviewer

Docs-only change; no code affected. The openmeter.io docs quickstarts are being aligned to the same convention separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TWiAB8V1mxpGjpfFVMUaw

---
_Generated by [Claude Code](https://claude.ai/code/session_014TWiAB8V1mxpGjpfFVMUaw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart usage-event examples to represent `duration_ms` values as JSON strings.
  * Added guidance to use JSON strings when numeric precision is important, helping prevent floating-point precision loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates numeric values in the quickstart event examples. The main changes are:

- Sends all three `duration_ms` values as JSON strings.
- Adds a note claiming that strings avoid floating-point precision loss.

<h3>Confidence Score: 5/5</h3>

The examples remain usable, but the new precision guidance should be corrected.

- Quoted numeric values are accepted by the event parser.
- Both quoted and unquoted values still pass through float64 under the quickstart defaults.
- The issue is limited to misleading documentation.

quickstart/README.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| quickstart/README.md | Quotes three event values and adds a precision claim that does not hold under the quickstart's float64 parsing path. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aquickstart%2FREADME.md%3A48-50%0A**Quoted%20Values%20Still%20Lose%20Precision**%0A%0AWhen%20a%20value%20exceeds%20float64's%20exact%20range%2C%20quoting%20it%20does%20not%20prevent%20precision%20loss%3A%20numeric%20strings%20are%20parsed%20with%20%60strconv.ParseFloat%28...%2C%2064%29%60%2C%20and%20the%20default%20query%20path%20converts%20them%20with%20%60toFloat64OrNull%60.%20The%20note%20therefore%20promises%20protection%20that%20the%20quickstart%20configuration%20does%20not%20provide.%0A%0A%60%60%60suggestion%0ANumeric%20event%20values%20may%20also%20be%20sent%20as%20JSON%20strings%2C%20as%20shown%20here%0A%28%60%22duration_ms%22%3A%20%2210%22%60%29.%0A%60%60%60%0A%0A&repo=openmeterio%2Fopenmeter&pr=4747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22claude%2Fquickstart-numbers-as-strings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fquickstart-numbers-as-strings%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aquickstart%2FREADME.md%3A48-50%0A**Quoted%20Values%20Still%20Lose%20Precision**%0A%0AWhen%20a%20value%20exceeds%20float64's%20exact%20range%2C%20quoting%20it%20does%20not%20prevent%20precision%20loss%3A%20numeric%20strings%20are%20parsed%20with%20%60strconv.ParseFloat%28...%2C%2064%29%60%2C%20and%20the%20default%20query%20path%20converts%20them%20with%20%60toFloat64OrNull%60.%20The%20note%20therefore%20promises%20protection%20that%20the%20quickstart%20configuration%20does%20not%20provide.%0A%0A%60%60%60suggestion%0ANumeric%20event%20values%20may%20also%20be%20sent%20as%20JSON%20strings%2C%20as%20shown%20here%0A%28%60%22duration_ms%22%3A%20%2210%22%60%29.%0A%60%60%60%0A%0A&repo=openmeterio%2Fopenmeter&pr=4747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
quickstart/README.md:48-50
**Quoted Values Still Lose Precision**

When a value exceeds float64's exact range, quoting it does not prevent precision loss: numeric strings are parsed with `strconv.ParseFloat(..., 64)`, and the default query path converts them with `toFloat64OrNull`. The note therefore promises protection that the quickstart configuration does not provide.

```suggestion
Numeric event values may also be sent as JSON strings, as shown here
(`"duration_ms": "10"`).
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: send numeric event values as strin..."](https://github.com/openmeterio/openmeter/commit/bb40120141e77a8bcee272a265334eabcd1a02c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45365554)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))

<!-- /greptile_comment -->