### PR TITLE
refactor(flatfee): split invoice realization and run realization

### DIFF
--- a/openmeter/billing/charges/flatfee/charge_test.go
+++ b/openmeter/billing/charges/flatfee/charge_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
@@ -15,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -130,6 +132,46 @@ func TestOverridableIntentPreservesCostBasis(t *testing.T) {
 		FiatCurrency: newFiatCurrency(t, "EUR"),
 	})
 	requireManualCostBasisIntent(t, overridable.GetCostBasisIntent())
+}
+
+func TestChargeGetRateableIntentUsesEffectiveIntent(t *testing.T) {
+	intent := newValidIntent(t, currenciestestutils.NewFiatCurrency(t, "USD"), productcatalog.CreditThenInvoiceSettlementMode)
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC),
+	}
+	override := intent.IntentMutableFields.Clone()
+	override.Name = "overridden flat fee"
+	override.ServicePeriod = servicePeriod
+	override.AmountBeforeProration = alpacadecimal.NewFromFloat(42.123)
+	override.PercentageDiscounts = &billing.PercentageDiscount{
+		PercentageDiscount: productcatalog.PercentageDiscount{
+			Percentage: models.NewPercentage(10),
+		},
+		CorrelationID: "discount-1",
+	}
+
+	charge := Charge{
+		ChargeBase: ChargeBase{
+			Intent: NewOverridableIntent(intent, &override),
+		},
+	}
+
+	rateableIntent, err := charge.GetRateableIntent()
+	require.NoError(t, err)
+	require.Equal(t, "overridden flat fee", rateableIntent.Name)
+	require.Equal(t, servicePeriod, rateableIntent.ServicePeriod)
+	require.Equal(t, float64(42.12), rateableIntent.AmountAfterProration.InexactFloat64())
+	require.Equal(t, "discount-1", rateableIntent.PercentageDiscounts.CorrelationID)
+
+	firstPrice := rateableIntent.GetPrice()
+	secondPrice := rateableIntent.GetPrice()
+	require.NotSame(t, firstPrice, secondPrice)
+
+	discounts := rateableIntent.GetRateCardDiscounts()
+	require.NotNil(t, discounts.Percentage)
+	discounts.Percentage.CorrelationID = "mutated"
+	require.Equal(t, "discount-1", rateableIntent.PercentageDiscounts.CorrelationID)
 }
 
 func newCustomCurrency(t testing.TB) currencies.Currency {

--- a/openmeter/billing/charges/flatfee/detailedline.go
+++ b/openmeter/billing/charges/flatfee/detailedline.go
@@ -1,33 +1,33 @@
 package flatfee
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type DetailedLine = stddetailedline.Base
 
-type DetailedLines []DetailedLine
+type DetailedLines = stddetailedline.Bases
 
-func (l DetailedLines) Clone() DetailedLines {
-	return lo.Map(l, func(dl DetailedLine, _ int) DetailedLine {
-		return dl.Clone()
-	})
-}
-
-func (l DetailedLines) Validate() error {
-	var errs []error
-
-	for idx, line := range l {
-		if err := line.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("[%d]: %w", idx, err))
+func NewDetailedLinesFromRating(defaultServicePeriod timeutil.ClosedPeriod, lines billingrating.DetailedLines) DetailedLines {
+	return lo.Map(lines, func(line billingrating.DetailedLine, idx int) DetailedLine {
+		return DetailedLine{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Name: line.Name,
+			}),
+			Category:               lo.CoalesceOrEmpty(line.Category, stddetailedline.CategoryRegular),
+			ChildUniqueReferenceID: line.ChildUniqueReferenceID,
+			Index:                  lo.ToPtr(idx),
+			PaymentTerm:            lo.CoalesceOrEmpty(line.PaymentTerm, productcatalog.InArrearsPaymentTerm),
+			ServicePeriod:          lo.FromPtrOr(line.Period, defaultServicePeriod),
+			PerUnitAmount:          line.PerUnitAmount,
+			Quantity:               line.Quantity,
+			Totals:                 line.Totals,
 		}
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
+	})
 }

