### PR TITLE
feat(customcurrencies): add configuration flag

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -643,7 +643,6 @@ Use these conventions for lifecycle tests:
 - for credit-only charges (usage-based or flat fee), handler callbacks must not return credit allocations above the requested amount; exact allocation paths must return allocations that sum to the requested amount
 - for flat fee credit-only tests, use `mustAdvanceFlatFeeCharges(...)` helper — it filters the advance result to flat fee charges only
 - for credit-purchase state-machine unit tests, use testify `mock.Mock` with `On(...).Run(...).Return(...).Once()` for expected handler callbacks so missing or unexpected calls fail; in service-suite tests, leave callbacks unset when validating that a flow fails before callbacks, because the shared `CreditPurchaseTestHandler` already errors if an unset callback is invoked
-- keep custom-currency support disabled on default charge service instances so tests continue covering the production unsupported boundary; when a test needs it enabled, use a semantic suite helper that constructs and enables the service instead of repeating `SetEnableCustomCurrency` interface assertions at call sites
 - when testing timestamp truncation, use sub-second fixtures and assert the persisted charge/run fields are second-aligned after create/advance
 - `time.Time` fields on domain models are value typed; use `s.False(ts.IsZero())` instead of `s.NotNil(ts)` when asserting they are populated
 - cover the temporary shrink/extend remap path as well; it synthesizes new intents and must normalize the replacement period ends before re-create

