### PR TITLE
docs(agents): improve domain guidance routing

### DIFF
--- a/.agents/skills/domain-docs/SKILL.md
+++ b/.agents/skills/domain-docs/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: domain-docs
+description: Locate and maintain OpenMeter's package-level domain documentation. Use for code reviews, planning, implementation, debugging, or explanations that depend on product behavior, domain ownership, or cross-domain contracts, and when creating or editing domain READMEs. Do not use for mechanical changes with no domain behavior.
+---
+
+# Domain docs
+
+Route domain work to the relevant package documentation and keep that
+documentation accurate, useful to humans, and small enough to read.
+
+## Find the relevant docs
+
+Establish the task's actual scope before selecting documents. For a review
+given only revisions, inspect the changed paths first.
+
+Use this routing table as a starting point:
+
+| paths or behavior | document |
+| --- | --- |
+| `openmeter/ledger/...`, credit balances, collection, correction, ledger routing | `openmeter/ledger/README.md` |
+| `openmeter/billing/charges/...`, charge lifecycle, settlement, realizations | `openmeter/billing/charges/README.md` |
+
+Use judgment about adjacent domains and how much context the task needs. For
+example, if a charge change affects ledger postings, read both documents.
+
+The table is not exhaustive; use repository structure, README links, and search
+when other domain documentation may be relevant.
+
+## Interpret docs and code together
+
+Domain docs describe intended product semantics and architecture. Code and
+tests show current behavior. Neither automatically overrides the other:
+
+- code that contradicts a documented invariant may be the defect under review
+- documentation that contradicts established behavior may be stale
+- resolve the discrepancy from surrounding code, tests, history, and the
+  requested product outcome before changing either
+
+Link a specific implementation or test from the assertion it supports when
+that materially shortens verification. Do not collect general navigation links
+in a separate code map.
+
+## Choose a home
+
+- Put domain documentation in the README at the package boundary that owns the
+  behavior.
+- Put a narrowly scoped algorithm or implementation contract in the owning
+  subpackage README when it would distract from the domain overview.
+- Use `docs/` only for cross-cutting architecture or developer guidance with no
+  natural package owner.
+- Keep one canonical explanation. Other domains should link to it and state
+  only the consequence they need.
+
+## Write useful domain documentation
+
+Write for an engineer who needs to understand what decisions the code is
+implementing. Include only sections the domain needs:
+
+- purpose and non-obvious vocabulary
+- ownership boundaries and intentional non-ownership
+- invariants and their failure consequences
+- lifecycle, time, retry, or persistence semantics that affect behavior
+- contracts with neighboring domains
+- intentional limitations
+
+Human-readable orientation is useful; introductory filler is not. Omit:
+
+- package trees, method inventories, and struct field mirrors
+- standalone code-entry-point sections that only catalog files or directories
+- prose that merely narrates a function or declaration
+- generic repository conventions and test commands
+- temporary implementation state without a durable consequence
+- future designs written as current architecture
+- changelog narration and speculative guidance
+
+If a fact is obvious from one declaration and carries no wider semantic
+consequence, it usually belongs in code rather than the README.
+
+## Create or revise a domain README
+
+1. Read the existing README, current domain types, validation, lifecycle code,
+   persistence mapping, representative tests, and cross-domain callers.
+2. Use deleted docs and history as sources of candidate intent, never as
+   current truth without verification.
+3. Identify the mistake each proposed assertion prevents. Remove assertions
+   with no clear consequence or evidence.
+4. Rewrite around the current model instead of appending another implementation
+   snapshot.
+5. Reconcile overlapping docs: keep the full contract with its owner and link
+   from consumers.
+6. Update this skill's routing table when adding, moving, or deleting a domain
+   README.
+7. Review the result for stale claims, duplicated explanations, and details
+   better expressed by code comments or focused developer docs.
+
+When domain semantics change, update the relevant README in the same change.
+Before deleting one, preserve any product meaning or cross-domain contract that
+is not documented elsewhere.
+
+Treat roughly 200 lines or 12 KB as a signal to edit for focus, not as a quota.

--- a/.agents/skills/domain-docs/SKILL.md
+++ b/.agents/skills/domain-docs/SKILL.md
@@ -13,18 +13,19 @@ documentation accurate, useful to humans, and small enough to read.
 Establish the task's actual scope before selecting documents. For a review
 given only revisions, inspect the changed paths first.
 
-Use this routing table as a starting point:
+Domain documentation lives in READMEs at package boundaries. Start with the
+README nearest the code or behavior in scope, then follow its links or inspect
+adjacent package READMEs when the behavior crosses an ownership boundary.
 
-| paths or behavior | document |
-| --- | --- |
-| `openmeter/ledger/...`, credit balances, collection, correction, ledger routing | `openmeter/ledger/README.md` |
-| `openmeter/billing/charges/...`, charge lifecycle, settlement, realizations | `openmeter/billing/charges/README.md` |
+Examples:
 
-Use judgment about adjacent domains and how much context the task needs. For
-example, if a charge change affects ledger postings, read both documents.
+- charge lifecycle work usually starts in `openmeter/billing/charges/README.md`;
+  read `openmeter/ledger/README.md` too when it changes accounting effects
+- subscription changes that affect billing may require the subscription,
+  subscription-sync, billing, or charges READMEs
 
-The table is not exhaustive; use repository structure, README links, and search
-when other domain documentation may be relevant.
+These are examples, not a registry. Use the repository structure and the
+task's behavior to decide how much context is relevant.
 
 ## Interpret docs and code together
 
@@ -35,6 +36,10 @@ tests show current behavior. Neither automatically overrides the other:
 - documentation that contradicts established behavior may be stale
 - resolve the discrepancy from surrounding code, tests, history, and the
   requested product outcome before changing either
+
+When reviewing a behavioral change, ask whether it makes an assertion in the
+relevant README false or introduces a consequential exception. Treat the
+corresponding documentation update as part of the change.
 
 Link a specific implementation or test from the assertion it supports when
 that materially shortens verification. Do not collect general navigation links
@@ -50,6 +55,8 @@ in a separate code map.
   natural package owner.
 - Keep one canonical explanation. Other domains should link to it and state
   only the consequence they need.
+- Use relative links between package READMEs so they work both in a checkout
+  and while browsing the repository on GitHub.
 
 ## Write useful domain documentation
 
@@ -88,9 +95,7 @@ consequence, it usually belongs in code rather than the README.
    snapshot.
 5. Reconcile overlapping docs: keep the full contract with its owner and link
    from consumers.
-6. Update this skill's routing table when adding, moving, or deleting a domain
-   README.
-7. Review the result for stale claims, duplicated explanations, and details
+6. Review the result for stale claims, duplicated explanations, and details
    better expressed by code comments or focused developer docs.
 
 When domain semantics change, update the relevant README in the same change.

--- a/.agents/skills/domain-docs/agents/openai.yaml
+++ b/.agents/skills/domain-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Domain Docs"
+  short_description: "Find and maintain OpenMeter domain docs"
+  default_prompt: "Use $domain-docs to locate the relevant package domain documentation for this task."

--- a/.agents/skills/iterative-engineering-design/SKILL.md
+++ b/.agents/skills/iterative-engineering-design/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: iterative-engineering-design
 description: >
