### PR TITLE
feat: add expand option to currency list api

### DIFF
--- a/openmeter/currencies/adapter/currencies.go
+++ b/openmeter/currencies/adapter/currencies.go
@@ -168,6 +168,21 @@ func (a *adapter) ListCustomCurrencies(ctx context.Context, params currencies.Li
 			q = filter.ApplyToQuery(q, params.Code, customcurrency.FieldCode)
 		}
 
+		now := time.Now()
+
+		if params.CurrencyExpandOptions.CostBasis {
+			q = q.WithCostBasisHistory(func(cbq *entdb.CurrencyCostBasisQuery) {
+				cbq.Where(
+					currencycostbasis.Namespace(params.Namespace),
+					currencycostbasis.EffectiveFromLTE(now),
+					currencycostbasis.Or(
+						currencycostbasis.EffectiveToIsNil(),
+						currencycostbasis.EffectiveToGT(now),
+					),
+				)
+			})
+		}
+
 		order := entutils.GetOrdering(sortx.OrderDefault)
 		if !params.Order.IsDefaultValue() {
 			order = entutils.GetOrdering(params.Order)

--- a/openmeter/currencies/adapter/currencies.go
+++ b/openmeter/currencies/adapter/currencies.go
@@ -168,19 +168,10 @@ func (a *adapter) ListCustomCurrencies(ctx context.Context, params currencies.Li
 			q = filter.ApplyToQuery(q, params.Code, customcurrency.FieldCode)
 		}
 
-		now := time.Now()
+		now := clock.Now()
 
 		if params.CurrencyExpandOptions.CostBasis {
-			q = q.WithCostBasisHistory(func(cbq *entdb.CurrencyCostBasisQuery) {
-				cbq.Where(
-					currencycostbasis.Namespace(params.Namespace),
-					currencycostbasis.EffectiveFromLTE(now),
-					currencycostbasis.Or(
-						currencycostbasis.EffectiveToIsNil(),
-						currencycostbasis.EffectiveToGT(now),
-					),
-				)
-			})
+			q = WithCostBasis(q, now)
 		}
 
 		order := entutils.GetOrdering(sortx.OrderDefault)
@@ -342,7 +333,7 @@ func (a *adapter) GetCurrency(ctx context.Context, params currencies.GetCurrency
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (currencies.Currency, error) {
 		at := clock.Now()
 
-		qetQuery := tx.db.CustomCurrency.Query().
+		q := tx.db.CustomCurrency.Query().
 			Where(
 				customcurrency.Namespace(params.Namespace),
 				customcurrency.ID(params.ID),
@@ -352,7 +343,11 @@ func (a *adapter) GetCurrency(ctx context.Context, params currencies.GetCurrency
 				),
 			)
 
-		c, err := qetQuery.First(ctx)
+		if params.CostBasis {
+			q = WithCostBasis(q, at)
+		}
+
+		c, err := q.First(ctx)
 		if err != nil {
 			if entdb.IsNotFound(err) {
 				return currencies.Currency{}, models.NewGenericNotFoundError(
@@ -368,42 +363,42 @@ func (a *adapter) GetCurrency(ctx context.Context, params currencies.GetCurrency
 			return currencies.Currency{}, fmt.Errorf("failed to map currency from database: %w", err)
 		}
 
-		if params.CostBasis {
-			if c.DeletedAt != nil {
-				at = *c.DeletedAt
-			}
+		return curr, nil
+	})
+}
 
-			costBasisQuery := tx.db.CurrencyCostBasis.Query().
-				Where(
-					currencycostbasis.Namespace(params.Namespace),
-					currencycostbasis.CurrencyID(params.ID),
-					currencycostbasis.EffectiveFromLTE(at),
-					currencycostbasis.Or(
-						currencycostbasis.EffectiveToIsNil(),
-						currencycostbasis.EffectiveToGT(at),
+func WithCostBasis(q *entdb.CustomCurrencyQuery, at time.Time) *entdb.CustomCurrencyQuery {
+	return q.WithCostBasisHistory(func(query *entdb.CurrencyCostBasisQuery) {
+		query.Where(func(s *sql.Selector) {
+			ct := sql.Table(customcurrency.Table)
+
+			s.Join(ct).On(ct.C(customcurrency.FieldID), s.C(currencycostbasis.FieldCurrencyID))
+
+			s.Where(
+				sql.Or(
+					sql.And(
+						sql.NotNull(ct.C(customcurrency.FieldDeletedAt)),
+						sql.ColumnsEQ(s.C(currencycostbasis.FieldDeletedAt), ct.C(currencycostbasis.FieldDeletedAt)),
+						sql.ColumnsLTE(s.C(currencycostbasis.FieldEffectiveFrom), ct.C(customcurrency.FieldDeletedAt)),
+						sql.Or(
+							sql.IsNull(s.C(currencycostbasis.FieldEffectiveTo)),
+							sql.ColumnsGT(s.C(currencycostbasis.FieldEffectiveTo), ct.C(customcurrency.FieldDeletedAt)),
+						),
 					),
-				)
-
-			cbs, err := costBasisQuery.All(ctx)
-			if err != nil {
-				if entdb.IsNotFound(err) {
-					return currencies.Currency{}, models.NewGenericNotFoundError(
-						fmt.Errorf("currency with id %s not found", params.ID),
-					)
-				}
-
-				return currencies.Currency{}, fmt.Errorf("failed to get currency: %w", err)
-			}
-
-			curr.CostBasis = lo.ToPtr(
-				lo.Map[*entdb.CurrencyCostBasis, currencies.CostBasis](cbs,
-					func(item *entdb.CurrencyCostBasis, _ int) currencies.CostBasis {
-						return mapCostBasisFromDB(item)
-					},
+					sql.And(
+						sql.IsNull(ct.C(customcurrency.FieldDeletedAt)),
+						sql.Or(
+							sql.IsNull(s.C(currencycostbasis.FieldDeletedAt)),
+							sql.GT(s.C(currencycostbasis.FieldDeletedAt), at),
+						),
+						sql.LTE(s.C(currencycostbasis.FieldEffectiveFrom), at),
+						sql.Or(
+							sql.IsNull(s.C(currencycostbasis.FieldEffectiveTo)),
+							sql.GT(s.C(currencycostbasis.FieldEffectiveTo), at),
+						),
+					),
 				),
 			)
-		}
-
-		return curr, nil
+		})
 	})
 }

--- a/openmeter/currencies/currencyresolver/resolver.go
+++ b/openmeter/currencies/currencyresolver/resolver.go
@@ -118,6 +118,9 @@ func (r *resolver) BatchResolveCurrencies(ctx context.Context, namespace string,
 			FilteringOptions: currencies.FilteringOptions{
 				Union: true,
 			},
+			CurrencyExpandOptions: currencies.CurrencyExpandOptions{
+				CostBasis: true,
+			},
 			Namespace: namespace,
 			ID:        idFilter,
 			Code:      codeFilter,

--- a/openmeter/currencies/service.go
+++ b/openmeter/currencies/service.go
@@ -61,6 +61,7 @@ type FilteringOptions struct {
 type ListCurrenciesInput struct {
 	pagination.Page
 	FilteringOptions
+	CurrencyExpandOptions
 
 	Namespace string `json:"namespace"`
 

--- a/openmeter/currencies/service/service_test.go
+++ b/openmeter/currencies/service/service_test.go
@@ -384,6 +384,94 @@ func TestCurrenciesService(t *testing.T) {
 			})
 		})
 
+		t.Run("ListDeletedCurrencyWithCostBasis", func(t *testing.T) {
+			// given:
+			// - a deleted custom currency whose cost-basis history contains entries that were expired, active, and future at deletion
+			deletedNamespace := currenciestestutils.NewTestNamespace(t)
+			deletedCurrency, err := env.Service.CreateCurrency(t.Context(), currencies.CreateCurrencyInput{
+				Namespace: deletedNamespace,
+				CurrencyDetails: currencyx.CurrencyDetails{
+					Code:               "CREDITS",
+					Name:               "Credits",
+					Symbol:             "C",
+					Precision:          2,
+					DecimalMark:        ".",
+					ThousandsSeparator: ",",
+				},
+			})
+			require.NoError(t, err)
+
+			deletedAt := now.Add(-24 * time.Hour)
+			costBasisFixtures := []struct {
+				fiatCode      currencyx.Code
+				effectiveFrom time.Time
+				effectiveTo   *time.Time
+				active        bool
+			}{
+				{
+					fiatCode:      "EUR",
+					effectiveFrom: deletedAt.Add(-48 * time.Hour),
+					effectiveTo:   lo.ToPtr(deletedAt.Add(-time.Hour)),
+				},
+				{
+					fiatCode:      "USD",
+					effectiveFrom: deletedAt.Add(-time.Hour),
+					effectiveTo:   lo.ToPtr(deletedAt.Add(time.Hour)),
+					active:        true,
+				},
+				{
+					fiatCode:      "GBP",
+					effectiveFrom: deletedAt.Add(time.Hour),
+				},
+			}
+
+			var activeCostBasisID string
+			for _, fixture := range costBasisFixtures {
+				costBasis, err := env.Client.CurrencyCostBasis.Create().
+					SetNamespace(deletedNamespace).
+					SetCurrencyID(deletedCurrency.ID).
+					SetFiatCode(fixture.fiatCode).
+					SetRate(alpacadecimal.RequireFromString("1")).
+					SetEffectiveFrom(fixture.effectiveFrom).
+					SetNillableEffectiveTo(fixture.effectiveTo).
+					SetDeletedAt(deletedAt).
+					Save(t.Context())
+				require.NoError(t, err)
+
+				if fixture.active {
+					activeCostBasisID = costBasis.ID
+				}
+			}
+			require.NotEmpty(t, activeCostBasisID)
+
+			_, err = env.Client.CustomCurrency.UpdateOneID(deletedCurrency.ID).
+				SetDeletedAt(deletedAt).
+				Save(t.Context())
+			require.NoError(t, err)
+
+			// when:
+			// - the deleted currency is listed with cost-basis data expanded
+			result, err := env.Service.ListCurrencies(t.Context(), currencies.ListCurrenciesInput{
+				Page:         pagination.NewPage(1, 10),
+				Namespace:    deletedNamespace,
+				CurrencyType: lo.ToPtr(currencies.CurrencyTypeCustom),
+				Code: &filter.FilterString{
+					In: lo.ToPtr([]string{"CREDITS"}),
+				},
+				CurrencyExpandOptions: currencies.CurrencyExpandOptions{
+					CostBasis: true,
+				},
+			})
+
+			// then:
+			// - only the cost basis effective at the currency's deletion time is returned
+			require.NoError(t, err)
+			require.Len(t, result.Items, 1)
+			require.NotNil(t, result.Items[0].CostBasis)
+			require.Len(t, *result.Items[0].CostBasis, 1)
+			assert.Equal(t, activeCostBasisID, (*result.Items[0].CostBasis)[0].ID)
+		})
+
 		t.Run("List", func(t *testing.T) {
 			// given:
 			// - independently persisted custom currencies

--- a/openmeter/currencies/service/service_test.go
+++ b/openmeter/currencies/service/service_test.go
@@ -190,6 +190,72 @@ func TestCurrenciesService(t *testing.T) {
 					})
 				})
 
+				t.Run("ListWithCostBasis", func(t *testing.T) {
+					// given:
+					// - a custom currency with an active USD cost basis
+					testCases := []struct {
+						name             string
+						currencyType     *currencies.CurrencyType
+						expectedTotal    int
+						expectFiatResult bool
+					}{
+						{
+							name:          "custom currencies",
+							currencyType:  lo.ToPtr(currencies.CurrencyTypeCustom),
+							expectedTotal: 1,
+						},
+						{
+							name:             "custom and fiat currencies",
+							expectedTotal:    2,
+							expectFiatResult: true,
+						},
+					}
+
+					for _, testCase := range testCases {
+						t.Run(testCase.name, func(t *testing.T) {
+							// when:
+							// - currencies are listed with cost-basis data expanded
+							result, err := env.Service.ListCurrencies(t.Context(), currencies.ListCurrenciesInput{
+								Page:         pagination.NewPage(1, 10),
+								Namespace:    namespace,
+								CurrencyType: testCase.currencyType,
+								Code: &filter.FilterString{
+									In: lo.ToPtr([]string{"TOKENS", "USD"}),
+								},
+								CurrencyExpandOptions: currencies.CurrencyExpandOptions{
+									CostBasis: true,
+								},
+							})
+
+							// then:
+							// - custom currencies include active cost-basis data while fiat currencies do not
+							require.NoError(t, err)
+							require.Equal(t, testCase.expectedTotal, result.TotalCount)
+							require.Len(t, result.Items, testCase.expectedTotal)
+
+							customCurrencies := lo.Filter(result.Items, func(item currencies.Currency, _ int) bool {
+								return item.Type() == currencyx.CurrencyTypeCustom
+							})
+							require.Len(t, customCurrencies, 1)
+							assert.Equal(t, createdCurrency.ID, customCurrencies[0].ID)
+							require.NotNil(t, customCurrencies[0].CostBasis)
+							require.Len(t, *customCurrencies[0].CostBasis, 1)
+							assert.Equal(t, usd.ID, (*customCurrencies[0].CostBasis)[0].ID)
+
+							fiatCurrencies := lo.Filter(result.Items, func(item currencies.Currency, _ int) bool {
+								return item.Type() == currencyx.CurrencyTypeFiat
+							})
+							if testCase.expectFiatResult {
+								require.Len(t, fiatCurrencies, 1)
+								assert.Equal(t, currencyx.Code("USD"), fiatCurrencies[0].Details().Code)
+								assert.Nil(t, fiatCurrencies[0].CostBasis)
+							} else {
+								assert.Empty(t, fiatCurrencies)
+							}
+						})
+					}
+				})
+
 				t.Run("Multiple", func(t *testing.T) {
 					// given:
 					// - a custom currency with an active USD cost basis


### PR DESCRIPTION
## Overview

Add expand options to list currencies service API.

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Currency listings can now optionally include the currently effective cost basis.
  * Batch currency resolution now requests cost-basis expansion to keep results consistent.

* **Bug Fixes**
  * Cost-basis records are now filtered by time, preventing expired or not-yet-effective entries from appearing.
  * Cost basis is correctly resolved at the time a custom currency was deleted.
  * When listing fiat currencies, cost-basis information remains unset as expected.

* **Tests**
  * Added coverage for custom currency cost-basis expansion (including deletion-time scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cost-basis expansion to currency listing and resolution. The main changes are:

- Adds an expansion option to the currency list input.
- Loads effective cost bases for custom currencies.
- Requests cost bases during batch currency resolution.
- Adds tests for live, fiat, and deleted currencies.

<h3>Confidence Score: 4/5</h3>

The deleted-currency query should be corrected before merging.

- The application clock is now used consistently.
- Deleted currencies are evaluated at their deletion time.
- A valid historical cost basis can still be omitted when parent and child deletion timestamps differ.

openmeter/currencies/adapter/currencies.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/currencies/adapter/currencies.go | Adds shared cost-basis expansion, but deleted currencies can lose an active basis when deletion timestamps differ. |
| openmeter/currencies/currencyresolver/resolver.go | Requests cost-basis expansion during batch currency resolution. |
| openmeter/currencies/service.go | Adds currency expansion options to list requests. |
| openmeter/currencies/service/service_test.go | Adds expansion coverage, including a deleted-currency case with matching deletion timestamps. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fcurrencies%2Fadapter%2Fcurrencies.go%3A381%0A**Deletion%20timestamps%20must%20match**%0A%0AThis%20predicate%20requires%20a%20cost%20basis%20and%20its%20currency%20to%20have%20identical%20%60deleted_at%60%20values.%20Cost%20bases%20are%20created%20with%20%60deleted_at%20%3D%20NULL%60%2C%20and%20the%20schema%20does%20not%20synchronize%20that%20field%20when%20the%20currency%20is%20deleted.%20When%20a%20basis%20was%20active%20at%20the%20currency's%20deletion%20time%20but%20remains%20undeleted%20or%20was%20deleted%20separately%2C%20expansion%20returns%20an%20empty%20cost%20basis.%20The%20query%20should%20select%20records%20that%20were%20active%20at%20the%20currency's%20deletion%20time%20without%20requiring%20matching%20deletion%20timestamps.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fcurrencies-list%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcurrencies-list%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenmeter%2Fcurrencies%2Fadapter%2Fcurrencies.go%3A381%0A**Deletion%20timestamps%20must%20match**%0A%0AThis%20predicate%20requires%20a%20cost%20basis%20and%20its%20currency%20to%20have%20identical%20%60deleted_at%60%20values.%20Cost%20bases%20are%20created%20with%20%60deleted_at%20%3D%20NULL%60%2C%20and%20the%20schema%20does%20not%20synchronize%20that%20field%20when%20the%20currency%20is%20deleted.%20When%20a%20basis%20was%20active%20at%20the%20currency's%20deletion%20time%20but%20remains%20undeleted%20or%20was%20deleted%20separately%2C%20expansion%20returns%20an%20empty%20cost%20basis.%20The%20query%20should%20select%20records%20that%20were%20active%20at%20the%20currency's%20deletion%20time%20without%20requiring%20matching%20deletion%20timestamps.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4771&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
openmeter/currencies/adapter/currencies.go:381
**Deletion timestamps must match**

This predicate requires a cost basis and its currency to have identical `deleted_at` values. Cost bases are created with `deleted_at = NULL`, and the schema does not synchronize that field when the currency is deleted. When a basis was active at the currency's deletion time but remains undeleted or was deleted separately, expansion returns an empty cost basis. The query should select records that were active at the currency's deletion time without requiring matching deletion timestamps.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: sideloading costbasis for curr..."](https://github.com/openmeterio/openmeter/commit/9156b94e3c2034ef3f87e877b11bc224e3f1bfb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46304041)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->