### PR TITLE
fix(api/spec): set explicit rootDir for TypeScript 7 SDK build

### DIFF
--- a/api/spec/packages/aip-client-javascript/tsconfig.json
+++ b/api/spec/packages/aip-client-javascript/tsconfig.json
@@ -7,6 +7,7 @@
     "types": ["node"],
     "strict": true,
     "declaration": true,
+    "rootDir": "./src",
     "outDir": "dist"
   },
   "include": ["src/**/*.ts"],

--- a/api/spec/packages/aip-client-javascript/tsconfig.tests.json
+++ b/api/spec/packages/aip-client-javascript/tsconfig.tests.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "rootDir": ".",
     "declaration": false,
     "declarationMap": false,
     "sourceMap": false,


### PR DESCRIPTION
TypeScript 7 (tsgo) no longer infers rootDir from the common source directory and fails with TS5011, breaking the publish-aip-sdk job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript build/publishing issues by explicitly setting the production source root.
  * Improved test type-checking by adjusting the test TypeScript source root to match the files being checked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the AIP JavaScript SDK’s TypeScript source roots explicit.
- Sets the production build root to `src` so TypeScript 7 can compile and publish the SDK with the intended `src`-to-`dist` layout.
- Overrides the test configuration root to the package directory so both `src` and `tests` remain valid type-checking inputs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both root directory settings aligned to their respective production and test input sets.

The production configuration includes only files beneath `src`, while the no-emit test configuration explicitly uses the package root to cover both `src` and `tests`; no conflicting imports, inputs, or output-layout changes were identified.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/spec/packages/aip-client-javascript/tsconfig.json | Adds an explicit `src` root that matches the production include pattern and emitted package layout. |
| api/spec/packages/aip-client-javascript/tsconfig.tests.json | Broadens the inherited root for the no-emit test configuration so test files outside `src` can still be type-checked. |

<sub>Reviews (1): Last reviewed commit: ["fix(api/spec): set explicit rootDir for ..."](https://github.com/openmeterio/openmeter/commit/455205835843001ea5cbd8eaea2127183335768b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47885174)</sub>

<!-- /greptile_comment -->