### PR TITLE
fix(productcatalog): require billingCadence when unmarshaling usage based rate cards

### DIFF
--- a/openmeter/productcatalog/plan/serializer.go
+++ b/openmeter/productcatalog/plan/serializer.go
@@ -199,13 +199,18 @@ func (p *Plan) UnmarshalJSON(data []byte) error {
 
 			case productcatalog.UsageBasedRateCardType:
 				urc := &productcatalog.UsageBasedRateCard{RateCardMeta: meta}
-				if rcData.BillingCadence != nil {
-					period, err := datetime.ISODurationString(*rcData.BillingCadence).Parse()
-					if err != nil {
-						return fmt.Errorf("invalid billing cadence for rate card %q: %w", rcData.Key, err)
-					}
-					urc.BillingCadence = period
+				// Unlike flat fee rate cards, billing cadence is required for
+				// usage based ones. Without this check a missing field would
+				// silently leave the zero value (P0D) in place.
+				if rcData.BillingCadence == nil {
+					return fmt.Errorf("missing billing cadence for rate card %q: required for usage based rate cards", rcData.Key)
 				}
+
+				period, err := datetime.ISODurationString(*rcData.BillingCadence).Parse()
+				if err != nil {
+					return fmt.Errorf("invalid billing cadence for rate card %q: %w", rcData.Key, err)
+				}
+				urc.BillingCadence = period
 				rc = urc
 
 			default:

--- a/openmeter/productcatalog/plan/serializer_test.go
+++ b/openmeter/productcatalog/plan/serializer_test.go
@@ -204,6 +204,45 @@ func TestPlanSerializationErrors(t *testing.T) {
 			wantErr:  true,
 			errMatch: "invalid billing cadence for rate card \"rate-card-1\"",
 		},
+		{
+			name: "missing billing cadence on usage based rate card",
+			json: `{
+				"namespace": "test",
+				"id": "plan-1",
+				"name": "Test Plan",
+				"phases": [{
+					"key": "phase-1",
+					"name": "Test Phase",
+					"rateCards": [{
+						"type": "usage_based",
+						"key": "rate-card-1",
+						"name": "Test Rate Card",
+						"featureKey": "tokens",
+						"price": {"type": "unit", "amount": "0.001"}
+					}]
+				}]
+			}`,
+			wantErr:  true,
+			errMatch: "missing billing cadence for rate card \"rate-card-1\"",
+		},
+		{
+			name: "missing billing cadence on flat fee rate card is allowed",
+			json: `{
+				"namespace": "test",
+				"id": "plan-1",
+				"name": "Test Plan",
+				"phases": [{
+					"key": "phase-1",
+					"name": "Test Phase",
+					"rateCards": [{
+						"type": "flat_fee",
+						"key": "rate-card-1",
+						"name": "Test Rate Card"
+					}]
+				}]
+			}`,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

`Plan.UnmarshalJSON` treats `billingCadence` as optional for usage based rate cards, mirroring the flat fee branch right above it:

```go
case productcatalog.UsageBasedRateCardType:
    urc := &productcatalog.UsageBasedRateCard{RateCardMeta: meta}
    if rcData.BillingCadence != nil {
        // ... parse and assign
    }
    rc = urc
```

But the two types differ. `FlatFeeRateCard.BillingCadence` is a `*datetime.ISODuration`, where nil legitimately means a one-time charge. `UsageBasedRateCard.BillingCadence` is a non-pointer `datetime.ISODuration`, so skipping the assignment doesn't leave it unset — it leaves the zero value `P0D` in place, and unmarshaling returns no error.

The result is a rate card that is invalid by construction: `UsageBasedRateCard.Validate()` rejects a zero cadence with `ErrBillingCadenceInvalidValue`, so the value can never be legal, yet the decode step happily produces it and defers the problem to whatever runs next.

This changes the usage based branch to return an error when the field is absent, instead of defaulting.

## Why this matters

Failing at decode keeps the invalid value from propagating. Callers that unmarshal a `Plan` and don't immediately call `Validate()` currently receive a `P0D` cadence with no indication anything is wrong, and how that surfaces depends on what touches it next.

This was found while investigating a bare `500` (no error body) from `POST /v3/openmeter/plans` on Kong Konnect when a `unit`-priced rate card omitted `billing_cadence` — adding the field made the identical request return `201`. Filed as #4812.

To be precise about scope: I could not reproduce that 500 from this repo. The v3 mapping path Konnect appears to use, `AsUsageBasedRateCard` in `openmeter/productcatalog/http/mapping.go`, takes `billingCadence` as a non-pointer `string` and calls `Parse()` unconditionally, which errors on `""` and is wrapped into a validation error by the `CreatePlan` handler — a correct `400`. So that path already behaves. The defect fixed here is the one I could demonstrate directly against this code: unmarshaling the payload below succeeds and yields `BillingCadence: P0D`.

I'm not claiming this patch is the fix for the Konnect 500 — that layer isn't in this repo. This is a real correctness bug on its own terms, and the same missing-required-field shape.

## Repro before this change

```go
var p plan.Plan
err := json.Unmarshal([]byte(`{
  "name": "Repro", "key": "repro_unit",
  "currency": "USD", "billing_cadence": "P1M",
  "phases": [{
    "name": "default", "key": "default",
    "rateCards": [{
      "type": "usage_based",
      "name": "Tokens", "key": "tokens",
      "featureKey": "tokens",
      "price": {"type": "unit", "amount": "0.001"}
    }]
  }]
}`), &p)

// err == nil
// p.Phases[0].RateCards[0].GetBillingCadence() == P0D
// ...but RateCards[0].Validate() reports
//   "billing cadence must be positive and 1 hour long duration at least"
```

After: unmarshal fails with `missing billing cadence for rate card "tokens": required for usage based rate cards`.

## Tests

Two cases added to the existing `TestPlanSerializationErrors` table:

- missing `billingCadence` on a usage based rate card now errors
- missing `billingCadence` on a flat fee rate card still succeeds, pinning that it stays optional

`go build ./...` and `go test ./openmeter/productcatalog/...` both pass.

## Note on the error type

The new error is a plain `fmt.Errorf`, consistent with the surrounding cases in this function (`unsupported rate card type`, `invalid billing cadence`). If you'd prefer these decode failures carry `models.NewGenericValidationError` so they map to a `400` rather than a `500` when this path is reached from an HTTP handler, I'm happy to change all of them in this PR or a follow-up — it seemed out of scope to alter the existing ones unprompted.

Closes #4812 if you consider the underlying defect the same; otherwise happy to leave that issue open for the Konnect-side behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-based rate cards now require a valid billing cadence during plan import.
  * Clear validation errors are returned when the billing cadence is missing or invalid.
  * Flat-fee rate cards can still be imported without a billing cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Require `billingCadence` when unmarshaling usage-based plan rate cards.
- Return a descriptive error instead of constructing a rate card with a zero cadence.
- Add coverage for the required usage-based cadence and the optional flat-fee cadence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The stricter deserialization behavior matches the usage-based rate-card invariant, preserves the distinct flat-fee semantics, and is covered by focused regression tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/plan/serializer.go | Rejects usage-based rate cards without billing cadence while preserving flat-fee behavior. |
| openmeter/productcatalog/plan/serializer_test.go | Covers missing cadence for both usage-based and flat-fee rate cards. |

<sub>Reviews (1): Last reviewed commit: ["fix(productcatalog): require billingCade..."](https://github.com/openmeterio/openmeter/commit/2e45076c823f36c67c5f9186727c5f6a96c5e8ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48485778)</sub>

<!-- /greptile_comment -->