### PR TITLE
fix: wire CreateDefaultBillingProfile through on v1 marketplace app install

### DIFF
--- a/api/v3/handlers/apps/install_app.go
+++ b/api/v3/handlers/apps/install_app.go
@@ -11,8 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/api/v3/apierrors"
 	"github.com/openmeterio/openmeter/api/v3/request"
 	"github.com/openmeterio/openmeter/openmeter/app"
-	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
-	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/app/billingprofile"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 )
@@ -112,8 +111,10 @@ func (h *handler) InstallApp() InstallAppHandler {
 			}
 		},
 		func(ctx context.Context, request InstallAppRequest) (InstallAppResponse, error) {
-			// make h.createBillingProfile transactional
-			request.CreateDefaultBillingProfileFn = h.createBillingProfile
+			// make the billing profile provisioning transactional
+			request.CreateDefaultBillingProfileFn = func(ctx context.Context, installedApp app.App) ([]app.CapabilityType, error) {
+				return billingprofile.CreateDefault(ctx, h.billingService, h.stripeAppService, installedApp)
+			}
 
 			resp, err := h.appService.InstallApp(ctx, request)
 			if err != nil {
@@ -144,84 +145,4 @@ func (h *handler) InstallApp() InstallAppHandler {
 			httptransport.WithErrorEncoder(apierrors.GenericErrorEncoder()),
 		)...,
 	)
-}
-
-// createBillingProfile creates a default billing profile for the installed app based on its type
-func (h *handler) createBillingProfile(ctx context.Context, installedApp app.App) ([]app.CapabilityType, error) {
-	switch installedApp.GetType() {
-	case app.AppTypeStripe:
-		return h.makeStripeDefaultBillingApp(ctx, installedApp)
-	case app.AppTypeSandbox:
-		namespace := installedApp.GetID().Namespace
-		if err := h.billingService.ProvisionDefaultBillingProfile(ctx, namespace); err != nil {
-			return nil, fmt.Errorf("provision default billing profile: %w", err)
-		}
-		return []app.CapabilityType{
-			app.CapabilityTypeCalculateTax,
-			app.CapabilityTypeInvoiceCustomers,
-			app.CapabilityTypeCollectPayments,
-		}, nil
-	case app.AppTypeCustomInvoicing:
-		// TODO: Implement custom invoicing billing profile creation
-		return nil, nil
-	default:
-		return nil, fmt.Errorf("unknown app type: %s", installedApp.GetType())
-	}
-}
-
-// Make Stripe app the default billing app if current one is Sandbox app
-func (h *handler) makeStripeDefaultBillingApp(ctx context.Context, stripeApp app.App) ([]app.CapabilityType, error) {
-	defaultForCapabilityTypes := []app.CapabilityType{}
-
-	appID := stripeApp.GetID()
-
-	// Check if it's a Stripe app
-	if stripeApp.GetType() != app.AppTypeStripe {
-		return defaultForCapabilityTypes, fmt.Errorf("app is not a stripe app: %s", appID.ID)
-	}
-
-	// Check if the default billing profile is a sandbox app type
-	defaultBillingProfile, err := h.billingService.GetDefaultProfile(ctx, billing.GetDefaultProfileInput{
-		Namespace: appID.Namespace,
-	})
-	if err != nil {
-		return defaultForCapabilityTypes, fmt.Errorf("failed to get default billing profile: %w", err)
-	}
-
-	// Set default billing profile if the current default is the sandbox
-	setDefaultBillingProfile := defaultBillingProfile != nil && defaultBillingProfile.Apps != nil && defaultBillingProfile.Apps.Invoicing.GetType() == app.AppTypeSandbox
-
-	// Get supplier contract from stripe app
-	supplierContract, err := h.stripeAppService.GetSupplierContact(ctx, appstripe.GetSupplierContactInput{
-		AppID: appID,
-	})
-	if err != nil {
-		return defaultForCapabilityTypes, fmt.Errorf("failed to get supplier contract for stripe app %s: %w", appID.ID, err)
-	}
-
-	// Create new default billing profile
-	_, err = h.billingService.CreateProfile(ctx, billing.CreateProfileInput{
-		Namespace:      appID.Namespace,
-		Name:           "Stripe Billing Profile",
-		Description:    lo.ToPtr("Stripe Billing Profile, created automatically"),
-		Default:        setDefaultBillingProfile,
-		Supplier:       supplierContract,
-		WorkflowConfig: billing.DefaultWorkflowConfig,
-		Apps: billing.ProfileAppReferences{
-			Tax:       appID,
-			Invoicing: appID,
-			Payment:   appID,
-		},
-	})
-	if err != nil {
-		return defaultForCapabilityTypes, fmt.Errorf("failed to create billing profile for stripe app %s: %w", appID.ID, err)
-	}
-
-	defaultForCapabilityTypes = []app.CapabilityType{
-		app.CapabilityTypeCalculateTax,
-		app.CapabilityTypeInvoiceCustomers,
-		app.CapabilityTypeCollectPayments,
-	}
-
-	return defaultForCapabilityTypes, nil
 }

