### PR TITLE
feat: add get cost-basis api

### DIFF
--- a/api/v3/handlers/currencies/get.go
+++ b/api/v3/handlers/currencies/get.go
@@ -32,7 +32,7 @@ func (h *handler) GetCurrency() GetCurrencyHandler {
 					Namespace: ns,
 					ID:        params,
 				},
-				ExpandOptions: currencies.ExpandOptions{
+				CurrencyExpandOptions: currencies.CurrencyExpandOptions{
 					CostBasis: true,
 				},
 			}, nil

--- a/openmeter/currencies/adapter/currencies.go
+++ b/openmeter/currencies/adapter/currencies.go
@@ -195,6 +195,42 @@ func (a *adapter) CreateCostBasis(ctx context.Context, params currencies.CreateC
 	})
 }
 
+func (a *adapter) GetCostBasis(ctx context.Context, params currencies.GetCostBasisInput) (currencies.CostBasis, error) {
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (currencies.CostBasis, error) {
+		q := tx.db.CurrencyCostBasis.Query().
+			Where(
+				currencycostbasis.Namespace(params.Namespace),
+				currencycostbasis.ID(params.ID),
+			)
+
+		if params.CustomCurrency {
+			q = q.WithCurrency()
+		}
+
+		costBasis, err := q.Only(ctx)
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return currencies.CostBasis{}, models.NewGenericNotFoundError(fmt.Errorf("cost basis %q not found", params.ID))
+			}
+
+			return currencies.CostBasis{}, fmt.Errorf("failed to get cost basis: %w", err)
+		}
+
+		result := mapCostBasisFromDB(costBasis)
+
+		if params.CustomCurrency {
+			customCurrency, err := mapCurrencyFromDB(costBasis.Edges.Currency)
+			if err != nil {
+				return currencies.CostBasis{}, fmt.Errorf("failed to map custom currency: %w", err)
+			}
+
+			result.CustomCurrency = &customCurrency
+		}
+
+		return result, nil
+	})
+}
+
 func (a *adapter) ListCostBases(ctx context.Context, params currencies.ListCostBasesInput) (pagination.Result[currencies.CostBasis], error) {
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (pagination.Result[currencies.CostBasis], error) {
 		q := tx.db.CurrencyCostBasis.Query().

--- a/openmeter/currencies/costbasis.go
+++ b/openmeter/currencies/costbasis.go
@@ -10,5 +10,6 @@ type CostBasis struct {
 	models.NamespacedID
 	currencyx.CostBasis
 
-	CurrencyID string
+	CurrencyID     string
+	CustomCurrency *Currency
 }

--- a/openmeter/currencies/costbasis.go
+++ b/openmeter/currencies/costbasis.go
@@ -10,6 +10,8 @@ type CostBasis struct {
 	models.NamespacedID
 	currencyx.CostBasis
 
-	CurrencyID     string
-	CustomCurrency *Currency
+	CurrencyID string `json:"currency_id"`
+
+	// CustomCurrency is included only if the CostBasis is expanded
+	CustomCurrency *Currency `json:"-"`
 }

--- a/openmeter/currencies/currency.go
+++ b/openmeter/currencies/currency.go
@@ -36,5 +36,6 @@ type Currency struct {
 	models.NamespacedID
 	currencyx.Currency
 
-	CostBasis *[]CostBasis
+	// CostBasis is included only if the Currency is expanded.
+	CostBasis *[]CostBasis `json:"-"`
 }

--- a/openmeter/currencies/repository.go
+++ b/openmeter/currencies/repository.go
@@ -22,5 +22,6 @@ type CurrencyRepository interface {
 
 type CostBasisRepository interface {
 	CreateCostBasis(ctx context.Context, params CreateCostBasisInput) (CostBasis, error)
+	GetCostBasis(ctx context.Context, params GetCostBasisInput) (CostBasis, error)
 	ListCostBases(ctx context.Context, params ListCostBasesInput) (pagination.Result[CostBasis], error)
 }

--- a/openmeter/currencies/service.go
+++ b/openmeter/currencies/service.go
@@ -28,6 +28,7 @@ type CurrencyService interface {
 
 type CostBasisService interface {
 	CreateCostBasis(ctx context.Context, params CreateCostBasisInput) (CostBasis, error)
+	GetCostBasis(ctx context.Context, params GetCostBasisInput) (CostBasis, error)
 	ListCostBases(ctx context.Context, params ListCostBasesInput) (pagination.Result[CostBasis], error)
 }
 
@@ -151,6 +152,23 @@ func (i CreateCostBasisInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+var _ models.Validator = (*GetCostBasisInput)(nil)
+
+type GetCostBasisInput struct {
+	models.NamespacedID
+	CostBasisExpandOptions
+}
+
+func (i GetCostBasisInput) Validate() error {
+	var errs []error
+
+	if err := i.NamespacedID.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 var _ models.Validator = (*ListCostBasesInput)(nil)
 
 type ListCostBasesInput struct {
@@ -177,13 +195,17 @@ func (i ListCostBasesInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-type ExpandOptions struct {
+type CostBasisExpandOptions struct {
+	CustomCurrency bool
+}
+
+type CurrencyExpandOptions struct {
 	CostBasis bool
 }
 
 type GetCurrencyInput struct {
 	models.NamespacedID
-	ExpandOptions
+	CurrencyExpandOptions
 }
 
 func (i GetCurrencyInput) Validate() error {

--- a/openmeter/currencies/service/service.go
+++ b/openmeter/currencies/service/service.go
@@ -177,6 +177,16 @@ func (s *service) CreateCostBasis(ctx context.Context, params currencies.CreateC
 	})
 }
 
+func (s *service) GetCostBasis(ctx context.Context, params currencies.GetCostBasisInput) (currencies.CostBasis, error) {
+	if err := params.Validate(); err != nil {
+		return currencies.CostBasis{}, models.NewGenericValidationError(fmt.Errorf("invalid input parameters: %w", err))
+	}
+
+	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (currencies.CostBasis, error) {
+		return s.adapter.GetCostBasis(ctx, params)
+	})
+}
+
 func (s *service) ListCostBases(ctx context.Context, params currencies.ListCostBasesInput) (pagination.Result[currencies.CostBasis], error) {
 	if err := params.Validate(); err != nil {
 		return pagination.Result[currencies.CostBasis]{}, models.NewGenericValidationError(fmt.Errorf("invalid input parameters: %w", err))

--- a/openmeter/currencies/service/service_test.go
+++ b/openmeter/currencies/service/service_test.go
@@ -122,6 +122,74 @@ func TestCurrenciesService(t *testing.T) {
 				assert.Equal(t, now, usd.EffectiveFrom)
 				assert.Nil(t, usd.EffectiveTo)
 
+				t.Run("Get", func(t *testing.T) {
+					// when:
+					// - the newly created cost basis is retrieved without expansions
+					result, err := env.Service.GetCostBasis(t.Context(), currencies.GetCostBasisInput{
+						NamespacedID: usd.NamespacedID,
+					})
+
+					// then:
+					// - the persisted cost basis is returned without its custom currency
+					require.NoError(t, err)
+					assert.Equal(t, usd.ID, result.ID)
+					assert.Equal(t, usd.Namespace, result.Namespace)
+					assert.Equal(t, usd.CurrencyID, result.CurrencyID)
+					assert.Equal(t, usd.FiatCode, result.FiatCode)
+					assert.Equal(t, usd.Rate.InexactFloat64(), result.Rate.InexactFloat64())
+					assert.Equal(t, usd.EffectiveFrom, result.EffectiveFrom)
+					assert.Equal(t, usd.EffectiveTo, result.EffectiveTo)
+					assert.Nil(t, result.CustomCurrency)
+
+					t.Run("WithCustomCurrency", func(t *testing.T) {
+						// when:
+						// - the cost basis is retrieved with its custom currency expanded
+						result, err := env.Service.GetCostBasis(t.Context(), currencies.GetCostBasisInput{
+							NamespacedID: usd.NamespacedID,
+							CostBasisExpandOptions: currencies.CostBasisExpandOptions{
+								CustomCurrency: true,
+							},
+						})
+
+						// then:
+						// - the cost basis includes the custom currency details
+						require.NoError(t, err)
+						assert.Equal(t, usd.ID, result.ID)
+						require.NotNil(t, result.CustomCurrency)
+						assert.Equal(t, createdCurrency.ID, result.CustomCurrency.ID)
+						assert.Equal(t, createdCurrency.Namespace, result.CustomCurrency.Namespace)
+						assert.Equal(t, createdCurrency.Details(), result.CustomCurrency.Details())
+						assert.Nil(t, result.CustomCurrency.CostBasis)
+					})
+
+					t.Run("NotFound", func(t *testing.T) {
+						// when:
+						// - the cost basis is retrieved from another namespace
+						_, err := env.Service.GetCostBasis(t.Context(), currencies.GetCostBasisInput{
+							NamespacedID: models.NamespacedID{
+								Namespace: currenciestestutils.NewTestNamespace(t),
+								ID:        usd.ID,
+							},
+						})
+
+						// then:
+						// - the namespace boundary is enforced
+						require.Error(t, err)
+						assert.True(t, models.IsGenericNotFoundError(err))
+					})
+
+					t.Run("Invalid", func(t *testing.T) {
+						// when:
+						// - a cost basis is retrieved without an identity
+						_, err := env.Service.GetCostBasis(t.Context(), currencies.GetCostBasisInput{})
+
+						// then:
+						// - validation fails before querying the repository
+						require.Error(t, err)
+						assert.True(t, models.IsGenericValidationError(err))
+					})
+				})
+
 				t.Run("Multiple", func(t *testing.T) {
 					// given:
 					// - a custom currency with an active USD cost basis
@@ -154,7 +222,7 @@ func TestCurrenciesService(t *testing.T) {
 						// - the custom currency is retrieved with cost bases expanded
 						result, err := env.Service.GetCurrency(t.Context(), currencies.GetCurrencyInput{
 							NamespacedID: createdCurrency.NamespacedID,
-							ExpandOptions: currencies.ExpandOptions{
+							CurrencyExpandOptions: currencies.CurrencyExpandOptions{
 								CostBasis: true,
 							},
 						})

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -2097,9 +2097,9 @@ func (n NoopIngestService) IngestEvents(ctx context.Context, request ingest.Inge
 	return true, nil
 }
 
-// NoopCurrencyService implements currencies.CurrencyService with no-op operations
+// NoopCurrencyService implements currencies.Service with no-op operations
 // for use in testing
-var _ currencies.CurrencyService = (*NoopCurrencyService)(nil)
+var _ currencies.Service = (*NoopCurrencyService)(nil)
 
 type NoopCurrencyService struct{}
 
@@ -2116,6 +2116,10 @@ func (n NoopCurrencyService) CreateCurrency(ctx context.Context, params currenci
 }
 
 func (n NoopCurrencyService) CreateCostBasis(ctx context.Context, params currencies.CreateCostBasisInput) (currencies.CostBasis, error) {
+	return currencies.CostBasis{}, nil
+}
+
+func (n NoopCurrencyService) GetCostBasis(ctx context.Context, params currencies.GetCostBasisInput) (currencies.CostBasis, error) {
 	return currencies.CostBasis{}, nil
 }
 


### PR DESCRIPTION
## Overview

Add support for getting CostBasis by id to Currencies Service with optionally retrieving the Custom Currency it belongs to as well.

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct retrieval of cost basis records.
  * Added optional inclusion of associated custom currency details with cost basis results.
  * Updated currency expansion to use clearer, separate options for cost basis vs. custom currency expansion.
* **Bug Fixes**
  * Strengthened cost basis request validation and namespace boundary enforcement.
  * Improved not-found behavior and ensured default expansion returns persisted cost basis without custom-currency details unless requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cost-basis lookup to the currencies service. The main changes are:

- A namespace-scoped service and repository lookup by cost-basis ID.
- Optional expansion of the associated custom currency.
- Separate expansion options for currencies and cost bases.
- Service tests for lookup, expansion, validation, and namespace isolation.
- An updated server test double for the aggregate currencies service.

<h3>Confidence Score: 5/5</h3>

The latest update appears safe to merge.

- The aggregate service test double now implements the full interface.
- No separate blocking issue qualifies for a new follow-up comment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/currencies/adapter/currencies.go | Adds the namespace-scoped database lookup and optional custom-currency expansion. |
| openmeter/currencies/service.go | Adds the retrieval contract, validated input, and separate expansion option types. |
| openmeter/currencies/service/service.go | Validates cost-basis lookup input and delegates the request through a transaction. |
| openmeter/currencies/service/service_test.go | Covers lookup, custom-currency expansion, missing records, and invalid input. |
| openmeter/server/server_test.go | Updates the test double to implement the complete aggregate currencies service. |

<sub>Reviews (3): Last reviewed commit: ["fix: noop currencies service"](https://github.com/openmeterio/openmeter/commit/19e4fb945ebbdcfaeec207ae6bc75a76ce964529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45627840)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->