--- a/openmeter/billing/charges/flatfee/rating.go
+++ b/openmeter/billing/charges/flatfee/rating.go
@@ -1,0 +1,136 @@
+package flatfee
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/alpacahq/alpacadecimal"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+var _ billingrating.StandardLineAccessor = (*RateableIntent)(nil)
+
+// RateableIntent is the effective charge intent for one flat-fee realization
+// period. It keeps charge valuation independent from the invoice line that may
+// eventually represent the realized amount.
+type RateableIntent struct {
+	Intent
+
+	AmountAfterProration alpacadecimal.Decimal
+}
+
+func (r RateableIntent) Validate() error {
+	var errs []error
+
+	if err := r.Intent.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("intent: %w", err))
+	}
+
+	if r.AmountAfterProration.IsNegative() {
+		errs = append(errs, errors.New("amount after proration cannot be negative"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// GetRateableIntent returns the normalized effective intent used for rating.
+// The effective intent is the sole source of both the realized service period
+// and the full period used as the proration reference.
+func (c Charge) GetRateableIntent() (RateableIntent, error) {
+	intent := c.Intent.GetEffectiveIntent()
+	intent = intent.Normalized()
+
+	if err := intent.Validate(); err != nil {
+		return RateableIntent{}, fmt.Errorf("validating effective intent: %w", err)
+	}
+
+	amountAfterProration, err := intent.CalculateAmountAfterProration()
+	if err != nil {
+		return RateableIntent{}, fmt.Errorf("calculating amount after proration: %w", err)
+	}
+
+	rateableIntent := RateableIntent{
+		Intent:               intent,
+		AmountAfterProration: intent.Currency.RoundToPrecision(amountAfterProration),
+	}
+	if err := rateableIntent.Validate(); err != nil {
+		return RateableIntent{}, err
+	}
+
+	return rateableIntent, nil
+}
+
+func (r RateableIntent) GetMeteredQuantity() (*alpacadecimal.Decimal, error) {
+	return nil, nil
+}
+
+func (r RateableIntent) GetMeteredPreLinePeriodQuantity() (*alpacadecimal.Decimal, error) {
+	return nil, nil
+}
+
+func (r RateableIntent) GetPrice() *productcatalog.Price {
+	return productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+		Amount:      r.AmountAfterProration,
+		PaymentTerm: r.PaymentTerm,
+	})
+}
+
+func (r RateableIntent) GetServicePeriod() timeutil.ClosedPeriod {
+	return r.ServicePeriod
+}
+
+func (r RateableIntent) GetFeatureKey() string {
+	if r.FeatureKey == nil {
+		return ""
+	}
+
+	return *r.FeatureKey
+}
+
+func (r RateableIntent) GetCurrencyCalculator() (currencyx.Currency, error) {
+	return r.Currency, nil
+}
+
+func (r RateableIntent) GetName() string {
+	return r.Name
+}
+
+func (r RateableIntent) GetRateCardDiscounts() billing.Discounts {
+	if r.PercentageDiscounts == nil {
+		return billing.Discounts{}
+	}
+
+	return billing.Discounts{
+		Percentage: r.PercentageDiscounts.CloneOrNil(),
+	}
+}
+
+func (r RateableIntent) GetUnitConfig() *productcatalog.UnitConfig {
+	return nil
+}
+
+func (r RateableIntent) GetStandardLineDiscounts() billing.StandardLineDiscounts {
+	return billing.StandardLineDiscounts{}
+}
+
+func (r RateableIntent) IsProgressivelyBilled() bool {
+	return false
+}
+
+func (r RateableIntent) GetProgressivelyBilledServicePeriod() (timeutil.ClosedPeriod, error) {
+	return r.ServicePeriod, nil
+}
+
+func (r RateableIntent) GetPreviouslyBilledAmount() (alpacadecimal.Decimal, error) {
+	return alpacadecimal.Zero, nil
+}
+
+func (r RateableIntent) GetCreditsApplied() billing.CreditsApplied {
+	return nil
+}

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -135,10 +135,11 @@ type RealizationRunBase struct {
 	Type        RealizationRunType `json:"type"`
 	InitialType RealizationRunType `json:"initialType"`
 
-	ServicePeriod             timeutil.ClosedPeriod `json:"servicePeriod"`
-	AmountAfterProration      alpacadecimal.Decimal `json:"amountAfterProration"`
-	Totals                    totals.Totals         `json:"totals"`
-	NoFiatTransactionRequired bool                  `json:"noFiatTransactionRequired"`
+	ServicePeriod        timeutil.ClosedPeriod `json:"servicePeriod"`
+	AmountAfterProration alpacadecimal.Decimal `json:"amountAfterProration"`
+	// Totals includes credit allocations and excludes taxes.
+	Totals                    totals.Totals `json:"totals"`
+	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
 	// Immutable means the backing invoice line can no longer be updated in place.
 	// When true, deleting this run requires issuing a credit note instead of mutating the invoice line.
 	Immutable bool `json:"immutable"`
@@ -210,7 +211,8 @@ type RealizationRun struct {
 	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
 	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
 	Payment            *payment.Invoiced              `json:"payment"`
-	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
+	// DetailedLines include discounts; credits are applied for credit_then_invoice but not for credit_only.
+	DetailedLines mo.Option[DetailedLines] `json:"detailedLines,omitzero"`
 }
 
 func (r RealizationRun) Validate() error {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -108,9 +108,8 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 
 			gatheringLine, err := buildFlatFeeGatheringLine(buildFlatFeeGatheringLineInput{
-				Charge:        charge,
-				ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
-				InvoiceAt:     charge.Intent.GetEffectiveInvoiceAt(),
+				Charge:    charge,
+				InvoiceAt: charge.Intent.GetEffectiveInvoiceAt(),
 			})
 			if err != nil {
 				return flatfee.ChargeWithGatheringLine{}, err
@@ -125,18 +124,13 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 }
 
 type buildFlatFeeGatheringLineInput struct {
-	Charge        flatfee.Charge
-	ServicePeriod timeutil.ClosedPeriod
-	InvoiceAt     time.Time
+	Charge    flatfee.Charge
+	InvoiceAt time.Time
 }
 
 func (i buildFlatFeeGatheringLineInput) Validate() error {
 	if err := i.Charge.Validate(); err != nil {
 		return fmt.Errorf("charge: %w", err)
-	}
-
-	if err := i.ServicePeriod.Validate(); err != nil {
-		return fmt.Errorf("service period: %w", err)
 	}
 
 	if i.InvoiceAt.IsZero() {
@@ -156,19 +150,13 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 	}
 
 	flatFee := input.Charge
-	lineIntent := flatFee.Intent.GetEffectiveIntent()
-	lineIntent.ServicePeriod = input.ServicePeriod
-	lineIntent.InvoiceAt = input.InvoiceAt
-	lineIntent = lineIntent.Normalized()
-
-	if err := lineIntent.Validate(); err != nil {
-		return billing.GatheringLine{}, fmt.Errorf("validating line intent: %w", err)
-	}
-
-	amountAfterProration, err := lineIntent.CalculateAmountAfterProration()
+	rateableIntent, err := flatFee.GetRateableIntent()
 	if err != nil {
-		return billing.GatheringLine{}, fmt.Errorf("calculating amount after proration: %w", err)
+		return billing.GatheringLine{}, fmt.Errorf("getting rateable intent: %w", err)
 	}
+
+	lineIntent := rateableIntent.Intent
+	lineIntent.InvoiceAt = meta.NormalizeTimestamp(input.InvoiceAt)
 
 	var subscription *billing.SubscriptionReference
 	if lineIntent.Subscription != nil {
@@ -210,14 +198,7 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 			Annotations: clonedAnnotations,
 			ManagedBy:   managedBy,
 
-			Price: lo.FromPtr(
-				productcatalog.NewPriceFrom(
-					productcatalog.FlatPrice{
-						Amount:      amountAfterProration,
-						PaymentTerm: lineIntent.PaymentTerm,
-					},
-				),
-			),
+			Price:      lo.FromPtr(rateableIntent.GetPrice()),
 			FeatureKey: lo.FromPtr(lineIntent.FeatureKey),
 
 			Currency:      invoiceCurrency,
@@ -232,11 +213,7 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 		},
 	}
 
-	if lineIntent.PercentageDiscounts != nil {
-		gatheringLine.RateCardDiscounts = billing.Discounts{
-			Percentage: lineIntent.PercentageDiscounts.CloneOrNil(),
-		}
-	}
+	gatheringLine.RateCardDiscounts = rateableIntent.GetRateCardDiscounts()
 
 	return gatheringLine, nil
 }

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -447,9 +447,9 @@ func (s *CreditThenInvoiceStateMachine) StartRealization(ctx context.Context, in
 	}
 
 	result, err := s.Realizations.StartCreditThenInvoiceRun(ctx, flatfeerealizations.StartCreditThenInvoiceRunInput{
-		Charge:  s.Charge,
-		Line:    *input.Line,
-		Invoice: input.Invoice,
+		Charge:    s.Charge,
+		LineID:    input.Line.ID,
+		InvoiceID: input.Invoice.ID,
 	})
 	if err != nil {
 		return fmt.Errorf("start credit-then-invoice run: %w", err)
@@ -486,9 +486,8 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	}
 
 	gatheringLine, err := buildFlatFeeGatheringLine(buildFlatFeeGatheringLineInput{
-		Charge:        s.Charge,
-		ServicePeriod: s.Charge.Intent.GetEffectiveServicePeriod(),
-		InvoiceAt:     s.Charge.Intent.GetEffectiveInvoiceAt(),
+		Charge:    s.Charge,
+		InvoiceAt: s.Charge.Intent.GetEffectiveInvoiceAt(),
 	})
 	if err != nil {
 		return fmt.Errorf("creating flat-fee attach target line: %w", err)
@@ -502,9 +501,9 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	line.ID = input.Line.ID
 
 	result, err := s.Realizations.StartCreditThenInvoiceRun(ctx, flatfeerealizations.StartCreditThenInvoiceRunInput{
-		Charge:  s.Charge,
-		Line:    *line,
-		Invoice: input.Invoice,
+		Charge:    s.Charge,
+		LineID:    line.ID,
+		InvoiceID: input.Invoice.ID,
 	})
 	if err != nil {
 		return fmt.Errorf("start attached credit-then-invoice run: %w", err)
@@ -512,7 +511,10 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 
 	s.Charge.Realizations.CurrentRun = &result.Run
 
-	if err := populateFlatFeeStandardLineFromRun(line, result.Run); err != nil {
+	if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+		Charge: s.Charge,
+		Run:    result.Run,
+	}); err != nil {
 		return fmt.Errorf("mapping attached flat-fee run to standard line[%s]: %w", line.ID, err)
 	}
 
@@ -615,9 +617,8 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 	s.Charge.State.AmountAfterProration = input.NewAmountAfterProration
 
 	updatedGatheringLine, err := buildFlatFeeGatheringLine(buildFlatFeeGatheringLineInput{
-		Charge:        s.Charge,
-		ServicePeriod: input.Period,
-		InvoiceAt:     s.Charge.Intent.GetEffectiveInvoiceAt(),
+		Charge:    s.Charge,
+		InvoiceAt: s.Charge.Intent.GetEffectiveInvoiceAt(),
 	})
 	if err != nil {
 		return fmt.Errorf("creating gathering line for %s period: %w", input.Op, err)
@@ -705,15 +706,19 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		result, err := s.Realizations.ReconcileStandardLineToIntent(ctx, flatfeerealizations.ReconcileStandardLineToIntentInput{
 			Charge:     s.Charge,
 			Run:        *currentRun,
-			Line:       *line,
-			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), currentRun.ServicePeriod),
+			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), s.Charge.Intent.GetEffectiveServicePeriod()),
 		})
 		if err != nil {
 			return fmt.Errorf("reconcile standard line to intent for %s flat-fee charge[%s]: %w", input.Op, s.Charge.ID, err)
 		}
 
 		s.Charge.Realizations.CurrentRun = &result.Run
-		line = &result.Line
+		if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+			Charge: s.Charge,
+			Run:    result.Run,
+		}); err != nil {
+			return fmt.Errorf("mapping reconciled flat-fee run to standard line[%s]: %w", line.ID, err)
+		}
 
 		genericLine, err := line.AsInvoiceLine().AsGenericLine()
 		if err != nil {

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
@@ -92,17 +90,17 @@ func (s *CreditsOnlyStateMachine) AdvanceAfterBookedAt(ctx context.Context) erro
 func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 	currency := s.Charge.Intent.GetCurrency()
 
-	amount := currency.RoundToPrecision(s.Charge.State.AmountAfterProration)
-
-	if amount.IsNegative() {
-		return fmt.Errorf("charge total is negative [charge_id=%s, amount=%s]", s.Charge.ID, amount.String())
+	ratingResult, err := s.rateEffectiveIntent()
+	if err != nil {
+		return err
 	}
+	s.Charge.State.AmountAfterProration = ratingResult.Intent.AmountAfterProration
 
 	if s.Charge.Realizations.CurrentRun == nil {
 		runBase, err := s.Adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 			Charge:                    s.Charge.ChargeBase,
-			ServicePeriod:             s.Charge.Intent.GetEffectiveServicePeriod(),
-			AmountAfterProration:      amount,
+			ServicePeriod:             ratingResult.Intent.ServicePeriod,
+			AmountAfterProration:      ratingResult.Intent.AmountAfterProration,
 			NoFiatTransactionRequired: true, // We are in credits-only mode
 		})
 		if err != nil {
@@ -111,24 +109,45 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 
 		s.Charge.Realizations.CurrentRun = &flatfee.RealizationRun{
 			RealizationRunBase: runBase,
+			DetailedLines:      mo.Some(ratingResult.DetailedLines),
+		}
+
+		if err := s.Adapter.UpsertDetailedLines(ctx, runBase.ID, ratingResult.DetailedLines); err != nil {
+			return fmt.Errorf("persist credit-only detailed lines: %w", err)
 		}
 	}
 
 	if s.Charge.Realizations.CurrentRun != nil && len(s.Charge.Realizations.CurrentRun.CreditRealizations) > 0 {
-		return s.reconcileCurrentRunCredits(ctx, amount)
+		return s.reconcileCurrentRunCredits(ctx, ratingResult)
 	}
 
 	result, err := s.Realizations.AllocateCreditsOnly(ctx, flatfeerealizations.AllocateCreditsOnlyInput{
 		Charge:             s.Charge,
-		Amount:             amount,
+		Totals:             ratingResult.Totals,
 		CurrencyCalculator: currency,
 	})
 	if err != nil {
 		return fmt.Errorf("allocate credits: %w", err)
 	}
 
-	s.Charge.Realizations.CurrentRun.CreditRealizations = append(s.Charge.Realizations.CurrentRun.CreditRealizations, result.Realizations...)
+	s.Charge.Realizations.CurrentRun.RealizationRunBase = result.RunBase
+	s.Charge.Realizations.CurrentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)
+	s.Charge.Realizations.CurrentRun.CreditRealizations = append(s.Charge.Realizations.CurrentRun.CreditRealizations, result.CreditRealizations...)
 	return nil
