### PR TITLE
fix(ledger): book advance attribution at purchase time

### DIFF
--- a/openmeter/billing/charges/creditpurchase/service/promotional_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/promotional_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils/currency"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -25,6 +26,10 @@ func TestPromotionalCreditPurchaseStateMachineAdvancesCreatedChargeToFinal(t *te
 	// - the promotional state machine advances until stable
 	// then:
 	// - it grants the promotional credits, backfills lineage, and persists the final status
+	purchasedAt := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(purchasedAt)
+	defer clock.UnFreeze()
+
 	stateMachine, charge, adapter, lineageService := newPromotionalStateMachineTestMachine(
 		t,
 		creditpurchase.StatusCreated,
@@ -37,11 +42,12 @@ func TestPromotionalCreditPurchaseStateMachineAdvancesCreatedChargeToFinal(t *te
 	require.Equal(t, creditpurchase.StatusFinal, advancedCharge.Status)
 	require.Equal(t, creditpurchase.StatusFinal, adapter.updatedBase.Status)
 	require.NotNil(t, advancedCharge.Realizations.CreditGrantRealization)
-	require.NotEmpty(t, advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
+	require.Equal(t, "ledger-tx-1", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
+	require.Equal(t, purchasedAt, advancedCharge.Realizations.CreditGrantRealization.Time)
 	require.Equal(t, 1, adapter.createCreditGrantCalls)
 	require.Equal(t, charge.GetChargeID(), adapter.createdGrantChargeID)
 	require.Equal(t, advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID, adapter.createdGrantInput.TransactionGroupID)
-	require.False(t, adapter.createdGrantInput.GrantedAt.IsZero())
+	require.Equal(t, purchasedAt, adapter.createdGrantInput.GrantedAt)
 	lineageService.AssertExpectations(t)
 }
 
@@ -217,7 +223,7 @@ func newPromotionalStateMachineTestMachine(
 				input.CustomerID == charge.Intent.CustomerID &&
 				input.Currency.GetCode() == charge.Intent.Currency.GetCode() &&
 				input.Amount.Equal(charge.Intent.CreditAmount) &&
-				input.BackingTransactionGroupID != ""
+				input.BackingTransactionGroupID == "ledger-tx-1"
 		})).
 		Return(nil).
 		Once()

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/ledger/breakage"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
@@ -227,7 +228,15 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	}
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 	featureFilters := charge.Intent.FeatureFilters.Normalize()
-	bookedAt := charge.Intent.ServicePeriod.To
+	effectiveAt := charge.Intent.ServicePeriod.To
+	// LedgerTransaction.CreatedAt retains recording time. For effective time,
+	// future-effective purchases book attribution immediately so subsequent
+	// committed purchases observe reduced advance; already-effective purchases
+	// backdate attribution alongside issuance and settlement.
+	advanceAttributionEffectiveAt := clock.Now()
+	if effectiveAt.Before(advanceAttributionEffectiveAt) {
+		advanceAttributionEffectiveAt = effectiveAt
+	}
 
 	advanceAttributions, err := h.advanceAttributions(ctx, customerID, charge.Intent.Currency.GetCode(), charge.Intent.CreditAmount, featureFilters)
 	if err != nil {
@@ -248,7 +257,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 
 	for _, attribution := range advanceAttributions {
 		templates = append(templates, transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{
-			At:                 bookedAt,
+			At:                 advanceAttributionEffectiveAt,
 			Amount:             attribution.advanceAmount,
 			Currency:           charge.Intent.Currency.GetCode(),
 			CostBasis:          &costBasis,
@@ -260,7 +269,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 
 		if attribution.accruedAmount.IsPositive() {
 			templates = append(templates, transactions.TranslateCustomerAccruedCostBasisTemplate{
-				At:             bookedAt,
+				At:             advanceAttributionEffectiveAt,
 				Amount:         attribution.accruedAmount,
 				Currency:       charge.Intent.Currency.GetCode(),
 				TaxCode:        attribution.taxCode,
@@ -275,7 +284,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 
 	if issuableAmount.IsPositive() {
 		templates = append(templates, transactions.IssueCustomerReceivableTemplate{
-			At:             bookedAt,
+			At:             effectiveAt,
 			Amount:         issuableAmount,
 			Currency:       charge.Intent.Currency.GetCode(),
 			CostBasis:      &costBasis,
@@ -291,7 +300,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		// does not leave an unsettled receivable behind.
 		templates = append(templates,
 			transactions.AuthorizeCustomerReceivablePaymentTemplate{
-				At:             bookedAt,
+				At:             effectiveAt,
 				Amount:         charge.Intent.CreditAmount,
 				Currency:       charge.Intent.Currency.GetCode(),
 				CostBasis:      &costBasis,
@@ -299,7 +308,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 				SourceChargeID: &charge.ID,
 			},
 			transactions.SettleCustomerReceivableFromPaymentTemplate{
-				At:             bookedAt,
+				At:             effectiveAt,
 				Amount:         charge.Intent.CreditAmount,
 				Currency:       charge.Intent.Currency.GetCode(),
 				CostBasis:      &costBasis,

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -75,6 +75,68 @@ func TestOnPromotionalCreditPurchase_BacksAdvanceBeforeTopUp(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.washSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(-100)))
 }
 
+func TestOnCreditPurchaseInitiated_PastEffectiveGrantBackdatesAdvanceAttribution(t *testing.T) {
+	env := newCreditPurchaseHandlerTestEnv(t)
+
+	// given:
+	// - advance exposure that predates a credit purchase's effective time
+	// - the purchase is materialized after that effective time
+	// when:
+	// - the purchase is initiated
+	// then:
+	// - recording time stays current while every purchase posting is effective in the past
+	recordedAt := env.Now()
+	effectiveAt := recordedAt.Add(-2 * time.Hour)
+	func() {
+		clock.FreezeTime(effectiveAt.Add(-time.Hour))
+		defer clock.UnFreeze()
+		env.createAdvanceExposure(t, alpacadecimal.NewFromInt(40))
+	}()
+	clock.FreezeTime(recordedAt)
+	defer clock.UnFreeze()
+
+	costBasis := mustDecimal(t, "0.5")
+	charge := env.newExternalCharge(alpacadecimal.NewFromInt(100), costBasis)
+	effectivePeriod := timeutil.ClosedPeriod{From: effectiveAt, To: effectiveAt}
+	charge.Intent.ServicePeriod = effectivePeriod
+	charge.Intent.FullServicePeriod = effectivePeriod
+	charge.Intent.BillingPeriod = effectivePeriod
+
+	ref, err := env.handler.OnCreditPurchaseInitiated(t.Context(), charge)
+	require.NoError(t, err)
+	require.NotEmpty(t, ref.TransactionGroupID)
+
+	bookedAtByTemplate := env.transactionBookedAtByTemplateCode(t, ref.TransactionGroupID)
+	for _, template := range []transactions.TransactionTemplate{
+		transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{},
+		transactions.TranslateCustomerAccruedCostBasisTemplate{},
+		transactions.IssueCustomerReceivableTemplate{},
+	} {
+		bookedAt := bookedAtByTemplate[transactions.TemplateCode(template)]
+		require.Len(t, bookedAt, 1)
+		requireLedgerBookedAtEqual(t, effectiveAt, bookedAt[0])
+	}
+
+	transactionRows, err := env.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(env.Namespace),
+			ledgertransactiondb.GroupID(ref.TransactionGroupID),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, transactionRows)
+	for _, transactionRow := range transactionRows {
+		require.False(t, transactionRow.CreatedAt.Before(recordedAt))
+	}
+
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.unknownReceivableSubAccount(t), effectiveAt).InexactFloat64())
+	require.Equal(t, float64(-100), env.sumBalanceAsOf(t, env.receivableSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.authorizedReceivableSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+	require.Equal(t, float64(40), env.sumBalanceAsOf(t, env.accruedSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+	require.Equal(t, float64(60), env.sumBalanceAsOf(t, env.fboSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.washSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+}
+
 func TestOnCreditPurchaseInitiated_BackfillsOnlyMatchingFeatureAdvances(t *testing.T) {
 	env := newCreditPurchaseHandlerTestEnv(t)
 	env.createAdvanceExposureWithFeatures(t, alpacadecimal.NewFromInt(40), []string{"api-calls"})
@@ -140,12 +202,21 @@ func TestOnCreditPurchaseInitiated(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
 }
 
-func TestOnCreditPurchaseInitiated_UsesServicePeriodEndAsBookedAt(t *testing.T) {
+func TestOnCreditPurchaseInitiated_FutureEffectiveGrantBackfillsAdvanceAtPurchaseTime(t *testing.T) {
 	env := newCreditPurchaseHandlerTestEnv(t)
+
+	// given:
+	// - existing advance and a credit purchase whose remainder becomes effective later
+	// when:
+	// - the materialized charge initiates the purchase now
+	// then:
+	// - advance attribution is booked now while only the remainder is issued later
+	purchasedAt := env.Now()
+	env.createAdvanceExposure(t, alpacadecimal.NewFromInt(40))
 
 	costBasis := mustDecimal(t, "0.5")
 	charge := env.newExternalCharge(alpacadecimal.NewFromInt(100), costBasis)
-	effectiveAt := charge.CreatedAt.Add(2 * time.Hour)
+	effectiveAt := purchasedAt.Add(2 * time.Hour)
 	effectivePeriod := timeutil.ClosedPeriod{From: effectiveAt, To: effectiveAt}
 	charge.Intent.ServicePeriod = effectivePeriod
 	charge.Intent.FullServicePeriod = effectivePeriod
@@ -155,10 +226,71 @@ func TestOnCreditPurchaseInitiated_UsesServicePeriodEndAsBookedAt(t *testing.T) 
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.TransactionGroupID)
 
-	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-		requireLedgerBookedAtEqual(t, effectiveAt, bookedAt)
-		requireLedgerBookedAtNotEqual(t, charge.CreatedAt, bookedAt)
+	bookedAtByTemplate := env.transactionBookedAtByTemplateCode(t, ref.TransactionGroupID)
+	for _, template := range []transactions.TransactionTemplate{
+		transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{},
+		transactions.TranslateCustomerAccruedCostBasisTemplate{},
+	} {
+		bookedAt := bookedAtByTemplate[transactions.TemplateCode(template)]
+		require.Len(t, bookedAt, 1)
+		requireLedgerBookedAtEqual(t, purchasedAt, bookedAt[0])
 	}
+
+	issuanceBookedAt := bookedAtByTemplate[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})]
+	require.Len(t, issuanceBookedAt, 1)
+	requireLedgerBookedAtEqual(t, effectiveAt, issuanceBookedAt[0])
+
+	// The backfilled amount is reflected now, but the future remainder is not spendable yet.
+	require.Equal(t, float64(40), env.sumBalanceAsOf(t, env.accruedSubAccount(t, costBasis), purchasedAt).InexactFloat64())
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.fboSubAccount(t, costBasis), purchasedAt).InexactFloat64())
+	require.Equal(t, float64(60), env.sumBalanceAsOf(t, env.fboSubAccount(t, costBasis), effectiveAt).InexactFloat64())
+}
+
+func TestOnCreditPurchaseInitiated_SubsequentFuturePurchaseCannotOverAttributeAdvance(t *testing.T) {
+	env := newCreditPurchaseHandlerTestEnv(t)
+
+	// given:
+	// - 100 of existing advance and two future-effective purchases of 60 each
+	// when:
+	// - both purchases are initiated now
+	// then:
+	// - the first attributes 60, the second attributes only the remaining 40, and 20 stays future issuance
+	purchasedAt := env.Now()
+	effectiveAt := purchasedAt.Add(2 * time.Hour)
+	effectivePeriod := timeutil.ClosedPeriod{From: effectiveAt, To: effectiveAt}
+	env.createAdvanceExposure(t, alpacadecimal.NewFromInt(100))
+
+	costBasis := mustDecimal(t, "0.5")
+	firstCharge := env.newExternalCharge(alpacadecimal.NewFromInt(60), costBasis)
+	firstCharge.ID = "01JABCDEF0123456789ABCDEFG"
+	firstCharge.Intent.ServicePeriod = effectivePeriod
+	firstCharge.Intent.FullServicePeriod = effectivePeriod
+	firstCharge.Intent.BillingPeriod = effectivePeriod
+
+	secondCharge := env.newExternalCharge(alpacadecimal.NewFromInt(60), costBasis)
+	secondCharge.ID = "01JBCDEF0123456789ABCDEFGH"
+	secondCharge.Intent.ServicePeriod = effectivePeriod
+	secondCharge.Intent.FullServicePeriod = effectivePeriod
+	secondCharge.Intent.BillingPeriod = effectivePeriod
+
+	firstRef, err := env.handler.OnCreditPurchaseInitiated(t.Context(), firstCharge)
+	require.NoError(t, err)
+	secondRef, err := env.handler.OnCreditPurchaseInitiated(t.Context(), secondCharge)
+	require.NoError(t, err)
+
+	require.NotContains(t, env.transactionTemplateCodes(t, firstRef.TransactionGroupID), transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{}))
+	secondBookedAtByTemplate := env.transactionBookedAtByTemplateCode(t, secondRef.TransactionGroupID)
+	secondAttributionBookedAt := secondBookedAtByTemplate[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})]
+	require.Len(t, secondAttributionBookedAt, 1)
+	requireLedgerBookedAtEqual(t, purchasedAt, secondAttributionBookedAt[0])
+	secondIssuanceBookedAt := secondBookedAtByTemplate[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})]
+	require.Len(t, secondIssuanceBookedAt, 1)
+	requireLedgerBookedAtEqual(t, effectiveAt, secondIssuanceBookedAt[0])
+
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.unknownReceivableSubAccount(t), purchasedAt).InexactFloat64())
+	require.Equal(t, float64(100), env.sumBalanceAsOf(t, env.accruedSubAccount(t, costBasis), purchasedAt).InexactFloat64())
+	require.Equal(t, float64(0), env.sumBalanceAsOf(t, env.fboSubAccount(t, costBasis), purchasedAt).InexactFloat64())
+	require.Equal(t, float64(20), env.sumBalanceAsOf(t, env.fboSubAccount(t, costBasis), effectiveAt).InexactFloat64())
 }
 
 func TestOnCreditPurchaseInitiated_SeparatesSourceChargeBuckets(t *testing.T) {
@@ -871,6 +1003,32 @@ func (e *creditPurchaseHandlerTestEnv) transactionBookedAtTimes(t *testing.T, gr
 	out := make([]time.Time, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.BookedAt)
+	}
+
+	return out
+}
+
+func (e *creditPurchaseHandlerTestEnv) transactionBookedAtByTemplateCode(t *testing.T, groupID string) map[string][]time.Time {
+	t.Helper()
+
+	transactionRows, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, transactionRows, "expected at least one ledger transaction for group")
+
+	out := make(map[string][]time.Time, len(transactionRows))
+	for _, transactionRow := range transactionRows {
+		code, err := ledger.TransactionTemplateCodeFromAnnotations(transactionRow.Annotations)
+		require.NoError(t, err)
+		out[code] = append(out[code], transactionRow.BookedAt)
 	}
 
 	return out


### PR DESCRIPTION
## Summary

- keep subscription and schedule definitions ledger-neutral; this changes only the materialized credit-purchase initiation path
- determine and book existing advance attribution at purchase time
- keep only the non-attributed remainder as issuance at the grant's future `effective_at`
- align the ledger timing with the immediate lineage backfill so a subsequent committed purchase sees the already-settled advance

## Behavior

- a future-effective 100-credit purchase against 40 of existing advance books 40 of attribution immediately and 60 of issuance at `effective_at`
- the future 60 does not appear in the current spendable balance
- two sequential 60-credit purchases against 100 of advance attribute 60 + 40, with only the remaining 20 issued in the future
- promotional purchase coverage verifies that grant realization and lineage use the same purchase-time ledger transaction group

Invoice-settled purchases keep their existing trigger at invoice draft creation. This PR does not add payment control or recurring subscription grants.

## Cancellation / void limitation

The existing void path operates on currently issued future-balance-overage value for the source charge. Before a future grant reaches `effective_at`, its scheduled remainder has no spendable balance slice to void, and the purchase-time advance attribution is not such a slice. As a result, future-effective grants remain non-voidable before `effective_at`; this PR does not add cancellation of scheduled ledger entries or claim to solve that lifecycle. Void behavior for remaining issued value after `effective_at` is unchanged.

## Tests

- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/ledger/chargeadapter ./openmeter/billing/charges/creditpurchase/service`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -v ./openmeter/ledger/chargeadapter ./openmeter/billing/charges/creditpurchase/service`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -v ./test/credits`

All database-backed tests ran against PostgreSQL; none were skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the timing of credit purchase accounting for purchases with past or future effective dates.
  - Advance credits are now attributed at the appropriate purchase or effective time, preventing over-attribution across multiple future purchases.
  - Credit grant timestamps and ledger transaction references now remain consistent and accurate.

- **Tests**
  - Expanded coverage for time-based credit grants, future-effective purchases, balance calculations, and transaction booking dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes when credit purchases are recorded in the ledger. The main changes are:

- Books existing advance attribution when the purchase is initiated.
- Defers only the remaining credit issuance until the grant becomes effective.
- Backdates attribution for already-effective purchases to match issuance and settlement.
- Adds tests for past-effective, future-effective, sequential, and promotional purchases.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- Past-effective attribution now uses the same effective time as issuance and settlement.
- Future-effective purchases attribute existing advances immediately while keeping the remainder deferred.
- Tests cover the timing cases changed by this update.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/ledger/chargeadapter/creditpurchase.go | Separates advance-attribution timing from deferred issuance and keeps past-effective ledger entries aligned. |
| openmeter/ledger/chargeadapter/creditpurchase_test.go | Adds tests for historical timing, future issuance, and sequential consumption of an existing advance. |
| openmeter/billing/charges/creditpurchase/service/promotional_test.go | Verifies promotional grant realization and lineage use the purchase-time ledger transaction group. |

<sub>Reviews (2): Last reviewed commit: ["fix(ledger): book advance attribution at..."](https://github.com/openmeterio/openmeter/commit/5f4e6a82de0d2bde13150a52c4186086711ac979) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45953865)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->