### PR TITLE
refactor: tests for currencies service

### DIFF
--- a/openmeter/currencies/service/service_test.go
+++ b/openmeter/currencies/service/service_test.go
@@ -1,8 +1,7 @@
-package service
+package service_test
 
 import (
-	"context"
-	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -12,344 +11,281 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/filter"
-	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
-	"github.com/openmeterio/openmeter/pkg/sortx"
 )
 
-// noopDriver implements transaction.Driver as a no-op for unit tests.
-type noopDriver struct{}
+func TestCurrenciesService(t *testing.T) {
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
 
-func (noopDriver) Commit() error    { return nil }
-func (noopDriver) Rollback() error  { return nil }
-func (noopDriver) SavePoint() error { return nil }
+	env := currenciestestutils.NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
 
-// fakeAdapter implements currencies.Adapter for unit testing the service layer.
-// ListCustomCurrencies applies the Code filter from params to simulate DB-level filtering.
-type fakeAdapter struct {
-	custom          []currencies.Currency
-	createCostBasis func(context.Context, currencies.CreateCostBasisInput) (currencies.CostBasis, error)
-}
+	namespace := currenciestestutils.NewTestNamespace(t)
 
-func (f *fakeAdapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
-	return ctx, noopDriver{}, nil
-}
-
-func (f *fakeAdapter) ListCustomCurrencies(_ context.Context, params currencies.ListCurrenciesInput) (pagination.Result[currencies.Currency], error) {
-	items := make([]currencies.Currency, 0, len(f.custom))
-	for _, c := range f.custom {
-		if ok, _ := params.Code.Match(c.Details().Code.String()); ok {
-			items = append(items, c)
-		}
-	}
-	return pagination.Result[currencies.Currency]{
-		Items:      items,
-		TotalCount: len(items),
-		Page:       params.Page,
-	}, nil
-}
-
-func (f *fakeAdapter) CreateCurrency(_ context.Context, _ currencies.CreateCurrencyInput) (currencies.Currency, error) {
-	return currencies.Currency{}, errors.New("fakeAdapter.CreateCurrency is not implemented")
-}
-
-func (f *fakeAdapter) CreateCostBasis(ctx context.Context, input currencies.CreateCostBasisInput) (currencies.CostBasis, error) {
-	if f.createCostBasis != nil {
-		return f.createCostBasis(ctx, input)
-	}
-
-	return currencies.CostBasis{}, errors.New("fakeAdapter.CreateCostBasis is not implemented")
-}
-
-func (f *fakeAdapter) ListCostBases(_ context.Context, _ currencies.ListCostBasesInput) (pagination.Result[currencies.CostBasis], error) {
-	return pagination.Result[currencies.CostBasis]{}, errors.New("fakeAdapter.ListCostBases is not implemented")
-}
-
-func (f *fakeAdapter) GetCurrency(_ context.Context, _ currencies.GetCurrencyInput) (currencies.Currency, error) {
-	return currencies.Currency{}, errors.New("fakeAdapter.GetCurrency is not implemented")
-}
-
-// newTestService creates a Service backed by a fake adapter seeded with custom currencies.
-func newTestService(custom []currencies.Currency) (currencies.Service, error) {
-	return New(&fakeAdapter{custom: custom})
-}
-
-func TestListCurrencies_CombinedPath(t *testing.T) {
-	curr, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
-		WithCode("MYCUSTOM").
-		WithSymbol("MC").
-		WithName("My Custom Currency").
-		Build()
-	require.NoError(t, err)
-
-	customCurrency := currencies.Currency{
-		Currency: curr,
-	}
-
-	svc, err := newTestService([]currencies.Currency{customCurrency})
-	require.NoErrorf(t, err, "failed to create test service")
-
-	tests := []struct {
-		name          string
-		input         currencies.ListCurrenciesInput
-		wantErr       bool
-		assertResults func(t *testing.T, result pagination.Result[currencies.Currency])
-	}{
-		{
-			name: "no filter no sort returns combined list sorted by code asc",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Page:      pagination.NewPage(1, 5),
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 5, len(result.Items))
-				for i := 1; i < len(result.Items); i++ {
-					assert.LessOrEqual(t, result.Items[i-1].Details().Code, result.Items[i].Details().Code, "items should be sorted by code asc")
-				}
-			},
-		},
-		{
-			name: "filter by single fiat code returns only that currency",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{Eq: lo.ToPtr("USD")},
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 1, result.TotalCount)
-				assert.Equal(t, "USD", result.Items[0].Details().Code.String())
-			},
-		},
-		{
-			name: "filter by multiple fiat codes using In returns only those currencies",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{In: lo.ToPtr([]string{"USD", "EUR"})},
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 2, result.TotalCount)
-				codes := []string{result.Items[0].Details().Code.String(), result.Items[1].Details().Code.String()}
-				assert.ElementsMatch(t, []string{"USD", "EUR"}, codes)
-			},
-		},
-		{
-			name: "filter by custom currency code returns only that custom currency",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{Eq: lo.ToPtr("MYCUSTOM")},
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 1, result.TotalCount)
-				assert.Equal(t, "MYCUSTOM", result.Items[0].Details().Code.String())
-			},
-		},
-		{
-			name: "sort by name returns items sorted by name asc",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{In: lo.ToPtr([]string{"USD", "EUR", "GBP"})},
-				OrderBy:   currencies.OrderByName,
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 3, result.TotalCount)
-				for i := 1; i < len(result.Items); i++ {
-					assert.LessOrEqual(t, result.Items[i-1].Details().Name, result.Items[i].Details().Name, "items should be sorted by name asc")
-				}
-			},
-		},
-		{
-			name: "sort by code desc returns items sorted by code descending",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{In: lo.ToPtr([]string{"USD", "EUR", "GBP"})},
-				Order:     sortx.OrderDesc,
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				require.Equal(t, 3, result.TotalCount)
-				for i := 1; i < len(result.Items); i++ {
-					assert.GreaterOrEqual(t, result.Items[i-1].Details().Code, result.Items[i].Details().Code, "items should be sorted by code desc")
-				}
-			},
-		},
-		{
-			name: "filter by Ne excludes a single code from combined results",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				Code:      &filter.FilterString{Ne: lo.ToPtr("USD")},
-				// Limit to known codes plus our custom one to make the assertion easy
-				Page: pagination.NewPage(1, 5),
-			},
-			assertResults: func(t *testing.T, result pagination.Result[currencies.Currency]) {
-				t.Helper()
-				for _, item := range result.Items {
-					assert.NotEqual(t, "USD", item.Details().Code, "USD should be excluded")
-				}
-			},
-		},
-		{
-			name: "invalid order by returns validation error",
-			input: currencies.ListCurrenciesInput{
-				Namespace: "test",
-				OrderBy:   currencies.OrderBy("invalid"),
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tc.input.Namespace = "test"
-			result, err := svc.ListCurrencies(t.Context(), tc.input)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
+	t.Run("CustomCurrency", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			// given:
+			// - valid custom currency details
+			input := currencies.CreateCurrencyInput{
+				Namespace: namespace,
+				CurrencyDetails: currencyx.CurrencyDetails{
+					Code:               "TOKENS",
+					Name:               "Tokens",
+					Symbol:             "T",
+					Precision:          2,
+					DecimalMark:        ".",
+					ThousandsSeparator: ",",
+				},
 			}
+
+			// when:
+			// - the custom currency is created
+			createdCurrency, err := env.Service.CreateCurrency(t.Context(), input)
+
+			// then:
+			// - its managed identity and formatting details are persisted
 			require.NoError(t, err)
-			tc.assertResults(t, result)
+			require.NotEmpty(t, createdCurrency.ID)
+			assert.Equal(t, namespace, createdCurrency.Namespace)
+			assert.Equal(t, currencyx.CurrencyTypeCustom, createdCurrency.Type())
+			assert.Equal(t, input.CurrencyDetails, createdCurrency.Details())
+			assert.Nil(t, createdCurrency.CostBasis)
+
+			t.Run("Get", func(t *testing.T) {
+				// when:
+				// - the newly created custom currency is retrieved without expansions
+				result, err := env.Service.GetCurrency(t.Context(), currencies.GetCurrencyInput{
+					NamespacedID: createdCurrency.NamespacedID,
+				})
+
+				// then:
+				// - the same currency is returned without cost-basis data
+				require.NoError(t, err)
+				assert.Equal(t, createdCurrency.ID, result.ID)
+				assert.Equal(t, input.CurrencyDetails, result.Details())
+				assert.Nil(t, result.CostBasis)
+			})
+
+			t.Run("Invalid", func(t *testing.T) {
+				// given:
+				// - custom currency details with an invalid code and missing name
+				invalidInput := currencies.CreateCurrencyInput{
+					Namespace: namespace,
+					CurrencyDetails: currencyx.CurrencyDetails{
+						Code:               "BAD",
+						Precision:          2,
+						DecimalMark:        ".",
+						ThousandsSeparator: ",",
+					},
+				}
+
+				// when:
+				// - the invalid custom currency is created
+				_, err := env.Service.CreateCurrency(t.Context(), invalidInput)
+
+				// then:
+				// - validation fails before persistence
+				require.Error(t, err)
+				assert.True(t, models.IsGenericValidationError(err))
+				assert.Contains(t, err.Error(), "currency code")
+				assert.Contains(t, err.Error(), "name is required")
+			})
+
+			t.Run("CostBasis", func(t *testing.T) {
+				// given:
+				// - the newly created custom currency
+				// when:
+				// - its initial USD cost basis is created
+				usd, err := env.Service.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+					Namespace:  namespace,
+					CurrencyID: createdCurrency.ID,
+					FiatCode:   "USD",
+					Rate:       alpacadecimal.RequireFromString("0.01"),
+				})
+
+				// then:
+				// - the cost basis is immediately effective and open-ended
+				require.NoError(t, err)
+				require.NotEmpty(t, usd.ID)
+				assert.Equal(t, createdCurrency.ID, usd.CurrencyID)
+				assert.Equal(t, currencyx.Code("USD"), usd.FiatCode)
+				assert.Equal(t, float64(0.01), usd.Rate.InexactFloat64())
+				assert.Equal(t, now, usd.EffectiveFrom)
+				assert.Nil(t, usd.EffectiveTo)
+
+				t.Run("Multiple", func(t *testing.T) {
+					// given:
+					// - a custom currency with an active USD cost basis
+					// when:
+					// - an active EUR basis and a future USD replacement are created
+					eur, err := env.Service.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+						Namespace:  namespace,
+						CurrencyID: createdCurrency.ID,
+						FiatCode:   "EUR",
+						Rate:       alpacadecimal.RequireFromString("0.009"),
+					})
+					require.NoError(t, err)
+					assert.Equal(t, now, eur.EffectiveFrom)
+					assert.Nil(t, eur.EffectiveTo)
+
+					futureEffectiveFrom := now.Add(24 * time.Hour)
+					futureUSD, err := env.Service.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+						Namespace:     namespace,
+						CurrencyID:    createdCurrency.ID,
+						FiatCode:      "USD",
+						Rate:          alpacadecimal.RequireFromString("0.012"),
+						EffectiveFrom: &futureEffectiveFrom,
+					})
+					require.NoError(t, err)
+					assert.Equal(t, futureEffectiveFrom, futureUSD.EffectiveFrom)
+					assert.Nil(t, futureUSD.EffectiveTo)
+
+					t.Run("Get", func(t *testing.T) {
+						// when:
+						// - the custom currency is retrieved with cost bases expanded
+						result, err := env.Service.GetCurrency(t.Context(), currencies.GetCurrencyInput{
+							NamespacedID: createdCurrency.NamespacedID,
+							ExpandOptions: currencies.ExpandOptions{
+								CostBasis: true,
+							},
+						})
+
+						// then:
+						// - only the currently active USD and EUR cost bases are returned
+						require.NoError(t, err)
+						require.NotNil(t, result.CostBasis)
+						require.Len(t, *result.CostBasis, 2)
+
+						byFiatCode := lo.SliceToMap(*result.CostBasis, func(item currencies.CostBasis) (currencyx.Code, currencies.CostBasis) {
+							return item.FiatCode, item
+						})
+						require.Contains(t, byFiatCode, currencyx.Code("USD"))
+						require.Contains(t, byFiatCode, currencyx.Code("EUR"))
+						assert.Equal(t, float64(0.01), byFiatCode["USD"].Rate.InexactFloat64())
+						assert.Equal(t, float64(0.009), byFiatCode["EUR"].Rate.InexactFloat64())
+						assert.Equal(t, futureEffectiveFrom, lo.FromPtr(byFiatCode["USD"].EffectiveTo))
+						assert.Nil(t, byFiatCode["EUR"].EffectiveTo)
+					})
+
+					t.Run("List", func(t *testing.T) {
+						// when:
+						// - the complete cost-basis history is listed
+						result, err := env.Service.ListCostBases(t.Context(), currencies.ListCostBasesInput{
+							Page:       pagination.NewPage(1, 10),
+							Namespace:  namespace,
+							CurrencyID: createdCurrency.ID,
+						})
+
+						// then:
+						// - both fiat currencies and the superseding USD entry are returned
+						require.NoError(t, err)
+						require.Equal(t, 3, result.TotalCount)
+						require.Len(t, result.Items, 3)
+						assert.True(t, slices.IsSortedFunc(result.Items, func(a, b currencies.CostBasis) int {
+							return b.EffectiveFrom.Compare(a.EffectiveFrom)
+						}))
+
+						usdItems := lo.Filter(result.Items, func(item currencies.CostBasis, _ int) bool {
+							return item.FiatCode == "USD"
+						})
+						require.Len(t, usdItems, 2)
+						assert.Equal(t, futureUSD.ID, usdItems[0].ID)
+						assert.Equal(t, futureEffectiveFrom, usdItems[0].EffectiveFrom)
+						assert.Equal(t, usd.ID, usdItems[1].ID)
+						assert.Equal(t, now, usdItems[1].EffectiveFrom)
+						assert.Equal(t, futureEffectiveFrom, lo.FromPtr(usdItems[1].EffectiveTo))
+					})
+
+					t.Run("ListByFiatCode", func(t *testing.T) {
+						// when:
+						// - the cost-basis history is filtered to EUR
+						result, err := env.Service.ListCostBases(t.Context(), currencies.ListCostBasesInput{
+							Page:           pagination.NewPage(1, 10),
+							Namespace:      namespace,
+							CurrencyID:     createdCurrency.ID,
+							FilterFiatCode: lo.ToPtr(currencyx.Code("EUR")),
+						})
+
+						// then:
+						// - only the EUR cost basis is returned
+						require.NoError(t, err)
+						require.Equal(t, 1, result.TotalCount)
+						require.Len(t, result.Items, 1)
+						assert.Equal(t, eur.ID, result.Items[0].ID)
+						assert.Equal(t, currencyx.Code("EUR"), result.Items[0].FiatCode)
+					})
+				})
+
+				t.Run("InvalidEffectivePeriod", func(t *testing.T) {
+					// given:
+					// - an effective period whose end equals its start
+					effectiveFrom := now.Add(48 * time.Hour)
+
+					// when:
+					// - a cost basis is created with that period
+					_, err := env.Service.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+						Namespace:     namespace,
+						CurrencyID:    createdCurrency.ID,
+						FiatCode:      "GBP",
+						Rate:          alpacadecimal.RequireFromString("0.008"),
+						EffectiveFrom: &effectiveFrom,
+						EffectiveTo:   &effectiveFrom,
+					})
+
+					// then:
+					// - validation fails before persistence
+					require.Error(t, err)
+					assert.True(t, models.IsGenericValidationError(err))
+					assert.Contains(t, err.Error(), "effective_to")
+				})
+			})
 		})