--- a/api/v3/handlers/currencies/create.go
+++ b/api/v3/handlers/currencies/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type (
@@ -24,6 +25,10 @@ type (
 func (h *handler) CreateCurrency() CreateCurrencyHandler {
 	return httptransport.NewHandler(
 		func(ctx context.Context, r *http.Request) (CreateCurrencyRequest, error) {
+			if !h.creditsEnabled {
+				return CreateCurrencyRequest{}, models.NewGenericValidationError(errCustomCurrenciesDisabled)
+			}
+
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return CreateCurrencyRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)

--- a/api/v3/handlers/currencies/create_cost_basis.go
+++ b/api/v3/handlers/currencies/create_cost_basis.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type (
@@ -24,6 +25,10 @@ type (
 func (h *handler) CreateCostBasis() CreateCostBasisHandler {
 	return httptransport.NewHandlerWithArgs(
 		func(ctx context.Context, r *http.Request, currencyID string) (CreateCostBasisRequest, error) {
+			if !h.creditsEnabled {
+				return CreateCostBasisRequest{}, models.NewGenericValidationError(errCustomCurrenciesDisabled)
+			}
+
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return CreateCostBasisRequest{}, err

--- a/api/v3/handlers/currencies/handler.go
+++ b/api/v3/handlers/currencies/handler.go
@@ -2,10 +2,13 @@ package currencies
 
 import (
 	"context"
+	"errors"
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 )
+
+var errCustomCurrenciesDisabled = errors.New("custom currencies are not enabled on this deployment of OpenMeter")
 
 type Handler interface {
 	ListCurrencies() ListCurrenciesHandler
@@ -19,16 +22,19 @@ type handler struct {
 	resolveNamespace func(ctx context.Context) (string, error)
 	options          []httptransport.HandlerOption
 	service          currencies.Service
+	creditsEnabled   bool
 }
 
 func New(
 	resolveNamespace func(ctx context.Context) (string, error),
 	currencyService currencies.Service,
+	creditsEnabled bool,
 	options ...httptransport.HandlerOption,
 ) Handler {
 	return &handler{
 		resolveNamespace: resolveNamespace,
 		options:          options,
 		service:          currencyService,
+		creditsEnabled:   creditsEnabled,
 	}
 }

--- a/api/v3/handlers/currencies/handler_test.go
+++ b/api/v3/handlers/currencies/handler_test.go
@@ -1,0 +1,34 @@
+package currencies
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomCurrencyMutationsRequireCredits(t *testing.T) {
+	handler := New(func(context.Context) (string, error) {
+		return "test", nil
+	}, nil, false)
+
+	t.Run("create currency", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "/api/v3/openmeter/currencies/custom", nil)
+		response := httptest.NewRecorder()
+
+		handler.CreateCurrency().ServeHTTP(response, request)
+
+		require.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	t.Run("create cost basis", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPost, "/api/v3/openmeter/currencies/custom/currency-id/cost-bases", nil)
+		response := httptest.NewRecorder()
+
+		handler.CreateCostBasis().With("currency-id").ServeHTTP(response, request)
+
+		require.Equal(t, http.StatusBadRequest, response.Code)
+	})
+}

--- a/api/v3/handlers/currencies/list_test.go
+++ b/api/v3/handlers/currencies/list_test.go
@@ -53,7 +53,7 @@ func TestListCurrenciesFilterByType(t *testing.T) {
 			service := &listCurrenciesService{}
 			handler := New(func(context.Context) (string, error) {
 				return "test", nil
-			}, service)
+			}, service, true)
 
 			request := httptest.NewRequest(http.MethodGet, "/api/v3/currencies", nil)
 			response := httptest.NewRecorder()

--- a/api/v3/server/server.go
+++ b/api/v3/server/server.go
@@ -332,7 +332,7 @@ func NewServer(config *Config) (*Server, error) {
 	plansHandler := planshandler.New(resolveNamespace, config.PlanService, config.UnitConfig.Enabled, httptransport.WithErrorHandler(config.ErrorHandler))
 	planAddonsHandler := planaddonshandler.New(resolveNamespace, config.PlanService, config.PlanAddonService, httptransport.WithErrorHandler(config.ErrorHandler))
 	taxcodesHandler := taxcodeshandler.New(resolveNamespace, config.TaxCodeService, httptransport.WithErrorHandler(config.ErrorHandler))
-	currenciesHandler := currencieshandler.New(resolveNamespace, config.CurrencyService, httptransport.WithErrorHandler(config.ErrorHandler))
+	currenciesHandler := currencieshandler.New(resolveNamespace, config.CurrencyService, config.Credits.Enabled, httptransport.WithErrorHandler(config.ErrorHandler))
 
 	var chargesH chargeshandler.Handler
 	if config.ChargeService != nil {

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -20,10 +19,6 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditpurchase.ChargeWithGatheringLine, error) {
-		if input.Intent.Currency.IsCustom() && !s.enableCustomCurrency.Load() {
-			return creditpurchase.ChargeWithGatheringLine{}, fmt.Errorf("custom currency %s is not supported for credit purchases: %w", input.Intent.Currency.GetCode(), meta.ErrCustomCurrencyNotSupported)
-		}
-
 		input.Intent = input.Intent.Normalized()
 
 		// Let's create the credit purchase charge

--- a/openmeter/billing/charges/creditpurchase/service/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/service.go
@@ -3,8 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"sync/atomic"
-	"testing"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
@@ -65,20 +63,9 @@ func New(config Config) (creditpurchase.Service, error) {
 }
 
 type service struct {
-	adapter              creditpurchase.Adapter
-	metaAdapter          meta.Adapter
-	handler              creditpurchase.Handler
-	lineage              lineage.Service
-	realizations         *creditpurchaserealizations.Service
-	enableCustomCurrency atomic.Bool
-}
-
-func (s *service) SetEnableCustomCurrency(t *testing.T, enabled bool) error {
-	if t == nil {
-		return errors.New("testing is nil")
-	}
-
-	t.Helper()
-	s.enableCustomCurrency.Store(enabled)
-	return nil
+	adapter      creditpurchase.Adapter
+	metaAdapter  meta.Adapter
+	handler      creditpurchase.Handler
+	lineage      lineage.Service
+	realizations *creditpurchaserealizations.Service
 }

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -33,10 +33,6 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		now := clock.Now().UTC()
 		// Let's create all the flat fee charges in bulk
 		intentsWithStatus, err := slicesx.MapWithErr(input.Intents, func(intent flatfee.Intent) (flatfee.IntentWithInitialStatus, error) {
-			if intent.Currency.IsCustom() && !s.enableCustomCurrency.Load() {
-				return flatfee.IntentWithInitialStatus{}, fmt.Errorf("creating flat fee charge with custom currency %q: %w", intent.Currency.GetCode(), meta.ErrCustomCurrencyNotSupported)
-			}
-
 			chargeIntent := intent.Normalized()
 
 			var resolvedCostBasis *costbasis.State

--- a/openmeter/billing/charges/flatfee/service/service.go
+++ b/openmeter/billing/charges/flatfee/service/service.go
@@ -103,7 +103,6 @@ type service struct {
 	locker               *lockr.Locker
 	realizations         *flatfeerealizations.Service
 	creditNotesSupported atomic.Bool
-	enableCustomCurrency atomic.Bool
 	costbasisResolver    costbasis.Resolver
 }
 
@@ -123,15 +122,5 @@ func (s *service) SetCreditNotesSupportedByLineUpdater(t *testing.T, supported b
 
 	t.Helper()
 	s.creditNotesSupported.Store(supported)
-	return nil
-}
-
-func (s *service) SetEnableCustomCurrency(t *testing.T, enabled bool) error {
-	if t == nil {
-		return errors.New("testing is nil")
-	}
-
-	t.Helper()
-	s.enableCustomCurrency.Store(enabled)
 	return nil
 }

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"testing"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
@@ -70,18 +69,6 @@ type BaseSuite struct {
 	FlatFeeTestHandler        *flatFeeTestHandler
 	CreditPurchaseTestHandler *creditPurchaseTestHandler
 	UsageBasedTestHandler     *usageBasedTestHandler
-}
-
-type customCurrencyEnabler interface {
-	SetEnableCustomCurrency(t *testing.T, enabled bool) error
-}
-
-func (s *BaseSuite) setUsageBasedCustomCurrencyEnabled(enabled bool) {
-	s.T().Helper()
-
-	enabler, ok := s.Charges.usageBasedService.(customCurrencyEnabler)
-	s.Require().True(ok)
-	s.Require().NoError(enabler.SetEnableCustomCurrency(s.T(), enabled))
 }
 
 func (s *BaseSuite) SetupSuite() {

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
@@ -49,24 +48,6 @@ func (s *CreditPurchaseTestSuite) SetupSuite() {
 
 func (s *CreditPurchaseTestSuite) TearDownTest() {
 	s.BaseSuite.TearDownTest()
-}
-
-func (s *CreditPurchaseTestSuite) getCustomCurrenciesEnabledCreditPurchaseService(lineageService lineage.Service) creditpurchase.Service {
-	s.T().Helper()
-
-	creditPurchaseService, err := creditpurchaseservice.New(creditpurchaseservice.Config{
-		Adapter:     s.CreditPurchaseAdapter,
-		Handler:     s.CreditPurchaseTestHandler,
-		Lineage:     lineageService,
-		MetaAdapter: s.MetaAdapter,
-	})
-	s.Require().NoError(err)
-
-	customCurrencyEnabler, ok := creditPurchaseService.(customCurrencyEnabler)
-	s.Require().True(ok)
-	s.Require().NoError(customCurrencyEnabler.SetEnableCustomCurrency(s.T(), true))
-
-	return creditPurchaseService
 }
 
 func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
@@ -197,16 +178,9 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchaseWithCustomCurrenc
 			MetaAdapter: s.MetaAdapter,
 		})
 		s.Require().NoError(err)
-		_, err = creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
-			Namespace: ns,
-			Intent:    creditPurchaseIntent,
-		})
-		s.Require().ErrorIs(err, meta.ErrCustomCurrencyNotSupported)
-
-		customCurrencyCreditPurchaseService := s.getCustomCurrenciesEnabledCreditPurchaseService(lineageMock)
 
 		originalCreditPurchaseService := s.Charges.creditPurchaseService
-		s.Charges.creditPurchaseService = customCurrencyCreditPurchaseService
+		s.Charges.creditPurchaseService = creditPurchaseService
 		defer func() {
 			s.Charges.creditPurchaseService = originalCreditPurchaseService
 		}()
@@ -292,30 +266,14 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() 
 	})
 	s.Require().NoError(err)
 
-	s.Run("disabled by default", func() {
+	s.Run("create", func() {
 		// given:
-		// - a custom-currency invoice credit purchase and the default service configuration
-		// when:
-		// - the credit-purchase service creates the charge
-		// then:
-		// - the service preserves the production unsupported boundary
-		_, err := creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
-			Namespace: ns,
-			Intent:    intent,
-		})
-		s.ErrorIs(err, meta.ErrCustomCurrencyNotSupported)
-	})
-
-	s.Run("enabled for tests", func() {
-		// given:
-		// - the test-only custom-currency gate is enabled
+		// - a custom-currency invoice credit purchase
 		// when:
 		// - the invoice credit purchase is created
 		// then:
 		// - the charge keeps the purchased currency while the gathering line uses fiat settlement
-		customCurrencyCreditPurchaseService := s.getCustomCurrenciesEnabledCreditPurchaseService(s.LineageService)
-
-		created, err := customCurrencyCreditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		created, err := creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
 			Namespace: ns,
 			Intent:    intent,
 		})
@@ -334,7 +292,7 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() 
 		s.Require().NoError(err)
 		s.Equal(float64(50.06), flatPrice.Amount.InexactFloat64())
 
-		persisted, err := customCurrencyCreditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+		persisted, err := creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
 			Namespace: ns,
 			IDs:       []string{created.Charge.ID},
 		})

--- a/openmeter/billing/charges/service/flatfee_costbasis_test.go
+++ b/openmeter/billing/charges/service/flatfee_costbasis_test.go
@@ -34,41 +34,11 @@ func (s *FlatFeeCostBasisCreateSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 }
 
-func (s *FlatFeeCostBasisCreateSuite) TearDownTest() {
-	s.setCustomCurrencyEnabled(false)
-	s.BaseSuite.TearDownTest()
-}
-
-func (s *FlatFeeCostBasisCreateSuite) TestCustomCurrencyCreditOnlyIsDisabledByDefault() {
-	// given:
-	// - a valid custom-currency credit-only flat fee
-	// - the test-only custom-currency switch left at its default value
-	// when:
-	// - the charge is created
-	// then:
-	// - creation is rejected before the charge is persisted
-	ctx := s.T().Context()
-	namespace := s.GetUniqueNamespace("flat-fee-cost-basis-disabled")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
-	customer := s.CreateTestCustomer(namespace, "flat-fee-cost-basis-disabled")
-	currency := s.createTestCustomCurrency(ctx, namespace)
-
-	_, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
-		Namespace: namespace,
-		Intents: []flatfee.Intent{
-			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "disabled", productcatalog.CreditOnlySettlementMode, nil),
-		},
-		FeatureMeters: feature.FeatureMeterCollection{},
-	})
-	s.Require().ErrorIs(err, meta.ErrCustomCurrencyNotSupported)
-	s.Require().Equal(0, s.countCostBases(namespace))
-}
-
 func (s *FlatFeeCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynamicCostBasesInInputOrder() {
 	// given:
 	// - manual, pinned, and dynamic cost-basis intents in one custom-currency batch
 	// when:
-	// - custom-currency creation is enabled, the flat fees are created, and each is reloaded through the charge service
+	// - the flat fees are created and each is reloaded through the charge service
 	// then:
 	// - each charge references its own persisted cost basis and its intent and resolved state survive the normal read path
 	ctx := s.T().Context()
@@ -101,7 +71,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynamicCo
 		FiatCurrency: fiatCurrency,
 	})
 
-	s.setCustomCurrencyEnabled(true)
 	created, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
 		Namespace: namespace,
 		Intents: []flatfee.Intent{
@@ -185,7 +154,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetrySafe
 	dynamicIntent := costbasis.NewIntent(costbasis.DynamicIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 	})
-	s.setCustomCurrencyEnabled(true)
 	created, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
 		Namespace: namespace,
 		Intents: []flatfee.Intent{
@@ -315,7 +283,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeBeco
 	dynamicIntent := costbasis.NewIntent(costbasis.DynamicIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 	})
-	s.setCustomCurrencyEnabled(true)
 	clock.FreezeTime(activationAt)
 	created, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
 		Namespace: namespace,
@@ -391,7 +358,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAndFia
 		{name: "fiat currency", costBasisID: eurCostBasis.ID, errorText: "currency cost basis fiat currency mismatch"},
 	}
 
-	s.setCustomCurrencyEnabled(true)
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			// given:
@@ -435,7 +401,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeCrea
 		Rate:         alpacadecimal.NewFromInt(2),
 	})
 