--- a/app/billingprofile/provision.go
+++ b/app/billingprofile/provision.go
@@ -1,0 +1,98 @@
+// Package billingprofile provisions the default billing profile created when an app
+// is installed with CreateDefaultBillingProfile set. It is shared by every HTTP driver
+// that installs apps (currently the v1 marketplace endpoints and the v3 apps endpoint)
+// so the provisioning rules stay identical across API versions.
+package billingprofile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+// CreateDefault creates a default billing profile for the installed app based on its type.
+// Assign it to app.InstallAppV3Input.CreateDefaultBillingProfileFn (bound to concrete
+// billingService/stripeAppService instances) to enable CreateDefaultBillingProfile.
+func CreateDefault(ctx context.Context, billingService billing.Service, stripeAppService appstripe.Service, installedApp app.App) ([]app.CapabilityType, error) {
+	switch installedApp.GetType() {
+	case app.AppTypeStripe:
+		return makeStripeDefaultBillingApp(ctx, billingService, stripeAppService, installedApp)
+	case app.AppTypeSandbox:
+		namespace := installedApp.GetID().Namespace
+		if err := billingService.ProvisionDefaultBillingProfile(ctx, namespace); err != nil {
+			return nil, fmt.Errorf("provision default billing profile: %w", err)
+		}
+		return []app.CapabilityType{
+			app.CapabilityTypeCalculateTax,
+			app.CapabilityTypeInvoiceCustomers,
+			app.CapabilityTypeCollectPayments,
+		}, nil
+	case app.AppTypeCustomInvoicing:
+		// TODO: Implement custom invoicing billing profile creation
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown app type: %s", installedApp.GetType())
+	}
+}
+
+// Make Stripe app the default billing app if current one is Sandbox app
+func makeStripeDefaultBillingApp(ctx context.Context, billingService billing.Service, stripeAppService appstripe.Service, stripeApp app.App) ([]app.CapabilityType, error) {
+	defaultForCapabilityTypes := []app.CapabilityType{}
+
+	appID := stripeApp.GetID()
+
+	// Check if it's a Stripe app
+	if stripeApp.GetType() != app.AppTypeStripe {
+		return defaultForCapabilityTypes, fmt.Errorf("app is not a stripe app: %s", appID.ID)
+	}
+
+	// Check if the default billing profile is a sandbox app type
+	defaultBillingProfile, err := billingService.GetDefaultProfile(ctx, billing.GetDefaultProfileInput{
+		Namespace: appID.Namespace,
+	})
+	if err != nil {
+		return defaultForCapabilityTypes, fmt.Errorf("failed to get default billing profile: %w", err)
+	}
+
+	// Set default billing profile if the current default is the sandbox
+	setDefaultBillingProfile := defaultBillingProfile != nil && defaultBillingProfile.Apps != nil && defaultBillingProfile.Apps.Invoicing.GetType() == app.AppTypeSandbox
+
+	// Get supplier contract from stripe app
+	supplierContract, err := stripeAppService.GetSupplierContact(ctx, appstripe.GetSupplierContactInput{
+		AppID: appID,
+	})
+	if err != nil {
+		return defaultForCapabilityTypes, fmt.Errorf("failed to get supplier contract for stripe app %s: %w", appID.ID, err)
+	}
+
+	// Create new default billing profile
+	_, err = billingService.CreateProfile(ctx, billing.CreateProfileInput{
+		Namespace:      appID.Namespace,
+		Name:           "Stripe Billing Profile",
+		Description:    lo.ToPtr("Stripe Billing Profile, created automatically"),
+		Default:        setDefaultBillingProfile,
+		Supplier:       supplierContract,
+		WorkflowConfig: billing.DefaultWorkflowConfig,
+		Apps: billing.ProfileAppReferences{
+			Tax:       appID,
+			Invoicing: appID,
+			Payment:   appID,
+		},
+	})
+	if err != nil {
+		return defaultForCapabilityTypes, fmt.Errorf("failed to create billing profile for stripe app %s: %w", appID.ID, err)
+	}
+
+	defaultForCapabilityTypes = []app.CapabilityType{
+		app.CapabilityTypeCalculateTax,
+		app.CapabilityTypeInvoiceCustomers,
+		app.CapabilityTypeCollectPayments,
+	}
+
+	return defaultForCapabilityTypes, nil
+}