-  Use for ambiguous, design-heavy, or cross-cutting engineering changes where
-  the existing system, domain model, lifecycle behavior, or production
-  compatibility must be understood before implementation. Helps build and
-  preserve a shared model through design, implementation, review, and reset.
-  Not needed for narrow fixes or already-specified mechanical work.
+  Use when planning or implementing ambiguous, design-heavy, or cross-cutting
+  engineering changes where the existing system, domain model, lifecycle
+  behavior, or production compatibility must be understood. Helps build and
+  preserve a shared model through design, implementation, and reset. Do not use
+  for code review, audits, explanation-only tasks, narrow fixes, or
+  already-specified mechanical work.
 ---
 
 # Complex Engineering Collaboration

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,11 @@ Fixes #(issue)
 ## Notes for reviewer
 
 <!-- Anything the reviewer should know? -->
+
+<!--
+## Checklist
+
+- [ ] I updated the relevant package README, or this change does not affect
+      domain behavior, ownership, lifecycle semantics, or a cross-domain
+      contract.
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,8 @@ on broad subsystem summaries.
 - Treat graph relationships as navigation hints. Current source and tests are
   authoritative; fall back to normal source navigation when CodeGraph is
   unavailable or inconclusive.
-- For ambiguous, design-heavy, or cross-cutting work, use the
+- When planning or implementing ambiguous, design-heavy, or cross-cutting
+  engineering changes, use the
   [`iterative-engineering-design`](.agents/skills/iterative-engineering-design/SKILL.md)
   skill.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,11 @@ See [Testing](docs/development/testing.md) for harness patterns and examples.
   [type conversions](docs/development/type-conversions.md), and
   [collection helpers](docs/development/collection-helpers.md).
 
-For changing domain behavior, inspect current code and tests rather than relying
-on broad subsystem summaries.
+For changes or reviews that affect domain behavior, use the
+[`domain-docs`](.agents/skills/domain-docs/SKILL.md) skill after establishing
+the scope to locate the relevant package documentation. Treat domain docs as
+intended semantics and code and tests as current behavior; investigate
+discrepancies instead of automatically preferring either.
 
 ## CodeGraph and complex work
 

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -1,191 +1,118 @@
 # Billing
 
