### PR TITLE
fix(usagebased): persist credits in CTI run details

### DIFF
--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -40,7 +40,7 @@ type ChargeAdapter interface {
 type RealizationRunAdapter interface {
 	CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input CreateRealizationRunInput) (RealizationRunBase, error)
 	UpdateRealizationRun(ctx context.Context, input UpdateRealizationRunInput) (RealizationRunBase, error)
-	UpsertRunDetailedLines(ctx context.Context, chargeID meta.ChargeID, runID RealizationRunID, lines DetailedLines) error
+	UpsertRunDetailedLines(ctx context.Context, input UpsertRunDetailedLinesInput) error
 	FetchDetailedLines(ctx context.Context, charge Charge) (Charge, error)
 }
 

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeusagebasedrundetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrundetailedline"
 	dbchargeusagebasedruns "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
@@ -53,9 +55,17 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 			return usagebased.Charge{}, err
 		}
 
-		detailedLinesPresentByRunID := make(map[string]bool, len(dbRuns))
+		type detailedLinesMetadata struct {
+			Present                  bool
+			IncludeCreditAllocations bool
+		}
+
+		detailedLinesMetadataByRunID := make(map[string]detailedLinesMetadata, len(dbRuns))
 		for _, dbRun := range dbRuns {
-			detailedLinesPresentByRunID[dbRun.ID] = dbRun.DetailedLinesPresent
+			detailedLinesMetadataByRunID[dbRun.ID] = detailedLinesMetadata{
+				Present:                  dbRun.DetailedLinesPresent,
+				IncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
+			}
 		}
 
 		linesByRunID := make(map[string]usagebased.DetailedLines, len(charge.Realizations))
@@ -72,49 +82,75 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 			lines := linesByRunID[run.ID.ID]
 			slices.SortStableFunc(lines, stddetailedline.Compare[usagebased.DetailedLine])
 
-			detailedLinesPresent, found := detailedLinesPresentByRunID[run.ID.ID]
+			metadata, found := detailedLinesMetadataByRunID[run.ID.ID]
 			if !found {
 				charge.Realizations[idx].DetailedLines = mo.None[usagebased.DetailedLines]()
 				continue
 			}
 
+			charge.Realizations[idx].DetailedLinesIncludeCreditAllocations = metadata.IncludeCreditAllocations
+
 			// Safety measure: only mark detailed lines as expanded when the persisted
 			// run records that detailed lines were written at least once. Treating
 			// unknown detailed lines as an empty set can make
 			// late-event rating overcharge.
-			if detailedLinesPresent {
-				charge.Realizations[idx].DetailedLines = mo.Some(lines)
-			} else {
+			if !metadata.Present {
 				charge.Realizations[idx].DetailedLines = mo.None[usagebased.DetailedLines]()
+				continue
 			}
+
+			// Previously credit then invoice would not store credit allocations, but due to custom currency support
+			// and consistency's sake, we should now start storing them.
+			//
+			// We are applying the credit allocations to the detailed lines dynamically here, once all data has been
+			// migrated we can get rid of this code.
+			if charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode &&
+				!metadata.IncludeCreditAllocations {
+				creditsApplied, err := run.CreditsAllocated.AsCreditsApplied()
+				if err != nil {
+					return usagebased.Charge{}, fmt.Errorf(
+						"mapping legacy run credit allocations to detailed lines [run_id=%s]: %w",
+						run.ID.ID,
+						err,
+					)
+				}
+
+				lines, err = lines.WithCreditsApplied(creditsApplied, charge.Intent.GetCurrency())
+				if err != nil {
+					return usagebased.Charge{}, fmt.Errorf(
+						"applying legacy run credit allocations to detailed lines [run_id=%s]: %w",
+						run.ID.ID,
+						err,
+					)
+				}
+
+				charge.Realizations[idx].DetailedLinesIncludeCreditAllocations = true
+			}
+
+			charge.Realizations[idx].DetailedLines = mo.Some(lines)
 		}
 
 		return charge, nil
 	})
 }
 
