### PR TITLE
chore: validate pointer receiver

### DIFF
--- a/pkg/currencyx/currency.go
+++ b/pkg/currencyx/currency.go
@@ -115,39 +115,39 @@ type FiatCurrency struct {
 	def *currency.Def
 }
 
-func (f *FiatCurrency) Definition() *currency.Def {
+func (f FiatCurrency) Definition() *currency.Def {
 	return cloneDef(f.def)
 }
 
-func (f *FiatCurrency) FormatAmount(amount alpacadecimal.Decimal) string {
+func (f FiatCurrency) FormatAmount(amount alpacadecimal.Decimal) string {
 	return formatCurrencyAmount(f.def, amount)
 }
 
-func (f *FiatCurrency) Unit() alpacadecimal.Decimal {
+func (f FiatCurrency) Unit() alpacadecimal.Decimal {
 	return alpacadecimal.NewFromInt(1).Shift(-int32(f.def.Subunits))
 }
 
-func (f *FiatCurrency) RoundUp(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
+func (f FiatCurrency) RoundUp(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
 	return amount.RoundUp(int32(f.def.Subunits))
 }
 
-func (f *FiatCurrency) RoundDown(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
+func (f FiatCurrency) RoundDown(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
 	return amount.RoundDown(int32(f.def.Subunits))
 }
 
-func (f *FiatCurrency) IsRoundedToPrecision(amount alpacadecimal.Decimal) bool {
+func (f FiatCurrency) IsRoundedToPrecision(amount alpacadecimal.Decimal) bool {
 	return amount.Equal(f.RoundToPrecision(amount))
 }
 
-func (f *FiatCurrency) RoundToPrecision(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
+func (f FiatCurrency) RoundToPrecision(amount alpacadecimal.Decimal) alpacadecimal.Decimal {
 	return amount.Round(int32(f.def.Subunits))
 }
 
-func (f *FiatCurrency) Type() CurrencyType {
+func (f FiatCurrency) Type() CurrencyType {
 	return CurrencyTypeFiat
 }
 
-func (f *FiatCurrency) Details() CurrencyDetails {
+func (f FiatCurrency) Details() CurrencyDetails {
 	return CurrencyDetails{
 		Code:               Code(f.def.ISOCode),
 		Name:               f.def.Name,
@@ -158,13 +158,13 @@ func (f *FiatCurrency) Details() CurrencyDetails {
 	}
 }
 
-func (f *FiatCurrency) AsFiat() (*FiatCurrency, error) {
+func (f FiatCurrency) AsFiat() (*FiatCurrency, error) {
 	return &FiatCurrency{
 		def: cloneDef(f.def),
 	}, nil
 }
 
-func (f *FiatCurrency) AsCustom() (*CustomCurrency, error) {
+func (f FiatCurrency) AsCustom() (*CustomCurrency, error) {
 	return nil, fmt.Errorf("cannot convert fiat to custom currency")
 }
 

--- a/pkg/currencyx/currency.go
+++ b/pkg/currencyx/currency.go
@@ -172,11 +172,7 @@ func (f *FiatCurrency) ValidateWith(v ...models.ValidatorFunc[Currency]) error {
 	return models.Validate[Currency](f, v...)
 }
 
-func (f *FiatCurrency) Validate() error {
-	if f == nil {
-		return errors.New("fiat currency is not initialized")
-	}
-
+func (f FiatCurrency) Validate() error {
 	var errs []error
 
 	if f.def == nil {

--- a/pkg/currencyx/currency_test.go
+++ b/pkg/currencyx/currency_test.go
@@ -515,3 +515,14 @@ func TestRoundingBehavior(t *testing.T) {
 		})
 	}
 }
+
+func TestFiatCurrencyReceivers(t *testing.T) {
+	fiat, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeFiat).
+		WithCode(currencyx.Code("USD")).
+		Build()
+	require.NoError(t, err)
+
+	currency := fiat.(*currencyx.FiatCurrency)
+	require.NoError(t, currency.Validate())
+	require.NoError(t, (*currency).Validate())
+}

--- a/pkg/currencyx/currency_test.go
+++ b/pkg/currencyx/currency_test.go
@@ -525,4 +525,11 @@ func TestFiatCurrencyReceivers(t *testing.T) {
 	currency := fiat.(*currencyx.FiatCurrency)
 	require.NoError(t, currency.Validate())
 	require.NoError(t, (*currency).Validate())
+
+	// Does not work
+	// require.NoError(t, returnFiatCurrency(*currency).Validate())
+}
+
+func returnFiatCurrency(x currencyx.FiatCurrency) currencyx.FiatCurrency {
+	return x
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `FiatCurrency` to support value-based method calls. The main changes are:

- Converts the primary `FiatCurrency` methods from pointer receivers to value receivers.
- Updates `Validate` while preserving uninitialized-definition handling.
- Adds tests for pointer and dereferenced-value validation calls.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated receiver methods continue to satisfy the existing interfaces.
- Validation still returns an error when the currency definition is missing.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/currencyx/currency.go | Changes the main `FiatCurrency` methods to value receivers while retaining validation for a missing definition. |
| pkg/currencyx/currency_test.go | Adds receiver-focused validation coverage for pointer and dereferenced-value calls. |

<sub>Reviews (2): Last reviewed commit: ["feat: xxx"](https://github.com/openmeterio/openmeter/commit/fb51793eadcfa80f83273ea34aad8b7decbf8744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46026821)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->