+}
+
+func (s *CreditsOnlyStateMachine) rateEffectiveIntent() (flatfeerealizations.RateResult, error) {
+	rateableIntent, err := s.Charge.GetRateableIntent()
+	if err != nil {
+		return flatfeerealizations.RateResult{}, fmt.Errorf("getting rateable intent: %w", err)
+	}
+
+	ratingResult, err := s.Realizations.Rate(rateableIntent)
+	if err != nil {
+		return flatfeerealizations.RateResult{}, fmt.Errorf("rating flat fee: %w", err)
+	}
+
+	return ratingResult, nil
 }
 
 func (s *CreditsOnlyStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
@@ -170,20 +189,20 @@ func (s *CreditsOnlyStateMachine) applyPeriodPatch(ctx context.Context, patch pe
 
 	s.Charge.Intent = intent
 
-	amountAfterProration, err := intent.CalculateAmountAfterProration()
+	ratingResult, err := s.rateEffectiveIntent()
 	if err != nil {
-		return fmt.Errorf("calculating amount after proration: %w", err)
+		return err
 	}
-	s.Charge.State.AmountAfterProration = amountAfterProration
+	s.Charge.State.AmountAfterProration = ratingResult.Intent.AmountAfterProration
 
 	if s.Charge.Realizations.CurrentRun == nil {
 		return nil
 	}
 
-	return s.reconcileCurrentRunCredits(ctx, amountAfterProration)
+	return s.reconcileCurrentRunCredits(ctx, ratingResult)
 }
 
-func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context, amount alpacadecimal.Decimal) error {
+func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context, ratingResult flatfeerealizations.RateResult) error {
 	currentRun := s.Charge.Realizations.CurrentRun
 	if currentRun == nil {
 		return nil
@@ -191,8 +210,8 @@ func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context
 
 	currency := s.Charge.Intent.GetCurrency()
 
-	amount = currency.RoundToPrecision(amount)
-	servicePeriod := s.Charge.Intent.GetEffectiveServicePeriod()
+	creditAllocationTarget := currency.RoundToPrecision(ratingResult.Totals.Total)
+	servicePeriod := ratingResult.Intent.ServicePeriod
 	run := *currentRun
 	run.ServicePeriod = servicePeriod
 
@@ -200,7 +219,7 @@ func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context
 		Charge:             s.Charge,
 		Run:                run,
 		AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
-		TargetAmount:       amount,
+		TargetAmount:       creditAllocationTarget,
 		CurrencyCalculator: currency,
 	})
 	if err != nil {
@@ -209,15 +228,31 @@ func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context
 
 	run.CreditRealizations = append(run.CreditRealizations, reconcileResult.Realizations...)
 
+	// Given ReconcileCredits is both used for credits only and credit-then-invoice modes,
+	// we need to ensure that the allocated credits match the rated total.
+	allocated := currency.RoundToPrecision(run.CreditRealizations.Sum())
+	if !allocated.Equal(creditAllocationTarget) {
+		return fmt.Errorf(
+			"credit allocations do not match rated total [charge_id=%s total=%s allocated=%s]",
+			s.Charge.ID,
+			creditAllocationTarget.String(),
+			allocated.String(),
+		)
+	}
+
+	if err := s.Adapter.UpsertDetailedLines(ctx, run.ID, ratingResult.DetailedLines); err != nil {
+		return fmt.Errorf("persist credit-only detailed lines: %w", err)
+	}
+
+	runTotals := ratingResult.Totals
+	runTotals.CreditsTotal = currency.RoundToPrecision(runTotals.CreditsTotal.Add(allocated))
+	runTotals.Total = currency.RoundToPrecision(runTotals.Total.Sub(allocated))
+
 	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:                   run.ID,
-		ServicePeriod:        mo.Some(servicePeriod),
-		AmountAfterProration: mo.Some(amount),
-		Totals: mo.Some(totals.Totals{
-			Amount:       amount,
-			CreditsTotal: amount,
-			Total:        alpacadecimal.Zero,
-		}),
+		ID:                        run.ID,
+		ServicePeriod:             mo.Some(servicePeriod),
+		AmountAfterProration:      mo.Some(ratingResult.Intent.AmountAfterProration),
+		Totals:                    mo.Some(runTotals),
 		NoFiatTransactionRequired: mo.Some(true),
 	})
 	if err != nil {
@@ -225,6 +260,7 @@ func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context
 	}
 
 	run.RealizationRunBase = runBase