-func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesmeta.ChargeID, runID usagebased.RealizationRunID, lines usagebased.DetailedLines) error {
-	if err := chargeID.Validate(); err != nil {
-		return err
-	}
-
-	if err := runID.Validate(); err != nil {
-		return err
-	}
-
-	if err := lines.Validate(); err != nil {
+func (a *adapter) UpsertRunDetailedLines(
+	ctx context.Context,
+	input usagebased.UpsertRunDetailedLinesInput,
+) error {
+	if err := input.Validate(); err != nil {
 		return err
 	}
 
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
-		createBuilders := make([]*entdb.ChargeUsageBasedRunDetailedLineCreate, 0, len(lines))
+		createBuilders := make([]*entdb.ChargeUsageBasedRunDetailedLineCreate, 0, len(input.DetailedLines))
 
-		for _, line := range lines {
+		for _, line := range input.DetailedLines {
 			lineToPersist := line.Clone()
-			lineToPersist.Namespace = runID.Namespace
+			lineToPersist.Namespace = input.RunID.Namespace
 			lineToPersist.DeletedAt = nil
 
-			create, err := buildDetailedLineCreate(tx.db, chargeID, runID, lineToPersist)
+			create, err := buildDetailedLineCreate(tx.db, input.ChargeID, input.RunID, lineToPersist)
 			if err != nil {
 				return err
 			}
@@ -125,14 +161,14 @@ func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesme
 		now := clock.Now().In(time.UTC)
 		deleteQuery := tx.db.ChargeUsageBasedRunDetailedLine.Update().
 			Where(
-				dbchargeusagebasedrundetailedline.NamespaceEQ(runID.Namespace),
-				dbchargeusagebasedrundetailedline.ChargeIDEQ(chargeID.ID),
-				dbchargeusagebasedrundetailedline.RunIDEQ(runID.ID),
+				dbchargeusagebasedrundetailedline.NamespaceEQ(input.RunID.Namespace),
+				dbchargeusagebasedrundetailedline.ChargeIDEQ(input.ChargeID.ID),
+				dbchargeusagebasedrundetailedline.RunIDEQ(input.RunID.ID),
 				dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
 			).
 			SetDeletedAt(now)
 
-		childRefsToKeep := lo.FilterMap(lines, func(line usagebased.DetailedLine, _ int) (string, bool) {
+		childRefsToKeep := lo.FilterMap(input.DetailedLines, func(line usagebased.DetailedLine, _ int) (string, bool) {
 			if line.ChildUniqueReferenceID == "" {
 				return "", false
 			}
@@ -151,11 +187,12 @@ func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesme
 
 		if _, err := tx.db.ChargeUsageBasedRuns.Update().
 			Where(
-				dbchargeusagebasedruns.NamespaceEQ(runID.Namespace),
-				dbchargeusagebasedruns.ChargeIDEQ(chargeID.ID),
-				dbchargeusagebasedruns.ID(runID.ID),
+				dbchargeusagebasedruns.NamespaceEQ(input.RunID.Namespace),
+				dbchargeusagebasedruns.ChargeIDEQ(input.ChargeID.ID),
+				dbchargeusagebasedruns.ID(input.RunID.ID),
 			).
 			SetDetailedLinesPresent(true).
+			SetDetailedLinesIncludeCreditAllocations(input.DetailedLinesIncludeCreditAllocations).
 			Save(ctx); err != nil {
 			return err
 		}

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -176,7 +176,11 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 			Description:            lo.ToPtr("delete me"),
 		}),
 	}
-	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, initialLines))
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID:      charge.GetChargeID(),
+		RunID:         runBase.ID,
+		DetailedLines: initialLines,
+	}))
 
 	initialKeepRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
 		Where(
@@ -208,7 +212,11 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 			Description:            lo.ToPtr("new description"),
 		}),
 	}
-	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, replacementLines))
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID:      charge.GetChargeID(),
+		RunID:         runBase.ID,
+		DetailedLines: replacementLines,
+	}))
 
 	replacedKeepRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
 		Where(
@@ -274,7 +282,10 @@ func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesUsesDetailedLinesPresen
 	s.Require().Len(fetchedWithoutMaterializedLines.Realizations, 1)
 	s.False(fetchedWithoutMaterializedLines.Realizations[0].DetailedLines.IsPresent())
 
-	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, nil))
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID: charge.GetChargeID(),
+		RunID:    runBase.ID,
+	}))
 
 	fetchedWithMaterializedEmptyLines, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
@@ -303,14 +314,18 @@ func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesDoesNotRepairDetailedLi
 	namespace := "usagebased-detailedline-adapter-fetch-does-not-repair-flag"
 	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
 
-	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, usagebased.DetailedLines{
-		s.newDetailedLine(newDetailedLineInput{
-			Charge:                 charge,
-			RunID:                  runBase.ID,
-			ServicePeriod:          servicePeriod,
-			ChildUniqueReferenceID: "existing@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
-			Quantity:               1,
-		}),
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID: charge.GetChargeID(),
+		RunID:    runBase.ID,
+		DetailedLines: usagebased.DetailedLines{
+			s.newDetailedLine(newDetailedLineInput{
+				Charge:                 charge,
+				RunID:                  runBase.ID,
+				ServicePeriod:          servicePeriod,
+				ChildUniqueReferenceID: "existing@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+				Quantity:               1,
+			}),
+		},
 	}))
 
 	_, err := s.dbClient.ChargeUsageBasedRuns.UpdateOneID(runBase.ID.ID).
@@ -345,14 +360,18 @@ func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesUsesPersistedDetailedLi
 	namespace := "usagebased-detailedline-adapter-fetch-uses-persisted-flag"
 	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
 
-	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, usagebased.DetailedLines{
-		s.newDetailedLine(newDetailedLineInput{
-			Charge:                 charge,
-			RunID:                  runBase.ID,
-			ServicePeriod:          servicePeriod,
-			ChildUniqueReferenceID: "persisted@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
-			Quantity:               1,
-		}),
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID: charge.GetChargeID(),
+		RunID:    runBase.ID,
+		DetailedLines: usagebased.DetailedLines{
+			s.newDetailedLine(newDetailedLineInput{
+				Charge:                 charge,
+				RunID:                  runBase.ID,
+				ServicePeriod:          servicePeriod,
+				ChildUniqueReferenceID: "persisted@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+				Quantity:               1,
+			}),
+		},
 	}))
 
 	_, err := s.dbClient.ChargeUsageBasedRuns.UpdateOneID(runBase.ID.ID).

--- a/openmeter/billing/charges/usagebased/adapter/mapper.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapper.go
@@ -160,16 +160,17 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunB
 		},
 		ManagedModel: entutils.MapTimeMixinFromDB(dbRun),
 
