### PR TITLE
fix(charges): persist fiat payment amounts

### DIFF
--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -103,7 +103,7 @@ func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T)
 	// when:
 	// - the current external helpers grant credits and authorize payment
 	// then:
-	// - lineage and payment realization both use the currency-rounded credit amount
+	// - lineage and handlers use the currency-rounded credit amount
 	expectedAmount := alpacadecimal.NewFromFloat(100.12)
 	charge := newExternalStateMachineTestChargeWithInput(t, externalStateMachineTestChargeInput{
 		status:        creditpurchase.StatusActivePaymentPending,
@@ -155,7 +155,6 @@ func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T)
 	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
 	require.NoError(t, err)
 
-	require.Equal(t, expectedAmount.InexactFloat64(), adapter.createdExternalPayment.Amount.InexactFloat64())
 	handler.AssertExpectations(t)
 	lineageService.AssertExpectations(t)
 }
@@ -461,7 +460,7 @@ func TestExternalCreditPurchaseStateMachineAuthorizationUsesRealizationDuplicate
 			},
 			Base: payment.Base{
 				ServicePeriod: charge.Intent.ServicePeriod,
-				Amount:        charge.Intent.CreditAmount,
+				FiatAmount:    charge.Intent.CreditAmount,
 				Status:        payment.StatusAuthorized,
 				Authorized: &ledgertransaction.TimedGroupReference{
 					GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"},

--- a/openmeter/billing/charges/creditpurchase/service/invoice.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice.go
@@ -67,7 +67,7 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge credi
 		Namespace: charge.Namespace,
 		Base: payment.Base{
 			ServicePeriod: charge.Intent.ServicePeriod,
-			Amount:        charge.Intent.CreditAmount,
+			FiatAmount:    lineWithHeader.Line.Totals.Total,
 			Authorized: &ledgertransaction.TimedGroupReference{
 				GroupReference: ledgerTransactionGroupReference,
 				Time:           eventAt,

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -109,6 +109,20 @@ func (s *Service) AuthorizeExternalPayment(ctx context.Context, charge creditpur
 			WithAttrs(charge.Realizations.ExternalPaymentSettlement.ErrorAttributes())
 	}
 
+	externalSettlement, err := charge.Intent.Settlement.AsExternalSettlement()
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	fiatCurrency, err := externalSettlement.Currency.AsFiatCurrency()
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	fiatAmount := fiatCurrency.RoundToPrecision(
+		charge.Intent.CreditAmount.Mul(externalSettlement.CostBasis),
+	)
+
 	eventAt := clock.Now()
 	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
 		Charge:  charge,
@@ -122,7 +136,7 @@ func (s *Service) AuthorizeExternalPayment(ctx context.Context, charge creditpur
 		Namespace: charge.Namespace,
 		Base: payment.Base{
 			ServicePeriod: charge.Intent.ServicePeriod,
-			Amount:        charge.Intent.CreditAmount,
+			FiatAmount:    fiatAmount,
 			Authorized: &ledgertransaction.TimedGroupReference{
 				GroupReference: ledgerTransactionGroupReference,
 				Time:           eventAt,

--- a/openmeter/billing/charges/flatfee/service/payment.go
+++ b/openmeter/billing/charges/flatfee/service/payment.go
@@ -60,7 +60,7 @@ func (s *service) postInvoicePaymentAuthorized(ctx context.Context, charge flatf
 			InvoiceID: lineWithHeader.Invoice.ID,
 			Base: payment.Base{
 				ServicePeriod: run.ServicePeriod,
-				Amount:        lineWithHeader.Line.Totals.Total,
+				FiatAmount:    lineWithHeader.Line.Totals.Total,
 				Authorized: &ledgertransaction.TimedGroupReference{
 					GroupReference: ledgertransaction.GroupReference{
 						TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,

--- a/openmeter/billing/charges/models/payment/mixin.go
+++ b/openmeter/billing/charges/models/payment/mixin.go
@@ -38,7 +38,8 @@ func (mixin) Fields() []ent.Field {
 		field.Enum("status").
 			GoType(Status("")),
 
-		field.Other("amount", alpacadecimal.Decimal{}).
+		field.Other("fiat_amount", alpacadecimal.Decimal{}).
+			StorageKey("amount").
 			SchemaType(map[string]string{
 				dialect.Postgres: "numeric",
 			}),
@@ -67,7 +68,7 @@ func (mixin) Fields() []ent.Field {
 }
 
 type MutableFieldSetter[T any] interface {
-	SetAmount(amount alpacadecimal.Decimal) T
+	SetFiatAmount(fiatAmount alpacadecimal.Decimal) T
 	SetStatus(status Status) T
 	SetServicePeriodFrom(servicePeriodFrom time.Time) T
 	SetServicePeriodTo(servicePeriodTo time.Time) T
@@ -89,7 +90,7 @@ func Create[T Creator[T]](creator Creator[T], namespace string, paymentSettlemen
 		SetNamespace(namespace).
 		SetServicePeriodFrom(paymentSettlement.ServicePeriod.From).
 		SetServicePeriodTo(paymentSettlement.ServicePeriod.To).
-		SetAmount(paymentSettlement.Amount).
+		SetFiatAmount(paymentSettlement.FiatAmount).
 		SetStatus(paymentSettlement.Status).
 		SetNillableAuthorizedTransactionGroupID(paymentSettlement.Authorized.GetIDOrNull()).
 		SetNillableAuthorizedAt(paymentSettlement.Authorized.GetTimeOrNull()).
@@ -107,7 +108,7 @@ func Update[T Updater[T]](updater Updater[T], in Payment) T {
 	return updater.SetAnnotations(in.Annotations).
 		SetServicePeriodFrom(in.ServicePeriod.From).
 		SetServicePeriodTo(in.ServicePeriod.To).
-		SetAmount(in.Amount).
+		SetFiatAmount(in.FiatAmount).
 		SetStatus(in.Status).
 		SetNillableDeletedAt(convert.TimePtrIn(in.DeletedAt, time.UTC)).
 		SetNillableAuthorizedTransactionGroupID(in.Authorized.GetIDOrNull()).
@@ -123,7 +124,7 @@ type Getter interface {
 	entutils.AnnotationsMixinGetter
 	GetServicePeriodFrom() time.Time
 	GetServicePeriodTo() time.Time
-	GetAmount() alpacadecimal.Decimal
+	GetFiatAmount() alpacadecimal.Decimal
 	GetStatus() Status
 	GetAuthorizedTransactionGroupID() *string
 	GetAuthorizedAt() *time.Time
@@ -139,7 +140,7 @@ func mapBaseFromDB(dbEntity Getter) Base {
 			To:   dbEntity.GetServicePeriodTo().In(time.UTC),
 		},
 		Status:     dbEntity.GetStatus(),
-		Amount:     dbEntity.GetAmount(),
+		FiatAmount: dbEntity.GetFiatAmount(),
 		Authorized: mapTimedLedgerTransactionGroupReferenceFromDB(dbEntity.GetAuthorizedTransactionGroupID(), dbEntity.GetAuthorizedAt()),
 		Settled:    mapTimedLedgerTransactionGroupReferenceFromDB(dbEntity.GetSettledTransactionGroupID(), dbEntity.GetSettledAt()),
 	}

--- a/openmeter/billing/charges/models/payment/models.go
+++ b/openmeter/billing/charges/models/payment/models.go
@@ -48,8 +48,8 @@ type Base struct {
 	Annotations   models.Annotations    `json:"annotations"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
 
-	Status Status                `json:"status"`
-	Amount alpacadecimal.Decimal `json:"amount"`
+	Status     Status                `json:"status"`
+	FiatAmount alpacadecimal.Decimal `json:"fiatAmount"`
 
 	Authorized *ledgertransaction.TimedGroupReference `json:"authorized"`
 	Settled    *ledgertransaction.TimedGroupReference `json:"settled"`
@@ -78,8 +78,8 @@ func (r Base) Validate() error {
 		}
 	}
 
-	if !r.Amount.IsPositive() {
-		errs = append(errs, fmt.Errorf("amount must be positive"))
+	if !r.FiatAmount.IsPositive() {
+		errs = append(errs, fmt.Errorf("fiat amount must be positive"))
 	}
 
 	switch r.Status {

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -575,12 +575,13 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
 
-	// Let's buy 100 USD credits for $0.50 each (total cost is $50)
+	// Let's buy 100.123 USD credits for $0.50 each. The credit amount is rounded
+	// to 100.12 USD, so the total fiat cost is $50.06.
 	intent := CreateCreditPurchaseIntent(s.T(),
 		createCreditPurchaseIntentInput{
 			customer: cust.GetID(),
 			currency: USD,
-			amount:   alpacadecimal.NewFromFloat(100),
+			amount:   alpacadecimal.NewFromFloat(100.123),
 			servicePeriod: timeutil.ClosedPeriod{
 				From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
 				To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
@@ -667,7 +668,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 			s.NotNil(creditPurchaseCharge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 			s.Equal(authorizedCallback.id, creditPurchaseCharge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID, "authorized transaction group ID should be set")
 			s.Equal(settledCallback.id, creditPurchaseCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID, "settled transaction group ID should be set")
-			s.Equal(float64(50), creditPurchaseCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
+			s.Equal(float64(50.06), creditPurchaseCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 
 			// The charge should be final
 			s.Equal(creditpurchase.StatusFinal, creditPurchaseCharge.Status)

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -667,6 +667,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 			s.NotNil(creditPurchaseCharge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 			s.Equal(authorizedCallback.id, creditPurchaseCharge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID, "authorized transaction group ID should be set")
 			s.Equal(settledCallback.id, creditPurchaseCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID, "settled transaction group ID should be set")
+			s.Equal(float64(50), creditPurchaseCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 
 			// The charge should be final
 			s.Equal(creditpurchase.StatusFinal, creditPurchaseCharge.Status)
@@ -1028,6 +1029,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 
 		s.Equal(1, authorizedCallback.nrInvocations)
 		s.Equal(settledCallback.id, creditPurchaseCharge.Realizations.InvoiceSettlement.Settled.TransactionGroupID)
+		s.Equal(float64(50), creditPurchaseCharge.Realizations.InvoiceSettlement.FiatAmount.InexactFloat64())
 		s.Equal(payment.StatusSettled, creditPurchaseCharge.Realizations.InvoiceSettlement.Status)
 		s.Equal(creditpurchase.StatusFinal, creditPurchaseCharge.Status)
 	})

--- a/openmeter/billing/charges/usagebased/service/run/payment.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment.go
@@ -87,7 +87,7 @@ func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvo
 		InvoiceID: in.Invoice.ID,
 		Base: payment.Base{
 			ServicePeriod: in.Line.Period,
-			Amount:        in.Line.Totals.Total,
+			FiatAmount:    in.Line.Totals.Total,
 			Authorized: &ledgertransaction.TimedGroupReference{
 				GroupReference: ledgertransaction.GroupReference{
 					TransactionGroupID: ledgerTransactionRef.TransactionGroupID,

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -35,7 +35,7 @@ func TestBookInvoicedPaymentAuthorizedInputValidate(t *testing.T) {
 				Base: payment.Base{
 					ServicePeriod: in.Line.Period,
 					Status:        payment.StatusAuthorized,
-					Amount:        in.Line.Totals.Total,
+					FiatAmount:    in.Line.Totals.Total,
 					Authorized: &ledgertransaction.TimedGroupReference{
 						GroupReference: ledgertransaction.GroupReference{
 							TransactionGroupID: "authorized-group",
@@ -154,7 +154,7 @@ func newSettlePaymentInput(t testing.TB) SettleInvoicedPaymentInput {
 			Base: payment.Base{
 				ServicePeriod: authInput.Line.Period,
 				Status:        payment.StatusAuthorized,
-				Amount:        authInput.Line.Totals.Total,
+				FiatAmount:    authInput.Line.Totals.Total,
 				Authorized: &ledgertransaction.TimedGroupReference{
 					GroupReference: ledgertransaction.GroupReference{
 						TransactionGroupID: "authorized-group",

--- a/openmeter/ent/db/chargecreditpurchaseexternalpayment.go
+++ b/openmeter/ent/db/chargecreditpurchaseexternalpayment.go
@@ -28,8 +28,8 @@ type ChargeCreditPurchaseExternalPayment struct {
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
 	// Status holds the value of the "status" field.
 	Status payment.Status `json:"status,omitempty"`
-	// Amount holds the value of the "amount" field.
-	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
+	// FiatAmount holds the value of the "fiat_amount" field.
+	FiatAmount alpacadecimal.Decimal `json:"fiat_amount,omitempty"`
 	// AuthorizedTransactionGroupID holds the value of the "authorized_transaction_group_id" field.
 	AuthorizedTransactionGroupID *string `json:"authorized_transaction_group_id,omitempty"`
 	// AuthorizedAt holds the value of the "authorized_at" field.
@@ -83,7 +83,7 @@ func (*ChargeCreditPurchaseExternalPayment) scanValues(columns []string) ([]any,
 		switch columns[i] {
 		case chargecreditpurchaseexternalpayment.FieldAnnotations:
 			values[i] = new([]byte)
-		case chargecreditpurchaseexternalpayment.FieldAmount:
+		case chargecreditpurchaseexternalpayment.FieldFiatAmount:
 			values[i] = new(alpacadecimal.Decimal)
 		case chargecreditpurchaseexternalpayment.FieldID, chargecreditpurchaseexternalpayment.FieldStatus, chargecreditpurchaseexternalpayment.FieldAuthorizedTransactionGroupID, chargecreditpurchaseexternalpayment.FieldSettledTransactionGroupID, chargecreditpurchaseexternalpayment.FieldNamespace, chargecreditpurchaseexternalpayment.FieldChargeID:
 			values[i] = new(sql.NullString)
@@ -128,11 +128,11 @@ func (_m *ChargeCreditPurchaseExternalPayment) assignValues(columns []string, va
 			} else if value.Valid {
 				_m.Status = payment.Status(value.String)
 			}
-		case chargecreditpurchaseexternalpayment.FieldAmount:
+		case chargecreditpurchaseexternalpayment.FieldFiatAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
-				return fmt.Errorf("unexpected type %T for field amount", values[i])
+				return fmt.Errorf("unexpected type %T for field fiat_amount", values[i])
 			} else if value != nil {
-				_m.Amount = *value
+				_m.FiatAmount = *value
 			}
 		case chargecreditpurchaseexternalpayment.FieldAuthorizedTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -251,8 +251,8 @@ func (_m *ChargeCreditPurchaseExternalPayment) String() string {
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))
 	builder.WriteString(", ")
-	builder.WriteString("amount=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Amount))
+	builder.WriteString("fiat_amount=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatAmount))
 	builder.WriteString(", ")
 	if v := _m.AuthorizedTransactionGroupID; v != nil {
 		builder.WriteString("authorized_transaction_group_id=")

--- a/openmeter/ent/db/chargecreditpurchaseexternalpayment/chargecreditpurchaseexternalpayment.go
+++ b/openmeter/ent/db/chargecreditpurchaseexternalpayment/chargecreditpurchaseexternalpayment.go
@@ -22,8 +22,8 @@ const (
 	FieldServicePeriodTo = "service_period_to"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
-	// FieldAmount holds the string denoting the amount field in the database.
-	FieldAmount = "amount"
+	// FieldFiatAmount holds the string denoting the fiat_amount field in the database.
+	FieldFiatAmount = "amount"
 	// FieldAuthorizedTransactionGroupID holds the string denoting the authorized_transaction_group_id field in the database.
 	FieldAuthorizedTransactionGroupID = "authorized_transaction_group_id"
 	// FieldAuthorizedAt holds the string denoting the authorized_at field in the database.
@@ -63,7 +63,7 @@ var Columns = []string{
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
 	FieldStatus,
-	FieldAmount,
+	FieldFiatAmount,
 	FieldAuthorizedTransactionGroupID,
 	FieldAuthorizedAt,
 	FieldSettledTransactionGroupID,
@@ -136,9 +136,9 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
-// ByAmount orders the results by the amount field.
-func ByAmount(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+// ByFiatAmount orders the results by the fiat_amount field.
+func ByFiatAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatAmount, opts...).ToFunc()
 }
 
 // ByAuthorizedTransactionGroupID orders the results by the authorized_transaction_group_id field.

--- a/openmeter/ent/db/chargecreditpurchaseexternalpayment/where.go
+++ b/openmeter/ent/db/chargecreditpurchaseexternalpayment/where.go
@@ -77,9 +77,9 @@ func ServicePeriodTo(v time.Time) predicate.ChargeCreditPurchaseExternalPayment 
 	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
-// Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
-func Amount(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmount applies equality check predicate on the "fiat_amount" field. It's identical to FiatAmountEQ.
+func FiatAmount(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupID applies equality check predicate on the "authorized_transaction_group_id" field. It's identical to AuthorizedTransactionGroupIDEQ.
@@ -237,44 +237,44 @@ func StatusNotIn(vs ...payment.Status) predicate.ChargeCreditPurchaseExternalPay
 	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldNotIn(FieldStatus, v...))
 }
 
-// AmountEQ applies the EQ predicate on the "amount" field.
-func AmountEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmountEQ applies the EQ predicate on the "fiat_amount" field.
+func FiatAmountEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
-// AmountNEQ applies the NEQ predicate on the "amount" field.
-func AmountNEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldNEQ(FieldAmount, v))
+// FiatAmountNEQ applies the NEQ predicate on the "fiat_amount" field.
+func FiatAmountNEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldNEQ(FieldFiatAmount, v))
 }
 
-// AmountIn applies the In predicate on the "amount" field.
-func AmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldIn(FieldAmount, vs...))
+// FiatAmountIn applies the In predicate on the "fiat_amount" field.
+func FiatAmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldIn(FieldFiatAmount, vs...))
 }
 
-// AmountNotIn applies the NotIn predicate on the "amount" field.
-func AmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldNotIn(FieldAmount, vs...))
+// FiatAmountNotIn applies the NotIn predicate on the "fiat_amount" field.
+func FiatAmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldNotIn(FieldFiatAmount, vs...))
 }
 
-// AmountGT applies the GT predicate on the "amount" field.
-func AmountGT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldGT(FieldAmount, v))
+// FiatAmountGT applies the GT predicate on the "fiat_amount" field.
+func FiatAmountGT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldGT(FieldFiatAmount, v))
 }
 
-// AmountGTE applies the GTE predicate on the "amount" field.
-func AmountGTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldGTE(FieldAmount, v))
+// FiatAmountGTE applies the GTE predicate on the "fiat_amount" field.
+func FiatAmountGTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldGTE(FieldFiatAmount, v))
 }
 
-// AmountLT applies the LT predicate on the "amount" field.
-func AmountLT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldLT(FieldAmount, v))
+// FiatAmountLT applies the LT predicate on the "fiat_amount" field.
+func FiatAmountLT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldLT(FieldFiatAmount, v))
 }
 
-// AmountLTE applies the LTE predicate on the "amount" field.
-func AmountLTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
-	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldLTE(FieldAmount, v))
+// FiatAmountLTE applies the LTE predicate on the "fiat_amount" field.
+func FiatAmountLTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseExternalPayment {
+	return predicate.ChargeCreditPurchaseExternalPayment(sql.FieldLTE(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupIDEQ applies the EQ predicate on the "authorized_transaction_group_id" field.

--- a/openmeter/ent/db/chargecreditpurchaseexternalpayment_create.go
+++ b/openmeter/ent/db/chargecreditpurchaseexternalpayment_create.go
@@ -45,9 +45,9 @@ func (_c *ChargeCreditPurchaseExternalPaymentCreate) SetStatus(v payment.Status)
 	return _c
 }
 
-// SetAmount sets the "amount" field.
-func (_c *ChargeCreditPurchaseExternalPaymentCreate) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentCreate {
-	_c.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_c *ChargeCreditPurchaseExternalPaymentCreate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentCreate {
+	_c.mutation.SetFiatAmount(v)
 	return _c
 }
 
@@ -257,8 +257,8 @@ func (_c *ChargeCreditPurchaseExternalPaymentCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "ChargeCreditPurchaseExternalPayment.status": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.Amount(); !ok {
-		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "ChargeCreditPurchaseExternalPayment.amount"`)}
+	if _, ok := _c.mutation.FiatAmount(); !ok {
+		return &ValidationError{Name: "fiat_amount", err: errors.New(`db: missing required field "ChargeCreditPurchaseExternalPayment.fiat_amount"`)}
 	}
 	if v, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		if err := chargecreditpurchaseexternalpayment.AuthorizedTransactionGroupIDValidator(v); err != nil {
@@ -338,9 +338,9 @@ func (_c *ChargeCreditPurchaseExternalPaymentCreate) createSpec() (*ChargeCredit
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldStatus, field.TypeEnum, value)
 		_node.Status = value
 	}
-	if value, ok := _c.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAmount, field.TypeOther, value)
-		_node.Amount = value
+	if value, ok := _c.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseexternalpayment.FieldFiatAmount, field.TypeOther, value)
+		_node.FiatAmount = value
 	}
 	if value, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -483,15 +483,15 @@ func (u *ChargeCreditPurchaseExternalPaymentUpsert) UpdateStatus() *ChargeCredit
 	return u
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseExternalPaymentUpsert) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsert {
-	u.Set(chargecreditpurchaseexternalpayment.FieldAmount, v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseExternalPaymentUpsert) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsert {
+	u.Set(chargecreditpurchaseexternalpayment.FieldFiatAmount, v)
 	return u
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseExternalPaymentUpsert) UpdateAmount() *ChargeCreditPurchaseExternalPaymentUpsert {
-	u.SetExcluded(chargecreditpurchaseexternalpayment.FieldAmount)
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseExternalPaymentUpsert) UpdateFiatAmount() *ChargeCreditPurchaseExternalPaymentUpsert {
+	u.SetExcluded(chargecreditpurchaseexternalpayment.FieldFiatAmount)
 	return u
 }
 
@@ -714,17 +714,17 @@ func (u *ChargeCreditPurchaseExternalPaymentUpsertOne) UpdateStatus() *ChargeCre
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseExternalPaymentUpsertOne) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsertOne {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseExternalPaymentUpsertOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseExternalPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseExternalPaymentUpsertOne) UpdateAmount() *ChargeCreditPurchaseExternalPaymentUpsertOne {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseExternalPaymentUpsertOne) UpdateFiatAmount() *ChargeCreditPurchaseExternalPaymentUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseExternalPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 
@@ -1134,17 +1134,17 @@ func (u *ChargeCreditPurchaseExternalPaymentUpsertBulk) UpdateStatus() *ChargeCr
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseExternalPaymentUpsertBulk) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsertBulk {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseExternalPaymentUpsertBulk) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseExternalPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseExternalPaymentUpsertBulk) UpdateAmount() *ChargeCreditPurchaseExternalPaymentUpsertBulk {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseExternalPaymentUpsertBulk) UpdateFiatAmount() *ChargeCreditPurchaseExternalPaymentUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseExternalPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 

--- a/openmeter/ent/db/chargecreditpurchaseexternalpayment_update.go
+++ b/openmeter/ent/db/chargecreditpurchaseexternalpayment_update.go
@@ -73,16 +73,16 @@ func (_u *ChargeCreditPurchaseExternalPaymentUpdate) SetNillableStatus(v *paymen
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeCreditPurchaseExternalPaymentUpdate) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdate {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeCreditPurchaseExternalPaymentUpdate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdate {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeCreditPurchaseExternalPaymentUpdate) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdate {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseExternalPaymentUpdate) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdate {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -290,8 +290,8 @@ func (_u *ChargeCreditPurchaseExternalPaymentUpdate) sqlSave(ctx context.Context
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseexternalpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -394,16 +394,16 @@ func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) SetNillableStatus(v *pay
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdateOne {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdateOne {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdateOne {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseExternalPaymentUpdateOne {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -641,8 +641,8 @@ func (_u *ChargeCreditPurchaseExternalPaymentUpdateOne) sqlSave(ctx context.Cont
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseexternalpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseexternalpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)

--- a/openmeter/ent/db/chargecreditpurchaseinvoicedpayment.go
+++ b/openmeter/ent/db/chargecreditpurchaseinvoicedpayment.go
@@ -33,8 +33,8 @@ type ChargeCreditPurchaseInvoicedPayment struct {
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
 	// Status holds the value of the "status" field.
 	Status payment.Status `json:"status,omitempty"`
-	// Amount holds the value of the "amount" field.
-	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
+	// FiatAmount holds the value of the "fiat_amount" field.
+	FiatAmount alpacadecimal.Decimal `json:"fiat_amount,omitempty"`
 	// AuthorizedTransactionGroupID holds the value of the "authorized_transaction_group_id" field.
 	AuthorizedTransactionGroupID *string `json:"authorized_transaction_group_id,omitempty"`
 	// AuthorizedAt holds the value of the "authorized_at" field.
@@ -101,7 +101,7 @@ func (*ChargeCreditPurchaseInvoicedPayment) scanValues(columns []string) ([]any,
 		switch columns[i] {
 		case chargecreditpurchaseinvoicedpayment.FieldAnnotations:
 			values[i] = new([]byte)
-		case chargecreditpurchaseinvoicedpayment.FieldAmount:
+		case chargecreditpurchaseinvoicedpayment.FieldFiatAmount:
 			values[i] = new(alpacadecimal.Decimal)
 		case chargecreditpurchaseinvoicedpayment.FieldID, chargecreditpurchaseinvoicedpayment.FieldLineID, chargecreditpurchaseinvoicedpayment.FieldInvoiceID, chargecreditpurchaseinvoicedpayment.FieldStatus, chargecreditpurchaseinvoicedpayment.FieldAuthorizedTransactionGroupID, chargecreditpurchaseinvoicedpayment.FieldSettledTransactionGroupID, chargecreditpurchaseinvoicedpayment.FieldNamespace, chargecreditpurchaseinvoicedpayment.FieldChargeID:
 			values[i] = new(sql.NullString)
@@ -158,11 +158,11 @@ func (_m *ChargeCreditPurchaseInvoicedPayment) assignValues(columns []string, va
 			} else if value.Valid {
 				_m.Status = payment.Status(value.String)
 			}
-		case chargecreditpurchaseinvoicedpayment.FieldAmount:
+		case chargecreditpurchaseinvoicedpayment.FieldFiatAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
-				return fmt.Errorf("unexpected type %T for field amount", values[i])
+				return fmt.Errorf("unexpected type %T for field fiat_amount", values[i])
 			} else if value != nil {
-				_m.Amount = *value
+				_m.FiatAmount = *value
 			}
 		case chargecreditpurchaseinvoicedpayment.FieldAuthorizedTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -292,8 +292,8 @@ func (_m *ChargeCreditPurchaseInvoicedPayment) String() string {
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))
 	builder.WriteString(", ")
-	builder.WriteString("amount=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Amount))
+	builder.WriteString("fiat_amount=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatAmount))
 	builder.WriteString(", ")
 	if v := _m.AuthorizedTransactionGroupID; v != nil {
 		builder.WriteString("authorized_transaction_group_id=")

--- a/openmeter/ent/db/chargecreditpurchaseinvoicedpayment/chargecreditpurchaseinvoicedpayment.go
+++ b/openmeter/ent/db/chargecreditpurchaseinvoicedpayment/chargecreditpurchaseinvoicedpayment.go
@@ -26,8 +26,8 @@ const (
 	FieldServicePeriodTo = "service_period_to"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
-	// FieldAmount holds the string denoting the amount field in the database.
-	FieldAmount = "amount"
+	// FieldFiatAmount holds the string denoting the fiat_amount field in the database.
+	FieldFiatAmount = "amount"
 	// FieldAuthorizedTransactionGroupID holds the string denoting the authorized_transaction_group_id field in the database.
 	FieldAuthorizedTransactionGroupID = "authorized_transaction_group_id"
 	// FieldAuthorizedAt holds the string denoting the authorized_at field in the database.
@@ -78,7 +78,7 @@ var Columns = []string{
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
 	FieldStatus,
-	FieldAmount,
+	FieldFiatAmount,
 	FieldAuthorizedTransactionGroupID,
 	FieldAuthorizedAt,
 	FieldSettledTransactionGroupID,
@@ -161,9 +161,9 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
-// ByAmount orders the results by the amount field.
-func ByAmount(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+// ByFiatAmount orders the results by the fiat_amount field.
+func ByFiatAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatAmount, opts...).ToFunc()
 }
 
 // ByAuthorizedTransactionGroupID orders the results by the authorized_transaction_group_id field.

--- a/openmeter/ent/db/chargecreditpurchaseinvoicedpayment/where.go
+++ b/openmeter/ent/db/chargecreditpurchaseinvoicedpayment/where.go
@@ -87,9 +87,9 @@ func ServicePeriodTo(v time.Time) predicate.ChargeCreditPurchaseInvoicedPayment 
 	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
-// Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
-func Amount(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmount applies equality check predicate on the "fiat_amount" field. It's identical to FiatAmountEQ.
+func FiatAmount(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupID applies equality check predicate on the "authorized_transaction_group_id" field. It's identical to AuthorizedTransactionGroupIDEQ.
@@ -377,44 +377,44 @@ func StatusNotIn(vs ...payment.Status) predicate.ChargeCreditPurchaseInvoicedPay
 	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldNotIn(FieldStatus, v...))
 }
 
-// AmountEQ applies the EQ predicate on the "amount" field.
-func AmountEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmountEQ applies the EQ predicate on the "fiat_amount" field.
+func FiatAmountEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
-// AmountNEQ applies the NEQ predicate on the "amount" field.
-func AmountNEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldNEQ(FieldAmount, v))
+// FiatAmountNEQ applies the NEQ predicate on the "fiat_amount" field.
+func FiatAmountNEQ(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldNEQ(FieldFiatAmount, v))
 }
 
-// AmountIn applies the In predicate on the "amount" field.
-func AmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldIn(FieldAmount, vs...))
+// FiatAmountIn applies the In predicate on the "fiat_amount" field.
+func FiatAmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldIn(FieldFiatAmount, vs...))
 }
 
-// AmountNotIn applies the NotIn predicate on the "amount" field.
-func AmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldNotIn(FieldAmount, vs...))
+// FiatAmountNotIn applies the NotIn predicate on the "fiat_amount" field.
+func FiatAmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldNotIn(FieldFiatAmount, vs...))
 }
 
-// AmountGT applies the GT predicate on the "amount" field.
-func AmountGT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldGT(FieldAmount, v))
+// FiatAmountGT applies the GT predicate on the "fiat_amount" field.
+func FiatAmountGT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldGT(FieldFiatAmount, v))
 }
 
-// AmountGTE applies the GTE predicate on the "amount" field.
-func AmountGTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldGTE(FieldAmount, v))
+// FiatAmountGTE applies the GTE predicate on the "fiat_amount" field.
+func FiatAmountGTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldGTE(FieldFiatAmount, v))
 }
 
-// AmountLT applies the LT predicate on the "amount" field.
-func AmountLT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldLT(FieldAmount, v))
+// FiatAmountLT applies the LT predicate on the "fiat_amount" field.
+func FiatAmountLT(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldLT(FieldFiatAmount, v))
 }
 
-// AmountLTE applies the LTE predicate on the "amount" field.
-func AmountLTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
-	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldLTE(FieldAmount, v))
+// FiatAmountLTE applies the LTE predicate on the "fiat_amount" field.
+func FiatAmountLTE(v alpacadecimal.Decimal) predicate.ChargeCreditPurchaseInvoicedPayment {
+	return predicate.ChargeCreditPurchaseInvoicedPayment(sql.FieldLTE(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupIDEQ applies the EQ predicate on the "authorized_transaction_group_id" field.

--- a/openmeter/ent/db/chargecreditpurchaseinvoicedpayment_create.go
+++ b/openmeter/ent/db/chargecreditpurchaseinvoicedpayment_create.go
@@ -58,9 +58,9 @@ func (_c *ChargeCreditPurchaseInvoicedPaymentCreate) SetStatus(v payment.Status)
 	return _c
 }
 
-// SetAmount sets the "amount" field.
-func (_c *ChargeCreditPurchaseInvoicedPaymentCreate) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentCreate {
-	_c.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_c *ChargeCreditPurchaseInvoicedPaymentCreate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentCreate {
+	_c.mutation.SetFiatAmount(v)
 	return _c
 }
 
@@ -287,8 +287,8 @@ func (_c *ChargeCreditPurchaseInvoicedPaymentCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "ChargeCreditPurchaseInvoicedPayment.status": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.Amount(); !ok {
-		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "ChargeCreditPurchaseInvoicedPayment.amount"`)}
+	if _, ok := _c.mutation.FiatAmount(); !ok {
+		return &ValidationError{Name: "fiat_amount", err: errors.New(`db: missing required field "ChargeCreditPurchaseInvoicedPayment.fiat_amount"`)}
 	}
 	if v, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		if err := chargecreditpurchaseinvoicedpayment.AuthorizedTransactionGroupIDValidator(v); err != nil {
@@ -375,9 +375,9 @@ func (_c *ChargeCreditPurchaseInvoicedPaymentCreate) createSpec() (*ChargeCredit
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldStatus, field.TypeEnum, value)
 		_node.Status = value
 	}
-	if value, ok := _c.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAmount, field.TypeOther, value)
-		_node.Amount = value
+	if value, ok := _c.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldFiatAmount, field.TypeOther, value)
+		_node.FiatAmount = value
 	}
 	if value, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -537,15 +537,15 @@ func (u *ChargeCreditPurchaseInvoicedPaymentUpsert) UpdateStatus() *ChargeCredit
 	return u
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsert) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsert {
-	u.Set(chargecreditpurchaseinvoicedpayment.FieldAmount, v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsert) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsert {
+	u.Set(chargecreditpurchaseinvoicedpayment.FieldFiatAmount, v)
 	return u
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsert) UpdateAmount() *ChargeCreditPurchaseInvoicedPaymentUpsert {
-	u.SetExcluded(chargecreditpurchaseinvoicedpayment.FieldAmount)
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsert) UpdateFiatAmount() *ChargeCreditPurchaseInvoicedPaymentUpsert {
+	u.SetExcluded(chargecreditpurchaseinvoicedpayment.FieldFiatAmount)
 	return u
 }
 
@@ -774,17 +774,17 @@ func (u *ChargeCreditPurchaseInvoicedPaymentUpsertOne) UpdateStatus() *ChargeCre
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsertOne) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsertOne {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsertOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseInvoicedPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsertOne) UpdateAmount() *ChargeCreditPurchaseInvoicedPaymentUpsertOne {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsertOne) UpdateFiatAmount() *ChargeCreditPurchaseInvoicedPaymentUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseInvoicedPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 
@@ -1200,17 +1200,17 @@ func (u *ChargeCreditPurchaseInvoicedPaymentUpsertBulk) UpdateStatus() *ChargeCr
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsertBulk) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsertBulk {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsertBulk) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseInvoicedPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeCreditPurchaseInvoicedPaymentUpsertBulk) UpdateAmount() *ChargeCreditPurchaseInvoicedPaymentUpsertBulk {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseInvoicedPaymentUpsertBulk) UpdateFiatAmount() *ChargeCreditPurchaseInvoicedPaymentUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseInvoicedPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 

--- a/openmeter/ent/db/chargecreditpurchaseinvoicedpayment_update.go
+++ b/openmeter/ent/db/chargecreditpurchaseinvoicedpayment_update.go
@@ -73,16 +73,16 @@ func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) SetNillableStatus(v *paymen
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdate {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdate {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdate {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdate {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -293,8 +293,8 @@ func (_u *ChargeCreditPurchaseInvoicedPaymentUpdate) sqlSave(ctx context.Context
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -397,16 +397,16 @@ func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetNillableStatus(v *pay
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdateOne {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdateOne {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdateOne {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeCreditPurchaseInvoicedPaymentUpdateOne {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -647,8 +647,8 @@ func (_u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) sqlSave(ctx context.Cont
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargecreditpurchaseinvoicedpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)

--- a/openmeter/ent/db/chargeflatfeerunpayment.go
+++ b/openmeter/ent/db/chargeflatfeerunpayment.go
@@ -33,8 +33,8 @@ type ChargeFlatFeeRunPayment struct {
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
 	// Status holds the value of the "status" field.
 	Status payment.Status `json:"status,omitempty"`
-	// Amount holds the value of the "amount" field.
-	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
+	// FiatAmount holds the value of the "fiat_amount" field.
+	FiatAmount alpacadecimal.Decimal `json:"fiat_amount,omitempty"`
 	// AuthorizedTransactionGroupID holds the value of the "authorized_transaction_group_id" field.
 	AuthorizedTransactionGroupID *string `json:"authorized_transaction_group_id,omitempty"`
 	// AuthorizedAt holds the value of the "authorized_at" field.
@@ -101,7 +101,7 @@ func (*ChargeFlatFeeRunPayment) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeflatfeerunpayment.FieldAnnotations:
 			values[i] = new([]byte)
-		case chargeflatfeerunpayment.FieldAmount:
+		case chargeflatfeerunpayment.FieldFiatAmount:
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeflatfeerunpayment.FieldID, chargeflatfeerunpayment.FieldLineID, chargeflatfeerunpayment.FieldInvoiceID, chargeflatfeerunpayment.FieldStatus, chargeflatfeerunpayment.FieldAuthorizedTransactionGroupID, chargeflatfeerunpayment.FieldSettledTransactionGroupID, chargeflatfeerunpayment.FieldNamespace, chargeflatfeerunpayment.FieldRunID:
 			values[i] = new(sql.NullString)
@@ -158,11 +158,11 @@ func (_m *ChargeFlatFeeRunPayment) assignValues(columns []string, values []any) 
 			} else if value.Valid {
 				_m.Status = payment.Status(value.String)
 			}
-		case chargeflatfeerunpayment.FieldAmount:
+		case chargeflatfeerunpayment.FieldFiatAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
-				return fmt.Errorf("unexpected type %T for field amount", values[i])
+				return fmt.Errorf("unexpected type %T for field fiat_amount", values[i])
 			} else if value != nil {
-				_m.Amount = *value
+				_m.FiatAmount = *value
 			}
 		case chargeflatfeerunpayment.FieldAuthorizedTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -292,8 +292,8 @@ func (_m *ChargeFlatFeeRunPayment) String() string {
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))
 	builder.WriteString(", ")
-	builder.WriteString("amount=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Amount))
+	builder.WriteString("fiat_amount=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatAmount))
 	builder.WriteString(", ")
 	if v := _m.AuthorizedTransactionGroupID; v != nil {
 		builder.WriteString("authorized_transaction_group_id=")

--- a/openmeter/ent/db/chargeflatfeerunpayment/chargeflatfeerunpayment.go
+++ b/openmeter/ent/db/chargeflatfeerunpayment/chargeflatfeerunpayment.go
@@ -26,8 +26,8 @@ const (
 	FieldServicePeriodTo = "service_period_to"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
-	// FieldAmount holds the string denoting the amount field in the database.
-	FieldAmount = "amount"
+	// FieldFiatAmount holds the string denoting the fiat_amount field in the database.
+	FieldFiatAmount = "amount"
 	// FieldAuthorizedTransactionGroupID holds the string denoting the authorized_transaction_group_id field in the database.
 	FieldAuthorizedTransactionGroupID = "authorized_transaction_group_id"
 	// FieldAuthorizedAt holds the string denoting the authorized_at field in the database.
@@ -78,7 +78,7 @@ var Columns = []string{
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
 	FieldStatus,
-	FieldAmount,
+	FieldFiatAmount,
 	FieldAuthorizedTransactionGroupID,
 	FieldAuthorizedAt,
 	FieldSettledTransactionGroupID,
@@ -161,9 +161,9 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
-// ByAmount orders the results by the amount field.
-func ByAmount(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+// ByFiatAmount orders the results by the fiat_amount field.
+func ByFiatAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatAmount, opts...).ToFunc()
 }
 
 // ByAuthorizedTransactionGroupID orders the results by the authorized_transaction_group_id field.

--- a/openmeter/ent/db/chargeflatfeerunpayment/where.go
+++ b/openmeter/ent/db/chargeflatfeerunpayment/where.go
@@ -87,9 +87,9 @@ func ServicePeriodTo(v time.Time) predicate.ChargeFlatFeeRunPayment {
 	return predicate.ChargeFlatFeeRunPayment(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
-// Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
-func Amount(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmount applies equality check predicate on the "fiat_amount" field. It's identical to FiatAmountEQ.
+func FiatAmount(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupID applies equality check predicate on the "authorized_transaction_group_id" field. It's identical to AuthorizedTransactionGroupIDEQ.
@@ -377,44 +377,44 @@ func StatusNotIn(vs ...payment.Status) predicate.ChargeFlatFeeRunPayment {
 	return predicate.ChargeFlatFeeRunPayment(sql.FieldNotIn(FieldStatus, v...))
 }
 
-// AmountEQ applies the EQ predicate on the "amount" field.
-func AmountEQ(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmountEQ applies the EQ predicate on the "fiat_amount" field.
+func FiatAmountEQ(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
-// AmountNEQ applies the NEQ predicate on the "amount" field.
-func AmountNEQ(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldNEQ(FieldAmount, v))
+// FiatAmountNEQ applies the NEQ predicate on the "fiat_amount" field.
+func FiatAmountNEQ(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldNEQ(FieldFiatAmount, v))
 }
 
-// AmountIn applies the In predicate on the "amount" field.
-func AmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldIn(FieldAmount, vs...))
+// FiatAmountIn applies the In predicate on the "fiat_amount" field.
+func FiatAmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldIn(FieldFiatAmount, vs...))
 }
 
-// AmountNotIn applies the NotIn predicate on the "amount" field.
-func AmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldNotIn(FieldAmount, vs...))
+// FiatAmountNotIn applies the NotIn predicate on the "fiat_amount" field.
+func FiatAmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldNotIn(FieldFiatAmount, vs...))
 }
 
-// AmountGT applies the GT predicate on the "amount" field.
-func AmountGT(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldGT(FieldAmount, v))
+// FiatAmountGT applies the GT predicate on the "fiat_amount" field.
+func FiatAmountGT(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldGT(FieldFiatAmount, v))
 }
 
-// AmountGTE applies the GTE predicate on the "amount" field.
-func AmountGTE(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldGTE(FieldAmount, v))
+// FiatAmountGTE applies the GTE predicate on the "fiat_amount" field.
+func FiatAmountGTE(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldGTE(FieldFiatAmount, v))
 }
 
-// AmountLT applies the LT predicate on the "amount" field.
-func AmountLT(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldLT(FieldAmount, v))
+// FiatAmountLT applies the LT predicate on the "fiat_amount" field.
+func FiatAmountLT(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldLT(FieldFiatAmount, v))
 }
 
-// AmountLTE applies the LTE predicate on the "amount" field.
-func AmountLTE(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
-	return predicate.ChargeFlatFeeRunPayment(sql.FieldLTE(FieldAmount, v))
+// FiatAmountLTE applies the LTE predicate on the "fiat_amount" field.
+func FiatAmountLTE(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunPayment {
+	return predicate.ChargeFlatFeeRunPayment(sql.FieldLTE(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupIDEQ applies the EQ predicate on the "authorized_transaction_group_id" field.

--- a/openmeter/ent/db/chargeflatfeerunpayment_create.go
+++ b/openmeter/ent/db/chargeflatfeerunpayment_create.go
@@ -58,9 +58,9 @@ func (_c *ChargeFlatFeeRunPaymentCreate) SetStatus(v payment.Status) *ChargeFlat
 	return _c
 }
 
-// SetAmount sets the "amount" field.
-func (_c *ChargeFlatFeeRunPaymentCreate) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentCreate {
-	_c.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_c *ChargeFlatFeeRunPaymentCreate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentCreate {
+	_c.mutation.SetFiatAmount(v)
 	return _c
 }
 
@@ -281,8 +281,8 @@ func (_c *ChargeFlatFeeRunPaymentCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunPayment.status": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.Amount(); !ok {
-		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "ChargeFlatFeeRunPayment.amount"`)}
+	if _, ok := _c.mutation.FiatAmount(); !ok {
+		return &ValidationError{Name: "fiat_amount", err: errors.New(`db: missing required field "ChargeFlatFeeRunPayment.fiat_amount"`)}
 	}
 	if v, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		if err := chargeflatfeerunpayment.AuthorizedTransactionGroupIDValidator(v); err != nil {
@@ -369,9 +369,9 @@ func (_c *ChargeFlatFeeRunPaymentCreate) createSpec() (*ChargeFlatFeeRunPayment,
 		_spec.SetField(chargeflatfeerunpayment.FieldStatus, field.TypeEnum, value)
 		_node.Status = value
 	}
-	if value, ok := _c.mutation.Amount(); ok {
-		_spec.SetField(chargeflatfeerunpayment.FieldAmount, field.TypeOther, value)
-		_node.Amount = value
+	if value, ok := _c.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeflatfeerunpayment.FieldFiatAmount, field.TypeOther, value)
+		_node.FiatAmount = value
 	}
 	if value, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeerunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -531,15 +531,15 @@ func (u *ChargeFlatFeeRunPaymentUpsert) UpdateStatus() *ChargeFlatFeeRunPaymentU
 	return u
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeFlatFeeRunPaymentUpsert) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsert {
-	u.Set(chargeflatfeerunpayment.FieldAmount, v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeFlatFeeRunPaymentUpsert) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsert {
+	u.Set(chargeflatfeerunpayment.FieldFiatAmount, v)
 	return u
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunPaymentUpsert) UpdateAmount() *ChargeFlatFeeRunPaymentUpsert {
-	u.SetExcluded(chargeflatfeerunpayment.FieldAmount)
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunPaymentUpsert) UpdateFiatAmount() *ChargeFlatFeeRunPaymentUpsert {
+	u.SetExcluded(chargeflatfeerunpayment.FieldFiatAmount)
 	return u
 }
 
@@ -768,17 +768,17 @@ func (u *ChargeFlatFeeRunPaymentUpsertOne) UpdateStatus() *ChargeFlatFeeRunPayme
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeFlatFeeRunPaymentUpsertOne) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsertOne {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeFlatFeeRunPaymentUpsertOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunPaymentUpsertOne) UpdateAmount() *ChargeFlatFeeRunPaymentUpsertOne {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunPaymentUpsertOne) UpdateFiatAmount() *ChargeFlatFeeRunPaymentUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 
@@ -1194,17 +1194,17 @@ func (u *ChargeFlatFeeRunPaymentUpsertBulk) UpdateStatus() *ChargeFlatFeeRunPaym
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeFlatFeeRunPaymentUpsertBulk) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsertBulk {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeFlatFeeRunPaymentUpsertBulk) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunPaymentUpsertBulk) UpdateAmount() *ChargeFlatFeeRunPaymentUpsertBulk {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunPaymentUpsertBulk) UpdateFiatAmount() *ChargeFlatFeeRunPaymentUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeerunpayment_update.go
+++ b/openmeter/ent/db/chargeflatfeerunpayment_update.go
@@ -73,16 +73,16 @@ func (_u *ChargeFlatFeeRunPaymentUpdate) SetNillableStatus(v *payment.Status) *C
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeFlatFeeRunPaymentUpdate) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdate {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeFlatFeeRunPaymentUpdate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdate {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunPaymentUpdate) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdate {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunPaymentUpdate) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdate {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -293,8 +293,8 @@ func (_u *ChargeFlatFeeRunPaymentUpdate) sqlSave(ctx context.Context) (_node int
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargeflatfeerunpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargeflatfeerunpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeflatfeerunpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeerunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -397,16 +397,16 @@ func (_u *ChargeFlatFeeRunPaymentUpdateOne) SetNillableStatus(v *payment.Status)
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeFlatFeeRunPaymentUpdateOne) SetAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdateOne {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeFlatFeeRunPaymentUpdateOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdateOne {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunPaymentUpdateOne) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdateOne {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunPaymentUpdateOne) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeFlatFeeRunPaymentUpdateOne {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -647,8 +647,8 @@ func (_u *ChargeFlatFeeRunPaymentUpdateOne) sqlSave(ctx context.Context) (_node 
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargeflatfeerunpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargeflatfeerunpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeflatfeerunpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeerunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)

--- a/openmeter/ent/db/chargeusagebasedrunpayment.go
+++ b/openmeter/ent/db/chargeusagebasedrunpayment.go
@@ -32,8 +32,8 @@ type ChargeUsageBasedRunPayment struct {
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
 	// Status holds the value of the "status" field.
 	Status payment.Status `json:"status,omitempty"`
-	// Amount holds the value of the "amount" field.
-	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
+	// FiatAmount holds the value of the "fiat_amount" field.
+	FiatAmount alpacadecimal.Decimal `json:"fiat_amount,omitempty"`
 	// AuthorizedTransactionGroupID holds the value of the "authorized_transaction_group_id" field.
 	AuthorizedTransactionGroupID *string `json:"authorized_transaction_group_id,omitempty"`
 	// AuthorizedAt holds the value of the "authorized_at" field.
@@ -87,7 +87,7 @@ func (*ChargeUsageBasedRunPayment) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedrunpayment.FieldAnnotations:
 			values[i] = new([]byte)
-		case chargeusagebasedrunpayment.FieldAmount:
+		case chargeusagebasedrunpayment.FieldFiatAmount:
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeusagebasedrunpayment.FieldID, chargeusagebasedrunpayment.FieldLineID, chargeusagebasedrunpayment.FieldInvoiceID, chargeusagebasedrunpayment.FieldStatus, chargeusagebasedrunpayment.FieldAuthorizedTransactionGroupID, chargeusagebasedrunpayment.FieldSettledTransactionGroupID, chargeusagebasedrunpayment.FieldNamespace, chargeusagebasedrunpayment.FieldRunID:
 			values[i] = new(sql.NullString)
@@ -144,11 +144,11 @@ func (_m *ChargeUsageBasedRunPayment) assignValues(columns []string, values []an
 			} else if value.Valid {
 				_m.Status = payment.Status(value.String)
 			}
-		case chargeusagebasedrunpayment.FieldAmount:
+		case chargeusagebasedrunpayment.FieldFiatAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
-				return fmt.Errorf("unexpected type %T for field amount", values[i])
+				return fmt.Errorf("unexpected type %T for field fiat_amount", values[i])
 			} else if value != nil {
-				_m.Amount = *value
+				_m.FiatAmount = *value
 			}
 		case chargeusagebasedrunpayment.FieldAuthorizedTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -273,8 +273,8 @@ func (_m *ChargeUsageBasedRunPayment) String() string {
 	builder.WriteString("status=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Status))
 	builder.WriteString(", ")
-	builder.WriteString("amount=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Amount))
+	builder.WriteString("fiat_amount=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatAmount))
 	builder.WriteString(", ")
 	if v := _m.AuthorizedTransactionGroupID; v != nil {
 		builder.WriteString("authorized_transaction_group_id=")

--- a/openmeter/ent/db/chargeusagebasedrunpayment/chargeusagebasedrunpayment.go
+++ b/openmeter/ent/db/chargeusagebasedrunpayment/chargeusagebasedrunpayment.go
@@ -26,8 +26,8 @@ const (
 	FieldServicePeriodTo = "service_period_to"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
-	// FieldAmount holds the string denoting the amount field in the database.
-	FieldAmount = "amount"
+	// FieldFiatAmount holds the string denoting the fiat_amount field in the database.
+	FieldFiatAmount = "amount"
 	// FieldAuthorizedTransactionGroupID holds the string denoting the authorized_transaction_group_id field in the database.
 	FieldAuthorizedTransactionGroupID = "authorized_transaction_group_id"
 	// FieldAuthorizedAt holds the string denoting the authorized_at field in the database.
@@ -69,7 +69,7 @@ var Columns = []string{
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
 	FieldStatus,
-	FieldAmount,
+	FieldFiatAmount,
 	FieldAuthorizedTransactionGroupID,
 	FieldAuthorizedAt,
 	FieldSettledTransactionGroupID,
@@ -152,9 +152,9 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
 }
 
-// ByAmount orders the results by the amount field.
-func ByAmount(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+// ByFiatAmount orders the results by the fiat_amount field.
+func ByFiatAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatAmount, opts...).ToFunc()
 }
 
 // ByAuthorizedTransactionGroupID orders the results by the authorized_transaction_group_id field.

--- a/openmeter/ent/db/chargeusagebasedrunpayment/where.go
+++ b/openmeter/ent/db/chargeusagebasedrunpayment/where.go
@@ -87,9 +87,9 @@ func ServicePeriodTo(v time.Time) predicate.ChargeUsageBasedRunPayment {
 	return predicate.ChargeUsageBasedRunPayment(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
-// Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
-func Amount(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmount applies equality check predicate on the "fiat_amount" field. It's identical to FiatAmountEQ.
+func FiatAmount(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupID applies equality check predicate on the "authorized_transaction_group_id" field. It's identical to AuthorizedTransactionGroupIDEQ.
@@ -377,44 +377,44 @@ func StatusNotIn(vs ...payment.Status) predicate.ChargeUsageBasedRunPayment {
 	return predicate.ChargeUsageBasedRunPayment(sql.FieldNotIn(FieldStatus, v...))
 }
 
-// AmountEQ applies the EQ predicate on the "amount" field.
-func AmountEQ(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldEQ(FieldAmount, v))
+// FiatAmountEQ applies the EQ predicate on the "fiat_amount" field.
+func FiatAmountEQ(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldEQ(FieldFiatAmount, v))
 }
 
-// AmountNEQ applies the NEQ predicate on the "amount" field.
-func AmountNEQ(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldNEQ(FieldAmount, v))
+// FiatAmountNEQ applies the NEQ predicate on the "fiat_amount" field.
+func FiatAmountNEQ(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldNEQ(FieldFiatAmount, v))
 }
 
-// AmountIn applies the In predicate on the "amount" field.
-func AmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldIn(FieldAmount, vs...))
+// FiatAmountIn applies the In predicate on the "fiat_amount" field.
+func FiatAmountIn(vs ...alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldIn(FieldFiatAmount, vs...))
 }
 
-// AmountNotIn applies the NotIn predicate on the "amount" field.
-func AmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldNotIn(FieldAmount, vs...))
+// FiatAmountNotIn applies the NotIn predicate on the "fiat_amount" field.
+func FiatAmountNotIn(vs ...alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldNotIn(FieldFiatAmount, vs...))
 }
 
-// AmountGT applies the GT predicate on the "amount" field.
-func AmountGT(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldGT(FieldAmount, v))
+// FiatAmountGT applies the GT predicate on the "fiat_amount" field.
+func FiatAmountGT(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldGT(FieldFiatAmount, v))
 }
 
-// AmountGTE applies the GTE predicate on the "amount" field.
-func AmountGTE(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldGTE(FieldAmount, v))
+// FiatAmountGTE applies the GTE predicate on the "fiat_amount" field.
+func FiatAmountGTE(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldGTE(FieldFiatAmount, v))
 }
 
-// AmountLT applies the LT predicate on the "amount" field.
-func AmountLT(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldLT(FieldAmount, v))
+// FiatAmountLT applies the LT predicate on the "fiat_amount" field.
+func FiatAmountLT(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldLT(FieldFiatAmount, v))
 }
 
-// AmountLTE applies the LTE predicate on the "amount" field.
-func AmountLTE(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
-	return predicate.ChargeUsageBasedRunPayment(sql.FieldLTE(FieldAmount, v))
+// FiatAmountLTE applies the LTE predicate on the "fiat_amount" field.
+func FiatAmountLTE(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunPayment {
+	return predicate.ChargeUsageBasedRunPayment(sql.FieldLTE(FieldFiatAmount, v))
 }
 
 // AuthorizedTransactionGroupIDEQ applies the EQ predicate on the "authorized_transaction_group_id" field.

--- a/openmeter/ent/db/chargeusagebasedrunpayment_create.go
+++ b/openmeter/ent/db/chargeusagebasedrunpayment_create.go
@@ -57,9 +57,9 @@ func (_c *ChargeUsageBasedRunPaymentCreate) SetStatus(v payment.Status) *ChargeU
 	return _c
 }
 
-// SetAmount sets the "amount" field.
-func (_c *ChargeUsageBasedRunPaymentCreate) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentCreate {
-	_c.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_c *ChargeUsageBasedRunPaymentCreate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentCreate {
+	_c.mutation.SetFiatAmount(v)
 	return _c
 }
 
@@ -269,8 +269,8 @@ func (_c *ChargeUsageBasedRunPaymentCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunPayment.status": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.Amount(); !ok {
-		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "ChargeUsageBasedRunPayment.amount"`)}
+	if _, ok := _c.mutation.FiatAmount(); !ok {
+		return &ValidationError{Name: "fiat_amount", err: errors.New(`db: missing required field "ChargeUsageBasedRunPayment.fiat_amount"`)}
 	}
 	if v, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		if err := chargeusagebasedrunpayment.AuthorizedTransactionGroupIDValidator(v); err != nil {
@@ -358,9 +358,9 @@ func (_c *ChargeUsageBasedRunPaymentCreate) createSpec() (*ChargeUsageBasedRunPa
 		_spec.SetField(chargeusagebasedrunpayment.FieldStatus, field.TypeEnum, value)
 		_node.Status = value
 	}
-	if value, ok := _c.mutation.Amount(); ok {
-		_spec.SetField(chargeusagebasedrunpayment.FieldAmount, field.TypeOther, value)
-		_node.Amount = value
+	if value, ok := _c.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeusagebasedrunpayment.FieldFiatAmount, field.TypeOther, value)
+		_node.FiatAmount = value
 	}
 	if value, ok := _c.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedrunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -503,15 +503,15 @@ func (u *ChargeUsageBasedRunPaymentUpsert) UpdateStatus() *ChargeUsageBasedRunPa
 	return u
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeUsageBasedRunPaymentUpsert) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsert {
-	u.Set(chargeusagebasedrunpayment.FieldAmount, v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeUsageBasedRunPaymentUpsert) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsert {
+	u.Set(chargeusagebasedrunpayment.FieldFiatAmount, v)
 	return u
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunPaymentUpsert) UpdateAmount() *ChargeUsageBasedRunPaymentUpsert {
-	u.SetExcluded(chargeusagebasedrunpayment.FieldAmount)
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunPaymentUpsert) UpdateFiatAmount() *ChargeUsageBasedRunPaymentUpsert {
+	u.SetExcluded(chargeusagebasedrunpayment.FieldFiatAmount)
 	return u
 }
 
@@ -740,17 +740,17 @@ func (u *ChargeUsageBasedRunPaymentUpsertOne) UpdateStatus() *ChargeUsageBasedRu
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeUsageBasedRunPaymentUpsertOne) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsertOne {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeUsageBasedRunPaymentUpsertOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunPaymentUpsertOne) UpdateAmount() *ChargeUsageBasedRunPaymentUpsertOne {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunPaymentUpsertOne) UpdateFiatAmount() *ChargeUsageBasedRunPaymentUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 
@@ -1166,17 +1166,17 @@ func (u *ChargeUsageBasedRunPaymentUpsertBulk) UpdateStatus() *ChargeUsageBasedR
 	})
 }
 
-// SetAmount sets the "amount" field.
-func (u *ChargeUsageBasedRunPaymentUpsertBulk) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsertBulk {
+// SetFiatAmount sets the "fiat_amount" field.
+func (u *ChargeUsageBasedRunPaymentUpsertBulk) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunPaymentUpsert) {
-		s.SetAmount(v)
+		s.SetFiatAmount(v)
 	})
 }
 
-// UpdateAmount sets the "amount" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunPaymentUpsertBulk) UpdateAmount() *ChargeUsageBasedRunPaymentUpsertBulk {
+// UpdateFiatAmount sets the "fiat_amount" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunPaymentUpsertBulk) UpdateFiatAmount() *ChargeUsageBasedRunPaymentUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunPaymentUpsert) {
-		s.UpdateAmount()
+		s.UpdateFiatAmount()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedrunpayment_update.go
+++ b/openmeter/ent/db/chargeusagebasedrunpayment_update.go
@@ -73,16 +73,16 @@ func (_u *ChargeUsageBasedRunPaymentUpdate) SetNillableStatus(v *payment.Status)
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeUsageBasedRunPaymentUpdate) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdate {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeUsageBasedRunPaymentUpdate) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdate {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunPaymentUpdate) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdate {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunPaymentUpdate) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdate {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -290,8 +290,8 @@ func (_u *ChargeUsageBasedRunPaymentUpdate) sqlSave(ctx context.Context) (_node 
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargeusagebasedrunpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargeusagebasedrunpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeusagebasedrunpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedrunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)
@@ -394,16 +394,16 @@ func (_u *ChargeUsageBasedRunPaymentUpdateOne) SetNillableStatus(v *payment.Stat
 	return _u
 }
 
-// SetAmount sets the "amount" field.
-func (_u *ChargeUsageBasedRunPaymentUpdateOne) SetAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdateOne {
-	_u.mutation.SetAmount(v)
+// SetFiatAmount sets the "fiat_amount" field.
+func (_u *ChargeUsageBasedRunPaymentUpdateOne) SetFiatAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdateOne {
+	_u.mutation.SetFiatAmount(v)
 	return _u
 }
 
-// SetNillableAmount sets the "amount" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunPaymentUpdateOne) SetNillableAmount(v *alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdateOne {
+// SetNillableFiatAmount sets the "fiat_amount" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunPaymentUpdateOne) SetNillableFiatAmount(v *alpacadecimal.Decimal) *ChargeUsageBasedRunPaymentUpdateOne {
 	if v != nil {
-		_u.SetAmount(*v)
+		_u.SetFiatAmount(*v)
 	}
 	return _u
 }
@@ -641,8 +641,8 @@ func (_u *ChargeUsageBasedRunPaymentUpdateOne) sqlSave(ctx context.Context) (_no
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(chargeusagebasedrunpayment.FieldStatus, field.TypeEnum, value)
 	}
-	if value, ok := _u.mutation.Amount(); ok {
-		_spec.SetField(chargeusagebasedrunpayment.FieldAmount, field.TypeOther, value)
+	if value, ok := _u.mutation.FiatAmount(); ok {
+		_spec.SetField(chargeusagebasedrunpayment.FieldFiatAmount, field.TypeOther, value)
 	}
 	if value, ok := _u.mutation.AuthorizedTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedrunpayment.FieldAuthorizedTransactionGroupID, field.TypeString, value)

--- a/openmeter/ent/db/entmixinaccessor.go
+++ b/openmeter/ent/db/entmixinaccessor.go
@@ -1186,8 +1186,8 @@ func (e *ChargeCreditPurchaseExternalPayment) GetStatus() payment.Status {
 	return e.Status
 }
 
-func (e *ChargeCreditPurchaseExternalPayment) GetAmount() alpacadecimal.Decimal {
-	return e.Amount
+func (e *ChargeCreditPurchaseExternalPayment) GetFiatAmount() alpacadecimal.Decimal {
+	return e.FiatAmount
 }
 
 func (e *ChargeCreditPurchaseExternalPayment) GetAuthorizedTransactionGroupID() *string {
@@ -1250,8 +1250,8 @@ func (e *ChargeCreditPurchaseInvoicedPayment) GetStatus() payment.Status {
 	return e.Status
 }
 
-func (e *ChargeCreditPurchaseInvoicedPayment) GetAmount() alpacadecimal.Decimal {
-	return e.Amount
+func (e *ChargeCreditPurchaseInvoicedPayment) GetFiatAmount() alpacadecimal.Decimal {
+	return e.FiatAmount
 }
 
 func (e *ChargeCreditPurchaseInvoicedPayment) GetAuthorizedTransactionGroupID() *string {
@@ -1770,8 +1770,8 @@ func (e *ChargeFlatFeeRunPayment) GetStatus() payment.Status {
 	return e.Status
 }
 
-func (e *ChargeFlatFeeRunPayment) GetAmount() alpacadecimal.Decimal {
-	return e.Amount
+func (e *ChargeFlatFeeRunPayment) GetFiatAmount() alpacadecimal.Decimal {
+	return e.FiatAmount
 }
 
 func (e *ChargeFlatFeeRunPayment) GetAuthorizedTransactionGroupID() *string {
@@ -2238,8 +2238,8 @@ func (e *ChargeUsageBasedRunPayment) GetStatus() payment.Status {
 	return e.Status
 }
 
-func (e *ChargeUsageBasedRunPayment) GetAmount() alpacadecimal.Decimal {
-	return e.Amount
+func (e *ChargeUsageBasedRunPayment) GetFiatAmount() alpacadecimal.Decimal {
+	return e.FiatAmount
 }
 
 func (e *ChargeUsageBasedRunPayment) GetAuthorizedTransactionGroupID() *string {

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -719,7 +719,7 @@ func (e *usageBasedHandlerTestEnv) newRunWithAuthorizedPaymentAndInvoiceUsage(li
 			Base: payment.Base{
 				ServicePeriod: run.InvoiceUsage.ServicePeriod,
 				Status:        payment.StatusAuthorized,
-				Amount:        paymentAmount,
+				FiatAmount:    paymentAmount,
 				Authorized: &ledgertransaction.TimedGroupReference{
 					GroupReference: ledgertransaction.GroupReference{
 						TransactionGroupID: "authorized-group",

--- a/tools/migrate/migrations/20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql
+++ b/tools/migrate/migrations/20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql
@@ -1,0 +1,59 @@
+-- Repair invoiced credit-purchase payments that stored the purchased credit amount
+-- instead of the final fiat total of their standard invoice line.
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM charge_credit_purchase_invoiced_payments p
+    LEFT JOIN billing_invoice_lines l
+      ON l.id = p.line_id
+    WHERE l.id IS NULL
+      OR l.namespace IS DISTINCT FROM p.namespace
+      OR l.invoice_id IS DISTINCT FROM p.invoice_id
+  ) THEN
+    RAISE EXCEPTION 'cannot backfill credit-purchase invoice payments with mismatched invoice-line references';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM charge_credit_purchase_invoiced_payments p
+    JOIN billing_invoice_lines l
+      ON l.id = p.line_id
+     AND l.namespace = p.namespace
+     AND l.invoice_id = p.invoice_id
+    WHERE l.total <= 0
+  ) THEN
+    RAISE EXCEPTION 'cannot backfill credit-purchase invoice payments from non-positive invoice-line totals';
+  END IF;
+END
+$$;
+
+UPDATE charge_credit_purchase_invoiced_payments p
+SET
+  amount = l.total,
+  updated_at = now()
+FROM billing_invoice_lines l
+WHERE l.id = p.line_id
+  AND l.namespace = p.namespace
+  AND l.invoice_id = p.invoice_id
+  AND p.amount IS DISTINCT FROM l.total;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM charge_credit_purchase_invoiced_payments p
+    JOIN billing_invoice_lines l
+      ON l.id = p.line_id
+     AND l.namespace = p.namespace
+     AND l.invoice_id = p.invoice_id
+    WHERE p.amount IS DISTINCT FROM l.total
+  ) THEN
+    RAISE EXCEPTION 'credit-purchase invoice payment fiat amount backfill is incomplete';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/tools/migrate/migrations/20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql
+++ b/tools/migrate/migrations/20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql
@@ -23,9 +23,9 @@ BEGIN
       ON l.id = p.line_id
      AND l.namespace = p.namespace
      AND l.invoice_id = p.invoice_id
-    WHERE l.total <= 0
+    WHERE l.total < 0
   ) THEN
-    RAISE EXCEPTION 'cannot backfill credit-purchase invoice payments from non-positive invoice-line totals';
+    RAISE EXCEPTION 'cannot backfill credit-purchase invoice payments from negative invoice-line totals';
   END IF;
 END
 $$;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:eruJ4NCdirj6K6npl5WW0YbJ6jj03gp0eldeQo2A6hQ=
+h1:1axDZMRP46xQM46SB/jAziKIFQ9F+I/7fZSS4U1f+pM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -242,3 +242,4 @@ h1:eruJ4NCdirj6K6npl5WW0YbJ6jj03gp0eldeQo2A6hQ=
 20260720093016_charges-custom-currencies.up.sql h1:U9K4UDDHwNCCqcAQ3n9HFTXaibsm66KPebSa/7XB2OE=
 20260721140844_deprecate_detailed_line_currency.up.sql h1:wG5tChhpzGEfeXdAVvpYmLzxKnmqPcACAYvcSdH9sJ0=
 20260722145858_add_charge_cost_basis.up.sql h1:fkgfCOoDlg9XsWATSRmBXUywHwTiUfq9FAmRQ0mNGHw=
+20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql h1:IZNa0ZFMau3ruvWQ4TaGT/cKeyeE/QdpsVY+9/mKivs=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1axDZMRP46xQM46SB/jAziKIFQ9F+I/7fZSS4U1f+pM=
+h1:H3bk/UtzIVOtrA6G0DoHGgYbhQrfDdLaXCVk6JDd+Tw=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -242,4 +242,4 @@ h1:1axDZMRP46xQM46SB/jAziKIFQ9F+I/7fZSS4U1f+pM=
 20260720093016_charges-custom-currencies.up.sql h1:U9K4UDDHwNCCqcAQ3n9HFTXaibsm66KPebSa/7XB2OE=
 20260721140844_deprecate_detailed_line_currency.up.sql h1:wG5tChhpzGEfeXdAVvpYmLzxKnmqPcACAYvcSdH9sJ0=
 20260722145858_add_charge_cost_basis.up.sql h1:fkgfCOoDlg9XsWATSRmBXUywHwTiUfq9FAmRQ0mNGHw=
-20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql h1:IZNa0ZFMau3ruvWQ4TaGT/cKeyeE/QdpsVY+9/mKivs=
+20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql h1:LtvTl3P0Hco9fZgYS29v8Gk4lGSZJ2k+/6Z14qLN+QM=


### PR DESCRIPTION
## Summary

- make charge payment amounts explicitly represent fiat amounts while preserving the existing database column
- persist the final invoice-line total for invoiced credit purchases
- derive external credit-purchase fiat amounts from cost basis using the settlement currency precision
- backfill existing invoiced credit-purchase payment rows from their invoice-line totals
- cover invoiced and external credit purchases in the ledger-backed integration suite

## Testing

- nix develop --impure .#ci -c make lint-go-fast
- nix develop --impure .#ci -c make test-nocache (6321 passed, 9 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Payment settlements now consistently store and surface the correct fiat amount across credit purchases, flat-fee charges, and usage-based billing.
  - External credit-purchase payments are now authorized/settled using a currency-rounded fiat amount.
  - Invoice payment and external payment records now reconcile to the same line totals.

- **Data Updates**
  - Added a migration to backfill and validate existing credit-purchase invoiced payment amounts so they match their corresponding invoice line totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects persisted payment amounts to represent fiat value consistently.
- Renames the payment model and generated Ent field from `Amount` to `FiatAmount` while retaining the existing database column.
- Persists invoice-line totals for invoiced credit purchases and cost-basis-derived, currency-rounded totals for external purchases.
- Backfills existing invoiced credit-purchase payments and expands integration coverage for invoiced and external settlement paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no blocking failures remaining from the reviewed follow-up threads.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/creditpurchase/service/invoice.go | Persists the finalized invoice-line total as the invoiced credit-purchase fiat amount. |
| openmeter/billing/charges/creditpurchase/service/realizations/service.go | Derives external-payment fiat amounts from credit quantity and cost basis, rounded to settlement-currency precision. |
| openmeter/billing/charges/models/payment/models.go | Makes the payment amount's fiat semantics explicit in the domain model and validation. |
| openmeter/billing/charges/models/payment/mixin.go | Maps the renamed Ent field to the existing physical `amount` database column. |
| tools/migrate/migrations/20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql | Validates invoice-line references and backfills invoiced credit-purchase payment amounts from line totals. |

<sub>Reviews (2): Last reviewed commit: ["fix(charges): address payment review fee..."](https://github.com/openmeterio/openmeter/commit/2d2fec979987486c539989438343320ccd716bf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46946972)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)

<!-- /greptile_comment -->