### PR TITLE
fix: if there is no billing cadence set allow construction and flow through validation

### DIFF
--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -779,11 +779,10 @@ func FromAPIBillingRateCard(rc api.BillingRateCard) (productcatalog.RateCard, er
 		return flatRC, nil
 
 	case "unit", "graduated", "volume":
-		if billingCadence == nil {
-			return nil, fmt.Errorf("billing cadence is required for usage-based rate card %q", rc.Key)
+		var bc datetime.ISODuration
+		if billingCadence != nil {
+			bc = *billingCadence
 		}
-
-		bc := *billingCadence
 
 		price, err := FromAPIBillingPriceWithCommitments(rc.Price, rc.Commitments)
 		if err != nil {

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1352,7 +1352,7 @@ func TestToRateCard(t *testing.T) {
 		assert.Equal(t, "0.05", unit.Amount.String())
 	})
 
-	t.Run("usage based without billing cadence returns error", func(t *testing.T) {
+	t.Run("usage based without billing cadence converts with empty cadence", func(t *testing.T) {
 		var price api.BillingPrice
 		require.NoError(t, price.FromBillingPriceUnit(api.BillingPriceUnit{Amount: "0.05", Type: "unit"}))
 
@@ -1362,9 +1362,18 @@ func TestToRateCard(t *testing.T) {
 			Price: price,
 		}
 
-		_, err := FromAPIBillingRateCard(rc)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "billing cadence is required")
+		result, err := FromAPIBillingRateCard(rc)
+		require.NoError(t, err)
+
+		require.NotNil(t, result.GetBillingCadence())
+		assert.True(t, result.GetBillingCadence().IsZero())
+
+		validationIssues, err := models.AsValidationIssues(result.Validate())
+		require.NoError(t, err)
+		require.NotEmpty(t, validationIssues)
+		assert.Contains(t, lo.Map(validationIssues, func(i models.ValidationIssue, _ int) models.ErrorCode {
+			return i.Code()
+		}), productcatalog.ErrCodeBillingCadenceInvalidValue)
 	})
 
 	t.Run("usage based with commitments", func(t *testing.T) {


### PR DESCRIPTION
## What
Usage-based (unit/graduated/volume) rate cards created without a billing_cadence no longer crash plan create/update with a 500; the conversion now defaults to an empty cadence and lets the existing rate-card validation surface it as a normal validation_errors entry.

## Why
The previous code returned a raw, untyped fmt.Errorf from the HTTP-layer converter for a missing cadence, which isn't
recognized by the error encoder and fell through to a 500 instead of the structured 400-shaped validation issue the rest of
the rate-card pipeline already produces for this kind of problem.

## How
api/v3/handlers/plans/convert.go: removed the early nil-check/error in FromAPIBillingRateCard's usage-based case, defaulting the cadence to the zero-value datetime.ISODuration{} so the struct always constructs; the already-existing ErrBillingCadenceInvalidValue check inside UsageBasedRateCard.Validate() now catches it, consistent with how other non critical rate-card issues (e.g. unit_config/price-type mismatch) are already handled as non-blocking, service-layer validation rather than conversion-time errors. convert_test.go updated to assert the new behavior (successful conversion + validation issue present) in place of the old error-return expectation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-based rate cards that omit billing cadence can now be converted successfully.
  * When billing cadence is missing, conversion proceeds and any problems are surfaced during validation (including an invalid/zero billing cadence) instead of failing early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes missing usage-based billing cadence through normal rate-card validation instead of failing during API conversion.
- Defaults an omitted cadence to an empty ISO duration during conversion.
- Updates the converter test to verify successful construction and the resulting billing-cadence validation issue.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/handlers/plans/convert.go | Replaces the early missing-cadence conversion error with a zero duration that existing domain validation reports to clients and prevents from reaching publication. |
| api/v3/handlers/plans/convert_test.go | Updates coverage to assert successful conversion, an empty cadence, and the expected validation issue. |

<sub>Reviews (3): Last reviewed commit: ["fix: if ther is no billing cadence set a..."](https://github.com/openmeterio/openmeter/commit/7d7274f723ff6bd1ec014947464bf22be8ea1059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48665487)</sub>

<!-- /greptile_comment -->