-		FeatureID:                 dbRun.FeatureID,
-		LineID:                    dbRun.LineID,
-		InvoiceID:                 dbRun.InvoiceID,
-		Type:                      dbRun.Type,
-		InitialType:               dbRun.InitialType,
-		StoredAtLT:                dbRun.StoredAtLt.UTC(),
-		ServicePeriodTo:           dbRun.ServicePeriodTo.UTC(),
-		MeteredQuantity:           dbRun.MeteredQuantity,
-		Totals:                    totals.FromDB(dbRun),
-		NoFiatTransactionRequired: dbRun.NoFiatTransactionRequired,
+		FeatureID:                             dbRun.FeatureID,
+		LineID:                                dbRun.LineID,
+		InvoiceID:                             dbRun.InvoiceID,
+		Type:                                  dbRun.Type,
+		InitialType:                           dbRun.InitialType,
+		StoredAtLT:                            dbRun.StoredAtLt.UTC(),
+		ServicePeriodTo:                       dbRun.ServicePeriodTo.UTC(),
+		MeteredQuantity:                       dbRun.MeteredQuantity,
+		Totals:                                totals.FromDB(dbRun),
+		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
+		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
 	}
 }
 

--- a/openmeter/billing/charges/usagebased/detailedline.go
+++ b/openmeter/billing/charges/usagebased/detailedline.go
@@ -8,10 +8,13 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -53,6 +56,32 @@ func (l DetailedLine) Validate() error {
 
 type DetailedLines []DetailedLine
 
+type UpsertRunDetailedLinesInput struct {
+	ChargeID meta.ChargeID
+	RunID    RealizationRunID
+
+	DetailedLines                         DetailedLines
+	DetailedLinesIncludeCreditAllocations bool
+}
+
+func (i UpsertRunDetailedLinesInput) Validate() error {
+	var errs []error
+
+	if err := i.ChargeID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	if err := i.RunID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run ID: %w", err))
+	}
+
+	if err := i.DetailedLines.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("detailed lines: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 func NewDetailedLinesFromBilling(
 	defaultServicePeriod timeutil.ClosedPeriod,
 	lines billingrating.DetailedLines,
@@ -91,6 +120,34 @@ func NewDetailedLinesFromBilling(
 func (l DetailedLines) Clone() DetailedLines {
 	return lo.Map(l, func(dl DetailedLine, _ int) DetailedLine {
 		return dl.Clone()
+	})
+}
+
+func (l DetailedLines) mapBase(fn func(stddetailedline.Bases) (stddetailedline.Bases, error)) (DetailedLines, error) {
+	out := l.Clone()
+	bases, err := fn(lo.Map(out, func(line DetailedLine, _ int) stddetailedline.Base {
+		return line.Base
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	for idx := range out {
+		out[idx].Base = bases[idx]
+	}
+
+	return out, nil
+}
+
+// WithCreditsApplied returns a cloned run-detail snapshot with the authoritative
+// run credit realizations applied. Existing applications are reversed first, so
+// rebuilding a persisted credit-then-invoice snapshot is retry-safe.
+func (l DetailedLines) WithCreditsApplied(
+	creditsApplied creditsapplied.CreditsApplied,
+	currency currencyx.Currency,
+) (DetailedLines, error) {
+	return l.mapBase(func(bases stddetailedline.Bases) (stddetailedline.Bases, error) {
+		return bases.WithCreditsApplied(creditsApplied, currency)
 	})
 }
 

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -212,6 +212,12 @@ type RealizationRunBase struct {
 	// Totals includes credit allocations and excludes taxes.
 	Totals                    totals.Totals `json:"totals"`
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
+	// DetailedLinesIncludeCreditAllocations describes if credit allocation is applied to the detailed lines.
+	// Credits-only: always false
+	// Credit-then-invoice:
+	// - true, for all runs (even when 0 credits were allocated)
+	// - legacy runs have false, as previously we didn't store credit allocations on detailed lines
+	DetailedLinesIncludeCreditAllocations bool `json:"detailedLinesIncludeCreditAllocations"`
 }
 
 func (r RealizationRunBase) Normalized() RealizationRunBase {
@@ -282,7 +288,8 @@ type RealizationRun struct {
 	CreditsAllocated creditrealization.Realizations `json:"creditsAllocated"`
 	InvoiceUsage     *invoicedusage.AccruedUsage    `json:"invoicedUsage"`
 	Payment          *payment.Invoiced              `json:"payment"`
-	// DetailedLines contains rated details before credit allocations and taxes.
+	// DetailedLines excludes taxes. Credit-then-invoice runs include credit
+	// allocations, while credits-only runs retain their gross rated details.
 	DetailedLines mo.Option[DetailedLines] `json:"detailedLines,omitzero"`
 }
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -869,10 +869,26 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	currentTotals.CreditsTotal = s.CurrencyCalculator.RoundToPrecision(currentRun.CreditsAllocated.Sum())
 	currentTotals.Total = s.CurrencyCalculator.RoundToPrecision(currentTotals.Total.Sub(currentTotals.CreditsTotal))
 
-	if err := s.Adapter.UpsertRunDetailedLines(ctx, s.Charge.GetChargeID(), currentRun.ID, ratingResult.DetailedLines); err != nil {
+	creditsApplied, err := currentRun.CreditsAllocated.AsCreditsApplied()
+	if err != nil {
+		return fmt.Errorf("map credit realizations to detailed line credits: %w", err)
+	}
+
+	detailedLines, err := ratingResult.DetailedLines.WithCreditsApplied(creditsApplied, s.CurrencyCalculator)
+	if err != nil {
+		return fmt.Errorf("apply credit allocations to run detailed lines: %w", err)
+	}
+
+	if err := s.Adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID:                              s.Charge.GetChargeID(),
+		RunID:                                 currentRun.ID,
+		DetailedLines:                         detailedLines,
+		DetailedLinesIncludeCreditAllocations: true,
+	}); err != nil {
 		return fmt.Errorf("upsert run detailed lines: %w", err)
 	}
-	currentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)
+	currentRun.DetailedLines = mo.Some(detailedLines)
+	currentRun.DetailedLinesIncludeCreditAllocations = true
 
 	noFiatTransactionRequired := currentTotals.Total.IsZero()
 	if s.Charge.Intent.GetCurrency().IsCustom() {

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -363,7 +363,11 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 	currentTotals.CreditsTotal = currentTotals.CreditsTotal.Add(targetCreditsTotal)
 	currentTotals.Total = alpacadecimal.Zero
 
-	if err := s.Adapter.UpsertRunDetailedLines(ctx, s.Charge.GetChargeID(), currentRun.ID, ratingResult.DetailedLines); err != nil {
+	if err := s.Adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID:      s.Charge.GetChargeID(),
+		RunID:         currentRun.ID,
+		DetailedLines: ratingResult.DetailedLines,
+	}); err != nil {
 		return fmt.Errorf("upsert run detailed lines: %w", err)
 	}
 	currentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -172,9 +172,6 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		return CreateRatedRunResult{}, err
 	}
 
-	if err := s.adapter.UpsertRunDetailedLines(ctx, updatedCharge.GetChargeID(), currentRun.ID, ratingResult.DetailedLines); err != nil {
-		return CreateRatedRunResult{}, fmt.Errorf("upsert run detailed lines: %w", err)
-	}
 	currentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)
 
 	allocationResult, err := s.allocate(ctx, allocateCreditRealizationsInput{
@@ -192,6 +189,31 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 	currentRun.CreditsAllocated = allocationResult.Realizations
 	runTotals.CreditsTotal = runTotals.CreditsTotal.Add(allocationResult.Allocated)
 	runTotals.Total = in.CurrencyCalculator.RoundToPrecision(runTotals.Total.Sub(allocationResult.Allocated))
+
+	detailedLines := ratingResult.DetailedLines
+	detailedLinesIncludeCreditAllocations := settlementMode == productcatalog.CreditThenInvoiceSettlementMode
+	if detailedLinesIncludeCreditAllocations {
+		creditsApplied, err := currentRun.CreditsAllocated.AsCreditsApplied()
+		if err != nil {
+			return CreateRatedRunResult{}, fmt.Errorf("map credit realizations to detailed line credits: %w", err)
+		}
+
+		detailedLines, err = detailedLines.WithCreditsApplied(creditsApplied, in.CurrencyCalculator)
+		if err != nil {
+			return CreateRatedRunResult{}, fmt.Errorf("apply credit allocations to run detailed lines: %w", err)
+		}
+	}
+
+	if err := s.adapter.UpsertRunDetailedLines(ctx, usagebased.UpsertRunDetailedLinesInput{
+		ChargeID:                              updatedCharge.GetChargeID(),
+		RunID:                                 currentRun.ID,
+		DetailedLines:                         detailedLines,
+		DetailedLinesIncludeCreditAllocations: detailedLinesIncludeCreditAllocations,
+	}); err != nil {
+		return CreateRatedRunResult{}, fmt.Errorf("upsert run detailed lines: %w", err)
+	}
+	currentRun.DetailedLines = mo.Some(detailedLines)
+	currentRun.DetailedLinesIncludeCreditAllocations = detailedLinesIncludeCreditAllocations
 
 	// Let's calculate if the current run at this point requires a fiat transaction.
 	noFiatTransactionRequired := isCreditsOnlySettlementMode || runTotals.Total.IsZero()

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -63,6 +63,8 @@ type ChargeUsageBasedRuns struct {
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
 	// DetailedLinesPresent holds the value of the "detailed_lines_present" field.
 	DetailedLinesPresent bool `json:"detailed_lines_present,omitempty"`
+	// DetailedLinesIncludeCreditAllocations holds the value of the "detailed_lines_include_credit_allocations" field.
+	DetailedLinesIncludeCreditAllocations bool `json:"detailed_lines_include_credit_allocations,omitempty"`
 	// LineID holds the value of the "line_id" field.
 	LineID *string `json:"line_id,omitempty"`
 	// InvoiceID holds the value of the "invoice_id" field.
@@ -202,7 +204,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -343,6 +345,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 				return fmt.Errorf("unexpected type %T for field detailed_lines_present", values[i])
 			} else if value.Valid {
 				_m.DetailedLinesPresent = value.Bool
+			}
+		case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field detailed_lines_include_credit_allocations", values[i])
+			} else if value.Valid {
+				_m.DetailedLinesIncludeCreditAllocations = value.Bool
 			}
 		case chargeusagebasedruns.FieldLineID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -509,6 +517,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("detailed_lines_present=")
 	builder.WriteString(fmt.Sprintf("%v", _m.DetailedLinesPresent))
+	builder.WriteString(", ")
+	builder.WriteString("detailed_lines_include_credit_allocations=")
+	builder.WriteString(fmt.Sprintf("%v", _m.DetailedLinesIncludeCreditAllocations))
 	builder.WriteString(", ")
 	if v := _m.LineID; v != nil {
 		builder.WriteString("line_id=")

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -54,6 +54,8 @@ const (
 	FieldServicePeriodTo = "service_period_to"
 	// FieldDetailedLinesPresent holds the string denoting the detailed_lines_present field in the database.
 	FieldDetailedLinesPresent = "detailed_lines_present"
+	// FieldDetailedLinesIncludeCreditAllocations holds the string denoting the detailed_lines_include_credit_allocations field in the database.
+	FieldDetailedLinesIncludeCreditAllocations = "detailed_lines_include_credit_allocations"
 	// FieldLineID holds the string denoting the line_id field in the database.
 	FieldLineID = "line_id"
 	// FieldInvoiceID holds the string denoting the invoice_id field in the database.
@@ -169,6 +171,7 @@ var Columns = []string{
 	FieldStoredAtLt,
 	FieldServicePeriodTo,
 	FieldDetailedLinesPresent,
+	FieldDetailedLinesIncludeCreditAllocations,
 	FieldLineID,
 	FieldInvoiceID,
 	FieldMeteredQuantity,
@@ -196,6 +199,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	FeatureIDValidator func(string) error
+	// DefaultDetailedLinesIncludeCreditAllocations holds the default value on creation for the "detailed_lines_include_credit_allocations" field.
+	DefaultDetailedLinesIncludeCreditAllocations bool
 	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	LineIDValidator func(string) error
 	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
@@ -325,6 +330,11 @@ func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 // ByDetailedLinesPresent orders the results by the detailed_lines_present field.
 func ByDetailedLinesPresent(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDetailedLinesPresent, opts...).ToFunc()
+}
+
+// ByDetailedLinesIncludeCreditAllocations orders the results by the detailed_lines_include_credit_allocations field.
+func ByDetailedLinesIncludeCreditAllocations(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDetailedLinesIncludeCreditAllocations, opts...).ToFunc()
 }
 
 // ByLineID orders the results by the line_id field.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -152,6 +152,11 @@ func DetailedLinesPresent(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesPresent, v))
 }
 
+// DetailedLinesIncludeCreditAllocations applies equality check predicate on the "detailed_lines_include_credit_allocations" field. It's identical to DetailedLinesIncludeCreditAllocationsEQ.
+func DetailedLinesIncludeCreditAllocations(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesIncludeCreditAllocations, v))
+}
+
 // LineID applies equality check predicate on the "line_id" field. It's identical to LineIDEQ.
 func LineID(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldLineID, v))
@@ -965,6 +970,16 @@ func DetailedLinesPresentEQ(v bool) predicate.ChargeUsageBasedRuns {
 // DetailedLinesPresentNEQ applies the NEQ predicate on the "detailed_lines_present" field.
 func DetailedLinesPresentNEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldDetailedLinesPresent, v))
