### PR TITLE
fix: active entitlement validation blocking meter delete

### DIFF
--- a/openmeter/meter/adapter/adapter_test.go
+++ b/openmeter/meter/adapter/adapter_test.go
@@ -135,11 +135,12 @@ func TestHasEntitlementForMeter(t *testing.T) {
 	defer clock.UnFreeze()
 
 	tests := []struct {
-		name            string
-		activeFrom      time.Time
-		activeTo        *time.Time
-		customerDeleted bool
-		want            bool
+		name               string
+		activeFrom         time.Time
+		activeTo           *time.Time
+		customerDeleted    bool
+		entitlementDeleted bool
+		want               bool
 	}{
 		{
 			name:       "active entitlement",
@@ -147,11 +148,22 @@ func TestHasEntitlementForMeter(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:            "ended entitlement for deleted customer",
-			activeFrom:      now.Add(-2 * time.Hour),
-			activeTo:        lo.ToPtr(now.Add(-time.Hour)),
+			name:       "ended entitlement",
+			activeFrom: now.Add(-2 * time.Hour),
+			activeTo:   lo.ToPtr(now.Add(-time.Hour)),
+			want:       false,
+		},
+		{
+			name:            "active entitlement for deleted customer",
+			activeFrom:      now.Add(-time.Hour),
 			customerDeleted: true,
 			want:            false,
+		},
+		{
+			name:               "deleted active entitlement",
+			activeFrom:         now.Add(-time.Hour),
+			entitlementDeleted: true,
+			want:               false,
 		},
 		{
 			name:       "scheduled entitlement",
@@ -187,15 +199,19 @@ func TestHasEntitlementForMeter(t *testing.T) {
 				Save(t.Context())
 			require.NoError(t, err)
 
-			_, err = env.Client.Entitlement.Create().
+			entitlementCreate := env.Client.Entitlement.Create().
 				SetNamespace(namespace).
 				SetEntitlementType(entitlementdb.EntitlementTypeBoolean).
 				SetFeatureID(featureEntity.ID).
 				SetFeatureKey(featureEntity.Key).
 				SetCustomerID(customerEntity.ID).
 				SetActiveFrom(tt.activeFrom).
-				SetNillableActiveTo(tt.activeTo).
-				Save(t.Context())
+				SetNillableActiveTo(tt.activeTo)
+			if tt.entitlementDeleted {
+				entitlementCreate.SetDeletedAt(now)
+			}
+
+			_, err = entitlementCreate.Save(t.Context())
 			require.NoError(t, err)
 
 			if tt.customerDeleted {

--- a/openmeter/meter/adapter/adapter_test.go
+++ b/openmeter/meter/adapter/adapter_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	entitlementdb "github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
@@ -120,6 +122,95 @@ func Test_Adapter(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestHasEntitlementForMeter(t *testing.T) {
+	env := NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
+
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	tests := []struct {
+		name            string
+		activeFrom      time.Time
+		activeTo        *time.Time
+		customerDeleted bool
+		want            bool
+	}{
+		{
+			name:       "active entitlement",
+			activeFrom: now.Add(-time.Hour),
+			want:       true,
+		},
+		{
+			name:            "ended entitlement for deleted customer",
+			activeFrom:      now.Add(-2 * time.Hour),
+			activeTo:        lo.ToPtr(now.Add(-time.Hour)),
+			customerDeleted: true,
+			want:            false,
+		},
+		{
+			name:       "scheduled entitlement",
+			activeFrom: now.Add(time.Hour),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given a meter with an entitlement in the requested lifecycle state.
+			namespace := NewTestNamespace(t)
+			meterEntity, err := env.Meter.CreateMeter(t.Context(), meter.CreateMeterInput{
+				Namespace:   namespace,
+				Name:        tt.name,
+				Key:         "meter-" + NewTestULID(t),
+				Aggregation: meter.MeterAggregationCount,
+				EventType:   "test.event",
+			})
+			require.NoError(t, err)
+
+			featureEntity, err := env.Client.Feature.Create().
+				SetNamespace(namespace).
+				SetName(tt.name).
+				SetKey("feature-" + NewTestULID(t)).
+				SetMeterID(meterEntity.ID).
+				Save(t.Context())
+			require.NoError(t, err)
+
+			customerEntity, err := env.Client.Customer.Create().
+				SetNamespace(namespace).
+				SetName(tt.name).
+				Save(t.Context())
+			require.NoError(t, err)
+
+			_, err = env.Client.Entitlement.Create().
+				SetNamespace(namespace).
+				SetEntitlementType(entitlementdb.EntitlementTypeBoolean).
+				SetFeatureID(featureEntity.ID).
+				SetFeatureKey(featureEntity.Key).
+				SetCustomerID(customerEntity.ID).
+				SetActiveFrom(tt.activeFrom).
+				SetNillableActiveTo(tt.activeTo).
+				Save(t.Context())
+			require.NoError(t, err)
+
+			if tt.customerDeleted {
+				_, err = customerEntity.Update().SetDeletedAt(now).Save(t.Context())
+				require.NoError(t, err)
+			}
+
+			// When checking whether the meter has a blocking entitlement.
+			got, err := env.Meter.HasEntitlementForMeter(t.Context(), namespace, meterEntity.ID)
+
+			// Then only an entitlement active now blocks meter deletion.
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 type TestEnv struct {

--- a/openmeter/meter/adapter/manage.go
+++ b/openmeter/meter/adapter/manage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	customerdb "github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	entitlementdb "github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
 	featuredb "github.com/openmeterio/openmeter/openmeter/ent/db/feature"
 	meterdb "github.com/openmeterio/openmeter/openmeter/ent/db/meter"
@@ -159,6 +160,9 @@ func (a *Adapter) HasEntitlementForMeter(ctx context.Context, namespace, meterID
 						),
 						entitlementdb.Or(entitlementdb.ActiveToIsNil(), entitlementdb.ActiveToGT(now)),
 						entitlementdb.Namespace(namespace),
+						entitlementdb.HasCustomerWith(
+							customerdb.Or(customerdb.DeletedAtGT(now), customerdb.DeletedAtIsNil()),
+						),
 						entitlementdb.HasFeatureWith(featuredb.MeterIDEQ(meterID)),
 					).
 					Exist(ctx)

--- a/openmeter/meter/adapter/manage.go
+++ b/openmeter/meter/adapter/manage.go
@@ -148,9 +148,16 @@ func (a *Adapter) HasEntitlementForMeter(ctx context.Context, namespace, meterID
 			ctx,
 			a,
 			func(ctx context.Context, repo *Adapter) (bool, error) {
+				now := clock.Now()
+
 				exists, err := repo.db.Entitlement.Query().
 					Where(
-						entitlementdb.Or(entitlementdb.DeletedAtGT(clock.Now()), entitlementdb.DeletedAtIsNil()),
+						entitlementdb.Or(entitlementdb.DeletedAtGT(now), entitlementdb.DeletedAtIsNil()),
+						entitlementdb.Or(
+							entitlementdb.And(entitlementdb.ActiveFromIsNil(), entitlementdb.CreatedAtLTE(now)),
+							entitlementdb.ActiveFromLTE(now),
+						),
+						entitlementdb.Or(entitlementdb.ActiveToIsNil(), entitlementdb.ActiveToGT(now)),
 						entitlementdb.Namespace(namespace),
 						entitlementdb.HasFeatureWith(featuredb.MeterIDEQ(meterID)),
 					).


### PR DESCRIPTION
## Overview

Fix validation of active entitlements for meter delete where wrong boundary check prevented meter delete even if the entitlements referencing the meter via it feature were not considered "active" anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Meter deletion checks now consider only active, non-deleted entitlements.
  * Expired, future-scheduled, deleted, or customer-deleted entitlements no longer incorrectly prevent meter deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects meter-deletion validation so only currently active entitlements belonging to non-deleted customers block deletion.
- Adds canonical active-window and soft-deletion predicates to the entitlement lookup.
- Adds coverage for active, expired, scheduled, deleted-entitlement, and deleted-customer cases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported deleted-customer case is excluded by the new customer-edge predicate, which matches the canonical entitlement lifecycle query.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/meter/adapter/manage.go | Aligns the meter deletion guard with canonical entitlement and customer lifecycle predicates, resolving the previously reported deleted-customer issue. |
| openmeter/meter/adapter/adapter_test.go | Adds focused lifecycle-state coverage for the entitlement check used by meter deletion. |

<sub>Reviews (2): Last reviewed commit: ["fix: include customer lookup"](https://github.com/openmeterio/openmeter/commit/c515373c578fd2bbb09904a34648eb75df9c237c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49599074)</sub>

<!-- /greptile_comment -->