### PR TITLE
feat(taxcode): prevent deletion of subscription-referenced tax codes

### DIFF
--- a/app/common/taxcode.go
+++ b/app/common/taxcode.go
@@ -90,6 +90,28 @@ func NewTaxCodeAddonServiceHook(
 	return h, nil
 }
 
+// TaxCodeSubscriptionHook prevents deleting tax codes that are still referenced by subscriptions.
+type TaxCodeSubscriptionHook taxcodehooks.SubscriptionHook
+
+// NewTaxCodeSubscriptionServiceHook builds the subscription-reference hook and registers it
+// on the tax code service. It depends on both the subscription and tax code services so wire constructs
+// it only after both exist, avoiding a construction cycle (subscription already depends on tax code).
+func NewTaxCodeSubscriptionServiceHook(
+	subscriptionServices SubscriptionServiceWithWorkflow,
+	taxCodeService taxcode.Service,
+) (TaxCodeSubscriptionHook, error) {
+	h, err := taxcodehooks.NewSubscriptionHook(taxcodehooks.SubscriptionHookConfig{
+		SubscriptionService: subscriptionServices.Service,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tax code subscription hook: %w", err)
+	}
+
+	taxCodeService.RegisterHooks(h)
+
+	return h, nil
+}
+
 func NewTaxCodeNamespaceHandler(
 	logger *slog.Logger,
 	service taxcode.Service,

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -101,6 +101,7 @@ type Application struct {
 	TaxCodeService                   taxcode.Service
 	TaxCodePlanHook                  common.TaxCodePlanHook
 	TaxCodeAddonHook                 common.TaxCodeAddonHook
+	TaxCodeSubscriptionHook          common.TaxCodeSubscriptionHook
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker
 	RuntimeMetricsCollector          common.RuntimeMetricsCollector
@@ -152,6 +153,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.TaxCodeNamespaceHandler,
 		common.NewTaxCodePlanServiceHook,
 		common.NewTaxCodeAddonServiceHook,
+		common.NewTaxCodeSubscriptionServiceHook,
 		common.Subscription,
 		common.Lockr,
 		common.Secret,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -822,6 +822,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	taxCodeSubscriptionHook, err := common.NewTaxCodeSubscriptionServiceHook(subscriptionServiceWithWorkflow, taxcodeService)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	health := common.NewHealthChecker(logger)
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, logger)
 	v10, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
@@ -919,6 +931,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		TaxCodeService:                   taxcodeService,
 		TaxCodePlanHook:                  taxCodePlanHook,
 		TaxCodeAddonHook:                 taxCodeAddonHook,
+		TaxCodeSubscriptionHook:          taxCodeSubscriptionHook,
 		TelemetryServer:                  v10,
 		TerminationChecker:               terminationChecker,
 		RuntimeMetricsCollector:          runtimeMetricsCollector,
@@ -994,6 +1007,7 @@ type Application struct {
 	TaxCodeService                   taxcode.Service
 	TaxCodePlanHook                  common.TaxCodePlanHook
 	TaxCodeAddonHook                 common.TaxCodeAddonHook
+	TaxCodeSubscriptionHook          common.TaxCodeSubscriptionHook
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker
 	RuntimeMetricsCollector          common.RuntimeMetricsCollector

--- a/openmeter/subscription/list.go
+++ b/openmeter/subscription/list.go
@@ -44,6 +44,9 @@ type ListSubscriptionsInput struct {
 	PlanID    *filter.FilterULID
 	PlanKey   *filter.FilterString
 	DeletedAt *filter.FilterTime
+
+	// TaxCodes filters subscriptions by the tax code IDs referenced on their rate cards.
+	TaxCodes *filter.FilterString
 }
 
 func (i ListSubscriptionsInput) Validate() error {
@@ -94,6 +97,12 @@ func (i ListSubscriptionsInput) Validate() error {
 	if i.DeletedAt != nil {
 		if err := i.DeletedAt.Validate(); err != nil {
 			errs = append(errs, models.NewGenericValidationError(fmt.Errorf("invalid deleted_at filter: %w", err)))
+		}
+	}
+
+	if i.TaxCodes != nil {
+		if err := i.TaxCodes.Validate(); err != nil {
+			errs = append(errs, models.NewGenericValidationError(fmt.Errorf("invalid tax_codes filter: %w", err)))
 		}
 	}
 

--- a/openmeter/subscription/repo/subscriptionrepo.go
+++ b/openmeter/subscription/repo/subscriptionrepo.go
@@ -12,6 +12,8 @@ import (
 	dbplan "github.com/openmeterio/openmeter/openmeter/ent/db/plan"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	dbsubscription "github.com/openmeterio/openmeter/openmeter/ent/db/subscription"
+	dbsubscriptionitem "github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
+	dbsubscriptionphase "github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/filter"
@@ -172,6 +174,26 @@ func (r *subscriptionRepo) List(ctx context.Context, in subscription.ListSubscri
 				query = query.Where(dbsubscription.HasPlanWith(*p))
 			}
 		}
+
+		if in.TaxCodes != nil {
+			if p := filter.SelectPredicate[predicate.SubscriptionItem](filter.Filter(*in.TaxCodes), dbsubscriptionitem.FieldTaxCodeID); p != nil {
+				// Match only items the subscription view would still surface. The view loads items
+				// with "deleted_at IS NULL OR deleted_at > now" (see subscriptionItemRepo item load),
+				// so mirror that here: without it the filter would also match items soft-deleted in
+				// the past, which the view drops, making the tax-code delete guard fail with a
+				// spurious "matched filter but no rate card references" error.
+				query = query.Where(dbsubscription.HasPhasesWith(
+					dbsubscriptionphase.HasItemsWith(
+						*p,
+						dbsubscriptionitem.Or(
+							dbsubscriptionitem.DeletedAtIsNil(),
+							dbsubscriptionitem.DeletedAtGT(now),
+						),
+					),
+				))
+			}
+		}
+
 		query = filter.ApplyToQuery(query, in.ID, dbsubscription.FieldID)
 		query = filter.ApplyToQuery(query, in.CustomerID, dbsubscription.FieldCustomerID)
 		query = filter.ApplyToQuery(query, in.PlanID, dbsubscription.FieldPlanID)

--- a/openmeter/taxcode/service/hooks/subscriptionhook.go
+++ b/openmeter/taxcode/service/hooks/subscriptionhook.go
@@ -1,0 +1,108 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/pkg/filter"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+type (
+	SubscriptionHook     = models.ServiceHook[taxcode.TaxCode]
+	NoopSubscriptionHook = models.NoopServiceHook[taxcode.TaxCode]
+)
+
+type SubscriptionHookConfig struct {
+	SubscriptionService subscription.Service
+}
+
+func (e SubscriptionHookConfig) Validate() error {
+	if e.SubscriptionService == nil {
+		return fmt.Errorf("subscription service is required")
+	}
+
+	return nil
+}
+
+var _ models.ServiceHook[taxcode.TaxCode] = (*subscriptionHook)(nil)
+
+type subscriptionHook struct {
+	NoopSubscriptionHook
+
+	subscriptionService subscription.Service
+}
+
+func NewSubscriptionHook(config SubscriptionHookConfig) (SubscriptionHook, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid subscription hook config: %w", err)
+	}
+
+	return &subscriptionHook{
+		subscriptionService: config.SubscriptionService,
+	}, nil
+}
+
+func (e *subscriptionHook) PreDelete(ctx context.Context, tc *taxcode.TaxCode) error {
+	affected, err := e.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
+		Namespaces: []string{tc.Namespace},
+		Status: []subscription.SubscriptionStatus{
+			subscription.SubscriptionStatusActive,
+			subscription.SubscriptionStatusCanceled,
+			subscription.SubscriptionStatusInactive,
+			subscription.SubscriptionStatusScheduled,
+		},
+		TaxCodes: &filter.FilterString{
+			In: &[]string{
+				tc.ID,
+			},
+		},
+		Page: pagination.Page{
+			PageSize:   5,
+			PageNumber: 1,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	if len(affected.Items) == 0 {
+		return nil
+	}
+
+	var errs []error
+
+	// The subscription List result carries no rate cards, so expand each matched
+	// subscription to a view to reach its rate cards. GetView is used per subscription
+	// instead of ExpandViews because ExpandViews only supports a single customer id,
+	// while the matched subscriptions may belong to different customers.
+	for _, sub := range affected.Items {
+		view, err := e.subscriptionService.GetView(ctx, sub.NamespacedID)
+		if err != nil {
+			return fmt.Errorf("failed to get subscription view: %w", err)
+		}
+
+		for _, phase := range view.Phases {
+			for _, items := range phase.ItemsByKey {
+				for _, item := range items {
+					taxCodeID := item.SubscriptionItem.RateCard.AsMeta().TaxCodeReference()
+					if taxCodeID == nil || *taxCodeID != tc.ID {
+						continue
+					}
+
+					errs = append(errs, taxcode.NewTaxCodeReferencedByRateCardError(tc.ID, item.SubscriptionItem.RateCard.Key()))
+				}
+			}
+		}
+	}
+
+	if len(errs) == 0 {
+		return fmt.Errorf("subscription %s matched tax code filter but no rate card references tax code %s", affected.Items[0].ID, tc.ID)
+	}
+
+	return errors.Join(errs...)
+}

--- a/openmeter/taxcode/service/hooks/subscriptionhook_test.go
+++ b/openmeter/taxcode/service/hooks/subscriptionhook_test.go
@@ -1,0 +1,298 @@
+package hooks_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/openmeter/taxcode/service/hooks"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// provisionSubscriptionOrgDefaults provisions the organization-default tax codes that
+// DeleteTaxCode requires to exist before it calls the pre-delete hook. This is the
+// subscription test environment variant, taking a taxcode.Service instead of pctestutils.TestEnv.
+func provisionSubscriptionOrgDefaults(t *testing.T, svc taxcode.Service, ns string) {
+	t.Helper()
+
+	invoicing, err := svc.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-invoicing",
+		Name:      "Provider Default",
+	})
+	require.NoError(t, err)
+
+	creditGrant, err := svc.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-credit-grant",
+		Name:      "Non-Taxable",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000000"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            ns,
+		InvoicingTaxCodeID:   invoicing.ID,
+		CreditGrantTaxCodeID: creditGrant.ID,
+	})
+	require.NoError(t, err)
+}
+
+func TestSubscriptionHookPreDelete(t *testing.T) {
+	// Setup real services backed by Postgres.
+	currentTime := testutils.GetRFC3339Time(t, "2021-01-01T00:00:11Z")
+	clock.SetTime(currentTime)
+	defer clock.ResetTime()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+
+	// Register the subscription hook on the real tax code service.
+	subHook, err := hooks.NewSubscriptionHook(hooks.SubscriptionHookConfig{SubscriptionService: deps.SubscriptionService})
+	require.NoError(t, err)
+	deps.TaxCodeService.RegisterHooks(subHook)
+
+	ns := subscriptiontestutils.ExampleNamespace
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past
+	// the org-defaults check and reach the pre-delete hook.
+	provisionSubscriptionOrgDefaults(t, deps.TaxCodeService, ns)
+
+	t.Run("blocks deletion when a subscription references the tax code", func(t *testing.T) {
+		// given: a tax code that a subscription will reference
+		referenced, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "sub-referenced",
+			Name:      "Referenced Tax Code",
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: "txcd_20000005"},
+			},
+		})
+		require.NoError(t, err)
+
+		// given: a plan whose rate card references the tax code
+		rc := subscriptiontestutils.ExampleRateCard1.Clone().(*productcatalog.UsageBasedRateCard)
+		rc.TaxConfig = &productcatalog.TaxConfig{TaxCodeID: lo.ToPtr(referenced.ID)}
+
+		planInput := subscriptiontestutils.BuildTestPlanInput(t).
+			AddPhase(nil, rc).
+			Build()
+
+		// Create example features before plan creation (plan publish validates feature references)
+		_ = deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+		// CreatePlan both creates and publishes the plan
+		pl := deps.PlanHelper.CreatePlan(t, planInput)
+
+		// given: a running subscription that references the tax code via the rate card
+		subView := subscriptiontestutils.CreateSubscriptionFromPlan(t, &deps, pl, clock.Now())
+		_ = subView
+
+		// when: attempting to delete the referenced tax code
+		err = deps.TaxCodeService.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+			NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
+		})
+
+		// then: an error is returned and it is a TaxCodeReferencedByRateCard error
+		require.Error(t, err)
+		require.True(t, taxcode.IsTaxCodeReferencedByRateCardError(err),
+			"expected TaxCodeReferencedByRateCard error, got: %v", err)
+	})
+
+	t.Run("allows deletion when no subscription references the tax code", func(t *testing.T) {
+		// given: a tax code that no subscription references
+		unreferenced, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "sub-unreferenced",
+			Name:      "Unreferenced Tax Code",
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: "txcd_20000006"},
+			},
+		})
+		require.NoError(t, err)
+
+		// when: deleting the unreferenced tax code
+		err = deps.TaxCodeService.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+			NamespacedID: models.NamespacedID{Namespace: ns, ID: unreferenced.ID},
+		})
+
+		// then: no error is returned
+		require.NoError(t, err)
+	})
+}
+
+func TestSubscriptionHookPreDeleteScheduledSubscription(t *testing.T) {
+	// A subscription scheduled to start in the future still references the tax code and
+	// must block deletion with the typed error. This guards the "all statuses" requirement:
+	// the hook lists every status, and the subscription view loads phases/items structurally
+	// (only gated on soft-delete, not on being active as-of-now), so a not-yet-active
+	// subscription still surfaces its rate cards and yields the typed referenced-by error.
+	currentTime := testutils.GetRFC3339Time(t, "2021-01-01T00:00:11Z")
+	clock.SetTime(currentTime)
+	defer clock.ResetTime()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+
+	// Register the subscription hook on the real tax code service.
+	subHook, err := hooks.NewSubscriptionHook(hooks.SubscriptionHookConfig{SubscriptionService: deps.SubscriptionService})
+	require.NoError(t, err)
+	deps.TaxCodeService.RegisterHooks(subHook)
+
+	ns := subscriptiontestutils.ExampleNamespace
+
+	// Provision organization-default tax codes so DeleteTaxCode reaches the pre-delete hook.
+	provisionSubscriptionOrgDefaults(t, deps.TaxCodeService, ns)
+
+	// given: a tax code referenced by a plan rate card
+	referenced, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "sub-scheduled-referenced",
+		Name:      "Referenced Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_20000007"},
+		},
+	})
+	require.NoError(t, err)
+
+	rc := subscriptiontestutils.ExampleRateCard1.Clone().(*productcatalog.UsageBasedRateCard)
+	rc.TaxConfig = &productcatalog.TaxConfig{TaxCodeID: lo.ToPtr(referenced.ID)}
+
+	planInput := subscriptiontestutils.BuildTestPlanInput(t).
+		AddPhase(nil, rc).
+		Build()
+
+	// Example features must exist before plan publish (plan publish validates feature references).
+	_ = deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	// CreatePlan both creates and publishes the plan.
+	pl := deps.PlanHelper.CreatePlan(t, planInput)
+
+	// given: a subscription SCHEDULED to start one year in the future (not active as-of-now)
+	futureStart := clock.Now().AddDate(1, 0, 0)
+	_ = subscriptiontestutils.CreateSubscriptionFromPlan(t, &deps, pl, futureStart)
+
+	// when: attempting to delete the referenced tax code
+	err = deps.TaxCodeService.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
+	})
+
+	// then: deletion is blocked with the TYPED referenced-by-rate-card error (not a generic error)
+	require.Error(t, err)
+	require.True(t, taxcode.IsTaxCodeReferencedByRateCardError(err),
+		"expected TaxCodeReferencedByRateCard error for a scheduled subscription, got: %v", err)
+}
+
+func TestSubscriptionHookPreDeleteSoftDeletedItem(t *testing.T) {
+	// given:
+	// - a running subscription with a FUTURE (not-yet-started) phase whose only referencing
+	//   rate-card item is removed via EditRunning, then the clock advances well past the edit
+	// - removing an item from a future phase (as opposed to the current phase, which can only
+	//   ever be "closed" going forward, never truly deleted, since history cannot be falsified)
+	//   genuinely soft-deletes its row with no replacement version, so its deleted_at timestamp
+	//   ends up in the past once the clock advances - the exact shape the DB soft-delete guard
+	//   in subscriptionrepo.go's List targets. The raw DB row still carries the tax code
+	//   reference, so a filter without the "deleted_at IS NULL OR deleted_at > now" guard would
+	//   still match this subscription even though the item is long gone.
+	// when: the tax code is deleted
+	// then: deletion must succeed, because the subscription view (which is what actually
+	//   determines whether a rate card references the tax code) never surfaces an item that was
+	//   soft-deleted in the past, so no view item references the tax code anymore. Without the
+	//   guard in subscriptionrepo.go's List, the hook would still match this subscription via
+	//   the DB filter, find no referencing view item, and return the generic (not the typed)
+	//   "matched tax code filter but no rate card references" error instead of nil.
+	currentTime := testutils.GetRFC3339Time(t, "2021-01-01T00:00:11Z")
+	clock.SetTime(currentTime)
+	defer clock.ResetTime()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+
+	// Register the subscription hook on the real tax code service.
+	subHook, err := hooks.NewSubscriptionHook(hooks.SubscriptionHookConfig{SubscriptionService: deps.SubscriptionService})
+	require.NoError(t, err)
+	deps.TaxCodeService.RegisterHooks(subHook)
+
+	ns := subscriptiontestutils.ExampleNamespace
+
+	// Provision organization-default tax codes so DeleteTaxCode reaches the pre-delete hook.
+	provisionSubscriptionOrgDefaults(t, deps.TaxCodeService, ns)
+
+	// given: a tax code referenced by a plan rate card in the subscription's second (future) phase
+	referenced, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "sub-soft-deleted-referenced",
+		Name:      "Referenced Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_20000008"},
+		},
+	})
+	require.NoError(t, err)
+
+	// given: a two-phase plan. The first phase (active immediately) has a single, unrelated
+	// item so the subscription always has a current phase to compare against. The second
+	// phase (starting in a month, i.e. still in the future at edit time) has two rate cards:
+	// one referencing the tax code, and one that does not, so the phase keeps at least one
+	// item once the referencing item is removed (a phase must keep at least one item).
+	rc := subscriptiontestutils.ExampleRateCard1.Clone().(*productcatalog.UsageBasedRateCard)
+	rc.TaxConfig = &productcatalog.TaxConfig{TaxCodeID: lo.ToPtr(referenced.ID)}
+	rcPhase1 := subscriptiontestutils.ExampleRateCard2.Clone()
+	rcPhase2Other := subscriptiontestutils.ExampleRateCard2.Clone()
+
+	planInput := subscriptiontestutils.BuildTestPlanInput(t).
+		AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P1M")), rcPhase1).
+		AddPhase(nil, rc, rcPhase2Other).
+		Build()
+
+	// Example features must exist before plan publish (plan publish validates feature references).
+	_ = deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	// CreatePlan both creates and publishes the plan.
+	pl := deps.PlanHelper.CreatePlan(t, planInput)
+
+	// given: a running subscription that references the tax code via the rc rate card in its
+	// second, not-yet-started phase
+	subView := subscriptiontestutils.CreateSubscriptionFromPlan(t, &deps, pl, clock.Now())
+
+	futurePhaseKey := subView.Phases[1].Spec.PhaseKey
+
+	// given: the referencing item is removed from the future phase. Since it's not the current
+	// phase, EditRunning genuinely deletes the item's history (no replacement version is kept,
+	// see patch.PatchRemoveItem.ApplyTo's future-phase branch), leaving only a soft-deleted row.
+	editTime := clock.Now()
+	_, err = deps.WorkflowService.EditRunning(t.Context(), subView.Subscription.NamespacedID, []subscription.Patch{
+		patch.PatchRemoveItem{PhaseKey: futurePhaseKey, ItemKey: rc.Key()},
+	}, subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)})
+	require.NoError(t, err)
+
+	// given: time advances well past the edit, so the item's soft-delete is now in the past
+	// and the subscription view will no longer surface it.
+	clock.SetTime(editTime.Add(time.Hour))
+
+	// when: attempting to delete the tax code whose only referencing item was soft-deleted in the past
+	err = deps.TaxCodeService.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
+	})
+
+	// then: deletion is allowed, since no currently-surfaced rate card references the tax code
+	require.NoError(t, err, "deleting a tax code whose only referencing subscription item was soft-deleted in the past must be allowed")
+}