+}
+
+// DetailedLinesIncludeCreditAllocationsEQ applies the EQ predicate on the "detailed_lines_include_credit_allocations" field.
+func DetailedLinesIncludeCreditAllocationsEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesIncludeCreditAllocations, v))
+}
+
+// DetailedLinesIncludeCreditAllocationsNEQ applies the NEQ predicate on the "detailed_lines_include_credit_allocations" field.
+func DetailedLinesIncludeCreditAllocationsNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldDetailedLinesIncludeCreditAllocations, v))
 }
 
 // LineIDEQ applies the EQ predicate on the "line_id" field.

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -171,6 +171,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetDetailedLinesPresent(v bool) *ChargeUsa
 	return _c
 }
 
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (_c *ChargeUsageBasedRunsCreate) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetDetailedLinesIncludeCreditAllocations(v)
+	return _c
+}
+
+// SetNillableDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableDetailedLinesIncludeCreditAllocations(v *bool) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetDetailedLinesIncludeCreditAllocations(*v)
+	}
+	return _c
+}
+
 // SetLineID sets the "line_id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetLineID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetLineID(v)
@@ -405,6 +419,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.DetailedLinesIncludeCreditAllocations(); !ok {
+		v := chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations
+		_c.mutation.SetDetailedLinesIncludeCreditAllocations(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeusagebasedruns.DefaultID()
 		_c.mutation.SetID(v)
@@ -486,6 +504,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.DetailedLinesPresent(); !ok {
 		return &ValidationError{Name: "detailed_lines_present", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.detailed_lines_present"`)}
+	}
+	if _, ok := _c.mutation.DetailedLinesIncludeCreditAllocations(); !ok {
+		return &ValidationError{Name: "detailed_lines_include_credit_allocations", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.detailed_lines_include_credit_allocations"`)}
 	}
 	if v, ok := _c.mutation.LineID(); ok {
 		if err := chargeusagebasedruns.LineIDValidator(v); err != nil {
@@ -612,6 +633,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 		_node.DetailedLinesPresent = value
+	}
+	if value, ok := _c.mutation.DetailedLinesIncludeCreditAllocations(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, field.TypeBool, value)
+		_node.DetailedLinesIncludeCreditAllocations = value
 	}
 	if value, ok := _c.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
@@ -983,6 +1008,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateDetailedLinesPresent() *ChargeUsageBa
 	return u
 }
 
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (u *ChargeUsageBasedRunsUpsert) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, v)
+	return u
+}
+
+// UpdateDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateDetailedLinesIncludeCreditAllocations() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations)
+	return u
+}
+
 // SetLineID sets the "line_id" field.
 func (u *ChargeUsageBasedRunsUpsert) SetLineID(v string) *ChargeUsageBasedRunsUpsert {
 	u.Set(chargeusagebasedruns.FieldLineID, v)
@@ -1280,6 +1317,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetDetailedLinesPresent(v bool) *ChargeU
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateDetailedLinesPresent() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateDetailedLinesPresent()
+	})
+}
+
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetDetailedLinesIncludeCreditAllocations(v)
+	})
+}
+
+// UpdateDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateDetailedLinesIncludeCreditAllocations() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateDetailedLinesIncludeCreditAllocations()
 	})
 }
 