-	s.setCustomCurrencyEnabled(true)
 	_, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
 		Namespace: namespace,
 		Intents: []flatfee.Intent{
@@ -454,8 +419,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeRefe
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "flat-fee-without-cost-basis")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	s.setCustomCurrencyEnabled(true)
-
 	created, err := s.Charges.flatFeeService.Create(ctx, flatfee.CreateInput{
 		Namespace: namespace,
 		Intents: []flatfee.Intent{
@@ -473,13 +436,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeRefe
 	s.Require().NoError(err)
 	s.Require().Nil(chargeEntity.CostBasisID)
 	s.Require().Equal(0, s.countCostBases(namespace))
-}
-
-func (s *FlatFeeCostBasisCreateSuite) setCustomCurrencyEnabled(enabled bool) {
-	s.T().Helper()
-	enabler, ok := s.Charges.flatFeeService.(customCurrencyEnabler)
-	s.Require().True(ok)
-	s.Require().NoError(enabler.SetEnableCustomCurrency(s.T(), enabled))
 }
 
 func (s *FlatFeeCostBasisCreateSuite) countCostBases(namespace string) int {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -4291,9 +4291,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 			Currencies:    s.CurrencyService,
 		})
 		s.Require().NoError(err)
-		customCurrencyEnabler, ok := customCurrencyFlatFeeService.(customCurrencyEnabler)
-		s.Require().True(ok)
-		s.Require().NoError(customCurrencyEnabler.SetEnableCustomCurrency(s.T(), true))
 
 		originalFlatFeeService := s.Charges.flatFeeService
 		s.Charges.flatFeeService = customCurrencyFlatFeeService
@@ -4471,9 +4468,6 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyWithCustomCurrency(
 			StreamingConnector:      s.MockStreamingConnector,
 		})
 		s.Require().NoError(err)