### PR DESCRIPTION
### What
  Deleting a tax code that is still referenced by a subscription's rate cards is now blocked with
  a typed `TaxCodeReferencedByRateCard` error, mirroring the existing plan and add-on delete
  guards.

  ### Why
  A tax code referenced by a live, scheduled, canceled, or inactive subscription could previously
  be deleted, leaving those subscriptions pointing at a non-existent tax code.

  ### How
  - **New `SubscriptionHook`** (`openmeter/taxcode/service/hooks/subscriptionhook.go`) registered
  on the tax code service as a `PreDelete` hook. It lists subscriptions filtered by tax-code
  reference (all statuses), expands each to a view, and returns a typed referenced-by error per
  matching rate card.
  - **`ListSubscriptionsInput.TaxCodes` filter** (`list.go` + `subscriptionrepo.go`) filters
  subscriptions by the tax code IDs on their rate-card items. The repo filter mirrors the
  subscription view's soft-delete gate (`deleted_at IS NULL OR deleted_at > now`), so items
  soft-deleted in the past don't produce spurious matches.
  - **Wiring** (`app/common/taxcode.go`, `cmd/server/wire*.go`) constructs the hook after both the
  subscription and tax code services exist, avoiding a construction cycle.
  - **Tests** cover referenced/unreferenced deletion, scheduled subscriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription filtering by tax code.
  * Prevented deletion of tax codes referenced by active or scheduled subscription rate cards.
  * Tax codes can still be deleted when references belong only to soft-deleted items.

