### PR TITLE
refactor: currency code validation and helpers

### DIFF
--- a/openmeter/billing/derived.gen.go
+++ b/openmeter/billing/derived.gen.go
@@ -17,7 +17,7 @@ func deriveEqualGatheringLineBase(this, that *GatheringLineBase) bool {
 			this.ManagedBy == that.ManagedBy &&
 			this.Engine == that.Engine &&
 			this.InvoiceID == that.InvoiceID &&
-			this.Currency == that.Currency &&
+			this.Currency.Equal(that.Currency) &&
 			this.ServicePeriod.Equal(that.ServicePeriod) &&
 			this.InvoiceAt.Equal(that.InvoiceAt) &&
 			this.Price.Equal(&that.Price) &&
@@ -86,7 +86,7 @@ func deriveEqualLineBase(this, that *StandardLineBase) bool {
 			this.ManagedBy == that.ManagedBy &&
 			this.Engine == that.Engine &&
 			this.InvoiceID == that.InvoiceID &&
-			this.Currency == that.Currency &&
+			this.Currency.Equal(that.Currency) &&
 			this.Period.Equal(that.Period) &&
 			this.InvoiceAt.Equal(that.InvoiceAt) &&
 			((this.OverrideCollectionPeriodEnd == nil && that.OverrideCollectionPeriodEnd == nil) || (this.OverrideCollectionPeriodEnd != nil && that.OverrideCollectionPeriodEnd != nil && (*(this.OverrideCollectionPeriodEnd)).Equal(*(that.OverrideCollectionPeriodEnd)))) &&

--- a/openmeter/billing/models/stddetailedline/derived.gen.go
+++ b/openmeter/billing/models/stddetailedline/derived.gen.go
@@ -17,7 +17,7 @@ func deriveEqualBase(this, that *Base) bool {
 			((this.Index == nil && that.Index == nil) || (this.Index != nil && that.Index != nil && *(this.Index) == *(that.Index))) &&
 			this.PaymentTerm == that.PaymentTerm &&
 			this.ServicePeriod.Equal(that.ServicePeriod) &&
-			this.Currency == that.Currency &&
+			this.Currency.Equal(that.Currency) &&
 			this.PerUnitAmount.Equal(that.PerUnitAmount) &&
 			this.Quantity.Equal(that.Quantity) &&
 			this.Totals.Equal(that.Totals) &&

--- a/openmeter/ledger/customerbalance/facade.go
+++ b/openmeter/ledger/customerbalance/facade.go
@@ -132,7 +132,7 @@ func (f *Facade) GetBalances(ctx context.Context, input GetBalancesInput) ([]Bal
 		codes = dedupeCurrencies(input.Currencies.Codes)
 
 		for _, code := range codes {
-			if err := code.Validate(); err != nil {
+			if err := ledger.ValidateCurrency(code); err != nil {
 				return nil, fmt.Errorf("currency %q is not supported by ledger: %w", code, err)
 			}
 		}

--- a/openmeter/ledger/customerbalance/service.go
+++ b/openmeter/ledger/customerbalance/service.go
@@ -118,7 +118,7 @@ func (i GetBalanceServiceInput) Validate() error {
 		errs = append(errs, fmt.Errorf("customer ID: %w", err))
 	}
 
-	if err := i.Currency.Validate(); err != nil {
+	if err := ledger.ValidateCurrency(i.Currency); err != nil {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
 	}
 

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -63,7 +63,15 @@ func TestGetBalanceServiceInputValidate(t *testing.T) {
 			name: "invalid currency",
 			input: GetBalanceServiceInput{
 				CustomerID: valid.CustomerID,
-				Currency:   currencyx.Code("not-a-currency"),
+				Currency:   currencyx.Code("INVALID|CURRENCY"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "custom currency",
+			input: GetBalanceServiceInput{
+				CustomerID: valid.CustomerID,
+				Currency:   currencyx.Code("CREDITS"),
 			},
 			wantErr: true,
 		},

--- a/openmeter/ledger/routing.go
+++ b/openmeter/ledger/routing.go
@@ -494,6 +494,13 @@ func ValidateCurrency(value currencyx.Code) error {
 		})
 	}
 
+	if !value.IsFiat() {
+		return ErrCurrencyInvalid.WithAttrs(models.Attributes{
+			"currency": value,
+			"reason":   "custom_currency_not_supported",
+		})
+	}
+
 	return nil
 }
 

--- a/openmeter/ledger/routing_test.go
+++ b/openmeter/ledger/routing_test.go
@@ -146,6 +146,42 @@ func TestTaxBehaviorValidate(t *testing.T) {
 	require.Error(t, TaxBehavior("").Validate())
 }
 
+func TestValidateCurrency(t *testing.T) {
+	testCases := []struct {
+		name    string
+		code    currencyx.Code
+		wantErr bool
+	}{
+		{
+			name: "fiat currency",
+			code: "USD",
+		},
+		{
+			name:    "custom currency",
+			code:    "CREDITS",
+			wantErr: true,
+		},
+		{
+			name:    "invalid currency",
+			code:    "INVALID|CURRENCY",
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := ValidateCurrency(testCase.code)
+			if testCase.wantErr {
+				require.ErrorIs(t, err, ErrCurrencyInvalid)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestRouteValidate_InvalidTaxBehavior(t *testing.T) {
 	r := Route{
 		Currency:    currencyx.Code("USD"),

--- a/pkg/currencyx/code.go
+++ b/pkg/currencyx/code.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	_ fmt.Stringer     = (*Code)(nil)
-	_ models.Validator = (*Code)(nil)
+	_ fmt.Stringer         = (*Code)(nil)
+	_ models.Validator     = (*Code)(nil)
+	_ models.Equaler[Code] = (*Code)(nil)
 )
 
 // Code represents a fiat or custom currency code. Code values used directly as
@@ -26,6 +27,10 @@ const (
 
 func (c Code) String() string {
 	return string(c)
+}
+
+func (c Code) Equal(other Code) bool {
+	return c == other
 }
 
 func (c Code) Validate() error {

--- a/pkg/currencyx/code.go
+++ b/pkg/currencyx/code.go
@@ -41,6 +41,14 @@ func (c Code) Type() CurrencyType {
 	return CurrencyTypeCustom
 }
 
+func (c Code) IsFiat() bool {
+	return c.Type() == CurrencyTypeFiat
+}
+
+func (c Code) IsCustom() bool {
+	return c.Type() == CurrencyTypeCustom
+}
+
 func (c Code) Validate() error {
 	var errs []error
 

--- a/pkg/currencyx/code.go
+++ b/pkg/currencyx/code.go
@@ -3,24 +3,89 @@ package currencyx
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/invopop/gobl/currency"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-var _ fmt.Stringer = (*Code)(nil)
+var (
+	_ fmt.Stringer     = (*Code)(nil)
+	_ models.Validator = (*Code)(nil)
+)
 
 // Code represents a fiat or custom currency code. Code values used directly as
 // Currency values are treated as fiat currencies for backwards compatibility.
 type Code currency.Code
+
+const (
+	CustomCurrencyCodeMinLength = 4
+	CustomCurrencyCodeMaxLength = 24
+)
 
 func (c Code) String() string {
 	return string(c)
 }
 
 func (c Code) Validate() error {
+	var errs []error
+
 	if c == "" {
-		return errors.New("currency code is required")
+		errs = append(errs, errors.New("currency code is required"))
+
+		return models.NewNillableGenericValidationError(errors.Join(errs...))
 	}
 
-	return currency.Code(c).Validate()
+	if len(c) == 3 {
+		if err := validateFiatCurrencyCode(c); err != nil {
+			errs = append(errs, err)
+		}
+	} else {
+		if err := validateCustomCurrencyCode(c); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func validateFiatCurrencyCode(code Code) error {
+	if len(code) != 3 {
+		return fmt.Errorf("invalid fiat currency code: %s", code)
+	}
+
+	definition := currency.Get(currency.Code(code))
+	if definition == nil || definition.ISONumeric == "" {
+		return fmt.Errorf("invalid fiat currency code: %s", code)
+	}
+
+	return nil
+}
+
+func validateCustomCurrencyCode(code Code) error {
+	var errs []error
+
+	if code == "" {
+		errs = append(errs, errors.New("currency code is required"))
+	}
+
+	codeString := code.String()
+	if len(codeString) != len(strings.TrimSpace(codeString)) {
+		errs = append(errs, fmt.Errorf("invalid currency code: cannot contain leading or trailing spaces: %s", code))
+	}
+
+	if strings.Contains(codeString, "|") {
+		errs = append(errs, fmt.Errorf("invalid currency code: cannot contain route delimiter: %s", code))
+	}
+
+	if fiatDefinition := currency.Get(currency.Code(code)); fiatDefinition != nil {
+		errs = append(errs, fmt.Errorf("currency code %s is a fiat currency", code))
+	}
+
+	if codeLength := len(codeString); codeLength < CustomCurrencyCodeMinLength || codeLength > CustomCurrencyCodeMaxLength {
+		errs = append(errs, fmt.Errorf("invalid currency code: it must be between %d and %d characters", CustomCurrencyCodeMinLength, CustomCurrencyCodeMaxLength))
+	}
+
+	return errors.Join(errs...)
 }

--- a/pkg/currencyx/code.go
+++ b/pkg/currencyx/code.go
@@ -33,6 +33,14 @@ func (c Code) Equal(other Code) bool {
 	return c == other
 }
 
+func (c Code) Type() CurrencyType {
+	if len(c) == 3 {
+		return CurrencyTypeFiat
+	}
+
+	return CurrencyTypeCustom
+}
+
 func (c Code) Validate() error {
 	var errs []error
 

--- a/pkg/currencyx/code_test.go
+++ b/pkg/currencyx/code_test.go
@@ -1,0 +1,81 @@
+package currencyx_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestCodeValidate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		code          currencyx.Code
+		expectedError string
+	}{
+		{
+			name:          "empty",
+			expectedError: "currency code is required",
+		},
+		{
+			name: "valid fiat",
+			code: "USD",
+		},
+		{
+			name:          "unknown three-character code",
+			code:          "ZZZ",
+			expectedError: "invalid fiat currency code",
+		},
+		{
+			name:          "non-fiat three-character code",
+			code:          "BTC",
+			expectedError: "invalid fiat currency code",
+		},
+		{
+			name: "custom minimum length",
+			code: "TOKN",
+		},
+		{
+			name: "custom maximum length",
+			code: currencyx.Code(strings.Repeat("A", currencyx.CustomCurrencyCodeMaxLength)),
+		},
+		{
+			name:          "custom code too short",
+			code:          "AB",
+			expectedError: "between 4 and 24 characters",
+		},
+		{
+			name:          "custom code too long",
+			code:          currencyx.Code(strings.Repeat("A", currencyx.CustomCurrencyCodeMaxLength+1)),
+			expectedError: "between 4 and 24 characters",
+		},
+		{
+			name:          "custom code contains route delimiter",
+			code:          "CRE|DITS",
+			expectedError: "cannot contain route delimiter",
+		},
+		{
+			name:          "custom code contains surrounding whitespace",
+			code:          " CREDITS",
+			expectedError: "cannot contain leading or trailing spaces",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.code.Validate()
+			if testCase.expectedError == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.True(t, models.IsGenericValidationError(err))
+			require.Contains(t, err.Error(), testCase.expectedError)
+		})
+	}
+}

--- a/pkg/currencyx/code_test.go
+++ b/pkg/currencyx/code_test.go
@@ -119,3 +119,28 @@ func TestCodeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestCodeType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		code     currencyx.Code
+		expected currencyx.CurrencyType
+	}{
+		{
+			name:     "fiat",
+			code:     "USD",
+			expected: currencyx.CurrencyTypeFiat,
+		},
+		{
+			name:     "custom",
+			code:     "CREDITS",
+			expected: currencyx.CurrencyTypeCustom,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, testCase.code.Type())
+		})
+	}
+}

--- a/pkg/currencyx/code_test.go
+++ b/pkg/currencyx/code_test.go
@@ -79,3 +79,43 @@ func TestCodeValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestCodeEqual(t *testing.T) {
+	testCases := []struct {
+		name     string
+		code     currencyx.Code
+		other    currencyx.Code
+		expected bool
+	}{
+		{
+			name:     "same fiat code",
+			code:     "USD",
+			other:    "USD",
+			expected: true,
+		},
+		{
+			name:     "different fiat code",
+			code:     "USD",
+			other:    "EUR",
+			expected: false,
+		},
+		{
+			name:     "same custom code",
+			code:     "CREDITS",
+			other:    "CREDITS",
+			expected: true,
+		},
+		{
+			name:     "case sensitive",
+			code:     "CREDITS",
+			other:    "credits",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, testCase.code.Equal(testCase.other))
+		})
+	}
+}

--- a/pkg/currencyx/code_test.go
+++ b/pkg/currencyx/code_test.go
@@ -141,6 +141,8 @@ func TestCodeType(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			require.Equal(t, testCase.expected, testCase.code.Type())
+			require.Equal(t, testCase.expected == currencyx.CurrencyTypeFiat, testCase.code.IsFiat())
+			require.Equal(t, testCase.expected == currencyx.CurrencyTypeCustom, testCase.code.IsCustom())
 		})
 	}
 }

--- a/pkg/currencyx/currency.go
+++ b/pkg/currencyx/currency.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"strings"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
@@ -180,11 +179,13 @@ func (f *FiatCurrency) Validate() error {
 
 	var errs []error
 
-	if f.def == nil || f.def.ISOCode == "" {
-		errs = append(errs, errors.New("invalid fiat currency: empty code"))
-	}
+	if f.def == nil {
+		errs = append(errs, errors.New("fiat currency is not initialized"))
+	} else {
+		if err := validateFiatCurrencyCode(Code(f.def.ISOCode)); err != nil {
+			errs = append(errs, err)
+		}
 
-	if f.def != nil {
 		if f.def.Name == "" {
 			errs = append(errs, errors.New("invalid fiat currency: empty name"))
 		}
@@ -194,10 +195,11 @@ func (f *FiatCurrency) Validate() error {
 }
 
 func newFiatCurrency(code string) (Currency, error) {
-	definition := currency.Get(currency.Code(code))
-	if definition == nil || definition.ISONumeric == "" {
-		return nil, fmt.Errorf("invalid fiat currency code: %s", code)
+	if err := validateFiatCurrencyCode(Code(code)); err != nil {
+		return nil, err
 	}
+
+	definition := currency.Get(currency.Code(code))
 
 	if definition.Subunits > math.MaxInt32 {
 		return nil, fmt.Errorf("value %d overflows int32", definition.Subunits)
@@ -275,12 +277,7 @@ func (c *CustomCurrency) ValidateWith(v ...models.ValidatorFunc[Currency]) error
 	return models.Validate[Currency](c, v...)
 }
 
-const (
-	CustomCurrencyCodeMinLength = 4
-	CustomCurrencyCodeMaxLength = 24
-
-	CustomCurrencyMaxPrecision uint32 = 12
-)
+const CustomCurrencyMaxPrecision uint32 = 12
 
 func (c *CustomCurrency) Validate() error {
 	if c == nil {
@@ -294,24 +291,8 @@ func (c *CustomCurrency) Validate() error {
 	}
 
 	if c.def != nil {
-		if c.def.ISOCode == "" {
-			errs = append(errs, errors.New("code is required"))
-		}
-
-		if len(c.def.ISOCode) != len(strings.TrimSpace(c.def.ISOCode.String())) {
-			errs = append(errs, fmt.Errorf("invalid currency code: cannot contain leading or trailing spaces: %s", c.def.ISOCode))
-		}
-
-		if strings.Contains(c.def.ISOCode.String(), "|") {
-			errs = append(errs, fmt.Errorf("invalid currency code: cannot contain route delimiter: %s", c.def.ISOCode))
-		}
-
-		if fiatDef := currency.Get(c.def.ISOCode); fiatDef != nil {
-			errs = append(errs, fmt.Errorf("currency code %s is a fiat currency", c.def.ISOCode))
-		}
-
-		if cl := len(c.def.ISOCode); cl < CustomCurrencyCodeMinLength || cl > CustomCurrencyCodeMaxLength {
-			errs = append(errs, fmt.Errorf("invalid currency code: it must be between %d and %d characters", CustomCurrencyCodeMinLength, CustomCurrencyCodeMaxLength))
+		if err := validateCustomCurrencyCode(Code(c.def.ISOCode)); err != nil {
+			errs = append(errs, err)
 		}
 
 		if c.def.Name == "" {


### PR DESCRIPTION
## Summary

- centralize fiat and custom currency-code validation in shared helpers
- allow `currencyx.Code` to represent and validate both fiat and custom currency codes
- implement `models.Equaler[Code]` with exact, case-sensitive equality
- expose `Code.Type()` to classify three-character fiat codes and custom currency codes

## Impact

Callers can use `currencyx.Code` consistently for fiat and custom currencies, compare codes through the standard `models.Equaler` contract, and determine the currency type without constructing a full currency value.

## Validation

- `go vet ./pkg/currencyx/...`
- `go test ./pkg/currencyx/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exported custom currency-code length bounds and improved currency-code equality/type classification.
  * Strengthened custom currency-code validation (rejects empty/whitespace/`|`, enforces length bounds, and blocks fiat-recognized values).
* **Bug Fixes**
  * Improved validation consistency across fiat/custom currency creation and validation.
  * Updated balance and input validation to use centralized currency validation; non-fiat currencies are now rejected with a clear invalid-currency reason.
* **Tests**
  * Added unit tests for currency-code validation, equality, type detection, and centralized currency validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes currency-code behavior and keeps ledger accounting limited to fiat currencies. The main changes are:

- Shared validation for fiat and custom currency codes.
- Exact, case-sensitive code equality and currency-type helpers.
- Fiat-only validation for ledger balance operations.
- Updated generated billing equality helpers and focused tests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Currency validity is checked before the ledger applies its fiat-only restriction.
- The new equality method preserves the previous exact string comparison.
- No blocking issue remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/currencyx/code.go | Adds shared code validation, exact equality, and fiat/custom classification helpers. |
| pkg/currencyx/currency.go | Reuses the shared helpers when validating and constructing currency values. |
| openmeter/ledger/routing.go | Rejects custom currency codes after validating the general code format. |
| openmeter/ledger/customerbalance/facade.go | Applies ledger-specific currency validation to explicit balance queries. |
| openmeter/ledger/customerbalance/service.go | Applies the fiat-only ledger contract during service input validation. |
| openmeter/billing/derived.gen.go | Uses the new exact code equality method in generated billing comparisons. |
| openmeter/billing/models/stddetailedline/derived.gen.go | Uses the new exact code equality method for detailed billing lines. |

<sub>Reviews (3): Last reviewed commit: ["fix: reject custom currencies in ledger ..."](https://github.com/openmeterio/openmeter/commit/53c9d2d4b30638be9e040102e7a7b7d4aeea31fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45885609)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->