-		customCurrencyEnabler, ok := customCurrencyUsageBasedService.(customCurrencyEnabler)
-		s.Require().True(ok)
-		s.Require().NoError(customCurrencyEnabler.SetEnableCustomCurrency(s.T(), true))
 
 		originalUsageBasedService := s.Charges.usageBasedService
 		s.Charges.usageBasedService = customCurrencyUsageBasedService
@@ -4745,10 +4739,6 @@ func (s *InvoicableChargesTestSuite) enableFlatFeeCustomCurrenciesWithMockLineag
 		Currencies:    s.CurrencyService,
 	})
 	s.Require().NoError(err)
-
-	customCurrencyEnabler, ok := customCurrencyFlatFeeService.(customCurrencyEnabler)
-	s.Require().True(ok)
-	s.Require().NoError(customCurrencyEnabler.SetEnableCustomCurrency(s.T(), true))
 
 	originalFlatFeeService := s.Charges.flatFeeService
 	s.Charges.flatFeeService = customCurrencyFlatFeeService

--- a/openmeter/billing/charges/service/usagebased_costbasis_test.go
+++ b/openmeter/billing/charges/service/usagebased_costbasis_test.go
@@ -37,42 +37,11 @@ func (s *UsageBasedCostBasisCreateSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 }
 