* **Bug Fixes**
  * Improved protection against removing tax codes that subscriptions depend on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=45899435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

No additional blocking issue was found in this review.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Ftaxcode%2Fservice%2Fhooks%2Fsubscriptionhook.go%3A51-69%0AThe%20guard%20only%20scans%20subscriptions%20before%20the%20tax-code%20delete.%20A%20concurrent%20subscription%20creation%20or%20rate-card%20update%20can%20add%20this%20tax-code%20ID%20after%20%60List%60%20completes%20but%20before%20deletion%2C%20so%20both%20operations%20can%20commit%20and%20leave%20a%20subscription%20referencing%20a%20deleted%20tax%20code%20unless%20the%20database%20transaction%20locks%20or%20otherwise%20serializes%20those%20writes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4758&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Reference Check Races With Writes** <a href="https://github.com/openmeterio/openmeter/pull/4758#discussion_r3621080692">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
openmeter/taxcode/service/hooks/subscriptionhook.go:51-69
The guard only scans subscriptions before the tax-code delete. A concurrent subscription creation or rate-card update can add this tax-code ID after `List` completes but before deletion, so both operations can commit and leave a subscription referencing a deleted tax code unless the database transaction locks or otherwise serializes those writes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

This PR prevents deletion of tax codes referenced by subscription rate cards. The main changes are:

- Adds subscription filtering by rate-card tax code.
- Registers a subscription pre-delete hook on the tax-code service.
- Covers referenced, scheduled, unreferenced, and soft-deleted subscription items.

<sub>Reviews (2) · Last reviewed commit: ["feat(taxcode): prevent deletion of subsc..."](https://github.com/openmeterio/openmeter/commit/002b9b7c8eac59fdebe705ee8026d559ddc38a76)</sub>

<!-- /greptile_comment -->