+	run.DetailedLines = mo.Some(ratingResult.DetailedLines)
 	s.Charge.Realizations.CurrentRun = &run
 	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -82,14 +82,18 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 		}
 
 		previewResult, err := e.service.realizations.BuildCreditThenInvoiceGatheringPreviewRun(flatfeerealizations.BuildCreditThenInvoiceGatheringPreviewRunInput{
-			Charge: charge,
-			Line:   *stdLine,
+			Charge:    charge,
+			LineID:    stdLine.ID,
+			InvoiceID: stdLine.InvoiceID,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("building gathering preview run for line[%s]: %w", stdLine.ID, err)
 		}
 
-		if err := populateFlatFeeStandardLineFromRun(stdLine, previewResult.Run); err != nil {
+		if err := populateFlatFeeStandardLineFromRun(stdLine, populateFlatFeeStandardLineFromRunInput{
+			Charge: charge,
+			Run:    previewResult.Run,
+		}); err != nil {
 			return nil, fmt.Errorf("populating gathering preview line[%s] from run: %w", stdLine.ID, err)
 		}
 
@@ -132,7 +136,10 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			return nil, fmt.Errorf("flat fee charge[%s]: current run is required for line[%s]", charge.ID, stdLine.ID)
 		}
 
-		if err := populateFlatFeeStandardLineFromRun(stdLine, *charge.Realizations.CurrentRun); err != nil {
+		if err := populateFlatFeeStandardLineFromRun(stdLine, populateFlatFeeStandardLineFromRunInput{
+			Charge: charge,
+			Run:    *charge.Realizations.CurrentRun,
+		}); err != nil {
 			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
 		}
 

--- a/openmeter/billing/charges/flatfee/service/linemapper.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -8,22 +9,70 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func populateFlatFeeStandardLineFromRun(stdLine *billing.StandardLine, run flatfee.RealizationRun) error {
+type populateFlatFeeStandardLineFromRunInput struct {
+	Charge flatfee.Charge
+	Run    flatfee.RealizationRun
+}
+
+func (i populateFlatFeeStandardLineFromRunInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	effectiveServicePeriod := i.Charge.Intent.GetEffectiveServicePeriod()
+	if !i.Run.ServicePeriod.Equal(effectiveServicePeriod) {
+		errs = append(errs, fmt.Errorf(
+			"run service period does not match effective intent [run_id=%s run_period=%v intent_period=%v]",
+			i.Run.ID.ID,
+			i.Run.ServicePeriod,
+			effectiveServicePeriod,
+		))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func populateFlatFeeStandardLineFromRun(stdLine *billing.StandardLine, input populateFlatFeeStandardLineFromRunInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if stdLine.UsageBased == nil {
+		return fmt.Errorf("standard line[%s]: usage based line is required", stdLine.ID)
+	}
+
+	rateableIntent, err := input.Charge.GetRateableIntent()
+	if err != nil {
+		return fmt.Errorf("getting rateable intent: %w", err)
+	}
+
+	stdLine.Name = rateableIntent.GetName()
+	stdLine.Period = rateableIntent.GetServicePeriod()
+	stdLine.UsageBased.Price = rateableIntent.GetPrice()
+	stdLine.RateCardDiscounts = rateableIntent.GetRateCardDiscounts()
+
 	currency, err := stdLine.Currency.AsFiatCurrency()
 	if err != nil {
 		return fmt.Errorf("creating currency calculator: %w", err)
 	}
 
-	creditsApplied, err := run.CreditRealizations.AsCreditsApplied()
+	creditsApplied, err := input.Run.CreditRealizations.AsCreditsApplied()
 	if err != nil {
 		return err
 	}
 
 	stdLine.CreditsApplied = creditsApplied
 
-	mappedDetailedLines, err := mapFlatFeeDetailedLines(stdLine, run)
+	mappedDetailedLines, err := mapFlatFeeDetailedLines(stdLine, input.Run)
 	if err != nil {
 		return fmt.Errorf("mapping run detailed lines: %w", err)
 	}
@@ -36,10 +85,10 @@ func populateFlatFeeStandardLineFromRun(stdLine *billing.StandardLine, run flatf
 	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(mappedDetailedLines)
 	stdLine.Totals = stdLine.DetailedLines.SumTotals().RoundToPrecision(currency)
 
-	expectedTotals := run.Totals.RoundToPrecision(currency)
+	expectedTotals := input.Run.Totals.RoundToPrecision(currency)
 	if !stdLine.Totals.Equal(expectedTotals) {
 		return fmt.Errorf("mapped line totals do not match run totals [line_id=%s run_id=%s line_total=%s run_total=%s]",
-			stdLine.ID, run.ID.ID, stdLine.Totals.Total.String(), expectedTotals.Total.String())
+			stdLine.ID, input.Run.ID.ID, stdLine.Totals.Total.String(), expectedTotals.Total.String())
 	}
 
 	return nil

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -2,6 +2,7 @@ package realizations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -22,23 +23,23 @@ type AllocateCreditsOnlyInput struct {
 }
 
 func (i AllocateCreditsOnlyInput) Validate() error {
+	var errs []error
+
 	if err := i.Charge.Validate(); err != nil {
-		return fmt.Errorf("charge: %w", err)
+		errs = append(errs, fmt.Errorf("charge: %w", err))
 	}
 
 	if err := i.Totals.Validate(); err != nil {
-		return fmt.Errorf("totals: %w", err)
+		errs = append(errs, fmt.Errorf("totals: %w", err))
 	}
 
 	if i.CurrencyCalculator == nil {
-		return fmt.Errorf("currency calculator is required")
+		errs = append(errs, errors.New("currency calculator is required"))
+	} else if err := i.CurrencyCalculator.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("currency calculator: %w", err))
 	}
 
-	if err := i.CurrencyCalculator.Validate(); err != nil {
-		return fmt.Errorf("currency calculator: %w", err)
-	}
-
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type AllocateCreditsOnlyResult struct {

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -17,7 +17,7 @@ import (
 
 type AllocateCreditsOnlyInput struct {
 	Charge             flatfee.Charge
-	Amount             alpacadecimal.Decimal
+	Totals             totals.Totals
 	CurrencyCalculator currencyx.Currency
 }
 
@@ -26,26 +26,25 @@ func (i AllocateCreditsOnlyInput) Validate() error {
 		return fmt.Errorf("charge: %w", err)
 	}
 
-	if i.Amount.IsNegative() {
-		return fmt.Errorf("amount cannot be negative")
+	if err := i.Totals.Validate(); err != nil {
+		return fmt.Errorf("totals: %w", err)
 	}
 
 	if i.CurrencyCalculator == nil {
 		return fmt.Errorf("currency calculator is required")
 	}
 
-	if i.CurrencyCalculator != nil {
-		if err := i.CurrencyCalculator.Validate(); err != nil {
-			return fmt.Errorf("currency calculator: %w", err)
-		}
+	if err := i.CurrencyCalculator.Validate(); err != nil {
+		return fmt.Errorf("currency calculator: %w", err)
 	}
 
 	return nil
 }
 
 type AllocateCreditsOnlyResult struct {
-	Allocated    alpacadecimal.Decimal
-	Realizations creditrealization.Realizations
+	Allocated          alpacadecimal.Decimal
+	CreditRealizations creditrealization.Realizations
+	RunBase            flatfee.RealizationRunBase
 }
 
 func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnlyInput) (AllocateCreditsOnlyResult, error) {
@@ -53,70 +52,67 @@ func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnl
 		return AllocateCreditsOnlyResult{}, err
 	}
 
-	in.Amount = in.CurrencyCalculator.RoundToPrecision(in.Amount)
-
-	if in.Amount.IsZero() {
-		return AllocateCreditsOnlyResult{}, nil
-	}
+	amountToAllocate := in.CurrencyCalculator.RoundToPrecision(in.Totals.Total)
 
 	servicePeriod := in.Charge.Intent.GetEffectiveServicePeriod()
-	input := flatfee.OnAllocateCreditsInput{
-		Charge:                 in.Charge,
-		ServicePeriod:          servicePeriod,
-		BookedAt:               flatfee.UsageBookedAt(in.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
-		PreTaxAmountToAllocate: in.Amount,
-	}
-	if err := input.Validate(); err != nil {
-		return AllocateCreditsOnlyResult{}, fmt.Errorf("validate input: %w", err)
-	}
+	var creditAllocations creditrealization.CreateAllocationInputs
+	if !amountToAllocate.IsZero() {
+		input := flatfee.OnAllocateCreditsInput{
+			Charge:                 in.Charge,
+			ServicePeriod:          servicePeriod,
+			BookedAt:               flatfee.UsageBookedAt(in.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
+			PreTaxAmountToAllocate: amountToAllocate,
+		}
+		if err := input.Validate(); err != nil {
+			return AllocateCreditsOnlyResult{}, fmt.Errorf("validate input: %w", err)
+		}
 
-	creditAllocations, err := s.handler.OnAllocateCredits(ctx, input)
-	if err != nil {
-		return AllocateCreditsOnlyResult{}, fmt.Errorf("allocate credits: %w", err)
+		var err error
+		creditAllocations, err = s.handler.OnAllocateCredits(ctx, input)
+		if err != nil {
+			return AllocateCreditsOnlyResult{}, fmt.Errorf("allocate credits: %w", err)
+		}
 	}
 
 	allocated := in.CurrencyCalculator.RoundToPrecision(creditAllocations.Sum())
-	if !allocated.Equal(in.Amount) {
+	if !allocated.Equal(amountToAllocate) {
 		return AllocateCreditsOnlyResult{}, models.NewGenericValidationError(
 			fmt.Errorf("credit allocations do not match total [charge_id=%s, total=%s, allocations_sum=%s]",
-				in.Charge.ID, in.Amount.String(), allocated.String()),
+				in.Charge.ID, amountToAllocate.String(), allocated.String()),
 		)
 	}
 
-	result := AllocateCreditsOnlyResult{
-		Allocated: allocated,
+	if in.Charge.Realizations.CurrentRun == nil {
+		return AllocateCreditsOnlyResult{}, fmt.Errorf("current run is required")
 	}
 
-	if len(creditAllocations) > 0 {
-		if in.Charge.Realizations.CurrentRun == nil {
-			return AllocateCreditsOnlyResult{}, fmt.Errorf("current run is required")
+	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (AllocateCreditsOnlyResult, error) {
+		var realizations creditrealization.Realizations
+		if len(creditAllocations) > 0 {
+			var err error
+			realizations, err = s.createCreditAllocations(ctx, in.Charge, in.Charge.Realizations.CurrentRun.ID, creditAllocations.AsCreateInputs())
+			if err != nil {
+				return AllocateCreditsOnlyResult{}, fmt.Errorf("create credit allocations: %w", err)
+			}
 		}
 
-		realizations, err := transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditrealization.Realizations, error) {
-			realizations, err := s.createCreditAllocations(ctx, in.Charge, in.Charge.Realizations.CurrentRun.ID, creditAllocations.AsCreateInputs())
-			if err != nil {
-				return nil, fmt.Errorf("create credit allocations: %w", err)
-			}
+		runTotals := in.Totals
+		runTotals.CreditsTotal = in.CurrencyCalculator.RoundToPrecision(runTotals.CreditsTotal.Add(allocated))
+		runTotals.Total = in.CurrencyCalculator.RoundToPrecision(runTotals.Total.Sub(allocated))
 
-			if _, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-				ID: in.Charge.Realizations.CurrentRun.ID,
-				Totals: mo.Some(totals.Totals{
-					Amount:       allocated,
-					CreditsTotal: allocated,
-					Total:        alpacadecimal.Zero,
-				}),
-			}); err != nil {
-				return nil, fmt.Errorf("update credit-only run totals: %w", err)
-			}
-
-			return realizations, nil
+		runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+			ID:                        in.Charge.Realizations.CurrentRun.ID,
+			Totals:                    mo.Some(runTotals),
+			NoFiatTransactionRequired: mo.Some(true),
 		})
 		if err != nil {
-			return AllocateCreditsOnlyResult{}, err
+			return AllocateCreditsOnlyResult{}, fmt.Errorf("update credit-only run totals: %w", err)
 		}
 
-		result.Realizations = realizations
-	}
-
-	return result, nil
+		return AllocateCreditsOnlyResult{
+			Allocated:          allocated,
+			CreditRealizations: realizations,
+			RunBase:            runBase,
+		}, nil
+	})
 }

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -9,21 +9,16 @@ import (
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
-	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
-	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type StartCreditThenInvoiceRunInput struct {
-	Charge  flatfee.Charge
-	Line    billing.StandardLine
-	Invoice billing.StandardInvoice
+	Charge    flatfee.Charge
+	LineID    string
+	InvoiceID string
 }
 
 func (i StartCreditThenInvoiceRunInput) Validate() error {
@@ -33,25 +28,12 @@ func (i StartCreditThenInvoiceRunInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
 	}
 
-	if err := i.Line.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("line: %w", err))
+	if i.LineID == "" {
+		errs = append(errs, errors.New("line ID is required"))
 	}
 
-	if err := i.Invoice.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invoice: %w", err))
-	}
-
-	lineChargeID := "<nil>"
-	if i.Line.ChargeID != nil {
-		lineChargeID = *i.Line.ChargeID
-	}
-
-	if i.Line.ChargeID == nil || *i.Line.ChargeID != i.Charge.ID {
-		errs = append(errs, fmt.Errorf("line charge id mismatch: got %s, want %s", lineChargeID, i.Charge.ID))
-	}
-
-	if i.Line.InvoiceID != i.Invoice.ID {
-		errs = append(errs, fmt.Errorf("line invoice id mismatch: got %s, want %s", i.Line.InvoiceID, i.Invoice.ID))
+	if i.InvoiceID == "" {
+		errs = append(errs, errors.New("invoice ID is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -69,21 +51,24 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (StartCreditThenInvoiceRunResult, error) {
 		currency := in.Charge.Intent.GetCurrency()
 
-		amountAfterProration, err := invoiceupdater.GetFlatFeePerUnitAmount(&in.Line)
+		rateableIntent, err := in.Charge.GetRateableIntent()
 		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("get flat fee line amount: %w", err)
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("getting rateable intent: %w", err)
 		}
 
-		amountAfterProration = currency.RoundToPrecision(amountAfterProration)
+		ratingResult, err := s.Rate(rateableIntent)
+		if err != nil {
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("rating flat fee: %w", err)
+		}
 
 		runBase, err := s.adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 			Charge:                    in.Charge.ChargeBase,
-			ServicePeriod:             in.Line.Period,
-			AmountAfterProration:      amountAfterProration,
-			NoFiatTransactionRequired: amountAfterProration.IsZero(),
+			ServicePeriod:             rateableIntent.ServicePeriod,
+			AmountAfterProration:      rateableIntent.AmountAfterProration,
+			NoFiatTransactionRequired: ratingResult.Totals.Total.IsZero(),
 			Immutable:                 false,
-			LineID:                    lo.ToPtr(in.Line.ID),
-			InvoiceID:                 lo.ToPtr(in.Invoice.ID),
+			LineID:                    lo.ToPtr(in.LineID),
+			InvoiceID:                 lo.ToPtr(in.InvoiceID),
 		})
 		if err != nil {
 			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("create current run: %w", err)
@@ -98,20 +83,15 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 		charge := in.Charge
 		charge.Realizations.CurrentRun = &flatfee.RealizationRun{
 			RealizationRunBase: runBase,
+			DetailedLines:      mo.Some(ratingResult.DetailedLines),
 		}
 
-		line, err := rateFlatFeeLine(in.Line, s.ratingService)
-		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, err
-		}
-
-		creditAllocationTarget := currency.RoundToPrecision(line.Totals.Total)
-
+		creditAllocationTarget := currency.RoundToPrecision(ratingResult.Totals.Total)
 		if !creditAllocationTarget.IsZero() {
 			handlerInput := flatfee.OnAllocateCreditsInput{
 				Charge:                 charge,
-				ServicePeriod:          in.Line.Period,
-				BookedAt:               flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), in.Line.Period),
+				ServicePeriod:          rateableIntent.ServicePeriod,
+				BookedAt:               flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), rateableIntent.ServicePeriod),
 				PreTaxAmountToAllocate: creditAllocationTarget,
 			}
 			if err := handlerInput.Validate(); err != nil {
@@ -124,7 +104,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			}
 
 			creditAllocationsWithLineID := creditrealization.CreateAllocationInputs(lo.Map(creditAllocations, func(allocation creditrealization.CreateAllocationInput, _ int) creditrealization.CreateAllocationInput {
-				allocation.LineID = lo.ToPtr(in.Line.ID)
+				allocation.LineID = lo.ToPtr(in.LineID)
 				return allocation
 			}))
 
@@ -138,31 +118,39 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			}
 		}
 
+		allocated := currency.RoundToPrecision(result.Run.CreditRealizations.Sum())
+		if allocated.GreaterThan(creditAllocationTarget) {
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf(
+				"credit allocations exceed rated total [charge_id=%s total=%s allocated=%s]",
+				in.Charge.ID,
+				creditAllocationTarget.String(),
+				allocated.String(),
+			)
+		}
+
 		creditsApplied, err := result.Run.CreditRealizations.AsCreditsApplied()
 		if err != nil {
 			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("mapping credit realizations to credits applied: %w", err)
 		}
 
-		mappedLine, err := applyCreditsToFlatFeeLine(*line, creditsApplied, currency)
+		detailedLines, err := ratingResult.DetailedLines.WithCreditsApplied(creditsApplied, currency)
 		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, err
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("applying credits to detailed lines: %w", err)
 		}
-
-		detailedLines := flatfee.DetailedLines(lo.Map(mappedLine.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
-			return detailedLine.Base.Clone()
-		}))
 
 		if err := s.adapter.UpsertDetailedLines(ctx, runBase.ID, detailedLines); err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("persisting detailed lines for line[%s]: %w", line.ID, err)
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("persisting detailed lines for run[%s]: %w", runBase.ID.ID, err)
 		}