-	}
-}
 
-func TestListCurrencies_CustomOnlyPath(t *testing.T) {
-	curr, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
-		WithCode("MYCUSTOM").
-		WithSymbol("MC").
-		WithName("My Custom Currency").
-		Build()
-	require.NoError(t, err)
+		t.Run("List", func(t *testing.T) {
+			// given:
+			// - an independently persisted custom currency
+			listNamespace := currenciestestutils.NewTestNamespace(t)
+			_, err := env.Service.CreateCurrency(t.Context(), currencies.CreateCurrencyInput{
+				Namespace: listNamespace,
+				CurrencyDetails: currencyx.CurrencyDetails{
+					Code:               "POINTS",
+					Name:               "Points",
+					Symbol:             "P",
+					Precision:          2,
+					DecimalMark:        ".",
+					ThousandsSeparator: ",",
+				},
+			})
+			require.NoError(t, err)
 
-	customCurrency := currencies.Currency{
-		Currency: curr,
-	}
+			// when:
+			// - the service lists the custom currency together with selected fiat currencies
+			result, err := env.Service.ListCurrencies(t.Context(), currencies.ListCurrenciesInput{
+				Namespace: listNamespace,
+				Page:      pagination.NewPage(1, 10),
+				Code: &filter.FilterString{
+					In: lo.ToPtr([]string{"POINTS", "USD", "EUR"}),
+				},
+			})
 
-	svc, err := newTestService([]currencies.Currency{customCurrency})
-	require.NoErrorf(t, err, "failed to create test service")
+			// then:
+			// - the custom currency and both fiat currencies are returned
+			require.NoError(t, err)
+			require.Equal(t, 3, result.TotalCount)
 
-	t.Run("filter by type custom with code filter uses custom-only fast path", func(t *testing.T) {
-		ft := currencies.CurrencyTypeCustom
-		result, err := svc.ListCurrencies(t.Context(), currencies.ListCurrenciesInput{
-			Namespace:  "test",
-			FilterType: &ft,
-			Code:       &filter.FilterString{Eq: lo.ToPtr("MYCUSTOM")},
+			codes := lo.Map(result.Items, func(item currencies.Currency, _ int) currencyx.Code {
+				return item.Details().Code
+			})
+			assert.ElementsMatch(t, []currencyx.Code{"POINTS", "USD", "EUR"}, codes)
 		})
-		require.NoError(t, err)
-		require.Equal(t, 1, result.TotalCount)
-		assert.Equal(t, "MYCUSTOM", result.Items[0].Details().Code.String())
 	})
-
-	t.Run("filter by type custom returns no fiat currencies", func(t *testing.T) {
-		ft := currencies.CurrencyTypeCustom
-		result, err := svc.ListCurrencies(t.Context(), currencies.ListCurrenciesInput{
-			Namespace:  "test",
-			FilterType: &ft,
-		})
-		require.NoError(t, err)
-		require.Equal(t, 1, result.TotalCount)
-		assert.Equal(t, "MYCUSTOM", result.Items[0].Details().Code.String())
-	})
-}
-
-func TestCreateCostBasis_EffectiveTo(t *testing.T) {
-	effectiveFrom := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
-	effectiveTo := effectiveFrom.Add(24 * time.Hour)
-
-	var gotInput currencies.CreateCostBasisInput
-	svc, err := New(&fakeAdapter{
-		createCostBasis: func(_ context.Context, input currencies.CreateCostBasisInput) (currencies.CostBasis, error) {
-			gotInput = input
-
-			return currencies.CostBasis{
-				NamespacedID: models.NamespacedID{
-					ID:        "01K00000000000000000000000",
-					Namespace: input.Namespace,
-				},
-				CurrencyID: input.CurrencyID,
-				CostBasis: currencyx.CostBasis{
-					FiatCode:      input.FiatCode,
-					Rate:          input.Rate,
-					EffectiveFrom: lo.FromPtr(input.EffectiveFrom),
-					EffectiveTo:   input.EffectiveTo,
-				},
-			}, nil
-		},
-	})
-	require.NoErrorf(t, err, "failed to create test service")
-
-	result, err := svc.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
-		Namespace:     "test",
-		CurrencyID:    "01J00000000000000000000000",
-		FiatCode:      "USD",
-		Rate:          alpacadecimal.RequireFromString("0.5"),
-		EffectiveFrom: &effectiveFrom,
-		EffectiveTo:   &effectiveTo,
-	})
-	require.NoError(t, err)
-
-	require.NotNil(t, gotInput.EffectiveFrom)
-	require.NotNil(t, gotInput.EffectiveTo)
-	require.Equal(t, effectiveFrom, *gotInput.EffectiveFrom)
-	require.Equal(t, effectiveTo, *gotInput.EffectiveTo)
-	require.Equal(t, "01K00000000000000000000000", result.ID)
-	require.NotNil(t, result.EffectiveTo)
-	require.Equal(t, effectiveTo, *result.EffectiveTo)
-}
-
-func TestCreateCostBasis_DefaultEffectiveFromAllowsOpenEndedCostBasis(t *testing.T) {
-	var gotInput currencies.CreateCostBasisInput
-	svc, err := New(&fakeAdapter{
-		createCostBasis: func(_ context.Context, input currencies.CreateCostBasisInput) (currencies.CostBasis, error) {
-			gotInput = input
-
-			return currencies.CostBasis{
-				CurrencyID: input.CurrencyID,
-				CostBasis: currencyx.CostBasis{
-					FiatCode:      input.FiatCode,
-					Rate:          input.Rate,
-					EffectiveFrom: lo.FromPtr(input.EffectiveFrom),
-					EffectiveTo:   input.EffectiveTo,
-				},
-			}, nil
-		},
-	})
-	require.NoErrorf(t, err, "failed to create test service")
-
-	_, err = svc.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
-		Namespace:  "test",
-		CurrencyID: "01J00000000000000000000000",
-		FiatCode:   "USD",
-		Rate:       alpacadecimal.RequireFromString("0.5"),
-	})
-	require.NoError(t, err)
-
-	require.NotNil(t, gotInput.EffectiveFrom)
-	require.Nil(t, gotInput.EffectiveTo)
-}
-
-func TestCreateCostBasis_RejectsInvalidEffectiveTo(t *testing.T) {
-	effectiveFrom := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
-	effectiveTo := effectiveFrom
-
-	svc, err := New(&fakeAdapter{})
-	require.NoErrorf(t, err, "failed to create test service")
-
-	_, err = svc.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
-		Namespace:     "test",
-		CurrencyID:    "01J00000000000000000000000",
-		FiatCode:      "USD",
-		Rate:          alpacadecimal.RequireFromString("0.5"),
-		EffectiveFrom: &effectiveFrom,
-		EffectiveTo:   &effectiveTo,
-	})
-	require.Error(t, err)
-	require.True(t, models.IsGenericValidationError(err), "error must be a validation error")
-	require.Contains(t, err.Error(), "effective_to")
-	require.Contains(t, err.Error(), "must be after effective_from")
 }