-This package contains the implementation for the billing stack (invoicing, tax and payments).
-
-The package has the following main entities:
-
-## BillingProfile
-
-Captures all the billing details, two main information is stored inside:
-- The [billing workflow](./entity/customeroverride.go) (when to invoice, due periods etc)
-- References to the apps responsible for tax, invoicing and payments (Sandbox or Stripe for now)
-
-Only one default billing profile can exist per namespace.
-
-## CustomerOverride
-
-Contains customer specific overrides for billing pruposes. It can reference a billing profile other than the default (e.g. when different apps or lifecycle should be used) and allows to override the billing workflow.
-
-## Invoice
-
-Invoices are used to store the data required by tax, invoicing and payment app's master copy at OpenMeter side.
-
-Upon creation all the data required to generate invoices are snapshotted into the invoice entity, so that no updates to entities like Customer, BillingProfile, CustomerOverride change an invoice retrospectively.
-
-### Gathering invoices
-
-There are two general kinds of invoices (Invoice.Status) `gathering` invoices are used to collect upcoming lines that are to be added to future invoices. `gathering` invocie's state never changes: when upcoming line items become due, they are just assigned to a new invoice, so that we clone the data required afresh.
-
-Each customer can have one `gathering` issue per currency.
-> For example, if the customer has upcoming charges in USD and HUF, then there will be one `gathering` invoice for HUF and one for USD.
-
-If there are no upcoming items, the `gathering` invoices are (soft) deleted.
-
-### Collection
-
-TODO: document when implemented
-
-### Invoices
-
-The invoices are governed by the [invoice state machine](./service/invoicestate.go).
-
-Invoices are composed of [lines](./entity/invoiceline.go). Each invoice can only have lines from the same currency.
-
-The lines can be of different types:
-- Fee: one time charge
-- UsageBased: usage-based charge (can be used to charge additional usage-based prices without the product catalog features)
-
-Each line has a `period` (`start`, `end`) and an `invoiceAt` property. The period specifies which period of time the line is referring to (in case of usage-based pricing, the underlying meter will be queried for this time-period). `invoiceAt` specifies the time when it is expected to create an invoice that contains this line. The invoice's collection settings can defer this.
-
-Invoices are always created by collecting one or more line from the `gathering` invoices. The `/v1/api/billing/invoices/lines` endpoint can be used to create new future line items. A new invoice can be created any time. In such case, the `gathering` items to be invoiced (`invoiceAt`) are already added to the invoice. Any usage-based line, that we can bill early is also added to the invoice for the period between the `period.start` of the line and the time of invoice creation.
-
-### Line splitting
-
-To achieve the behavior described above, we are using line splitting. By default we would have one line per billing period that would eventually be part of an invoice:
-
-```
- period.start                                              period.end
-Line1 [status=valid] |--------------------------------------------------------|
-```
-
-When the usage-based line can be billed mid-period, we `split` the line into two:
-
-```
- period.start              asOf                              period.end
-Line1 [status=split]         |--------------------------------------------------------|
-SplitLine1 [status=valid]    |------------------|
-SplitLine2 [status=valid]                       |-------------------------------------|
-```
-
-As visible:
-- Line1's status changes from `valid` to `split`: it will be ignored in any calculation, it becomes a grouping line between invoices
-- SplitLine1 is created with a period between `period.start` and `asof` (time of invoicing): it will be addedd to the freshly created invoice
-- SplitLine2 is created with a period between `asof` and `period.end`: it will be pushed to the gathering invoice
-
-When creating a new invoice between `asof` and `period.end` the same logic continues, but without marking SplitLine2 `split`, instead the new line is added to the original line's parent line:
-
-```
- period.start              asOf1          asof2                period.end
-Line1 [status=split]         |--------------------------------------------------------|
-SplitLine1 [status=valid]    |------------------|
-SplitLine2 [status=valid]                       |---------------|
-SplitLine3 [status=valid]                                       |---------------------|
-```
-
-This flattening approach allows us not to have to recursively traverse lines in the database.
-
-### Usage-based quantity
-
-When a line is created for an invoice, the quantity of the underlying meter is captured into the line's qty field. This information is never updated, so late events will have to create new invoice lines when needed.
-
-### Detailed Lines
-
-Each (`valid`) line can have one or more detailed lines (children). These lines represent the actual sub-charges that are caused by the parent line.
-
-Example:
-> If a line has:
-> - Usage of 200 units
-> - Tiered pricing:
-> - Tier1: 1 - 50 units cost flat $300
-> - Tier2: 51 - 100 units cost flat $400
-> - Tier3: 100 - 150 units cost flat $400 + $1/unit
-> - Tier4: more than 150 units cost $15/unit
-
-This would yield the following lines:
-
-- Line with quantity=200
-  - Line quantity=1 per_unit_amount=300 total=300 (Tier1)
-  - Line quantity=1 per_unit_amount=400 total=400 (Tier2)
-  - Line quantity=1 per_unit_amount=400 total=400 (Tier3, flat component)
-  - Line quantity=50 per_unit_amount=1 total=50 (Tier3, per unit price)
-  - Line quantity=50 per_unit_amount=15 total=759 (Tier4)
-
-Apps can choose to synchronize the original line (if the upstream system understands our pricing model) or can use the sublines to synchronize individual lines without having to understand billing details.
-
-### Detailed Lines vs Splitting
-
-When we are dealing with a split line, the calculation of the quantity is by taking the meter's quantity for the whole line period ([`parent.period.start`, `splitline.period.end`]) and the amount before the period (`parent.period.start`, `splitline.period.start`).
-
-When subtracting the two we get the delta for the period (this gets the delta for all supported meter types except Min and Avg).
-
-We execute the pricing logic (e.g. tiered pricing) for the line qty, while considering the before usage, as it reflects the already billed for items.
-
-Corner cases:
-- Graduating tiered prices cannot be billed mid-billing period (always arrears, as the calculation cannot be split into multiple items)
-- Min, Avg meters are always billed arrears as we cannot calculate the delta.
-
-### Detailed line persisting
-
-In order for the calculation logic, to not to have to deal with the contents of the database, it is (mostly) the adapter layer's responsibility to understand what have changed and persist only that data to the database.
-
-In practice the high level rules are the following (see [adapter/invoicelinediff_test.go](./adapter/invoicelinediff_test.go) for examples):
-- If an entity has an ID then it will be updated
-- If an entity has changed compared to the database fetch, it will be updated
-- If a child line, discount gets removed, it will be removed from the database (in case of lines with all sub-entities)
-- If an entity doesn't have an ID a new entity will be generated by the database
-
-For idempotent entity sources (detailed lines and discounts for now), we have also added a field called `ChildUniqueReferenceID` which can be used to detect entities serving the same purpose.
-
-#### ChildUniqueReferenceID example
-
-Let's say we have an usage-based line whose detailed lines are persisted to the database, but then we would want to change the quantity of the line.
-
-First we load the existing detailed lines from the database, and save the database versions of the entities in memory.
-
-We execute the calculation for the new quantity that yields new detailed lines without database IDs.
-
-The entity's `ChildrenWithIDReuse` call can be used to facilitate the line reuse by assigning the known IDs to the yielded lines where the `ChildUniqueReferenceID` is set.
-
-Then the adapter layer will use those IDs to make decisions if they want to persist or recreate the records.
-
-We could do the same logic in the adapter layer, but this approach makes it more flexible on the calculation layer if we want to generate new lines or not. If this becomes a burden we can do the same matching logic as part of the upsert logic in adapter.
-
-## Lineengine Charges Integration Plan
-
-Mutable invoice edits route created, updated, and deleted invoice lines through the line engine that owns the line. For charge-backed manual line creation, billing and charges have a circular dependency:
-
-- the invoice line must reference the charge via `ChargeID`
-- the charge realization must reference the invoice line via `LineID` and `InvoiceID`
-
-Billing owns invoice line identity and persistence. Charges owns charge creation, charge state transitions, realization runs, credit allocation, and mapping realization output back to invoice lines.
-
-The intended charge-backed manual create flow is:
-
-1. A mutable invoice is loaded and edited through `UpdateStandardInvoice`.
-2. The edit diff routes a newly created line to the create line router.
-3. Billing preallocates the created invoice line ID and inserts a provisional invoice line inside the same invoice manipulation transaction.
-4. Billing refreshes or updates the in-memory line DB snapshot so the final invoice update treats the provisional line as an existing row to update, not as another create.
-5. Billing invokes `LineEngine.OnMutableInvoiceLinesEditedViaAPI` with created lines that already have `LineID`, `InvoiceID`, and `Engine` populated. Charge-backed created lines do not have `ChargeID` yet.
-6. The charge line engine creates the manually managed charge from the created line payload.
-7. The charge line engine moves the new charge through an attach-to-existing-invoice-line state-machine transition. The exact trigger/state name can change, but the business meaning is that the charge attaches to a billing-owned invoice line that already exists.
-8. The charge state machine creates the realization run with the provided `LineID` and `InvoiceID`, persists charge state, allocates/corrects credits as needed, and maps the realization result back onto the invoice line.
-9. The charge line engine returns the realized invoice line with `ChargeID`, totals, detailed lines, and other charge-owned fields populated.
-10. Billing replaces the provisional line in the invoice aggregate with the returned line and persists it as an update to the provisional row.
-
-All steps above must stay within the invoice manipulation transaction. If charge creation or realization fails, the provisional invoice line must roll back with the rest of the invoice edit.
-
-Callback expectations for this flow:
-
-- created lines passed to charge line engines must already have stable invoice line IDs
-- charge engines must return created lines with the same line IDs as the created input lines
-- updated lines are matched by existing line ID
-- deleted lines are side-effect/validation inputs and are not returned in the API invoice line edit result
-- billing validates callback output identity before replacing invoice lines
-
-## Subscription adapter
-
-The subscription adapter is responsible for feeding the billing with line items during the subscription's lifecycle. The generation of items is event-driven, new items are yielded when:
-- A subscription is created
-- A new invoice is created
-- A subscription is modified
-- Upgrade/Downgrade is handled as a subscription create/cancel
+Billing turns billable work into fiat invoices and advances those invoices
+through calculation, external invoicing, and payment.
+
+It owns:
+
+- billing profiles and customer-specific workflow overrides
+- gathering and standard invoice aggregates
+- invoice-line identity and persistence
+- invoice calculation, validation, and lifecycle orchestration
+- coordination with tax, invoicing, and payment apps
+
+It does not own the subscription schedule that produces billable work, or the
+charge and ledger semantics behind a charge-backed line. Subscription
+reconciliation is described in
+[Subscription sync](worker/subscriptionsync/README.md); charge behavior is
+described in [Charges](charges/README.md).
+
+## Billing configuration becomes invoice history
+
+A billing profile selects the workflow and the apps responsible for tax,
+invoicing, and payment. A namespace has one default profile. A customer
+override may select another profile and replace supported parts of its
+workflow.
+
+The merged customer configuration is resolved when a standard invoice is
+created. The invoice keeps the customer, supplier, workflow configuration, and
+app references needed to finish its lifecycle. Customer-visible invoice
+history must not retrospectively follow later customer or profile changes.
+
+## Gathering and standard invoices
+
+A **gathering invoice** is mutable staging for future invoice lines. There is at
+most one per customer and fiat currency. It does not advance through the
+standard invoice state machine and is deleted when it has no remaining lines.
+
+A **standard invoice** is created by collecting eligible gathering lines for
+one customer and currency. The collected line identities are preserved while
+their gathering representations are replaced by standard lines. The standard
+invoice then owns the calculated and externally synchronized record presented
+to the customer.
+
+An invoice's lines may be absent because they were not expanded. This is
+different from a loaded but empty line collection.
+
+A standard line is the billable item on the invoice. Detailed lines explain
+the calculated price components beneath it, such as tier or flat-fee
+components. They are derived calculation output, not another source of
+subscription intent.
+
+## Time has distinct meanings
+
+- a line's service period is when the service was provided
+- `InvoiceAt` is when the line becomes eligible to be invoiced
+- a gathering invoice's next collection time is when the collector should
+  reconsider its pending lines
+- a standard invoice's collection time is the cutoff used while snapshotting
+  quantities and completing collection
+
+Collection alignment may move the effective collection cutoff to an anchor.
+Do not use one of these timestamps as a substitute for another.
+
+Progressive billing may split a service period across invoices. The split-line
+group preserves the full service-period identity while its children represent
+the portions materialized on individual invoices. Already immutable invoice
+history is not rewritten to make a later subscription change look as if it had
+always existed.
+
+## Line ownership
+
+Billing owns the invoice aggregate, line IDs, and persistence. A line's engine
+owns the line-specific calculations and lifecycle side effects for the lines
+routed to it. The built-in invoicing engine handles billing-native lines;
+charge engines handle charge-backed lines.
+
+Engine callbacks operate on groups of lines. When a callback replaces lines,
+billing requires it to preserve the input line IDs before accepting the
+result. API-originated line edits and system-originated reconciliation are
+different change sources: API edits may change manual ownership, while system
+edits preserve the ownership contract of their source.
+
+## Invoice lifecycle and failure
+
+The standard invoice state machine coordinates:
+
+1. collection and quantity snapshotting
+2. calculation and validation
+3. draft synchronization with the invoicing app
+4. approval and issuing
+5. charge booking and payment processing
+
+Critical validation issues stop advancement. External app and line-engine
+failures leave the invoice in an explicit failed state so the failed step can
+be retried without replaying stable lifecycle states. Issuing and payment
+booking therefore happen in retryable intermediary states; authorization is
+booked before settlement when a payment provider reports both at once.
+
+Retrying and deleting are separate domain actions. Use the billing service's
+retry operation for a retryable failure and its delete operation for the
+delete lifecycle; firing a generic state-machine trigger bypasses preparation
+and audit semantics owned by those operations.
+
+Billing publishes created and updated standard-invoice snapshots for
+downstream consumers. [Notifications](../notification/README.md) maps those
+snapshots into its own API-shaped historical payloads and delivers them
+asynchronously; webhook delivery is not part of the invoice lifecycle.
+
+## Consistency invariants
+
+- invoice manipulation is serialized per customer and runs under the billing
+  transaction and customer update lock
+- every invoice contains one fiat currency
+- a customer cannot have two active gathering invoices for the same currency
+- gathering-to-standard conversion preserves line IDs
+- line engines cannot silently change the identity or count of callback output
+- immutable invoice drift is recorded as validation issues rather than
+  rewriting customer-visible history

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -1,0 +1,163 @@
+# Charges
+
+A charge is a durable billing intent plus the lifecycle state and realizations
+created while fulfilling it. Charges connect subscription-derived or manually
+created commercial intent to credit allocation, invoicing, payment, and ledger
+effects.
+
+## Domain model
+
+The three charge types have distinct product behavior:
+
+| type | intent |
+| --- | --- |
+| flat fee | realize a fixed, possibly prorated amount |
+| usage based | meter and rate a service period, possibly through multiple realization runs |
+| credit purchase | grant customer credit and track promotional, external, or invoice settlement |
+
+The root `charges.Charge` is a tagged wrapper over concrete charge aggregates.
+Each aggregate separates:
+
+- intent: what should happen
+- base state: current durable lifecycle and scheduling state
+- realizations: persisted child facts such as runs, credit allocations,
+  corrections, payments, detailed lines, and ledger transaction references
+
+The shared meta status (`created`, `active`, `final`, `deleted`) is a query
+projection. The type-specific detailed status is the lifecycle state.
+
+## Ownership and boundaries
+
+- The root charges service owns cross-type creation, lookup, listing, patch
+  dispatch, and customer-scoped advancement.
+- Flat-fee, usage-based, and credit-purchase packages own their lifecycle,
+  detailed status, persistence, and settlement-specific behavior.
+- State machines decide transitions and externally visible lifecycle effects.
+  Realization subservices perform rating, allocation, correction, payment, or
+  persistence mechanics without inventing transitions.
+- Billing owns invoice aggregates, invoice creation, collection, and invoice
+  lifecycle. Charge line engines translate charge state into billing lines and
+  feed billing events back into the owning charge state machine.
+- [Ledger charge adapters](../../ledger/README.md) translate requested economic
+  effects into ledger transactions. They do not decide when a charge advances.
+- [Subscription sync](../worker/subscriptionsync/README.md) reconciles
+  subscription-derived source intent. It does not treat API overrides as new
+  subscription source state.
+
+`AdvanceCharges` coordinates concrete services; it is not a second
+implementation of their state machines.
+
+## Intent layers
+
+Flat-fee and usage-based charges have an immutable intent, a mutable base layer,
+and an optional mutable override layer.
+
+- The base layer is the source intent. For subscription-managed charges it
+  reflects subscription state.
+- When present, the override is the effective customer-facing mutable intent.
+- Customer-facing lifecycle, rating, invoice, and API behavior reads the
+  effective layer.
+- Subscription sync, repair, and adapter base persistence read the base layer.
+- Immutable attribution such as customer, currency, subscription identity,
+  feature identity, settlement mode, cost-basis intent, and tax configuration
+  cannot silently move into an override.
+- Override presence is represented by its dedicated row. Deprecated embedded
+  override columns are not active behavior.
+- Credit-purchase charges do not use this override model.
+
+Patch source determines the target layer. System reconciliation targets source
+state; API edits target an existing override, a manually managed base, or a new
+override as appropriate. A state machine rejects a hidden base target while an
+override is active. Service-level sync may update that hidden source state, but
+does not emit invoice patches, rerate, or mutate customer-facing realizations
+for it.
+
+Effective deletion and base-intent deletion are therefore different query
+concepts. Subscription reconciliation must be able to find a base intent even
+when an active override hides it.
+
+## Lifecycle and persistence invariants
+
+- Each concrete state machine is the authority for reachable detailed states.
+  Every reachable status validates, and every detailed status maps to its short
+  meta status.
+- Invoice-backed charges remain in an `active.*` state while authorization or
+  settlement is pending. `final` means the required payment lifecycle is
+  complete, not merely that rating or line creation finished.
+- Lifecycle entry points run in database transactions. Flat-fee and usage-based
+  advancement and patching also take charge-scoped locks.
+- `UpdateCharge` persists the concrete base row. Expanded realizations are read
+  model state and are written through dedicated adapter operations.
+- Ledger effects and the realization or payment facts that reference them are
+  written under the lifecycle transaction. Retry safety comes from persisted
+  lifecycle facts checked before handlers run, not from the
+  [ledger](../../ledger/README.md#transaction-invariants).
+- Due `credit_only` flat-fee and usage-based charges are persisted before
+  post-create auto-advance, so worker retries do not lose the intent. Credit
+  purchases follow their own creation and invoice-event lifecycle.
+
+## Settlement semantics
+
+Flat-fee and usage-based charges support two modes:
+
+- `credit_only` realizes against customer credit; live-balance projection treats
+  its impact as unbounded and may therefore go negative
+- `credit_then_invoice` consumes eligible positive credit and sends the
+  remaining overage through billing
+
+Their balance bounds, realizations, invoice behavior, and terminal conditions
+are different; they are not interchangeable forms of one amount flow.
+
+Credit purchases use a separate settlement union:
+
+- promotional grants credit without payment
+- external grants credit and tracks external authorization and settlement
+- invoice settlement is driven by billing hooks and the credit-purchase line
+  engine
+
+A credit grant, payment authorization, and payment settlement are separate
+durable facts. A later state cannot be inferred from the presence of an earlier
+one.
+
+## Realization and time semantics
+
+- A usage-based realization run is a persisted checkpoint. `ServicePeriodTo`
+  is the exclusive event-time bound; `StoredAtLT` is the exclusive ingestion
+  bound. Waiting and correction logic uses the persisted bounds rather than
+  recomputing them.
+- Usage-based run metered quantity is cumulative from charge start to the run
+  boundary. A billing standard line expects line-period and pre-line-period
+  quantities, so charge mappers translate rather than copy it.
+- Corrections reconcile against persisted runs and allocations and preserve
+  lineage to the facts previously billed or posted.
+- Charge lifecycle timestamps are normalized to streaming aggregation
+  precision before duration-sensitive calculations and persistence. Deletion
+  timestamps retain their supplied instant.
+- Charge-owned monetary inputs and totals are normalized with the charge
+  currency. A positive source amount can round to zero after fiat conversion;
+  that result requires explicit lifecycle handling.
+
+The usage-based rating algorithms have narrower contracts in
+[`delta`](usagebased/service/rating/delta/README.md),
+[`periodpreserving`](usagebased/service/rating/periodpreserving/README.md), and
+[`subtract`](usagebased/service/rating/subtract/README.md).
+
+## Currency identity
+
+`currencies.Currency` identity is the fiat code for fiat currencies and the
+namespace plus managed currency ID for custom currencies. A display code is not
+globally sufficient identity: distinct managed currencies may reuse one.
+
+Within the charges domain, custom-currency `credit_then_invoice`:
+
+- allocates and realizes in the custom currency first
+- resolves and persists the applicable cost basis
+- converts only the post-allocation overage to fiat
+- rounds the converted amount with the fiat currency
+- retains the managed currency as charge identity rather than replacing it
+  with the settlement fiat currency or display code
+
+This is a charge-domain contract, not end-to-end support: current ledger-backed
+charge adapters reject custom currencies. Enabling them spans ledger route
+identity and persistence, charge realization, settlement rounding, corrections,
+balance queries, and historical migration.

--- a/openmeter/billing/worker/subscriptionsync/README.md
+++ b/openmeter/billing/worker/subscriptionsync/README.md
@@ -1,0 +1,113 @@
+# Subscription sync
+
+Subscription sync is the reconciliation boundary between the desired schedule
+owned by [Subscription](../../../subscription/README.md) and the billing-side
+artifacts owned by [Billing](../../README.md) and
+[Charges](../../charges/README.md).
+
+It translates a subscription view into invoice lines or charge intents. It
+does not edit subscriptions, calculate invoice totals, realize charges, or
+advance invoice and payment lifecycles.
+
+## Reconciliation model
+
+A sync is given a subscription reference or expanded view and an `asOf`
+horizon. It resolves the subscription, including deleted records, and the
+customer's billing profile before acquiring billing's customer lock. Under that
+lock it:
+
+1. loads the persisted invoice-line and charge state owned by that subscription
+2. builds the target billable periods from the resolved subscription view
+3. diffs target and persisted items by their subscription-sync identity
+4. applies invoice patches, then charge patches
+5. records whether the subscription still has billables and when it next needs
+   reconciliation
+
+This is reconciliation, not event handling by side effect. Repeating the same
+sync must converge. Subscription events provide the prompt path, invoice
+creation triggers a refill of consumed future work, and the periodic reconciler
+repairs missed or failed event processing.
+
+Invoice patches, charge patches, and the sync-state update share the billing
+transaction. A failure rolls back the plan rather than leaving only the earlier
+patches applied.
+
+The entrypoints that also invoice the customer run pending-line collection
+after reconciliation so flat fees billed in advance can become invoices
+immediately.
+
+## Target time model
+
+The target builder walks each phase and item version into service periods up to
+the requested horizon. The horizon normally expands to the end of the aligned
+billing period containing `asOf`; it is not simply a database query cutoff.
+
+Each target item keeps three periods:
+
+- service period: the portion of service represented by this artifact
+- full service period: the untruncated period used for proration
+- billing period: the subscription-aligned outer period
+
+Flat fees billed in advance use the billing-period start as `InvoiceAt`.
+Everything else is invoiced no earlier than both the service-period and
+billing-period end.
+
+Recurring artifacts use the stable identity:
+
+```text
+{subscriptionID}/{phaseKey}/{itemKey}/v[{itemVersion}]/period[{periodIndex}]
+```
+
+One-time artifacts omit the period component. This identity is stored on both
+invoice-backed and charge-backed state. Duplicate identities, including a
+collision across the two backends, are an integrity error.
+
+## Backend ownership
+
+Persisted artifact type determines which backend continues to own an existing
+item. New target items are routed according to the available charge stack,
+feature gates, settlement mode, and price type. This permits gradual movement
+from invoice-backed subscription items to charge-backed items without silently
+replacing already persisted ownership.
+
+Charge-backed reconciliation is the replacement path for supported new
+artifacts. The invoice backend remains for compatibility while that transition
+is incomplete. Existing artifacts keep their persisted backend rather than
+being migrated implicitly.
+
+Invoice-backed patches may create gathering lines or update mutable gathering
+and standard invoices. If subscription state disagrees with an immutable
+standard invoice, sync records validation issues; it does not rewrite the
+invoice.
+
+Charge-backed patches operate on the charge intent. Charge-managed invoice
+lines are projections of charge state and are deliberately excluded from the
+subscription-sync invoice read model. A customer-facing charge override also
+does not erase the subscription-owned base intent: later subscription changes
+continue to reconcile that base without resurrecting the overridden effective
+charge.
+
+## Deletion, cancellation, and retries
+
+Cancellation syncs through the subscription end so artifacts are shortened or
+removed according to the final desired periods. A deleted subscription has no
+view and therefore produces an empty target, asking reconciliation to remove
+its remaining owned artifacts subject to immutable-invoice rules. Cleanup must
+use an ID-based entrypoint because the normal subscription view lookup excludes
+deleted records.
+
+Sync state is written only after the plan has been applied. `HasBillables`
+prevents needless future scheduling; `NextSyncAfter` is the end of the
+generated horizon. Errors remain retryable through the event handler or
+periodic reconciler. Dry-run builds the same plan but only logs it and does not
+write artifacts or sync state.
+
+## Intentional limitations
+
+- subscription sync currently materializes subscription currency as fiat; it
+  does not perform custom-currency-to-fiat conversion
+- subscription-owned credit-purchase charges are unsupported
+- immutable invoice drift is reported, not automatically corrected
+- an `asOf` at the current instant is not a request to provision the entire
+  future subscription; callers that need future artifacts must provide the
+  corresponding horizon

--- a/openmeter/ledger/README.md
+++ b/openmeter/ledger/README.md
@@ -1,0 +1,121 @@
+# Ledger
+
+The ledger is OpenMeter's immutable accounting journal for customer credit,
+receivables, accrued usage, recognized earnings, payments, currency conversion,
+and breakage.
+
+## Domain model
+
+Accounts express ownership and accounting purpose. Subaccounts are the actual
+posting addresses; a subaccount's normalized route is part of its identity.
+
+Customer accounts are provisioned per customer. Business accounts are shared
+within a namespace.
+
+| account | meaning |
+| --- | --- |
+| `customer_fbo` | customer credit or stored value; not a literal regulated FBO bank account |
+| `customer_receivable` | value owed by the customer, including open and payment-authorized stages |
+| `customer_accrued` | acknowledged usage or spend not yet recognized as earnings |
+| `wash` | the external payment or cash boundary |
+| `earnings` | recognized business revenue |
+| `brokerage` | business-side counterparty for currency conversion |
+| `breakage` | expired or otherwise forfeited customer credit |
+
+The historical ledger stores immutable transaction groups, transactions, and
+entries. Balances are projections over those entries; they are not mutable
+facts stored independently from the journal.
+
+## Ownership and boundaries
+
+- The ledger owns balanced posting, route identity, permitted accounting flows,
+  collection from concrete balances, corrections, and accounting provenance.
+- Transaction templates encode posting mechanics. They do not decide charge
+  lifecycle, payment lifecycle, settlement mode, or invoice orchestration.
+- `chargeadapter` translates charge lifecycle events into ledger templates.
+  Charges decide when an effect is due; the ledger decides how that effect is
+  represented and validated. See the [charges domain](../billing/charges/README.md).
+- The collector owns source selection and correction unwind order. Callers
+  provide the target amount and attribution; they must not recreate collection
+  policy.
+- `customerbalance` is a customer-facing projection over booked ledger state,
+  breakage, and not-yet-booked charge impacts. It does not own posting,
+  collection, or correction rules.
+- Account resolvers provision canonical customer and namespace business
+  accounts. Higher-level domains request account-specific route parameters
+  rather than assembling generic accounts or posting addresses.
+
+## Transaction invariants
+
+- Every transaction sums to zero. Each entry amount is valid at the posting
+  currency's precision.
+- `CommitGroup` validates the whole input, locks every affected parent account,
+  and books the group atomically in the caller's database transaction.
+- Default routing rules constrain allowed account-type combinations, flow
+  direction, authorization stages, route compatibility, and dimension scope.
+  A balanced transaction can still be invalid.
+- Reversal and correction logic follows the actual original entries. It
+  preserves charge provenance and route pairing, links replacement postings to
+  their source entries, and uses deterministic source order rather than
+  recomputing an idealized replacement from current balances.
+- Entry identity records collection or correction linkage and source and spend
+  charge provenance when present. Template codes and transaction annotations
+  describe accounting meaning.
+
+The historical ledger makes a group atomic, but it does not deduplicate a
+repeated `CommitGroup` call. The initiating domain must make retries safe and
+persist the returned group reference with its own lifecycle state. Ledger
+annotations and entry identity preserve accounting meaning and provenance; they
+are not operation idempotency keys.
+
+## Route invariants
+
+Routes currently carry currency, feature restrictions, cost basis, credit
+priority, receivable authorization status, tax code, and tax behavior. These
+are accounting identity, not optional metadata. Dropping a populated dimension
+during translation or filtering can merge economically distinct balances while
+leaving each transaction locally balanced.
+
+- Routes are normalized before key creation and querying. Feature order is not
+  semantic.
+- `Route.Filter()` pins present values, including explicit nil values.
+  `RouteFilter` absence means "do not filter"; it differs from filtering for a
+  nil route dimension.
+- Feature dimensions belong only on FBO and receivable routes. Tax dimensions
+  belong only on accrued and earnings routes; FBO sources acquire the charge's
+  tax attribution when value moves into accrued.
+- Currency and cost-basis attribution survive the relevant FBO, receivable,
+  accrued, earnings, wash, brokerage, and breakage legs.
+- Credit priority controls FBO collection order. Corrections unwind the
+  recorded collection order rather than applying today's priorities.
+- Receivable authorization is an accounting stage. Moving between open and
+  authorized routes is a ledger transaction, not an in-place flag update.
+
+Adding or changing a route dimension is a storage and compatibility change. It
+affects normalization, routing-key versions, schema persistence, filters,
+account-specific route parameters, transaction rules, corrections, and
+historical data—not only the `Route` struct.
+
+## Feature-restricted balances
+
+Public balance filtering and source allocability are related but distinct:
+
+- no feature filter means the whole credit portfolio
+- an unrestricted-only filter selects routes with no feature restriction
+- filtering for one feature includes unrestricted routes and routes containing
+  that feature
+- unrestricted credit can fund any charge; restricted credit can fund only a
+  matching feature
+
+Public filtering cannot be implemented as exact route equality, and a public
+balance result is not necessarily the set of sources allocable to every charge.
+
+## Time and balance boundaries
+
+- `BookedAt` is accounting effective time. `CreatedAt` and transaction ID make
+  ordering deterministic when booked times tie.
+- `AsOf` and cursor behavior apply before customer-facing projection; future
+  ledger or breakage facts cannot leak into historical views.
+- `historical.Ledger` enforces transaction invariance, not post-transaction
+  account-balance constraints. Product-specific bounds, including when a
+  balance may go negative, belong to higher-level flows and collectors.

--- a/openmeter/notification/README.md
+++ b/openmeter/notification/README.md
@@ -1,0 +1,140 @@
+# Notifications
+
+Notifications turn selected OpenMeter domain events into durable,
+customer-configured webhook deliveries.
+
+A source event is not itself a notification event. The notification consumer
+matches it against active rules and creates notification events for the
+matching rule and trigger. A single balance snapshot can produce separate
+events for an active usage threshold and an active balance threshold. Each
+event contains a payload snapshot and one delivery status for every active
+channel assigned to that rule.
+
+## Domain model
+
+- A **channel** is a delivery destination. Webhooks are currently the only
+  channel type; the channel owns its URL, headers, signing secret, and disabled
+  state.
+- A **rule** selects one notification event type, its type-specific conditions,
+  and one to five channels. Rule and channel types are immutable.
+- An **event** records that one rule matched one source fact. Its type, rule ID,
+  payload, and creation time are immutable. The referenced rule remains mutable;
+  its configuration and channel assignments are not copied into the event.
+- A **delivery status** is the mutable per-event, per-channel delivery record.
+  It contains the state, next attempt, failure reason, and provider attempts.
+
+Rules and channels are namespaced and soft-deleted. A channel cannot be deleted
+while a rule still references it. Events have no update or delete lifecycle;
+payload compatibility and retention therefore matter for historical data.
+
+## Ownership and runtime boundaries
+
+- [Billing](../billing/README.md) owns invoice lifecycle and invoice domain
+  events. Entitlements own balance calculation, usage periods, and snapshot
+  events. Notifications do not reconstruct either domain's current state.
+- The notification consumer owns rule matching, threshold evaluation,
+  notification-event creation, and the mapping from source events to persisted
+  notification payloads.
+- Event creation atomically persists the event and its initial `PENDING`
+  delivery statuses. It does not synchronously send the webhook.
+- The notification worker consumes balance and invoice events and records
+  notification events. A leader-elected reconciler in the API server delivers
+  and reconciles them through Svix. See the
+  [runtime architecture](../../docs/architecture.md).
+- Svix owns outbound webhook attempts. OpenMeter owns the rule and channel
+  model, the durable notification event, and its mirrored per-channel delivery
+  state.
+
+Each OpenMeter webhook channel is mirrored by a Svix endpoint. Rule assignment
+is also reflected in Svix's endpoint filters. Channel and rule changes must
+keep PostgreSQL and provider state consistent; changing only one side breaks
+delivery or leaves delivery status unreconcilable.
+
+## Source events and matching
+
+| notification type | source | matching behavior |
+| --- | --- | --- |
+| `entitlements.balance.threshold` | entitlement snapshot update or reset | optional feature scope; evaluates configured usage and balance thresholds |
+| `entitlements.reset` | entitlement reset snapshot | optional feature scope |
+| `invoice.created` | billing standard-invoice created event | every active rule of the type |
+| `invoice.updated` | billing standard-invoice updated event | every active rule of the type |
+
+No active matching rule means no notification event is persisted. Invoice and
+balance-threshold rules are evaluated independently, so matching rules can
+produce separate events from the same source fact. Reset-event deduplication
+currently uses a broader usage-period lookup and does not provide that per-rule
+guarantee.
+
+Balance-threshold notifications are evaluated only for active metered
+entitlements with a complete balance and usage snapshot. Within each threshold
+kind, the most advanced active threshold is selected. Deduplication is scoped
+to the rule, entitlement, feature, usage period, measurement start, and
+threshold kind. It suppresses repeated snapshots at the same active threshold,
+not events from another rule.
+
+This deduplication belongs to the balance-threshold handler; `CreateEvent` has
+no generic source-event idempotency contract. Its hashes are persisted with the
+event and legacy hash forms remain part of lookup compatibility.
+
+Invoice notifications ignore invoices still in `gathering`: that state is an
+incomplete billing aggregate, not a deliverable invoice snapshot.
+
+## Payloads are historical snapshots
+
+The persisted payload is the source for both notification API responses and
+later webhook delivery. Delivery must not look up the current invoice,
+entitlement, customer, feature, or subject and silently change what the event
+means.
+
+- Entitlement payloads contain API-shaped entitlement, feature, customer,
+  subject, and calculated value data from the consumed snapshot.
+- Invoice payloads are eagerly converted from the billing event to
+  `api.Invoice` before persistence. The notification package does not persist
+  the internal billing aggregate.
+- Current invoice payloads use persisted payload version `1`. Invoice reads
+  reject unsupported versions. Entitlement payloads remain unversioned, so
+  payload-version changes must account for existing rows by event type.
+
+Adding or changing an event type is therefore a persistence and external
+contract change, not only a new consumer branch. The domain type, rule and
+payload validation, source-event mapping, API payload, stored JSON handling,
+Svix event registration, and historical reads must agree.
+
+Testing a rule is not a dry-run. It creates a normal persisted notification
+event, marked with the `notification.rule.test` annotation, and its delivery
+statuses enter the same reconciliation flow.
+
+## Delivery lifecycle
+
+Delivery is tracked independently for each channel:
+
+```text
+PENDING -> SENDING -> SUCCESS
+                   -> FAILED
+     \-> FAILED
+
+SENDING -> PENDING (missing provider message recovery)
+
+SENDING, SUCCESS, or FAILED -> RESENDING -> SENDING
+```
+
+- `PENDING` means the event exists but the provider message is not yet known to
+  be accepted. Repeated sends converge on the notification event ID at Svix.
+- `SENDING` mirrors provider-side retries and attempt details.
+- `SUCCESS` and `FAILED` are terminal until an explicit resend changes the
+  selected statuses to `RESENDING`.
+- Reconciliation handles transient provider errors using `next_attempt`.
+  Missing provider message state can eventually return `SENDING` to `PENDING`;
+  missing endpoints, missing rule assignments, disabled provider endpoints, and
+  invalid configuration are terminal for that delivery.
+- By default, a delivery that remains `PENDING` fails three hours after its
+  delivery status was created, and one in `SENDING` fails 48 hours after
+  creation. The current implementation does not restart that clock on resend,
+  so an old delivery can reach the sending timeout immediately after a resend.
+  These timeouts and the reconciliation interval are configurable.
+- A failed delivery does not disable its rule or channel. Future matching
+  source events remain independent.
+
+Resend reuses the persisted event payload. It may target selected channels, but
+only channels assigned to the event's rule and statuses already in
+`SENDING`, `SUCCESS`, or `FAILED` are eligible.

--- a/openmeter/subscription/README.md
+++ b/openmeter/subscription/README.md
@@ -1,0 +1,123 @@
+# Subscription
+
+A subscription is OpenMeter's desired commercial schedule for a customer. It
+combines plan-derived phases and rate cards with customer-specific timing,
+currency, settlement mode, and customizations.
+
+The subscription domain owns that schedule and keeps any derived entitlements
+aligned with it. It does not own invoices, charge realization, or ledger
+entries. Those are reconciled asynchronously from subscription state by
+[Subscription sync](../billing/worker/subscriptionsync/README.md).
+
+## The model
+
+A subscription has a customer, active interval, billing cadence and anchor,
+currency, settlement mode, and optional plan reference.
+
+Its complete desired shape is a `SubscriptionSpec`:
+
+- phases are keyed and ordered by their offset from the subscription start
+- a phase ends when the next phase begins, or when the subscription ends
+- items are grouped by key within a phase
+- each item carries a rate card, optional relative timing overrides, and the
+  information needed to schedule an entitlement
+
+`ItemsByKey[key]` is a time-ordered version history. Its slice index identifies
+a logical revision of the item; it is not quantity. Removing or inserting an
+element changes the identity used by downstream subscription reconciliation.
+
+A `SubscriptionView` is the hydrated read model: the subscription, its current
+spec, customer, phases, items, features, and entitlements. The spec is the
+desired state used for editing; the persisted child entities and expanded
+references show how that state is currently materialized. A valid view keeps
+the duplicated identity, cadence, currency, plan, and settlement facts
+consistent.
+
+## Lifecycle and edits
+
+Subscription status is derived at a point in time from its active interval,
+deletion time, and whether cancellation has set an end. The lifecycle supports
+scheduled creation, active updates, cancellation, continuation, and deletion;
+the state machine decides which action is legal from the current status.
+
+Cancellation shortens the subscription and the cadences of affected phases,
+items, and entitlements. Continuation removes a cancellable end and extends the
+derived children again. Deletion is distinct from cancellation: deleted
+subscriptions leave the normal read path but remain available to cleanup
+consumers that explicitly include deleted records.
+
+Updating a subscription reconciles its current view with a new spec. Customer,
+plan reference, subscription start, and settlement mode are not mutable through
+this path. Changed phases or items may be deleted and recreated, including
+their entitlements. Consumers must not treat a persisted phase, item, or
+entitlement ID as the durable identity of a logical spec path.
+
+Higher-level plan workflows create a spec from a plan and express running
+changes as patches. Addons also modify the spec, but an addon-bearing
+subscription cannot be edited through the general running-edit workflow; use
+the addon workflow so its overlay remains reversible. See
+[Subscription addons](addon/README.md).
+
+## Workflow, patches, and service
+
+The workflow layer owns customer-facing operations such as creating from a
+plan, editing a running subscription, changing plans, restoring, and applying
+addons. It resolves command timing, constructs the target spec, and coordinates
+operations that span more than one subscription.
+
+[Patches](patch/README.md) are ordered transformations of a
+`SubscriptionSpec`. They express how a workflow changes desired state; they do
+not persist subscription entities or billing artifacts.
+
+The core service owns subscription lifecycle validation, hooks, persistence,
+and event publication. Given a complete target spec, its
+[materialization](service/README.md) reconciles subscription-owned phase, item,
+and entitlement state. The service does not decide which plan workflow or
+patches produced that target.
+
+## Cadence and effective time
+
+`BillingAnchor` and `BillingCadence` define aligned billing periods. Periods
+are clipped to phase and subscription boundaries. The plan workflow defaults
+the anchor to `ActiveFrom`, but the stored anchor is an explicit subscription
+fact and must be carried through replacements and plan changes.
+
+`Timing` describes when a command should take effect. It contains exactly one
+of a custom timestamp or a supported enum. `immediate` resolves from the
+subscription clock; `next_billing_cycle` resolves to the end of the aligned
+billing period containing that clock time. The resolved time becomes the
+effective time used while applying patches.
+
+Allowed timing depends on the action. Running edits accept immediate or
+next-billing-cycle timing but not arbitrary custom timestamps. A custom
+cancellation time for an aligned subscription must fall on a billing-period
+boundary. Creation may be scheduled with a custom timestamp, subject to its
+past-time tolerance.
+
+Phase offsets and item timing overrides remain relative to the subscription
+and phase; do not persist a derived absolute end as independent source truth.
+
+## Neighboring domains
+
+- The product catalog supplies the plan shape used to build the initial spec.
+  The subscription owns the resulting customer-specific schedule, not the
+  mutable plan definition.
+- Entitlements are derived from entitlement-bearing rate cards and share the
+  effective cadence of their subscription item. Recreating an item may
+  recreate its entitlement.
+- Subscription commands publish lifecycle events. Successful subscription
+  mutation means the desired schedule was committed; it does not mean billing
+  artifacts have already been reconciled.
+- Billing behavior such as line generation, invoice collection, charge
+  realization, proration materialization, and immutable-invoice handling
+  belongs outside this package.
+
+## Invariants
+
+- phase order is determined from the full spec; a phase row alone cannot tell
+  you its end
+- item slice position is version identity, not quantity
+- subscription, spec, and expanded view must agree on shared top-level facts
+- item and entitlement cadences cannot escape their phase or subscription
+- downstream work must be derived from the committed view and tolerate event
+  retries

--- a/openmeter/subscription/patch/README.md
+++ b/openmeter/subscription/patch/README.md
@@ -1,0 +1,58 @@
+# Subscription patches
+
+Patches are typed, ordered transformations of a `SubscriptionSpec`. They let
+subscription workflows express a change to desired state before the core
+service materializes that state.
+
+Patches do not persist subscription rows, schedule entitlements, or create
+billing artifacts.
+
+## Patch contract
+
+Every patch provides:
+
+- an operation such as add, remove, stretch, or unschedule
+- a `SpecPath` identifying the affected phase, item key, or item version
+- validation of its own input
+- an `ApplyTo` transformation over the spec
+
+Paths express logical subscription identity:
+
+```text
+/phases/{phaseKey}
+/phases/{phaseKey}/items/{itemKey}
+/phases/{phaseKey}/items/{itemKey}/idx/{version}
+```
+
+Use an item-version path only when the operation addresses that exact version.
+An operation that selects or mutates the relevant version itself belongs at the
+item path.
+
+## Effective time and ordering
+
+`ApplyContext.CurrentTime` is the command's resolved effective time, not
+necessarily wall-clock time. Patch rules use it to protect past phases and
+items and to decide which item version is active.
+
+Patches are applied in order. A later patch sees the spec produced by earlier
+ones, so valid workflows may deliberately remove an item before adding its
+replacement. The complete spec is validated after application.
+
+Adding an item to the current phase closes the active version of the same item
+key and appends a new version. Its relative start is derived from the effective
+time when the patch does not provide one. Future-phase additions must not
+silently replace an existing item.
+
+Phase stretch and removal can shift later phase offsets. They must preserve
+phase ordering and cannot erase a phase by collapsing its duration.
+
+## Error meaning
+
+- validation errors mean the patch or resulting spec is structurally invalid
+- forbidden errors mean the requested edit would change protected historical
+  state
+- conflict errors mean the patch is individually meaningful but incompatible
+  with the surrounding spec or another requested change
+
+The workflow layer maps these errors for callers and passes the resulting
+complete spec to the [subscription service](../service/README.md).

--- a/openmeter/subscription/service/README.md
+++ b/openmeter/subscription/service/README.md
@@ -1,0 +1,55 @@
+# Subscription materialization
+
+The subscription service persists the desired `SubscriptionSpec` as
+subscription-owned phase and item rows and keeps derived entitlements aligned
+with them.
+
+This is synchronous materialization inside a subscription command. It is
+different from [billing subscription sync](../../billing/worker/subscriptionsync/README.md),
+which reacts to committed subscription state and reconciles invoice or charge
+artifacts asynchronously.
+
+## Ownership
+
+- The workflow layer decides the product operation, resolves its timing, and
+  constructs a complete target spec.
+- The subscription service validates lifecycle rules, runs command hooks,
+  materializes the target spec, and publishes the resulting subscription event.
+- The materializer owns subscription phases, items, and their entitlement
+  scheduling. It does not create invoice lines, charges, or ledger entries.
+
+Create, update, cancellation, continuation, and deletion run in the
+subscription transaction. A failed materialization does not leave a partially
+updated subscription graph.
+
+## Reconciliation model
+
+An update compares the current `SubscriptionView` with the complete target
+spec. Materialization proceeds in three passes:
+
+1. remove phases and item versions that disappeared or whose persisted shape
+   no longer matches the target
+2. recreate changed phases and item versions that still exist in the target
+3. create phases and item versions that are new to the target
+
+Phase keys identify logical phases. Within a phase, item key and slice position
+identify a logical item version. When a phase changes, its items are
+rematerialized with it.
+
+Changed rows are deleted and recreated rather than updated field by field.
+Their database IDs—and the IDs of entitlements derived from them—are therefore
+not stable domain identity. Consumers should use subscription paths and
+annotations intended for correlation, not persisted child IDs.
+
+## Boundaries and invariants
+
+- The target spec must keep the existing customer, plan reference,
+  subscription start, and settlement mode.
+- Item and entitlement cadence is derived from the target spec and cannot
+  escape the owning phase or subscription.
+- Entitlement creation and deletion follows the owning item within the same
+  transaction.
+- The materializer receives a complete desired state. It does not interpret
+  the user's patch sequence or decide command timing.
+- Events are published from the materialized view. Downstream consumers should
+  derive work from that committed view and tolerate delivery retries.


### PR DESCRIPTION
## What changed

- scope `iterative-engineering-design` to planning and implementation work
- add a small `domain-docs` skill for finding and maintaining package-level
  domain documentation
- route domain-affecting work to package READMEs from `AGENTS.md`
- add focused domain documentation for billing, charges, ledger, subscriptions,
  subscription patches and materialization, subscription-to-billing sync, and
  notifications
- add a hidden PR-template reminder to update the owning package README when a
  change affects domain behavior or a cross-domain contract

## Why

The deleted domain skills contained useful product semantics and invariants,
but also accumulated stale implementation detail and were too large to load
reliably.

This keeps durable domain knowledge next to the packages that own it, where it
is useful to both humans and agents. The READMEs focus on ownership, lifecycle,
invariants, time and persistence semantics, and cross-domain boundaries rather
than package maps or code inventories.

The docs remain evidence to interpret alongside current code and tests, not an
automatic source of truth when they disagree.

## Checks

- pre-commit hooks
- YAML frontmatter parsing
- local README links
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces package-level domain documentation and guidance for discovering and maintaining it.
- Adds the `domain-docs` skill and routes domain-affecting changes and reviews through it.
- Narrows `iterative-engineering-design` to planning and implementation work.
- Adds or rewrites domain READMEs for billing, charges, ledger, notifications, subscriptions, and related subpackages.
- Adds a pull-request checklist prompt for domain-documentation updates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the domain-doc skill’s ledger and billing-charge targets now resolve to the package-level READMEs added by this change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .agents/skills/domain-docs/SKILL.md | Adds proximity- and ownership-based guidance for finding and maintaining package domain documentation; the previously missing ledger and charge targets now exist. |
| AGENTS.md | Routes domain-affecting changes and reviews through the new domain-documentation skill. |
| .agents/skills/iterative-engineering-design/SKILL.md | Limits the design skill to planning and implementation rather than review or explanation tasks. |
| openmeter/billing/README.md | Replaces implementation-heavy billing documentation with focused semantics, ownership boundaries, lifecycle behavior, and consistency invariants. |
| openmeter/billing/charges/README.md | Adds charge-domain ownership, intent-layer, lifecycle, settlement, realization, and currency contracts. |
| openmeter/ledger/README.md | Adds ledger ownership, transaction, route, accounting, and historical-balance invariants. |
| openmeter/subscription/README.md | Documents subscription ownership, lifecycle, timing, versioning, and downstream contracts. |
| openmeter/notification/README.md | Documents notification event creation, matching, provider synchronization, and delivery boundaries. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Task[Domain-affecting task] --> Scope[Inspect changed paths and establish scope]
  Scope --> Nearest[Read nearest package README]
  Nearest --> Links[Follow relevant cross-domain links]
  Links --> Compare[Compare intended semantics with code and tests]
  Compare --> Reconcile[Investigate discrepancies and update owning README]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(domains): add package domain guides"](https://github.com/openmeterio/openmeter/commit/141810031e13aa5a812bf323b81743b6401a51e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48354872)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive domain documentation for billing, charges, subscriptions, subscription synchronization, ledger, and notifications.
  * Documented domain responsibilities, lifecycle behavior, ownership boundaries, invariants, reconciliation, retries, and timing semantics.
  * Added guidance for maintaining package-level domain documentation and complex engineering design.
  * Updated contributor guidance and pull request templates to encourage relevant documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->