+
+		runTotals := detailedLines.SumTotals().RoundToPrecision(currency)
 
 		runBase, err = s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
 			ID:                        runBase.ID,
-			Totals:                    mo.Some(mappedLine.Totals),
-			NoFiatTransactionRequired: mo.Some(mappedLine.Totals.Total.IsZero()),
+			Totals:                    mo.Some(runTotals),
+			NoFiatTransactionRequired: mo.Some(runTotals.Total.IsZero()),
 		})
 		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("updating run totals for line[%s]: %w", line.ID, err)
+			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("updating run totals for run[%s]: %w", runBase.ID.ID, err)
 		}
 
 		result.Run.RealizationRunBase = runBase
@@ -172,17 +160,9 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 	})
 }
 
-// ReconcileStandardLineToIntentInput describes a mutable CTI standard invoice
-// line that has already been rebuilt from the latest charge intent, plus the
-// realization run that still reflects the previous line state.
 type ReconcileStandardLineToIntentInput struct {
-	// Charge is the flat-fee charge whose intent produced Line.
 	Charge flatfee.Charge
-	// Run is the current mutable realization run backing Line.
-	Run flatfee.RealizationRun
-	// Line is the desired standard invoice line after applying the latest
-	// charge intent.
-	Line billing.StandardLine
+	Run    flatfee.RealizationRun
 	// AllocateAt is used as the ledger timestamp when reconciliation needs to
 	// allocate or correct credit rows.
 	AllocateAt time.Time
@@ -199,51 +179,27 @@ func (i ReconcileStandardLineToIntentInput) Validate() error {
 		errs = append(errs, fmt.Errorf("run: %w", err))
 	}
 
-	if err := i.Line.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("line: %w", err))
-	}
-
 	if i.AllocateAt.IsZero() {
 		errs = append(errs, errors.New("allocate at is required"))
 	}
 