--- a/openmeter/currencies/testutils/env.go
+++ b/openmeter/currencies/testutils/env.go
@@ -1,0 +1,73 @@
+package testutils
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciesadapter "github.com/openmeterio/openmeter/openmeter/currencies/adapter"
+	currenciesservice "github.com/openmeterio/openmeter/openmeter/currencies/service"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+type TestEnv struct {
+	Logger     *slog.Logger
+	Service    currencies.Service
+	Repository currencies.Repository
+	Client     *entdb.Client
+
+	db    *testutils.TestDB
+	close sync.Once
+}
+
+func (e *TestEnv) Close(t *testing.T) {
+	t.Helper()
+
+	e.close.Do(func() {
+		if e.db != nil {
+			if err := e.db.EntDriver.Close(); err != nil {
+				t.Errorf("failed to close ent driver: %v", err)
+			}
+
+			if err := e.db.PGDriver.Close(); err != nil {
+				t.Errorf("failed to close postgres driver: %v", err)
+			}
+		}
+
+		if e.Client != nil {
+			if err := e.Client.Close(); err != nil {
+				t.Errorf("failed to close ent client: %v", err)
+			}
+		}
+	})
+}
+
+func NewTestEnv(t *testing.T) *TestEnv {
+	t.Helper()
+
+	logger := testutils.NewDiscardLogger(t)
+	db := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
+	client := db.EntDriver.Client()
+
+	repository, err := currenciesadapter.New(currenciesadapter.Config{
+		Client: client,
+	})
+	require.NoErrorf(t, err, "initializing currencies adapter must not fail")
+	require.NotNil(t, repository, "currencies adapter must not be nil")
+
+	service, err := currenciesservice.New(repository)
+	require.NoErrorf(t, err, "initializing currencies service must not fail")
+	require.NotNil(t, service, "currencies service must not be nil")
+
+	return &TestEnv{
+		Logger:     logger,
+		Service:    service,
+		Repository: repository,
+		Client:     client,
+		db:         db,
+	}
+}

