### PR TITLE
fix(dev): initialize CodeGraph in worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,15 @@ discrepancies instead of automatically preferring either.
 ## CodeGraph and complex work
 
 - Use CodeGraph when it materially shortens symbol, caller, flow, or impact
-  exploration. Its server keeps the existing index synchronized; do not
-  initialize or manually sync it automatically.
+  exploration. If the worktree is not initialized, run
+  `nix develop --impure .#ci -c codegraph init -i` from the repository root,
+  then retry. Check `codegraph status`; if initialization left a truncated
+  index, rebuild it with `nix develop --impure .#ci -c codegraph index` before
+  falling back. Its server keeps a healthy index synchronized; do not manually
+  sync it.
 - Treat graph relationships as navigation hints. Current source and tests are
-  authoritative; fall back to normal source navigation when CodeGraph is
-  unavailable or inconclusive.
+  authoritative; fall back to normal source navigation only when initialization
+  fails, CodeGraph is unavailable, or its results are inconclusive.
 - When planning or implementing ambiguous, design-heavy, or cross-cutting
   engineering changes, use the
   [`iterative-engineering-design`](.agents/skills/iterative-engineering-design/SKILL.md)

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,10 @@
         };
 
         packages = {
-          codegraph = pkgs.llm-agents.codegraph;
+          # CodeGraph 1.5.0 aborts while indexing on macOS with Node 24.
+          codegraph = pkgs.llm-agents.codegraph.override {
+            buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
+          };
         } // import ./custom-packages.nix { inherit pkgs; };
       };
     };


### PR DESCRIPTION
## What changed

- initialize CodeGraph when a new worktree has no index
- rebuild an interrupted/truncated index before falling back to source navigation
- build CodeGraph with Node 22 while leaving the repository CI Node runtime unchanged

## Why

The existing guidance explicitly told agents not to initialize CodeGraph. Following the intended init path exposed a second problem: CodeGraph 1.5.0 aborted during indexing on macOS under the Nix package's Node 24 runtime, leaving a truncated index. The same CodeGraph bundle completed under Node 22.

## Impact

New worktrees can initialize a usable CodeGraph index through the documented Nix CI shell command instead of immediately falling back to grep/source navigation.

## Validation

- `nix build .#codegraph --no-link`
- fresh `nix develop --impure .#ci -c codegraph init -i`
- `codegraph status`: 2,437 files, 44,825 nodes, 175,458 edges, up to date
- live CodeGraph MCP exploration against the new index
- `git diff --check`
- pre-commit `nixpkgs-fmt` and commitizen checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates CodeGraph developer setup and recovery guidance, and packages CodeGraph with Node 22 while preserving the CI shell’s existing Node runtime.
- Documents initialization for new worktrees and reindexing after interrupted or truncated indexes.
- Overrides CodeGraph’s `buildNpmPackage` dependency to use Node 22.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed guidance or Nix package override.

The CodeGraph derivation override is structurally supported and its generated executable is wrapped to use Node 22, while the default CI shell and `.nvmrc` remain on their existing Node runtime.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Documents the CodeGraph initialization, status-checking, reindexing, and fallback workflow for new worktrees. |
| flake.nix | Overrides the CodeGraph package’s Node builder/runtime to Node 22 without changing the default CI shell Node version. |

<sub>Reviews (1): Last reviewed commit: ["fix(dev): initialize CodeGraph in worktr..."](https://github.com/openmeterio/openmeter/commit/721d6cc90bbcbbb9ab6abe3f684dfda1fdc4fc74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48660332)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer setup and troubleshooting guidance for CodeGraph, including initialization, status checks, index rebuilding, and fallback steps.

* **Bug Fixes**
  * Updated the CodeGraph package configuration to use Node.js 22, helping prevent indexing interruptions on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->