-func (s *UsageBasedCostBasisCreateSuite) TearDownTest() {
-	s.setUsageBasedCustomCurrencyEnabled(false)
-	s.BaseSuite.TearDownTest()
-}
-
-func (s *UsageBasedCostBasisCreateSuite) TestCustomCurrencyCreditOnlyIsDisabledByDefault() {
-	// given:
-	// - a valid custom-currency credit-only usage-based charge
-	// - the test-only custom-currency switch left at its default value
-	// when:
-	// - the charge is created
-	// then:
-	// - creation is rejected before the charge is persisted
-	ctx := s.T().Context()
-	namespace := s.GetUniqueNamespace("usage-based-cost-basis-disabled")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
-	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-disabled")
-	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "disabled-feature")
-
-	_, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
-		Namespace: namespace,
-		Intents: []usagebased.Intent{
-			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "disabled", "disabled-feature", productcatalog.CreditOnlySettlementMode, nil),
-		},
-		FeatureMeters: featureMeters,
-	})
-	s.Require().ErrorIs(err, meta.ErrCustomCurrencyNotSupported)
-	s.Require().Equal(0, s.countCostBases(namespace))
-}
-
 func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynamicCostBasesInInputOrder() {
 	// given:
 	// - manual, pinned, and dynamic cost-basis intents in one custom-currency batch
 	// when:
-	// - custom-currency creation is enabled, the charges are created, and each is reloaded through the charge service
+	// - the charges are created and each is reloaded through the charge service
 	// then:
 	// - each charge references its own persisted cost basis and its intent and resolved state survive the normal read path
 	ctx := s.T().Context()
@@ -106,7 +75,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynami
 		FiatCurrency: fiatCurrency,
 	})
 