-	lineChargeID := lo.FromPtrOr(i.Line.ChargeID, "<nil>")
-	if lineChargeID != i.Charge.ID {
-		errs = append(errs, fmt.Errorf("line charge id mismatch: got %s, want %s", lineChargeID, i.Charge.ID))
+	if i.Run.LineID == nil || *i.Run.LineID == "" {
+		errs = append(errs, errors.New("run line ID is required"))
 	}
 
-	runLineID := lo.FromPtrOr(i.Run.LineID, "<nil>")
-
-	if runLineID != i.Line.ID {
-		errs = append(errs, fmt.Errorf("run line id mismatch: got %s, want %s", runLineID, i.Line.ID))
-	}
-
-	runInvoiceID := lo.FromPtrOr(i.Run.InvoiceID, "<nil>")
-
-	if runInvoiceID != i.Line.InvoiceID {
-		errs = append(errs, fmt.Errorf("run invoice id mismatch: got %s, want %s", runInvoiceID, i.Line.InvoiceID))
+	if i.Run.InvoiceID == nil || *i.Run.InvoiceID == "" {
+		errs = append(errs, errors.New("run invoice ID is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-// ReconcileStandardLineToIntentResult returns both sides of the reconciliation:
-// the persisted run aggregate and the standard line that billing should write back.
 type ReconcileStandardLineToIntentResult struct {
 	Run flatfee.RealizationRun
-	// Line includes recalculated credits, detailed lines, and totals.
-	Line billing.StandardLine
 }
 
-// ReconcileStandardLineToIntent brings a mutable credit_then_invoice standard
-// invoice line and its realization run back in sync after the charge intent
-// changed.
-//
-// The caller passes the freshly rebuilt standard line. This method treats that
-// line as the desired state, computes its prorated amount, reconciles the run's
-// credit allocations to that amount, maps the resulting credit realizations
-// back to billing CreditsApplied, regenerates detailed lines/totals, persists
-// charge-owned detailed lines, and updates the run aggregate.
+// ReconcileStandardLineToIntent rerates a mutable credit_then_invoice run from
+// the effective charge intent and reconciles its credit allocations.
 func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in ReconcileStandardLineToIntentInput) (ReconcileStandardLineToIntentResult, error) {
 	if err := in.Validate(); err != nil {
 		return ReconcileStandardLineToIntentResult{}, err
@@ -252,27 +208,20 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (ReconcileStandardLineToIntentResult, error) {
 		currency := in.Charge.Intent.GetCurrency()
 
-		amountAfterProration, err := invoiceupdater.GetFlatFeePerUnitAmount(&in.Line)
+		rateableIntent, err := in.Charge.GetRateableIntent()
 		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("get flat fee line amount: %w", err)
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("getting rateable intent: %w", err)
 		}
 
-		amountAfterProration = currency.RoundToPrecision(amountAfterProration)
+		ratingResult, err := s.Rate(rateableIntent)
+		if err != nil {
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("rating flat fee: %w", err)
+		}
 
 		run := in.Run
-		// The rebuilt line may carry a prorated period that differs from the
-		// persisted run. Use the line period for both credit allocation and the
-		// run update so ledger and invoice state describe the same service
-		// window.
-		run.ServicePeriod = in.Line.Period
+		run.ServicePeriod = rateableIntent.ServicePeriod
 
-		line, err := rateFlatFeeLine(in.Line, s.ratingService)
-		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, err
-		}
-
-		creditAllocationTarget := currency.RoundToPrecision(line.Totals.Total)
-
+		creditAllocationTarget := currency.RoundToPrecision(ratingResult.Totals.Total)
 		reconcileResult, err := s.ReconcileCredits(ctx, ReconcileCreditRealizationsInput{
 			Charge:             in.Charge,
 			Run:                run,
@@ -286,102 +235,46 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 
 		run.CreditRealizations = append(run.CreditRealizations, reconcileResult.Realizations...)
 
+		allocated := currency.RoundToPrecision(run.CreditRealizations.Sum())
+		if allocated.GreaterThan(creditAllocationTarget) {
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf(
+				"credit allocations exceed rated total [charge_id=%s total=%s allocated=%s]",
+				in.Charge.ID,
+				creditAllocationTarget.String(),
+				allocated.String(),
+			)
+		}
+
 		creditsApplied, err := run.CreditRealizations.AsCreditsApplied()
 		if err != nil {
 			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("mapping credit realizations to credits applied: %w", err)
 		}
 
-		mappedLine, err := applyCreditsToFlatFeeLine(*line, creditsApplied, currency)
+		detailedLines, err := ratingResult.DetailedLines.WithCreditsApplied(creditsApplied, currency)
 		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, err
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("applying credits to detailed lines: %w", err)
 		}
-
-		detailedLines := flatfee.DetailedLines(lo.Map(mappedLine.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
-			return detailedLine.Base.Clone()
-		}))
 
 		if err := s.adapter.UpsertDetailedLines(ctx, run.ID, detailedLines); err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("persisting detailed lines for line[%s]: %w", line.ID, err)
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("persisting detailed lines for run[%s]: %w", run.ID.ID, err)
 		}
+
+		runTotals := detailedLines.SumTotals().RoundToPrecision(currency)
 
 		runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
 			ID:                        run.ID,
-			ServicePeriod:             mo.Some(line.Period),
-			AmountAfterProration:      mo.Some(amountAfterProration),
-			Totals:                    mo.Some(mappedLine.Totals),
-			NoFiatTransactionRequired: mo.Some(mappedLine.Totals.Total.IsZero()),
+			ServicePeriod:             mo.Some(rateableIntent.ServicePeriod),
+			AmountAfterProration:      mo.Some(rateableIntent.AmountAfterProration),
+			Totals:                    mo.Some(runTotals),
+			NoFiatTransactionRequired: mo.Some(runTotals.Total.IsZero()),
 		})
 		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("updating run totals for line[%s]: %w", line.ID, err)
+			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("updating run totals for run[%s]: %w", run.ID.ID, err)
 		}
 
 		run.RealizationRunBase = runBase
 		run.DetailedLines = mo.Some(detailedLines)
 
-		return ReconcileStandardLineToIntentResult{
-			Run:  run,
-			Line: *mappedLine,
-		}, nil
+		return ReconcileStandardLineToIntentResult{Run: run}, nil
 	})
-}
-
-func rateFlatFeeLine(line billing.StandardLine, ratingService billingrating.Service) (*billing.StandardLine, error) {
-	// Keep the caller-facing line shape on ratedLine, and use ratingLine only
-	// to clear split metadata for pricing before merging generated details back.
-	ratedLine, err := line.Clone()
-	if err != nil {
-		return nil, fmt.Errorf("cloning line: %w", err)
-	}
-
-	ratedLine.CreditsApplied = nil
-
-	ratingLine, err := line.Clone()
-	if err != nil {
-		return nil, fmt.Errorf("cloning rating line: %w", err)
-	}
-
-	ratingLine.CreditsApplied = nil
-	// Flat-fee charges materialize their own billable periods. Subscription
-	// split-line metadata must not make the flat pricer skip an otherwise
-	// billable in-advance or in-arrears charge run.
-	ratingLine.SplitLineGroupID = nil
-	ratingLine.SplitLineHierarchy = nil
-
-	generatedDetailedLines, err := ratingService.GenerateDetailedLines(ratingLine, billingrating.WithCreditsMutatorDisabled())
-	if err != nil {
-		return nil, fmt.Errorf("generating detailed lines for line[%s]: %w", ratedLine.ID, err)
-	}
-
-	if err := invoicecalc.MergeGeneratedDetailedLines(ratedLine, generatedDetailedLines); err != nil {
-		return nil, fmt.Errorf("merging generated detailed lines for line[%s]: %w", ratedLine.ID, err)
-	}
-
-	if err := ratedLine.Validate(); err != nil {
-		return nil, fmt.Errorf("validating standard line[%s]: %w", ratedLine.ID, err)
-	}
-
-	return ratedLine, nil
-}
-
-func applyCreditsToFlatFeeLine(line billing.StandardLine, creditsApplied billing.CreditsApplied, currencyCalculator currencyx.Currency) (*billing.StandardLine, error) {
-	mappedLine, err := line.Clone()
-	if err != nil {
-		return nil, fmt.Errorf("cloning line: %w", err)
-	}
-
-	mappedLine.CreditsApplied = creditsApplied
-
-	detailedLines, err := mappedLine.DetailedLines.WithCreditsApplied(creditsApplied, currencyCalculator)
-	if err != nil {
-		return nil, fmt.Errorf("applying credits to detailed lines for line[%s]: %w", mappedLine.ID, err)
-	}
-
-	mappedLine.DetailedLines = detailedLines
-	mappedLine.Totals = mappedLine.DetailedLines.SumTotals().RoundToPrecision(currencyCalculator)
-
-	if err := mappedLine.Validate(); err != nil {
-		return nil, fmt.Errorf("validating standard line[%s]: %w", mappedLine.ID, err)
-	}
-
-	return mappedLine, nil
 }

--- a/openmeter/billing/charges/flatfee/service/realizations/preview.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/preview.go
@@ -7,16 +7,16 @@ import (
 	"github.com/samber/lo"
 	"github.com/samber/mo"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type BuildCreditThenInvoiceGatheringPreviewRunInput struct {
-	Charge flatfee.Charge
-	Line   billing.StandardLine
+	Charge    flatfee.Charge
+	LineID    string
+	InvoiceID string
 }
 
 func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
@@ -26,13 +26,12 @@ func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
 	}
 
-	if err := i.Line.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("line: %w", err))
+	if i.LineID == "" {
+		errs = append(errs, errors.New("line ID is required"))
 	}
 
-	lineChargeID := lo.FromPtrOr(i.Line.ChargeID, "<nil>")
-	if lineChargeID != i.Charge.ID {
-		errs = append(errs, fmt.Errorf("line charge id mismatch: got %s, want %s", lineChargeID, i.Charge.ID))
+	if i.InvoiceID == "" {
+		errs = append(errs, errors.New("invoice ID is required"))
 	}
 
 	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
@@ -56,42 +55,38 @@ func (s *Service) BuildCreditThenInvoiceGatheringPreviewRun(in BuildCreditThenIn
 		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
 	}
 
-	currency := in.Charge.Intent.GetCurrency()
-
-	amountAfterProration, err := invoiceupdater.GetFlatFeePerUnitAmount(&in.Line)
+	rateableIntent, err := in.Charge.GetRateableIntent()
 	if err != nil {
-		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("get flat fee line amount: %w", err)
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("getting rateable intent: %w", err)
 	}
 
-	amountAfterProration = currency.RoundToPrecision(amountAfterProration)
-
-	line, err := rateFlatFeeLine(in.Line, s.ratingService)
+	ratingResult, err := s.Rate(rateableIntent)
 	if err != nil {
-		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("rating flat fee: %w", err)
 	}
 
-	detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
-		return detailedLine.Base.Clone()
-	}))
-
-	runTotals := line.Totals.RoundToPrecision(currency)
 	runType := flatfee.RealizationRunTypeFinalRealization
