### PR TITLE
perf: make balance calculation linear in entitlement reset count

### DIFF
--- a/openmeter/credit/adapter/balance_snapshot.go
+++ b/openmeter/credit/adapter/balance_snapshot.go
@@ -28,7 +28,12 @@ func NewPostgresBalanceSnapshotRepo(db *db.Client) *balanceSnapshotRepo {
 func (b *balanceSnapshotRepo) InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error {
 	return entutils.TransactingRepoWithNoValue(ctx, b, func(ctx context.Context, rep *balanceSnapshotRepo) error {
 		return rep.db.BalanceSnapshot.Update().
-			Where(db_balancesnapshot.OwnerID(owner.ID), db_balancesnapshot.Namespace(owner.Namespace), db_balancesnapshot.AtGT(at)).
+			Where(
+				db_balancesnapshot.OwnerID(owner.ID),
+				db_balancesnapshot.Namespace(owner.Namespace),
+				db_balancesnapshot.AtGT(at),
+				db_balancesnapshot.DeletedAtIsNil(),
+			).
 			SetDeletedAt(clock.Now()).
 			Exec(ctx)
 	})

--- a/openmeter/credit/balance/service.go
+++ b/openmeter/credit/balance/service.go
@@ -34,15 +34,8 @@ func NewSnapshotService(conf SnapshotServiceConfig) SnapshotService {
 		SnapshotServiceConfig: conf,
 		// We build a custom UsageQuerier for our usecase here
 		UsageQuerier: NewUsageQuerier(UsageQuerierConfig{
-			StreamingConnector: conf.StreamingConnector,
-			DescribeOwner:      conf.OwnerConnector.DescribeOwner,
-			GetDefaultParams: func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error) {
-				owner, err := conf.OwnerConnector.DescribeOwner(ctx, ownerID)
-				if err != nil {
-					return streaming.QueryParams{}, err
-				}
-				return owner.DefaultQueryParams, nil
-			},
+			StreamingConnector:    conf.StreamingConnector,
+			DescribeOwner:         conf.OwnerConnector.DescribeOwner,
 			GetUsagePeriodStartAt: conf.OwnerConnector.GetUsagePeriodStartAt,
 		}),
 	}

--- a/openmeter/credit/balance/usage.go
+++ b/openmeter/credit/balance/usage.go
@@ -22,7 +22,6 @@ type UsageQuerier interface {
 type UsageQuerierConfig struct {
 	StreamingConnector    streaming.Connector
 	DescribeOwner         func(ctx context.Context, id models.NamespacedID) (grant.Owner, error)
-	GetDefaultParams      func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error)
 	GetUsagePeriodStartAt func(ctx context.Context, ownerID models.NamespacedID, at time.Time) (time.Time, error)
 }
 
@@ -39,15 +38,12 @@ func NewUsageQuerier(conf UsageQuerierConfig) UsageQuerier {
 var _ UsageQuerier = (*usageQuerier)(nil)
 
 func (u *usageQuerier) QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.ClosedPeriod) (float64, error) {
-	params, err := u.GetDefaultParams(ctx, ownerID)
-	if err != nil {
-		return 0.0, err
-	}
-
 	owner, err := u.DescribeOwner(ctx, ownerID)
 	if err != nil {
 		return 0.0, err
 	}
+
+	params := owner.DefaultQueryParams
 
 	// Let's query the meter based on the aggregation
 	switch owner.Meter.Aggregation {

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -44,7 +44,9 @@ func (e *engine) Run(ctx context.Context, params RunParams) (RunResult, error) {
 	snapshot := params.StartingSnapshot
 	historySegments := make([]GrantBurnDownHistorySegment, 0)
 
-	for idx, period := range timeline.GetClosedPeriods() {
+	periods := timeline.GetClosedPeriods()
+
+	for idx, period := range periods {
 		// Let's reset the snapshot usage information as we're entering a new period (between resets)
 		if idx > 0 {
 			snapshot.Usage = balance.SnapshottedUsage{
@@ -62,7 +64,7 @@ func (e *engine) Run(ctx context.Context, params RunParams) (RunResult, error) {
 			Until:                               period.To,
 			StartingSnapshot:                    snapshot,
 			Meter:                               params.Meter,
-			PeriodEndRecurrenceBoundaryBehavior: lo.Ternary(idx == len(timeline.GetClosedPeriods())-1, timeutil.Inclusive, timeutil.Exclusive),
+			PeriodEndRecurrenceBoundaryBehavior: lo.Ternary(idx == len(periods)-1, timeutil.Inclusive, timeutil.Exclusive),
 		})
 		if err != nil {
 			return RunResult{}, fmt.Errorf("failed to run calculation for period %s - %s: %w", period.From, period.To, err)
@@ -71,7 +73,7 @@ func (e *engine) Run(ctx context.Context, params RunParams) (RunResult, error) {
 		snapshot = runRes.Snapshot
 		historySegments = append(historySegments, runRes.History.Segments()...)
 
-		if idx != len(timeline.GetClosedPeriods())-1 {
+		if idx != len(periods)-1 {
 			// We need to reset at each period, except the last one.
 			// If the ending time is also a reset, there will be a 0 length period at the end.
 			snap, err := e.reset(relevantGrants, runRes.Snapshot, params.ResetBehavior, period.To)

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/unitconfig"
-	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -149,12 +148,6 @@ func (m *connector) buildEngineForOwner(ctx context.Context, params buildEngineF
 				return grant.Owner{}, fmt.Errorf("expected owner %s, got %s", params.owner.NamespacedID.ID, id.ID)
 			}
 			return params.owner, nil
-		},
-		GetDefaultParams: func(ctx context.Context, oID models.NamespacedID) (streaming.QueryParams, error) {
-			if oID != params.owner.NamespacedID {
-				return streaming.QueryParams{}, fmt.Errorf("expected owner %s, got %s", params.owner.NamespacedID.ID, oID.ID)
-			}
-			return params.owner.DefaultQueryParams, nil
 		},
 		GetUsagePeriodStartAt: func(_ context.Context, _ models.NamespacedID, at time.Time) (time.Time, error) {
 			for _, period := range periodCache {

--- a/openmeter/entitlement/usageperiod.go
+++ b/openmeter/entitlement/usageperiod.go
@@ -67,8 +67,8 @@ type timedRecurrenceSerde struct {
 }
 
 func (u UsagePeriod) MarshalJSON() ([]byte, error) {
-	timedRecurrences := make([]timedRecurrenceSerde, len(u.recs.GetTimes()))
-	for i := range u.recs.GetTimes() {
+	timedRecurrences := make([]timedRecurrenceSerde, u.recs.Len())
+	for i := range u.recs.Len() {
 		timed := u.recs.GetAt(i)
 		timedRecurrences[i] = timedRecurrenceSerde{
 			Value: timed.GetValue(),
@@ -99,12 +99,12 @@ func (u UsagePeriod) Validate() error {
 	var errs []error
 
 	// Let's validate that we do have some recurrences
-	if len(u.recs.GetTimes()) == 0 {
+	if u.recs.Len() == 0 {
 		errs = append(errs, errors.New("UsagePeriod must have at least one recurrence"))
 	}
 
 	hour := datetime.NewISODuration(0, 0, 0, 0, 1, 0, 0)
-	for i := range u.recs.GetTimes() {
+	for i := range u.recs.Len() {
 		rec := u.recs.GetAt(i).GetValue()
 
 		// Let's validate the recurrence
@@ -126,7 +126,7 @@ func (u *UsagePeriod) GetOriginalValueAsUsagePeriodInput() *UsagePeriodInput {
 		return nil
 	}
 
-	if len(u.recs.GetTimes()) == 0 {
+	if u.recs.Len() == 0 {
 		return nil
 	}
 
@@ -138,11 +138,11 @@ func (u *UsagePeriod) GetOriginalValueAsUsagePeriodInput() *UsagePeriodInput {
 }
 
 func (u UsagePeriod) Equal(other UsagePeriod) bool {
-	if len(u.recs.GetTimes()) != len(other.recs.GetTimes()) {
+	if u.recs.Len() != other.recs.Len() {
 		return false
 	}
 
-	for i := range u.recs.GetTimes() {
+	for i := range u.recs.Len() {
 		if !u.recs.GetAt(i).Equal(other.recs.GetAt(i)) {
 			return false
 		}
@@ -173,7 +173,7 @@ func (u UsagePeriod) GetCurrentPeriodAt(at time.Time) (timeutil.ClosedPeriod, er
 	}
 
 	// Let's truncate the end
-	if idx < len(u.recs.GetTimes())-1 {
+	if idx < u.recs.Len()-1 {
 		next := u.recs.GetAt(idx + 1)
 		if next.GetTime().Before(fullPer.To) {
 			fullPer.To = next.GetTime()
@@ -198,7 +198,7 @@ func (u UsagePeriod) GetResetTimelineInclusive(inPeriod timeutil.ClosedPeriod) (
 
 	at := inPeriod.From
 
-	for i := firstPerIdx; i <= len(u.recs.GetTimes())-1; i++ {
+	for i := firstPerIdx; i <= u.recs.Len()-1; i++ {
 		rec := u.recs.GetAt(i)
 
 		// We're surely outside the period
@@ -209,7 +209,7 @@ func (u UsagePeriod) GetResetTimelineInclusive(inPeriod timeutil.ClosedPeriod) (
 		// We need to generate all the programmatic reset times for the current recurrence
 		limit := inPeriod.To
 
-		if i < len(u.recs.GetTimes())-1 {
+		if i < u.recs.Len()-1 {
 			next := u.recs.GetAt(i + 1)
 			if next.GetTime().Before(limit) {
 				limit = next.GetTime()
@@ -250,15 +250,13 @@ func (u UsagePeriod) GetResetTimelineInclusive(inPeriod timeutil.ClosedPeriod) (
 }
 
 func (u UsagePeriod) GetUsagePeriodInputAt(at time.Time) (UsagePeriodInput, int, error) {
-	// we'll iterate through all recurrences in the timed order (newest to oldest)
-	// we want ot return the first which is not after the at time (as that will be effective)
-	for i := len(u.recs.GetTimes()) - 1; i >= 0; i-- {
-		rec := u.recs.GetAt(i)
-		if !rec.GetTime().After(at) {
-			return timeutil.AsTimed(func(r timeutil.Recurrence) time.Time {
-				return rec.GetTime()
-			})(rec.GetValue()), i, nil
-		}
+	// The effective recurrence is the last one starting at or before at. This is on the
+	// hot path of the reset timeline walk, which calls it once per usage period, so it
+	// must stay sublinear and allocation-free in the entitlement's recurrence count.
+	if idx := u.recs.LastIndexNotAfter(at); idx >= 0 {
+		rec := u.recs.GetAt(idx)
+
+		return NewStartingUsagePeriodInput(rec.GetValue(), rec.GetTime()), idx, nil
 	}
 	// if we don't find any we simply return the last (oldest)
 

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -91,6 +91,27 @@ func (t Timeline[T]) GetTimes() []time.Time {
 	return times
 }
 
+// Len returns the number of entries in the timeline.
+func (t Timeline[T]) Len() int {
+	return len(t.times)
+}
+
+// LastIndexNotAfter returns the index of the last entry at or before at, or -1 when every
+// entry is after at. As the timeline is sorted ascending, that entry is the one in effect
+// at at. Entries sharing a timestamp resolve to the last of the tied group, so the most
+// recently added one wins.
+func (t Timeline[T]) LastIndexNotAfter(at time.Time) int {
+	firstAfter, _ := slices.BinarySearchFunc(t.times, at, func(e Timed[T], target time.Time) int {
+		if e.GetTime().After(target) {
+			return 1
+		}
+
+		return -1
+	})
+
+	return firstAfter - 1
+}
+
 func (t Timeline[T]) GetAt(idx int) Timed[T] {
 	return t.times[idx]
 }

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -3,6 +3,7 @@ package timeutil
 import (
 	"reflect"
 	"slices"
+	"sort"
 	"time"
 )
 
@@ -101,12 +102,11 @@ func (t Timeline[T]) Len() int {
 // at at. Entries sharing a timestamp resolve to the last of the tied group, so the most
 // recently added one wins.
 func (t Timeline[T]) LastIndexNotAfter(at time.Time) int {
-	firstAfter, _ := slices.BinarySearchFunc(t.times, at, func(e Timed[T], target time.Time) int {
-		if e.GetTime().After(target) {
-			return 1
-		}
-
-		return -1
+	// times is sorted ascending, so "is after at" is false across a prefix and true across
+	// the remainder — the monotonicity sort.Search requires. It yields len(times) when no
+	// entry is after at, which leaves the last index, and 0 when every entry is, giving -1.
+	firstAfter := sort.Search(len(t.times), func(i int) bool {
+		return t.times[i].GetTime().After(at)
 	})
 
 	return firstAfter - 1

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -97,14 +97,8 @@ func (t Timeline[T]) Len() int {
 	return len(t.times)
 }
 
-// LastIndexNotAfter returns the index of the last entry at or before at, or -1 when every
-// entry is after at. As the timeline is sorted ascending, that entry is the one in effect
-// at at. Entries sharing a timestamp resolve to the last of the tied group, so the most
-// recently added one wins.
+// LastIndexNotAfter uses binary search, returns -1 when no entry is not after at
 func (t Timeline[T]) LastIndexNotAfter(at time.Time) int {
-	// times is sorted ascending, so "is after at" is false across a prefix and true across
-	// the remainder — the monotonicity sort.Search requires. It yields len(times) when no
-	// entry is after at, which leaves the last index, and 0 when every entry is, giving -1.
 	firstAfter := sort.Search(len(t.times), func(i int) bool {
 		return t.times[i].GetTime().After(at)
 	})

--- a/pkg/timeutil/timeline_test.go
+++ b/pkg/timeutil/timeline_test.go
@@ -162,9 +162,7 @@ func TestTimelineGetOpenPeriods(t *testing.T) {
 	})
 }
 
-// lastIndexNotAfterLinear is the reverse linear scan that LastIndexNotAfter replaced.
-// It is kept as the differential oracle: the binary search must agree with it for every
-// input, including timelines carrying duplicate timestamps.
+// uses old linear scan implementation for reference
 func lastIndexNotAfterLinear[T any](tl timeutil.Timeline[T], at time.Time) int {
 	for i := tl.Len() - 1; i >= 0; i-- {
 		if !tl.GetAt(i).GetTime().After(at) {

--- a/pkg/timeutil/timeline_test.go
+++ b/pkg/timeutil/timeline_test.go
@@ -161,3 +161,60 @@ func TestTimelineGetOpenPeriods(t *testing.T) {
 		assert.Equal(t, time3, *periods[3].From)
 	})
 }
+
+// lastIndexNotAfterLinear is the reverse linear scan that LastIndexNotAfter replaced.
+// It is kept as the differential oracle: the binary search must agree with it for every
+// input, including timelines carrying duplicate timestamps.
+func lastIndexNotAfterLinear[T any](tl timeutil.Timeline[T], at time.Time) int {
+	for i := tl.Len() - 1; i >= 0; i-- {
+		if !tl.GetAt(i).GetTime().After(at) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestTimelineLastIndexNotAfter(t *testing.T) {
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("Empty timeline", func(t *testing.T) {
+		assert.Equal(t, -1, timeutil.NewSimpleTimeline([]time.Time{}).LastIndexNotAfter(base))
+	})
+
+	t.Run("All entries after at", func(t *testing.T) {
+		timeline := timeutil.NewSimpleTimeline([]time.Time{base.Add(time.Hour), base.Add(2 * time.Hour)})
+		assert.Equal(t, -1, timeline.LastIndexNotAfter(base))
+	})
+
+	t.Run("Boundary is inclusive", func(t *testing.T) {
+		timeline := timeutil.NewSimpleTimeline([]time.Time{base, base.Add(time.Hour)})
+		assert.Equal(t, 0, timeline.LastIndexNotAfter(base))
+	})
+
+	t.Run("Duplicate timestamps resolve to the last of the tied group", func(t *testing.T) {
+		timeline := timeutil.NewSimpleTimeline([]time.Time{base, base, base, base.Add(time.Hour)})
+		assert.Equal(t, 2, timeline.LastIndexNotAfter(base))
+	})
+
+	// Differential sweep: every probe against every timeline must match the linear oracle.
+	// Durations deliberately repeat so the generated timelines contain ties.
+	t.Run("Matches the linear scan", func(t *testing.T) {
+		offsets := []time.Duration{0, 0, time.Hour, time.Hour, 2 * time.Hour, 5 * time.Hour, 5 * time.Hour}
+
+		for size := 0; size <= len(offsets); size++ {
+			times := make([]time.Time, 0, size)
+			for _, offset := range offsets[:size] {
+				times = append(times, base.Add(offset))
+			}
+
+			timeline := timeutil.NewSimpleTimeline(times)
+
+			for probe := -time.Hour; probe <= 6*time.Hour; probe += 30 * time.Minute {
+				at := base.Add(probe)
+				assert.Equal(t, lastIndexNotAfterLinear(timeline, at), timeline.LastIndexNotAfter(at),
+					"size=%d at=%s", size, at)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`UsagePeriod.GetResetTimelineInclusive` was quadratic in an entitlement's usage-reset count, which grows without bound with account age. Balance calculation walks it several times per run, so old high-cadence entitlements blew the 30s message processing timeout. In one 16h production window the balance worker dead-lettered 294 messages, all `failed to describe owner <id>: context deadline exceeded` — the deadline always tripped before `engine.Run`, i.e. the whole budget went to metadata resolution rather than the balance math.

The failures were concentrated on ~16 entitlements in 2 namespaces that failed every hour, permanently. They are not slow; they are superlinear in a quantity that grows with wall-clock time.

Two independent causes, both loop-shaped:

- `Timeline.GetTimes()` allocates a fresh slice on every call, and was evaluated inside loop *conditions* — `usageperiod.go` (3 sites) and `engine/run.go` via `GetClosedPeriods()` (2 sites).
- `GetUsagePeriodInputAt`'s loop variable was captured by the returned closure, forcing a heap allocation **per iteration** of an O(n) scan that is itself called O(n) times. This was the dominant term: 88% of allocations.

The cost lands as **CPU, not memory**. The churn is transient garbage reclaimed continuously, so it never becomes RSS — it shows up as GC mark workers burning cores.

## Changes

**`perf(credit): iterations optimization`**
- `Timeline.Len()` — allocation-free, for use in loop conditions.
- `Timeline.LastIndexNotAfter()` — binary search over the ascending-sorted invariant `NewTimeline` guarantees, replacing the reverse linear scan in `GetUsagePeriodInputAt` and eliminating the closure capture.
- Hoist `GetClosedPeriods()` out of two loop conditions in `engine.Run`.

**`perf(credit): drop redundant owner fetch from the usage querier`**
`QueryUsage` called both `GetDefaultParams` and `DescribeOwner`, but at both (only) construction sites `GetDefaultParams` was `DescribeOwner(...).DefaultQueryParams` — literally so in the snapshot service, and closed over the same prefetched owner in `buildEngineForOwner`. Redundant since #2406 introduced it. On the snapshot usage-backfill path in `GetLatestValidAt` this halves the owner lookups, each of which is four uncached Postgres queries.

**`perf(credit): let InvalidateAfter use the balance snapshot index`**
`balancesnapshot_namespace_owner_id_at` is partial on `deleted_at IS NULL`, and Postgres only uses a partial index when the query predicate implies the index predicate. `InvalidateAfter` omitted it, so the planner fell back to the namespace-only index. Runs on every grant create and void.

## Numbers

Reset timeline resolution, median of 3 runs at `-benchtime=10x`, same machine, baseline measured in a worktree at the parent commit:

| resets | time | bytes/op | allocs/op |
|---|---|---|---|
| 100 | 1.28 ms → 0.19 ms | 3.3 MB → 81 KB | 12,135 → 1,430 |
| 1,000 | 104 ms → 1.8 ms | 309 MB → 869 KB | 1,021,132 → 14,040 |
| 8,760 (1 year hourly) | 7,484 ms → 16.6 ms | 23.5 GB → 7.8 MB | 76,926,253 → 122,745 |

That is **451× faster** and **~3,000× less allocation** at one year of hourly resets.

The scaling is the substantive result. Going from 1,000 to 8,760 resets (8.76× more): before, time grew **71.8×** ≈ 8.76² — quadratic. After, **9.1×** ≈ 8.76 — linear.

CPU profile at 1,000 resets:

| | before | after |
|---|---|---|
| total CPU samples | 3,940 ms (**163% CPU**) | 70 ms (34.6% CPU) |
| `gcBgMarkWorker` / `gcDrain` | 540 ms | below threshold |

A single-goroutine workload pulling 163% CPU is GC mark workers running on other cores — which is why this presents as CPU pressure with flat memory.

The benchmark used to produce these figures was intentionally not committed.

## Correctness

`LastIndexNotAfter` is covered by a differential test asserting it matches the previous reverse scan for every probe across every timeline size, including duplicate-timestamp ties (which must resolve to the last of the tied group to preserve the old semantics).

Green and unchanged: `openmeter/credit/...`, `openmeter/entitlement/...`, `pkg/timeutil/...`, `test/credits`, `test/entitlement/regression`, `test/billing`, `test/subscription`. `golangci-lint` reports 0 issues.

Note the OM-400 unit_config regime check in `GetLastValidSnapshotAt` is untouched — only the number of owner fetches changed, never the comparison.

## Follow-ups (not in this PR)

- The two `failed to describe owner %s` error strings in `helper.go` and `balance.go` are byte-identical, so logs alone cannot distinguish them.
- `snapshotEngineResult` takes `SELECT ... FOR UPDATE NOWAIT` in a transaction that commits before `saveSnapshot` runs, so the lock guards nothing while costing round-trips on every read.
- `ListInScopeEntitlements` materialises an entire namespace's entitlements before processing; `ProcessEntitlements` then walks them serially.
- Postgres `pool_max_conns` is unset, defaulting to `max(4, NumCPU)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented already-deleted balance snapshots from being selected for invalidation.
  * Usage queries now consistently apply each owner’s configured default parameters.
  * Improved recurrence handling for usage periods, including boundary and reset scenarios.

* **Performance**
  * Optimized usage-period recurrence lookups to reduce unnecessary computation and memory usage.

* **Reliability**
  * Improved timeline handling for empty timelines, duplicate timestamps, and exact time boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes entitlement balance calculation linear in the reset count while reducing redundant owner lookups and enabling the balance-snapshot partial index.
- Adds allocation-free timeline length and upper-bound lookup operations.
- Reuses closed periods during engine execution instead of repeatedly materializing them.
- Uses the already-described owner’s default query parameters.
- Restricts snapshot invalidation to active snapshots.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported comparator-contract issue is resolved by the monotonic predicate passed to sort.Search.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/timeutil/timeline.go | Adds allocation-free length access and a contract-correct upper-bound search over constructor-sorted timeline entries. |
| pkg/timeutil/timeline_test.go | Covers empty timelines, inclusive boundaries, duplicate timestamps, and differential equivalence with the former reverse scan. |
| openmeter/entitlement/usageperiod.go | Replaces allocating timeline reads and linear recurrence lookup while preserving effective-recurrence semantics. |
| openmeter/credit/engine/run.go | Materializes closed periods once and consistently uses that slice for iteration and final-period detection. |
| openmeter/credit/balance/usage.go | Derives streaming defaults from the owner already fetched for meter metadata. |
| openmeter/credit/balance/service.go | Removes the redundant owner-backed default-parameter callback from snapshot-service wiring. |
| openmeter/credit/helper.go | Simplifies owner-specific engine wiring after default query parameters moved to the existing owner description. |
| openmeter/credit/adapter/balance_snapshot.go | Limits invalidation to undeleted snapshots so the applicable partial database index can be used. |

<sub>Reviews (3): Last reviewed commit: ["style: comments"](https://github.com/openmeterio/openmeter/commit/3d523836141240861748e1e9c4481a6993ec150d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49324368)</sub>

**Context used:**

- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->