-	s.setUsageBasedCustomCurrencyEnabled(true)
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{
@@ -191,7 +159,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetryS
 	dynamicIntent := costbasis.NewIntent(costbasis.DynamicIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 	})
-	s.setUsageBasedCustomCurrencyEnabled(true)
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{
@@ -277,7 +244,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeB
 	dynamicIntent := costbasis.NewIntent(costbasis.DynamicIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 	})
-	s.setUsageBasedCustomCurrencyEnabled(true)
 	clock.FreezeTime(activationAt)
 	defer clock.UnFreeze()
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
@@ -353,7 +319,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAnd
 		{name: "fiat currency", costBasisID: eurCostBasis.ID, errorText: "currency cost basis fiat currency mismatch"},
 	}
 
-	s.setUsageBasedCustomCurrencyEnabled(true)
 	for _, test := range tests {
 		s.Run(test.name, func() {
 			// given:
@@ -398,7 +363,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeC
 		Rate:         alpacadecimal.NewFromInt(2),
 	})
 
-	s.setUsageBasedCustomCurrencyEnabled(true)
 	_, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{
@@ -418,8 +382,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeR
 	customer := s.CreateTestCustomer(namespace, "usage-based-without-cost-basis")
 	currency := s.createTestCustomCurrency(ctx, namespace)
 	featureMeters := s.createFeatureMeters(ctx, namespace, "credit-only-feature")
-	s.setUsageBasedCustomCurrencyEnabled(true)
-
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -70,9 +70,6 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyCreditThenInvoi
 		FiatCurrency: fiatCurrency,
 	})
 