+	previewAt := clock.Now()
 	run := flatfee.RealizationRun{
 		RealizationRunBase: flatfee.RealizationRunBase{
 			ID: flatfee.RealizationRunID{
-				Namespace: in.Line.Namespace,
-				ID:        fmt.Sprintf("preview-%s", in.Line.ID),
+				Namespace: in.Charge.Namespace,
+				ID:        fmt.Sprintf("preview-%s", in.LineID),
 			},
-			LineID:                    lo.ToPtr(in.Line.ID),
-			InvoiceID:                 lo.ToPtr(in.Line.InvoiceID),
+			ManagedModel: models.ManagedModel{
+				CreatedAt: previewAt,
+				UpdatedAt: previewAt,
+			},
+			LineID:                    lo.ToPtr(in.LineID),
+			InvoiceID:                 lo.ToPtr(in.InvoiceID),
 			Type:                      runType,
 			InitialType:               runType,
-			ServicePeriod:             in.Line.Period,
-			AmountAfterProration:      amountAfterProration,
-			Totals:                    runTotals,
-			NoFiatTransactionRequired: runTotals.Total.IsZero(),
+			ServicePeriod:             rateableIntent.ServicePeriod,
+			AmountAfterProration:      rateableIntent.AmountAfterProration,
+			Totals:                    ratingResult.Totals,
+			NoFiatTransactionRequired: ratingResult.Totals.Total.IsZero(),
 		},
-		DetailedLines: mo.Some(detailedLines),
+		DetailedLines: mo.Some(ratingResult.DetailedLines),
 	}
 
 	return BuildCreditThenInvoiceGatheringPreviewRunResult{Run: run}, nil

--- a/openmeter/billing/charges/flatfee/service/realizations/rating.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/rating.go
@@ -1,0 +1,40 @@
+package realizations
+
+import (
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+)
+
+type RateResult struct {
+	Intent        flatfee.RateableIntent
+	DetailedLines flatfee.DetailedLines
+	Totals        totals.Totals
+}
+
+func (s *Service) Rate(intent flatfee.RateableIntent) (RateResult, error) {
+	if err := intent.Validate(); err != nil {
+		return RateResult{}, fmt.Errorf("validating rateable intent: %w", err)
+	}
+
+	result, err := s.ratingService.GenerateDetailedLines(
+		intent,
+		billingrating.WithCreditsMutatorDisabled(),
+	)
+	if err != nil {
+		return RateResult{}, fmt.Errorf("generating detailed lines: %w", err)
+	}
+
+	detailedLines := flatfee.NewDetailedLinesFromRating(intent.ServicePeriod, result.DetailedLines)
+	if err := detailedLines.Validate(); err != nil {
+		return RateResult{}, fmt.Errorf("validating detailed lines: %w", err)
+	}
+
+	return RateResult{
+		Intent:        intent,
+		DetailedLines: detailedLines,
+		Totals:        result.Totals,
+	}, nil
+}

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -270,18 +270,19 @@ func (s *BaseSuite) createTestCustomCurrency(ctx context.Context, namespace stri
 }
 
 type createMockChargeIntentInput struct {
-	customer          customer.CustomerID
-	currency          currencyx.Code
-	servicePeriod     timeutil.ClosedPeriod
-	price             *productcatalog.Price
-	unitConfig        *productcatalog.UnitConfig
-	featureKey        string
-	name              string
-	settlementMode    productcatalog.SettlementMode
-	managedBy         billing.InvoiceLineManagedBy
-	uniqueReferenceID string
-	taxConfig         productcatalog.TaxCodeConfig
-	proRating         productcatalog.ProRatingConfig
+	customer            customer.CustomerID
+	currency            currencyx.Code
+	servicePeriod       timeutil.ClosedPeriod
+	price               *productcatalog.Price
+	unitConfig          *productcatalog.UnitConfig
+	featureKey          string
+	name                string
+	settlementMode      productcatalog.SettlementMode
+	managedBy           billing.InvoiceLineManagedBy
+	uniqueReferenceID   string
+	taxConfig           productcatalog.TaxCodeConfig
+	proRating           productcatalog.ProRatingConfig
+	percentageDiscounts *billing.PercentageDiscount
 }
 
 func (i *createMockChargeIntentInput) Validate() error {
@@ -351,6 +352,7 @@ func (s *BaseSuite) createMockChargeIntent(input createMockChargeIntentInput) ch
 				InvoiceAt:             invoiceAt,
 				AmountBeforeProration: price.Amount,
 				ProRating:             input.proRating,
+				PercentageDiscounts:   input.percentageDiscounts.CloneOrNil(),
 			},
 			FeatureKey:     lo.EmptyableToPtr(input.featureKey),
 			SettlementMode: lo.CoalesceOrEmpty(input.settlementMode, productcatalog.CreditThenInvoiceSettlementMode),

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
@@ -2745,6 +2746,12 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 					name:              flatFeeName,
 					managedBy:         billing.SubscriptionManagedLine,
 					uniqueReferenceID: flatFeeName,
+					percentageDiscounts: &billing.PercentageDiscount{
+						PercentageDiscount: productcatalog.PercentageDiscount{
+							Percentage: models.NewPercentage(10),
+						},
+						CorrelationID: "flat-fee-credit-only-discount",
+					},
 				}),
 			},
 		})
@@ -2834,12 +2841,26 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 
 		// The handler was called exactly once with the correct amount.
 		s.Len(callbacks, 1)
-		s.Equal(float64(100), callbacks[0].Input.PreTaxAmountToAllocate.InexactFloat64())
+		s.Equal(float64(90), callbacks[0].Input.PreTaxAmountToAllocate.InexactFloat64())
 
-		// Credit realizations were persisted.
+		// Credit realizations and gross rated details were persisted separately.
+		fetchedFF = s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
 		s.Require().NotNil(fetchedFF.Realizations.CurrentRun)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:         100,
+			DiscountsTotal: 10,
+			CreditsTotal:   90,
+		}, fetchedFF.Realizations.CurrentRun.Totals)
 		s.Len(fetchedFF.Realizations.CurrentRun.CreditRealizations, 1)
-		s.Equal(float64(100), fetchedFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+		s.Equal(float64(90), fetchedFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+		s.True(fetchedFF.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Require().Len(fetchedFF.Realizations.CurrentRun.DetailedLines.OrEmpty(), 1)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:         100,
+			DiscountsTotal: 10,
+			Total:          90,
+		}, fetchedFF.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Totals)
+		s.Empty(fetchedFF.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].CreditsApplied)
 	})
 
 	s.Run("#3 final charge advance is noop", func() {
@@ -3056,9 +3077,20 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 		s.True(createdCharge.Intent.GetCurrency().IsCustom())
 		s.Equal(customCurrency.ID, createdCharge.Intent.GetCurrency().ID)
 		s.Require().NotNil(createdCharge.Realizations.CurrentRun)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       50.123,
+			CreditsTotal: 50.123,
+		}, createdCharge.Realizations.CurrentRun.Totals)
 		s.Require().Len(createdCharge.Realizations.CurrentRun.CreditRealizations, 1)
 		s.Equal(float64(50.123), createdCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 		s.Equal(allocationTransactionGroupID, createdCharge.Realizations.CurrentRun.CreditRealizations[0].LedgerTransaction.TransactionGroupID)
+		s.True(createdCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Require().Len(createdCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), 1)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 50.123,
+			Total:  50.123,
+		}, createdCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Totals)
+		s.Empty(createdCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].CreditsApplied)
 	})
 
 	s.Run("#3 reload persisted charge", func() {
@@ -3066,8 +3098,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 		// - the flat-fee charge is loaded again from Postgres
 		// then:
 		// - its final state, custom currency, totals, and allocation are preserved
-		persisted, err := s.mustGetChargeByID(createdCharge.GetChargeID()).AsFlatFeeCharge()
-		s.Require().NoError(err)
+		persisted := s.mustGetFlatFeeChargeByIDWithDetailedLines(createdCharge.GetChargeID())
 		s.Equal(flatfee.StatusFinal, persisted.Status)
 		s.True(persisted.Intent.GetCurrency().IsCustom())
 		s.Equal(customCurrency.ID, persisted.Intent.GetCurrency().ID)
@@ -3078,6 +3109,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 		}, persisted.Realizations.CurrentRun.Totals)
 		s.Require().Len(persisted.Realizations.CurrentRun.CreditRealizations, 1)
 		s.Equal(allocationTransactionGroupID, persisted.Realizations.CurrentRun.CreditRealizations[0].LedgerTransaction.TransactionGroupID)
+		s.True(persisted.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Require().Len(persisted.Realizations.CurrentRun.DetailedLines.OrEmpty(), 1)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 50.123,
+			Total:  50.123,
+		}, persisted.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Totals)
+		s.Empty(persisted.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].CreditsApplied)
 	})
 }
 

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -208,9 +208,10 @@ type RealizationRunBase struct {
 	// ServicePeriodTo is the end of the service period for the realization run.
 	ServicePeriodTo time.Time `json:"servicePeriodTo"`
 	// MeteredQuantity is the metered quantity for time IN [intent.servicePeriod.from, servicePeriodTo) capped by stored_at < StoredAtLT.
-	MeteredQuantity           alpacadecimal.Decimal `json:"meteredQuantity"`
-	Totals                    totals.Totals         `json:"totals"`
-	NoFiatTransactionRequired bool                  `json:"noFiatTransactionRequired"`
+	MeteredQuantity alpacadecimal.Decimal `json:"meteredQuantity"`
+	// Totals includes credit allocations and excludes taxes.
+	Totals                    totals.Totals `json:"totals"`
+	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
 }
 
 func (r RealizationRunBase) Normalized() RealizationRunBase {
@@ -281,7 +282,8 @@ type RealizationRun struct {
 	CreditsAllocated creditrealization.Realizations `json:"creditsAllocated"`
 	InvoiceUsage     *invoicedusage.AccruedUsage    `json:"invoicedUsage"`
 	Payment          *payment.Invoiced              `json:"payment"`
-	DetailedLines    mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
+	// DetailedLines contains rated details before credit allocations and taxes.
+	DetailedLines mo.Option[DetailedLines] `json:"detailedLines,omitzero"`
 }
 
 func (r RealizationRun) Validate() error {

--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
@@ -112,6 +111,22 @@ func (l DetailedLines) Clone() DetailedLines {
 	})
 }
 