@@ -1754,6 +1805,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetDetailedLinesPresent(v bool) *Charge
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateDetailedLinesPresent() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateDetailedLinesPresent()
+	})
+}
+
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetDetailedLinesIncludeCreditAllocations(v)
+	})
+}
+
+// UpdateDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateDetailedLinesIncludeCreditAllocations() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateDetailedLinesIncludeCreditAllocations()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -215,6 +215,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableDetailedLinesPresent(v *bool) *
 	return _u
 }
 
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetDetailedLinesIncludeCreditAllocations(v)
+	return _u
+}
+
+// SetNillableDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableDetailedLinesIncludeCreditAllocations(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetDetailedLinesIncludeCreditAllocations(*v)
+	}
+	return _u
+}
+
 // SetLineID sets the "line_id" field.
 func (_u *ChargeUsageBasedRunsUpdate) SetLineID(v string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetLineID(v)
@@ -561,6 +575,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.DetailedLinesIncludeCreditAllocations(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
@@ -990,6 +1007,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableDetailedLinesPresent(v *bool
 	return _u
 }
 
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetDetailedLinesIncludeCreditAllocations(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetDetailedLinesIncludeCreditAllocations(v)
+	return _u
+}
+
+// SetNillableDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableDetailedLinesIncludeCreditAllocations(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetDetailedLinesIncludeCreditAllocations(*v)
+	}
+	return _u
+}
+
 // SetLineID sets the "line_id" field.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetLineID(v string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetLineID(v)