--- a/openmeter/app/httpdriver/marketplace.go
+++ b/openmeter/app/httpdriver/marketplace.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/app/billingprofile"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -94,7 +95,6 @@ type (
 
 type MarketplaceAppAPIKeyInstallRequest struct {
 	app.InstallAppV3Input
-	CreateBillingProfile bool
 }
 
 // MarketplaceAppAPIKeyInstall returns a handler for installing an app type with an API key
@@ -114,12 +114,12 @@ func (h *handler) MarketplaceAppAPIKeyInstall() MarketplaceAppAPIKeyInstallHandl
 
 			req := MarketplaceAppAPIKeyInstallRequest{
 				InstallAppV3Input: app.InstallAppV3Input{
-					MarketplaceListingID: app.MarketplaceListingID{Type: app.AppType(appType)},
-					Namespace:            namespace,
-					Name:                 lo.FromPtr(body.Name),
-					APIKey:               lo.ToPtr(body.ApiKey),
+					MarketplaceListingID:        app.MarketplaceListingID{Type: app.AppType(appType)},
+					Namespace:                   namespace,
+					Name:                        lo.FromPtr(body.Name),
+					APIKey:                      lo.ToPtr(body.ApiKey),
+					CreateDefaultBillingProfile: lo.FromPtrOr(body.CreateBillingProfile, true),
 				},
-				CreateBillingProfile: lo.FromPtrOr(body.CreateBillingProfile, true),
 			}
 
 			return req, nil