-	s.setUsageBasedCustomCurrencyEnabled(true)
-	defer s.setUsageBasedCustomCurrencyEnabled(false)
-
 	var charge usagebased.Charge
 
 	s.Run("create custom currency credit then invoice charge", func() {
@@ -446,8 +443,6 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 			lateUsageAt := usageAt.Add(12 * time.Hour)
 			lateUsageStoredAt := realizationVariant.invoiceAt.Add(-time.Second)
 
-			s.setUsageBasedCustomCurrencyEnabled(true)
-			defer s.setUsageBasedCustomCurrencyEnabled(false)
 			clock.FreezeTime(createAt)
 
 			var (

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -31,10 +30,6 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]usagebased.ChargeWithGatheringLine, error) {
 		now := clock.Now().UTC()
 		createIntents, err := slicesx.MapWithErr(input.Intents, func(intent usagebased.Intent) (usagebased.CreateIntent, error) {
-			if intent.Currency.IsCustom() && !s.enableCustomCurrency.Load() {
-				return usagebased.CreateIntent{}, fmt.Errorf("creating usage based charge with custom currency %q: %w", intent.Currency.GetCode(), meta.ErrCustomCurrencyNotSupported)
-			}
-
 			chargeIntent := intent.Normalized()
 
 			var resolvedCostBasis *costbasis.State

--- a/openmeter/billing/charges/usagebased/service/service.go
+++ b/openmeter/billing/charges/usagebased/service/service.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"errors"
-	"sync/atomic"
-	"testing"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
@@ -142,22 +140,11 @@ type service struct {
 	rater usagebasedrating.Service
 	runs  *usagebasedrun.Service
 
-	enableCustomCurrency atomic.Bool
-	costbasisResolver    costbasis.Resolver
+	costbasisResolver costbasis.Resolver
 }
 
 func (s *service) GetLineEngine() billing.LineEngine {
 	return &LineEngine{
 		service: s,
 	}
-}
-
-func (s *service) SetEnableCustomCurrency(t *testing.T, enabled bool) error {
-	if t == nil {
-		return errors.New("testing is nil")
-	}
-
-	t.Helper()
-	s.enableCustomCurrency.Store(enabled)
-	return nil
 }

--- a/openmeter/server/router/router.go
+++ b/openmeter/server/router/router.go
@@ -526,6 +526,7 @@ func NewRouter(config Config) (*Router, error) {
 	router.currencyHandler = currencyhandler.New(
 		resolveNamespace,
 		config.CurrencyService,
+		config.Credits.Enabled,
 		httptransport.WithErrorHandler(config.ErrorHandler),
 	)
 


### PR DESCRIPTION
## Summary

- gate custom-currency creation and cost-basis creation with the existing `credits.enabled` feature flag at the v3 currencies API boundary
- keep currency reads available when credits are disabled
- remove the separate `credits.customCurrenciesEnabled` configuration
- remove custom-currency feature flags and test-only enablement switches from charge services, where custom currencies are now supported unconditionally

When credits are disabled, the custom-currency mutation endpoints return `400 Bad Request`.

## Validation

- `go test -tags=dynamic ./api/v3/handlers/currencies ./app/config ./app/common ./openmeter/billing/charges/creditpurchase/service ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/usagebased/service`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service`
- focused `go vet` for the changed packages
- focused `golangci-lint` for the changed packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom currency charge creation is now controlled by the deployment’s credits setting.
  * Currency and cost-basis creation endpoints return a clear validation error when credits are disabled.
  * Custom currency charges can proceed when credits are enabled.

* **Bug Fixes**
  * Prevented disabled custom-currency endpoints from processing requests before rejecting them.

* **Tests**
  * Updated coverage to verify credits-based custom-currency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates custom-currency handling:
- Gates custom-currency and cost-basis creation endpoints using the existing credits configuration.
- Removes test-only custom-currency switches and service-level rejection checks from flat-fee, usage-based, and credit-purchase charge creation.
- Updates handler and charge-service tests for the revised behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge within the follow-up review scope.

No blocking failure eligible for this follow-up review remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/handlers/currencies/create.go | Adds a configuration-dependent validation guard before custom-currency creation. |
| api/v3/handlers/currencies/create_cost_basis.go | Adds the corresponding validation guard before custom cost-basis creation. |
| api/v3/server/server.go | Passes the credits configuration state into the v3 currency handler. |
| openmeter/server/router/router.go | Passes the credits configuration state into the legacy router's currency handler. |
| openmeter/billing/charges/flatfee/service/create.go | Removes the service-local custom-currency rejection from flat-fee charge creation. |
| openmeter/billing/charges/usagebased/service/create.go | Removes the service-local custom-currency rejection from usage-based charge creation. |
| openmeter/billing/charges/creditpurchase/service/create.go | Removes the service-local custom-currency rejection from credit-purchase creation. |

<sub>Reviews (3): Last reviewed commit: ["feat(customcurrencies): gate API with cr..."](https://github.com/openmeterio/openmeter/commit/1d58ed18b47246d1b6dfab21afed633faec3f1bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46623336)</sub>

**Context used:**

- Knowledge Base — [API Server: Request Routing, Auth, and Handler Dispatch](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/api-server.md)
- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->