@@ -1366,6 +1397,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.DetailedLinesIncludeCreditAllocations(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3338,6 +3338,7 @@ var (
 		{Name: "stored_at_lt", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "detailed_lines_present", Type: field.TypeBool},
+		{Name: "detailed_lines_include_credit_allocations", Type: field.TypeBool, Default: false},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -3353,25 +3354,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3390,7 +3391,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[22]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[23]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -73881,53 +73881,54 @@ func (m *ChargeUsageBasedRunPaymentMutation) ResetEdge(name string) error {
 // ChargeUsageBasedRunsMutation represents an operation that mutates the ChargeUsageBasedRuns nodes in the graph.
 type ChargeUsageBasedRunsMutation struct {
 	config
-	op                              Op
-	typ                             string
-	id                              *string
-	namespace                       *string
-	created_at                      *time.Time
-	updated_at                      *time.Time
-	deleted_at                      *time.Time
-	amount                          *alpacadecimal.Decimal
-	taxes_total                     *alpacadecimal.Decimal
-	taxes_inclusive_total           *alpacadecimal.Decimal
-	taxes_exclusive_total           *alpacadecimal.Decimal
-	charges_total                   *alpacadecimal.Decimal
-	discounts_total                 *alpacadecimal.Decimal
-	credits_total                   *alpacadecimal.Decimal
-	total                           *alpacadecimal.Decimal
-	_type                           *usagebased.RealizationRunType
-	initial_type                    *usagebased.RealizationRunType
-	stored_at_lt                    *time.Time
-	service_period_to               *time.Time
-	detailed_lines_present          *bool
-	metered_quantity                *alpacadecimal.Decimal
-	no_fiat_transaction_required    *bool
-	clearedFields                   map[string]struct{}
-	usage_based                     *string
-	clearedusage_based              bool
-	feature                         *string
-	clearedfeature                  bool
-	billing_invoice_line            *string
-	clearedbilling_invoice_line     bool
-	billing_invoice                 *string
-	clearedbilling_invoice          bool
-	credit_allocations              map[string]struct{}
-	removedcredit_allocations       map[string]struct{}
-	clearedcredit_allocations       bool
-	detailed_lines                  map[string]struct{}
-	removeddetailed_lines           map[string]struct{}
-	cleareddetailed_lines           bool
-	corrected_detailed_lines        map[string]struct{}
-	removedcorrected_detailed_lines map[string]struct{}
-	clearedcorrected_detailed_lines bool
-	invoiced_usage                  *string
-	clearedinvoiced_usage           bool
-	payment                         *string
-	clearedpayment                  bool
-	done                            bool
-	oldValue                        func(context.Context) (*ChargeUsageBasedRuns, error)
-	predicates                      []predicate.ChargeUsageBasedRuns
+	op                                        Op
+	typ                                       string
+	id                                        *string
+	namespace                                 *string
+	created_at                                *time.Time
+	updated_at                                *time.Time
+	deleted_at                                *time.Time
+	amount                                    *alpacadecimal.Decimal
+	taxes_total                               *alpacadecimal.Decimal
+	taxes_inclusive_total                     *alpacadecimal.Decimal
+	taxes_exclusive_total                     *alpacadecimal.Decimal
+	charges_total                             *alpacadecimal.Decimal
+	discounts_total                           *alpacadecimal.Decimal
+	credits_total                             *alpacadecimal.Decimal
+	total                                     *alpacadecimal.Decimal
+	_type                                     *usagebased.RealizationRunType
+	initial_type                              *usagebased.RealizationRunType
+	stored_at_lt                              *time.Time
+	service_period_to                         *time.Time
+	detailed_lines_present                    *bool
+	detailed_lines_include_credit_allocations *bool
+	metered_quantity                          *alpacadecimal.Decimal
+	no_fiat_transaction_required              *bool
+	clearedFields                             map[string]struct{}
+	usage_based                               *string
+	clearedusage_based                        bool
+	feature                                   *string
+	clearedfeature                            bool
+	billing_invoice_line                      *string
+	clearedbilling_invoice_line               bool
+	billing_invoice                           *string
+	clearedbilling_invoice                    bool
+	credit_allocations                        map[string]struct{}
+	removedcredit_allocations                 map[string]struct{}
+	clearedcredit_allocations                 bool
+	detailed_lines                            map[string]struct{}
+	removeddetailed_lines                     map[string]struct{}
+	cleareddetailed_lines                     bool
+	corrected_detailed_lines                  map[string]struct{}
+	removedcorrected_detailed_lines           map[string]struct{}
+	clearedcorrected_detailed_lines           bool
+	invoiced_usage                            *string
+	clearedinvoiced_usage                     bool
+	payment                                   *string
+	clearedpayment                            bool
+	done                                      bool
+	oldValue                                  func(context.Context) (*ChargeUsageBasedRuns, error)
+	predicates                                []predicate.ChargeUsageBasedRuns
 }
 
 var _ ent.Mutation = (*ChargeUsageBasedRunsMutation)(nil)
@@ -74731,6 +74732,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetDetailedLinesPresent() {
 	m.detailed_lines_present = nil
 }
 
+// SetDetailedLinesIncludeCreditAllocations sets the "detailed_lines_include_credit_allocations" field.
+func (m *ChargeUsageBasedRunsMutation) SetDetailedLinesIncludeCreditAllocations(b bool) {
+	m.detailed_lines_include_credit_allocations = &b
+}
+
+// DetailedLinesIncludeCreditAllocations returns the value of the "detailed_lines_include_credit_allocations" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) DetailedLinesIncludeCreditAllocations() (r bool, exists bool) {
+	v := m.detailed_lines_include_credit_allocations
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDetailedLinesIncludeCreditAllocations returns the old "detailed_lines_include_credit_allocations" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldDetailedLinesIncludeCreditAllocations(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDetailedLinesIncludeCreditAllocations is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDetailedLinesIncludeCreditAllocations requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDetailedLinesIncludeCreditAllocations: %w", err)
+	}
+	return oldValue.DetailedLinesIncludeCreditAllocations, nil
+}
+
+// ResetDetailedLinesIncludeCreditAllocations resets all changes to the "detailed_lines_include_credit_allocations" field.
+func (m *ChargeUsageBasedRunsMutation) ResetDetailedLinesIncludeCreditAllocations() {
+	m.detailed_lines_include_credit_allocations = nil
+}
+
 // SetLineID sets the "line_id" field.
 func (m *ChargeUsageBasedRunsMutation) SetLineID(s string) {
 	m.billing_invoice_line = &s
@@ -75322,7 +75359,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 23)
+	fields := make([]string, 0, 24)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -75379,6 +75416,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	}
 	if m.detailed_lines_present != nil {
 		fields = append(fields, chargeusagebasedruns.FieldDetailedLinesPresent)
+	}
+	if m.detailed_lines_include_credit_allocations != nil {
+		fields = append(fields, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations)
 	}
 	if m.billing_invoice_line != nil {
 		fields = append(fields, chargeusagebasedruns.FieldLineID)
@@ -75438,6 +75478,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.ServicePeriodTo()
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		return m.DetailedLinesPresent()
+	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
+		return m.DetailedLinesIncludeCreditAllocations()
 	case chargeusagebasedruns.FieldLineID:
 		return m.LineID()
 	case chargeusagebasedruns.FieldInvoiceID:
@@ -75493,6 +75535,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldServicePeriodTo(ctx)
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		return m.OldDetailedLinesPresent(ctx)
+	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
+		return m.OldDetailedLinesIncludeCreditAllocations(ctx)
 	case chargeusagebasedruns.FieldLineID:
 		return m.OldLineID(ctx)
 	case chargeusagebasedruns.FieldInvoiceID:
@@ -75642,6 +75686,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDetailedLinesPresent(v)
+		return nil
+	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDetailedLinesIncludeCreditAllocations(v)
 		return nil
 	case chargeusagebasedruns.FieldLineID:
 		v, ok := value.(string)
@@ -75797,6 +75848,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		m.ResetDetailedLinesPresent()
+		return nil
+	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
+		m.ResetDetailedLinesIncludeCreditAllocations()
 		return nil
 	case chargeusagebasedruns.FieldLineID:
 		m.ResetLineID()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1704,12 +1704,16 @@ func init() {
 	chargeusagebasedrunsDescFeatureID := chargeusagebasedrunsFields[1].Descriptor()
 	// chargeusagebasedruns.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	chargeusagebasedruns.FeatureIDValidator = chargeusagebasedrunsDescFeatureID.Validators[0].(func(string) error)
+	// chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations is the schema descriptor for detailed_lines_include_credit_allocations field.
+	chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations := chargeusagebasedrunsFields[7].Descriptor()
+	// chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations holds the default value on creation for the detailed_lines_include_credit_allocations field.
+	chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations = chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations.Default.(bool)
 	// chargeusagebasedrunsDescLineID is the schema descriptor for line_id field.
-	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[7].Descriptor()
+	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[8].Descriptor()
 	// chargeusagebasedruns.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	chargeusagebasedruns.LineIDValidator = chargeusagebasedrunsDescLineID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescInvoiceID is the schema descriptor for invoice_id field.
-	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[8].Descriptor()
+	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[9].Descriptor()
 	// chargeusagebasedruns.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeusagebasedruns.InvoiceIDValidator = chargeusagebasedrunsDescInvoiceID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -359,6 +359,9 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 
 		field.Bool("detailed_lines_present"),
 
+		field.Bool("detailed_lines_include_credit_allocations").
+			Default(false),
+
 		field.String("line_id").
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",

--- a/tools/migrate/migrations/20260727095118_usage_based_run_detailed_lines_credit_allocations.down.sql
+++ b/tools/migrate/migrations/20260727095118_usage_based_run_detailed_lines_credit_allocations.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "detailed_lines_include_credit_allocations";

--- a/tools/migrate/migrations/20260727095118_usage_based_run_detailed_lines_credit_allocations.up.sql
+++ b/tools/migrate/migrations/20260727095118_usage_based_run_detailed_lines_credit_allocations.up.sql
@@ -1,0 +1,2 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "detailed_lines_include_credit_allocations" boolean NOT NULL DEFAULT false;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:H3bk/UtzIVOtrA6G0DoHGgYbhQrfDdLaXCVk6JDd+Tw=
+h1:O7Ym+hKqFMonKIBUJYhhjQbia9R5yfIl2asIpHt54c0=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -243,3 +243,4 @@ h1:H3bk/UtzIVOtrA6G0DoHGgYbhQrfDdLaXCVk6JDd+Tw=
 20260721140844_deprecate_detailed_line_currency.up.sql h1:wG5tChhpzGEfeXdAVvpYmLzxKnmqPcACAYvcSdH9sJ0=
 20260722145858_add_charge_cost_basis.up.sql h1:fkgfCOoDlg9XsWATSRmBXUywHwTiUfq9FAmRQ0mNGHw=
 20260724082957_backfill_credit_purchase_invoice_fiat_amount.up.sql h1:LtvTl3P0Hco9fZgYS29v8Gk4lGSZJ2k+/6Z14qLN+QM=
+20260727095118_usage_based_run_detailed_lines_credit_allocations.up.sql h1:847BOg/hRLS9epUkmTmtKCpPVNRhcq+kF8h4XWMinhM=


### PR DESCRIPTION
## Summary

- Persist credit allocations in usage-based `credit_then_invoice` run detailed lines.
- Keep `credits_only` run detailed lines gross while retaining net run totals.
- Record the persisted detailed-line representation and normalize legacy CTI runs when read.

## Why

Usage-based CTI run totals already included allocated credits, but their persisted detailed lines remained gross. This made the run aggregate internally inconsistent and left readers unable to distinguish legacy gross details from the new credit-applied representation.

The representation marker preserves compatibility with existing rows, while read-time normalization lets callers consume a consistent current domain model without mutating historical data.

## Validation

- Focused usage-based Go tests
- Focused usage-based Go vet
- Go lint
- Atlas migration validation and lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detailed usage lines now show how credit allocations affect charges.
  * Added support for applying credits to detailed line items while preserving original data.
  * Legacy runs are automatically adapted when credit allocation details are unavailable.

* **Bug Fixes**
  * Improved retrieval and persistence of detailed usage lines.
  * Added clearer handling for runs without materialized detailed lines.

* **Database**
  * Added storage for whether detailed lines include credit allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Persists and exposes the credit-allocation representation of usage-based realization-run details.
- Applies allocated credits before persisting credit-then-invoice detailed lines while retaining gross details for credits-only runs.
- Adds a database representation marker and normalizes legacy credit-then-invoice details at read time.
- Updates the realization-run adapter contract, domain models, generated Ent code, migration, and focused adapter tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

Credit application is retry-safe because existing applications are reversed before authoritative allocations are reapplied, credits-only details remain gross, legacy normalization is marker-gated, and rating removes credits before gross-detail subtraction.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/adapter/detailedline.go | Persists the representation marker and normalizes unmarked legacy credit-then-invoice detailed lines during expansion. |
| openmeter/billing/charges/usagebased/detailedline.go | Adds validated upsert input and retry-safe credit application over cloned detailed-line bases. |
| openmeter/billing/charges/usagebased/service/run/create.go | Applies run allocations to newly created credit-then-invoice details before persisting them. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Persists reconciled credit allocations in credit-then-invoice snapshots and marks their representation. |
| openmeter/billing/charges/usagebased/service/creditsonly.go | Retains gross persisted details for credits-only runs while using the expanded upsert contract. |
| openmeter/ent/schema/chargesusagebased.go | Adds the default-false detailed-line credit-allocation representation marker. |
| tools/migrate/migrations/20260727095118_usage_based_run_detailed_lines_credit_allocations.up.sql | Adds the non-null representation marker with a legacy-compatible false default. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Rating[Gross rated detailed lines] --> Mode{Settlement mode}
  Mode -->|Credit then invoice| Apply[Apply run credit allocations]
  Mode -->|Credits only| Gross[Keep gross details]
  Apply --> Persist[Persist detailed lines and representation marker]
  Gross --> Persist
  Persist --> Read{Marker present?}
  Read -->|Current representation| Return[Return persisted details]
  Read -->|Legacy CTI representation| Normalize[Apply authoritative run credits at read time]
  Normalize --> Return
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(usagebased): persist credits in CTI ..."](https://github.com/openmeterio/openmeter/commit/76a10cb2b139e888bbd6a10680a721ec42967d56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47548076)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)

<!-- /greptile_comment -->