+func (l DetailedLines) mapBase(fn func(stddetailedline.Bases) (stddetailedline.Bases, error)) (DetailedLines, error) {
+	out := l.Clone()
+	bases, err := fn(lo.Map(out, func(line DetailedLine, _ int) stddetailedline.Base {
+		return line.Base
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	for idx := range out {
+		out[idx].Base = bases[idx]
+	}
+
+	return out, nil
+}
+
 func (l DetailedLines) SumTotals() totals.Totals {
 	return totals.Sum(lo.Map(l, func(line DetailedLine, _ int) totals.Totals {
 		return line.Totals
@@ -121,14 +136,12 @@ func (l DetailedLines) SumTotals() totals.Totals {
 // WithReversedCredits returns cloned detailed lines with credit applications
 // removed and totals recalculated as if no credits had been applied.
 func (l DetailedLines) WithReversedCredits() DetailedLines {
-	return l.Map(func(line DetailedLine) DetailedLine {
-		line = line.Clone()
-		line.CreditsApplied = nil
-		line.Totals.CreditsTotal = alpacadecimal.Zero
-		line.Totals.Total = line.Totals.CalculateTotal()
-
-		return line
+	// Error is ignored here, because only mapBase's callback can return an error.
+	out, _ := l.mapBase(func(bases stddetailedline.Bases) (stddetailedline.Bases, error) {
+		return bases.WithReversedCredits(), nil
 	})
+
+	return out
 }
 
 func (l DetailedLines) WithCreditsApplied(
@@ -139,41 +152,18 @@ func (l DetailedLines) WithCreditsApplied(
 		return nil, fmt.Errorf("currency is required")
 	}
 
-	detailedLines := l.WithReversedCredits()
-
-	for _, creditToApply := range creditsApplied {
-		creditValueRemaining := currency.RoundToPrecision(creditToApply.Amount)
-
-		for idx := range detailedLines {
-			if creditValueRemaining.IsZero() {
-				break
-			}
-
-			totalAmount := currency.RoundToPrecision(detailedLines[idx].Totals.Total)
-			if !totalAmount.IsPositive() {
-				continue
-			}
-
-			if totalAmount.LessThanOrEqual(creditValueRemaining) {
-				creditValueRemaining = currency.RoundToPrecision(creditValueRemaining.Sub(totalAmount))
-				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(totalAmount))
-				detailedLines[idx].Totals.CreditsTotal = currency.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(totalAmount))
-				detailedLines[idx].Totals.Total = currency.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(totalAmount))
-			} else {
-				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(creditValueRemaining))
-				detailedLines[idx].Totals.CreditsTotal = currency.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(creditValueRemaining))
-				detailedLines[idx].Totals.Total = currency.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(creditValueRemaining))
-				creditValueRemaining = alpacadecimal.Zero
-				break
-			}
-		}
-
-		if creditValueRemaining.IsPositive() {
+	out, err := l.mapBase(func(bases stddetailedline.Bases) (stddetailedline.Bases, error) {
+		return bases.WithCreditsApplied(creditsApplied, currency)
+	})
+	if err != nil {
+		if errors.Is(err, stddetailedline.ErrCreditsNotConsumedFully) {
 			return nil, ErrInvoiceLineCreditsNotConsumedFully
 		}
+
+		return nil, err
 	}
 
-	return detailedLines, nil
+	return out, nil
 }
 
 func (l DetailedLines) Validate() error {

--- a/openmeter/billing/models/stddetailedline/model.go
+++ b/openmeter/billing/models/stddetailedline/model.go
@@ -13,9 +13,14 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+// ErrCreditsNotConsumedFully indicates that the detailed lines cannot absorb
+// all supplied credit allocations.
+var ErrCreditsNotConsumedFully = errors.New("credits not consumed fully")
 
 type Category string
 
@@ -157,4 +162,90 @@ func Compare[T Comparable](a, b T) int {
 		return c
 	}
 	return cmp.Compare(a.GetID(), b.GetID())
+}
+
+type Bases []Base
+
+func (l Bases) Clone() Bases {
+	out := make(Bases, len(l))
+	for idx, line := range l {
+		out[idx] = line.Clone()
+	}
+
+	return out
+}
+
+func (l Bases) SumTotals() totals.Totals {
+	out := totals.Totals{}
+	for _, line := range l {
+		out = out.Add(line.Totals)
+	}
+
+	return out
+}
+
+// WithReversedCredits returns cloned detailed-line bases with credit applications
+// removed and totals recalculated as if no credits had been applied.
+func (l Bases) WithReversedCredits() Bases {
+	out := l.Clone()
+	for idx := range out {
+		out[idx].CreditsApplied = nil
+		out[idx].Totals.CreditsTotal = alpacadecimal.Zero
+		out[idx].Totals.Total = out[idx].Totals.CalculateTotal()
+	}
+
+	return out
+}
+
+func (l Bases) WithCreditsApplied(
+	creditsApplied creditsapplied.CreditsApplied,
+	currency currencyx.Currency,
+) (Bases, error) {
+	if currency == nil {
+		return nil, errors.New("currency is required")
+	}
+
+	detailedLines := l.WithReversedCredits()
+
+	for _, creditToApply := range creditsApplied {
+		creditValueRemaining := currency.RoundToPrecision(creditToApply.Amount)
+
+		for idx := range detailedLines {
+			if creditValueRemaining.IsZero() {
+				break
+			}
+
+			totalAmount := currency.RoundToPrecision(detailedLines[idx].Totals.Total)
+			if !totalAmount.IsPositive() {
+				continue
+			}
+
+			amountToApply := creditValueRemaining
+			if totalAmount.LessThan(creditValueRemaining) {
+				amountToApply = totalAmount
+			}
+			detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(amountToApply))
+			detailedLines[idx].Totals.CreditsTotal = currency.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(amountToApply))
+			detailedLines[idx].Totals.Total = currency.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(amountToApply))
+			creditValueRemaining = currency.RoundToPrecision(creditValueRemaining.Sub(amountToApply))
+		}
+
+		if creditValueRemaining.IsPositive() {
+			return nil, ErrCreditsNotConsumedFully
+		}
+	}
+
+	return detailedLines, nil
+}
+
+func (l Bases) Validate() error {
+	var errs []error
+
+	for idx, line := range l {
+		if err := line.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }


### PR DESCRIPTION
## Summary

This separates realization of a flat-fee charge run from realization of its standard invoice line.

The charge run now retains the charge-side rating and realization outcome, while the standard invoice line is produced from that outcome at the billing boundary. This allows credit-then-invoice runs and invoice lines to use different denominations, which is required when a run is realized in a custom credit currency but invoiced in fiat.

## Validation

Not run after rebase, as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced flat-fee rating via rateable intents, including proration, effective pricing, and percentage discounts.
  * Added support for building, validating, and persisting detailed billing lines from rating results.
  * Updated credit-only and credit-then-invoice realization flows for consistent credit allocation and reconciliation.
* **Bug Fixes**
  * Improved correctness of realization totals, detailed-line totals, and discount/credit handling across flat-fee scenarios.
  * Enforced alignment between charge intent service periods and realization service periods.
* **Documentation**
  * Clarified meaning of totals and detailed-line content on realization runs.
* **Tests**
  * Expanded coverage for effective-intent rateable intent behavior and discount/correlation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates flat-fee charge realization from standard invoice-line construction.
- Introduces an effective rateable intent and charge-side rating result.
- Persists realization detailed lines and reconciles credit allocations against rated totals.
- Rebuilds standard invoice lines from persisted realization runs at billing boundaries.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because custom-currency credit-then-invoice runs can still be written to fiat invoice lines without cost-basis conversion.

The realization path calculates and persists amounts in the charge currency, while the invoice mapper copies those values into a fiat-denominated standard line and only applies fiat rounding; the configured conversion rate is never applied.

**Files Needing Attention:** openmeter/billing/charges/flatfee/service/linemapper.go, openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/rating.go | Introduces the normalized rateable intent used to produce charge-side prices, discounts, periods, and totals. |
| openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go | Moves credit-then-invoice rating and detailed-line persistence into realization runs, while retaining the charge denomination for run calculations. |
| openmeter/billing/charges/flatfee/service/linemapper.go | Reconstructs invoice lines from charge-side runs, but the previously reported custom-to-fiat denomination boundary remains unresolved. |
| openmeter/billing/charges/flatfee/service/creditsonly.go | Rates effective intents before credit allocation and persists reconciled run totals and detailed lines. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Intent[Effective flat-fee intent] --> Rating[Charge-side rating]
  Rating --> Run[Realization run]
  Run --> Credits[Credit allocation and reconciliation]
  Run --> Mapper[Invoice-line mapper]
  Credits --> Mapper
  Mapper --> Line[Standard invoice line]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(flatfee): aggregate credits-only val..."](https://github.com/openmeterio/openmeter/commit/05a53d5ed62d1bded271e25b34a68a5640d8250a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47523500)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->