### PR TITLE
fix: add guard for unit config precision to avoid overflow/panic

### DIFF
--- a/openmeter/productcatalog/unitconfig/unitconfig.go
+++ b/openmeter/productcatalog/unitconfig/unitconfig.go
@@ -12,6 +12,7 @@ package unitconfig
 import (
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 
 	decimal "github.com/alpacahq/alpacadecimal"
@@ -127,10 +128,14 @@ func (c *UnitConfig) Validate() error {
 		errs = append(errs, fmt.Errorf("rounding: %w", err))
 	}
 
-	// Precision is ignored when no rounding is applied, so only enforce it when
-	// rounding is active.
-	if !c.Rounding.IsNone() && c.Precision < 0 {
-		errs = append(errs, errors.New("precision must not be negative"))
+	if !c.Rounding.IsNone() {
+		if c.Precision < 0 {
+			errs = append(errs, errors.New("precision must not be negative"))
+		}
+
+		if c.Precision > math.MaxInt32 {
+			errs = append(errs, fmt.Errorf("precision %d overflows int32", c.Precision))
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -206,6 +211,8 @@ func (c *UnitConfig) Apply(raw decimal.Decimal) (converted, invoiced decimal.Dec
 
 	invoiced = converted
 
+	// Precision fits in int32: Validate rejects Precision > math.MaxInt32 when rounding is active, and Apply requires callers to validate first.
+	// A broken caller should not silently drop rounding on a billing quantity so we don't clamp here.
 	places := int32(c.Precision)
 
 	switch c.Rounding {

--- a/openmeter/productcatalog/unitconfig/unitconfig_test.go
+++ b/openmeter/productcatalog/unitconfig/unitconfig_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestUnitConfigApply(t *testing.T) {
@@ -162,6 +164,14 @@ func TestUnitConfigApply(t *testing.T) {
 }
 
 func TestUnitConfigValidate(t *testing.T) {
+	// requireValidationError asserts Validate failed with a generic validation error whose
+	// message mentions the expected rule, so a case can't pass by tripping a different rule.
+	requireValidationError := func(t *testing.T, err error, contains string) {
+		t.Helper()
+		require.ErrorContains(t, err, contains)
+		require.True(t, models.IsGenericValidationError(err), "expected a generic validation error, got %T", err)
+	}
+
 	t.Run("nil is valid", func(t *testing.T) {
 		var c *UnitConfig
 		require.NoError(t, c.Validate())
@@ -190,7 +200,7 @@ func TestUnitConfigValidate(t *testing.T) {
 			Operation:        "bogus",
 			ConversionFactor: decimal.NewFromInt(1000),
 		}
-		require.Error(t, c.Validate())
+		requireValidationError(t, c.Validate(), "invalid unit config operation")
 	})
 
 	t.Run("conversion_factor must be greater than zero", func(t *testing.T) {
@@ -198,13 +208,13 @@ func TestUnitConfigValidate(t *testing.T) {
 			Operation:        UnitConfigOperationDivide,
 			ConversionFactor: decimal.NewFromInt(0),
 		}
-		require.Error(t, zero.Validate())
+		requireValidationError(t, zero.Validate(), "conversion_factor must be greater than zero")
 
 		negative := &UnitConfig{
 			Operation:        UnitConfigOperationDivide,
 			ConversionFactor: decimal.NewFromInt(-5),
 		}
-		require.Error(t, negative.Validate())
+		requireValidationError(t, negative.Validate(), "conversion_factor must be greater than zero")
 	})
 
 	t.Run("invalid rounding mode", func(t *testing.T) {
@@ -213,7 +223,7 @@ func TestUnitConfigValidate(t *testing.T) {
 			ConversionFactor: decimal.NewFromInt(1000),
 			Rounding:         "bogus",
 		}
-		require.Error(t, c.Validate())
+		requireValidationError(t, c.Validate(), "invalid unit config rounding mode")
 	})
 
 	t.Run("negative precision is rejected when rounding is active", func(t *testing.T) {
@@ -223,7 +233,7 @@ func TestUnitConfigValidate(t *testing.T) {
 			Rounding:         UnitConfigRoundingModeCeiling,
 			Precision:        -1,
 		}
-		require.Error(t, c.Validate())
+		requireValidationError(t, c.Validate(), "precision must not be negative")
 	})
 
 	t.Run("negative precision is ignored when rounding is none", func(t *testing.T) {
@@ -243,7 +253,7 @@ func TestUnitConfigValidate(t *testing.T) {
 			Rounding:         UnitConfigRoundingModeCeiling,
 			Precision:        math.MaxInt32 + 1,
 		}
-		require.Error(t, c.Validate())
+		requireValidationError(t, c.Validate(), "overflows int32")
 	})
 
 	t.Run("precision above int32 max is ignored when rounding is none", func(t *testing.T) {

--- a/openmeter/productcatalog/unitconfig/unitconfig_test.go
+++ b/openmeter/productcatalog/unitconfig/unitconfig_test.go
@@ -1,6 +1,7 @@
 package unitconfig
 
 import (
+	"math"
 	"testing"
 
 	decimal "github.com/alpacahq/alpacadecimal"
@@ -231,6 +232,26 @@ func TestUnitConfigValidate(t *testing.T) {
 			ConversionFactor: decimal.NewFromInt(1000),
 			Rounding:         UnitConfigRoundingModeNone,
 			Precision:        -1,
+		}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("precision above int32 max is rejected when rounding is active", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			Precision:        math.MaxInt32 + 1,
+		}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("precision above int32 max is ignored when rounding is none", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeNone,
+			Precision:        math.MaxInt32 + 1,
 		}
 		require.NoError(t, c.Validate())
 	})


### PR DESCRIPTION
## What

Guard UnitConfig.Precision against an int32 overflow. Validate() now rejects Precision > math.MaxInt32 when rounding is active (next to the existing < 0 check), and a comment at the int32(c.Precision) cast in Apply records the invariant and the deliberate choice not to clamp.

## Why

Apply casts places := int32(c.Precision) to drive RoundCeil/Floor/Round. Precision is user-authored (TypeSpec precision), so a value above MaxInt32 wraps to a negative int32, and the decimal rounding then attempts a ~10^(2e9) power-of-ten scale → panic/OOM. It's reachable from billing rating and — because ConvertUsage calls Apply — from the entitlement balance path too.

## How

Reject at the boundary in Validate() (runs at rate-card authoring and at the entitlement snapshot-write, so a bad value never gets persisted or reaches the cast) — same shape as the currencyx overflow guard. The cast is deliberately not clamped: clamping would silently drop rounding on a billing quantity if a future caller skipped Validate, whereas leaving it makes a broken validate-first contract fail loudly instead of mis-billing quietly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject excessively large precision values when rounding is enabled.
  * Preserved support for large precision values when rounding is disabled.
  * Improved error reporting for precision values exceeding the supported range.

* **Tests**
  * Added coverage for valid and invalid precision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an upper-bound validation guard for unit-config precision when rounding is active.
- Rejects precision values above `math.MaxInt32` before the existing `int32` conversion.
- Documents the validate-before-apply invariant without silently clamping invalid precision.
- Adds focused validation tests for active and disabled rounding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/unitconfig/unitconfig.go | Adds the overflow guard and documents the invariant at the precision conversion. |
| openmeter/productcatalog/unitconfig/unitconfig_test.go | Covers oversized precision with active rounding and confirms it remains ignored when rounding is disabled. |

<sub>Reviews (2): Last reviewed commit: ["test: more explicit assertions for unit ..."](https://github.com/openmeterio/openmeter/commit/65c8b9928e5fd6550e3151d2bb880f3fabdd0ec2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48721849)</sub>

<!-- /greptile_comment -->