--- a/openmeter/currencies/testutils/namespace.go
+++ b/openmeter/currencies/testutils/namespace.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+func NewTestNamespace(t *testing.T) string {
+	t.Helper()
+
+	return ulid.MustNew(ulid.Timestamp(time.Now().UTC()), rand.Reader).String()
+}


### PR DESCRIPTION
## Overview

Refactor testenv and tests for `currencies` service api.

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded currency service coverage with end-to-end scenarios for custom currencies, cost bases, validation, effective periods, filtering, and history.
  * Added verification for combining custom and fiat currencies in currency listings.
  * Added reusable test environment and namespace utilities with deterministic resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the currencies service tests to a database-backed test environment. The main changes are:

- Replaces the mocked adapter tests with exported service API tests.
- Adds coverage for custom currencies and cost-basis history.
- Adds reusable currencies test environment and namespace helpers.

<h3>Confidence Score: 5/5</h3>

The changed tests look mergeable after removing the redundant Ent client close.

- The service tests use isolated namespaces and sequential subtests.
- The environment cleanup closes the same Ent client through both the driver and the exposed client reference.

openmeter/currencies/testutils/env.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/currencies/service/service_test.go | Replaces mocked unit tests with database-backed service tests for currency and cost-basis behavior. |
| openmeter/currencies/testutils/env.go | Adds a reusable service environment, but cleanup closes the Ent client after its owning driver already closed it. |
| openmeter/currencies/testutils/namespace.go | Adds a helper that creates randomized ULID namespace identifiers. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fcurrencies%2Ftestutils%2Fenv.go%3A41-45%0A**Ent%20Client%20Is%20Closed%20Twice**%0A%0A%60e.Client%60%20is%20the%20same%20client%20returned%20by%20%60e.db.EntDriver.Client%28%29%60%2C%20and%20%60EntDriver.Close%28%29%60%20already%20closes%20that%20client.%20Closing%20it%20again%20can%20surface%20a%20second-close%20error%20during%20%60t.Cleanup%60%2C%20causing%20an%20otherwise%20successful%20currencies%20test%20to%20fail.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A&repo=openmeterio%2Fopenmeter&pr=4753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22refactor%2Fcurrencies-test%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fcurrencies-test%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fcurrencies%2Ftestutils%2Fenv.go%3A41-45%0A**Ent%20Client%20Is%20Closed%20Twice**%0A%0A%60e.Client%60%20is%20the%20same%20client%20returned%20by%20%60e.db.EntDriver.Client%28%29%60%2C%20and%20%60EntDriver.Close%28%29%60%20already%20closes%20that%20client.%20Closing%20it%20again%20can%20surface%20a%20second-close%20error%20during%20%60t.Cleanup%60%2C%20causing%20an%20otherwise%20successful%20currencies%20test%20to%20fail.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A&repo=openmeterio%2Fopenmeter&pr=4753&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
openmeter/currencies/testutils/env.go:41-45
**Ent Client Is Closed Twice**

`e.Client` is the same client returned by `e.db.EntDriver.Client()`, and `EntDriver.Close()` already closes that client. Closing it again can surface a second-close error during `t.Cleanup`, causing an otherwise successful currencies test to fail.

```suggestion

```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: tests for currencies service"](https://github.com/openmeterio/openmeter/commit/7384fee2ed039e671bf4b534c2d4c9106586390c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45623345)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->