@@ -127,6 +127,11 @@ func (h *handler) MarketplaceAppAPIKeyInstall() MarketplaceAppAPIKeyInstallHandl
 		func(ctx context.Context, request MarketplaceAppAPIKeyInstallRequest) (MarketplaceAppAPIKeyInstallResponse, error) {
 			resp := MarketplaceAppAPIKeyInstallResponse{
 				DefaultForCapabilityTypes: []api.AppCapabilityType{},
+			}
+
+			// make the billing profile provisioning transactional
+			request.CreateDefaultBillingProfileFn = func(ctx context.Context, installedApp app.App) ([]app.CapabilityType, error) {
+				return billingprofile.CreateDefault(ctx, h.billingService, h.stripeAppService, installedApp)
 			}
 
 			// Install app
@@ -163,7 +168,6 @@ type (
 
 type MarketplaceAppInstallRequest struct {
 	app.InstallAppV3Input
-	CreateBillingProfile bool
 }
 
 // MarketplaceAppInstall returns a handler for installing an app type
@@ -183,11 +187,11 @@ func (h *handler) MarketplaceAppInstall() MarketplaceAppInstallHandler {
 
 			req := MarketplaceAppInstallRequest{
 				InstallAppV3Input: app.InstallAppV3Input{
-					MarketplaceListingID: app.MarketplaceListingID{Type: app.AppType(appType)},
-					Namespace:            namespace,
-					Name:                 lo.FromPtr(body.Name),
+					MarketplaceListingID:        app.MarketplaceListingID{Type: app.AppType(appType)},
+					Namespace:                   namespace,
+					Name:                        lo.FromPtr(body.Name),
+					CreateDefaultBillingProfile: lo.FromPtrOr(body.CreateBillingProfile, true),
 				},
-				CreateBillingProfile: lo.FromPtrOr(body.CreateBillingProfile, true),
 			}
 
 			return req, nil
@@ -195,6 +199,11 @@ func (h *handler) MarketplaceAppInstall() MarketplaceAppInstallHandler {
 		func(ctx context.Context, request MarketplaceAppInstallRequest) (MarketplaceAppInstallResponse, error) {
 			resp := MarketplaceAppInstallResponse{
 				DefaultForCapabilityTypes: []api.AppCapabilityType{},
+			}
+
+			// make the billing profile provisioning transactional
+			request.CreateDefaultBillingProfileFn = func(ctx context.Context, installedApp app.App) ([]app.CapabilityType, error) {
+				return billingprofile.CreateDefault(ctx, h.billingService, h.stripeAppService, installedApp)
 			}
 
 			// Install app


### PR DESCRIPTION
POST /api/v1/marketplace/listings/{type}/install (and the API-key variant) accepted a createBillingProfile flag but silently ignored it — the flag was decoded into a dead field on the HTTP request wrapper struct instead of InstallAppV3Input.CreateDefaultBillingProfile, and CreateDefaultBillingProfileFn was never set at all, so no billing profile was ever provisioned regardless of the flag's value.

Changes:

Extracted the billing-profile provisioning logic (createBillingProfile/makeStripeDefaultBillingApp) out of api/v3/handlers/apps/install_app.go into a new shared package, openmeter/app/billingprofile, so both the v1 and v3 install handlers use identical provisioning behavior instead of duplicating it.
Fixed openmeter/app/httpdriver/marketplace.go (MarketplaceAppInstall and MarketplaceAppAPIKeyInstall) to set CreateDefaultBillingProfile on InstallAppV3Input and wire CreateDefaultBillingProfileFn via the new shared package, matching the v3 handler's pattern.
Removed the now-redundant CreateBillingProfile field from the v1 request wrapper structs.
No API contract changes — this only fixes existing, already-documented request/response behavior that wasn't functioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly installed apps can now receive an appropriate default billing profile automatically.
  * Default billing setup supports Stripe and Sandbox apps, including tax, invoicing, and payment capabilities.
  * Marketplace installations use the default billing profile option, enabled by default when omitted.

* **Bug Fixes**
  * Billing profile creation is now handled consistently as part of app installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR connects the existing create-billing-profile option to marketplace app installation.
- Extracts billing-profile provisioning into a shared package.
- Uses the shared provisioning callback from the v1 marketplace and v3 app-install handlers.
- Passes the v1 createBillingProfile request value into InstallAppV3Input.

<h3>Confidence Score: 1/5</h3>

The PR is not safe to merge because both changed handlers import the new provisioning package from a path that does not exist, preventing the server from compiling.

The module layout makes app/billingprofile available as github.com/openmeterio/openmeter/app/billingprofile, but both server handler packages reference github.com/openmeterio/openmeter/openmeter/app/billingprofile.

**Files Needing Attention:** api/v3/handlers/apps/install_app.go, openmeter/app/httpdriver/marketplace.go, and app/billingprofile/provision.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/handlers/apps/install_app.go | Replaces local provisioning methods with the shared helper, but imports that helper from a nonexistent package path. |
| app/billingprofile/provision.go | Mechanically extracts the existing Stripe, Sandbox, and custom-invoicing provisioning behavior, but its filesystem location does not match callers' imports. |
| openmeter/app/httpdriver/marketplace.go | Correctly propagates the request flag and callback, but its new billingprofile import prevents compilation. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as Install handler
    participant Apps as App service
    participant Profile as Billing profile provisioning
    Client->>Handler: Install app (createBillingProfile)
    Handler->>Apps: InstallAppV3Input + callback
    Apps->>Apps: Install app in transaction
    alt CreateDefaultBillingProfile
        Apps->>Profile: CreateDefault(installed app)
        Profile-->>Apps: Default capabilities
    end
    Apps-->>Handler: Installed app
    Handler-->>Client: Install response
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapi%2Fv3%2Fhandlers%2Fapps%2Finstall_app.go%3A14%0A**Broken%20billingprofile%20import%20path**%0A%0AWhen%20building%20the%20server%2C%20this%20import%20resolves%20to%20%60openmeter%2Fapp%2Fbillingprofile%60%2C%20but%20the%20new%20package%20was%20added%20at%20%60app%2Fbillingprofile%60.%20Because%20that%20imported%20package%20does%20not%20exist%20under%20the%20module%20layout%2C%20both%20changed%20handlers%20fail%20to%20compile.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4782&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22sandbox-fix%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sandbox-fix%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapi%2Fv3%2Fhandlers%2Fapps%2Finstall_app.go%3A14%0A**Broken%20billingprofile%20import%20path**%0A%0AWhen%20building%20the%20server%2C%20this%20import%20resolves%20to%20%60openmeter%2Fapp%2Fbillingprofile%60%2C%20but%20the%20new%20package%20was%20added%20at%20%60app%2Fbillingprofile%60.%20Because%20that%20imported%20package%20does%20not%20exist%20under%20the%20module%20layout%2C%20both%20changed%20handlers%20fail%20to%20compile.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4782&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
api/v3/handlers/apps/install_app.go:14
**Broken billingprofile import path**

When building the server, this import resolves to `openmeter/app/billingprofile`, but the new package was added at `app/billingprofile`. Because that imported package does not exist under the module layout, both changed handlers fail to compile.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add CreateDefaultBillingProfile to insta..."](https://github.com/openmeterio/openmeter/commit/2bc969b9bae063dcab1b5697de69b3b42784fb71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47355655)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->