### PR TITLE
fix: meter delete in tx

### DIFF
--- a/openmeter/meter/adapter/meter.go
+++ b/openmeter/meter/adapter/meter.go
@@ -91,27 +91,29 @@ func (a *Adapter) GetMeterByIDOrSlug(ctx context.Context, input meter.GetMeterIn
 		return meter.Meter{}, models.NewGenericValidationError(err)
 	}
 
-	entity, err := a.db.Meter.Query().
-		Where(meterdb.NamespaceEQ(input.Namespace)).
-		Where(meterdb.Or(
-			meterdb.ID(input.IDOrSlug),
-			meterdb.And(meterdb.Key(input.IDOrSlug), meterdb.DeletedAtIsNil()),
-		)).
-		First(ctx)
-	if err != nil {
-		if db.IsNotFound(err) {
-			return meter.Meter{}, meter.NewMeterNotFoundError(input.IDOrSlug)
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *Adapter) (meter.Meter, error) {
+		entity, err := repo.db.Meter.Query().
+			Where(meterdb.NamespaceEQ(input.Namespace)).
+			Where(meterdb.Or(
+				meterdb.ID(input.IDOrSlug),
+				meterdb.And(meterdb.Key(input.IDOrSlug), meterdb.DeletedAtIsNil()),
+			)).
+			First(ctx)
+		if err != nil {
+			if db.IsNotFound(err) {
+				return meter.Meter{}, meter.NewMeterNotFoundError(input.IDOrSlug)
+			}
+
+			return meter.Meter{}, fmt.Errorf("failed to get meter by ID or slug: %w", err)
 		}
 
-		return meter.Meter{}, fmt.Errorf("failed to get meter by ID or slug: %w", err)
-	}
+		m, err := MapFromEntityFactory(entity)
+		if err != nil {
+			return m, fmt.Errorf("failed to map meter: %w", err)
+		}
 
-	m, err := MapFromEntityFactory(entity)
-	if err != nil {
-		return m, fmt.Errorf("failed to map meter: %w", err)
-	}
-
-	return m, nil
+		return m, nil
+	})
 }
 
 // MapFromEntityFactory creates a function that maps a meter db entity to a meter model.

--- a/openmeter/meter/service/manage.go
+++ b/openmeter/meter/service/manage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter/adapter"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -82,76 +83,78 @@ func (s *ManageService) CreateMeter(ctx context.Context, input meter.CreateMeter
 
 // DeleteMeter deletes a meter
 func (s *ManageService) DeleteMeter(ctx context.Context, input meter.DeleteMeterInput) error {
-	// Get the meter
-	getMeter, err := s.GetMeterByIDOrSlug(ctx, meter.GetMeterInput{
-		Namespace: input.Namespace,
-		IDOrSlug:  input.IDOrSlug,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Check if the meter is already deleted
-	if getMeter.DeletedAt != nil {
-		return nil
-	}
-
-	// Validate input with reserved event types
-	if !input.AllowReservedEventTypes {
-		err = s.eventTypeValidator(getMeter.EventType)
+	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
+		// Get the meter
+		getMeter, err := s.GetMeterByIDOrSlug(ctx, meter.GetMeterInput{
+			Namespace: input.Namespace,
+			IDOrSlug:  input.IDOrSlug,
+		})
 		if err != nil {
-			return models.NewGenericValidationError(fmt.Errorf("invalid event type: %w", err))
+			return err
 		}
-	}
 
-	// Check if the meter has active features
-	hasFeatures, err := s.adapter.HasActiveFeatureForMeter(ctx, input.Namespace, getMeter.ID)
-	if err != nil {
-		return fmt.Errorf("failed to check if meter has features [namespace=%s, key=%s]: %w",
-			input.Namespace, getMeter.Key, err)
-	}
+		// Check if the meter is already deleted
+		if getMeter.DeletedAt != nil {
+			return nil
+		}
 
-	if hasFeatures {
-		return models.NewGenericConflictError(
-			fmt.Errorf("meter has active features and cannot be deleted"),
-		)
-	}
+		// Validate input with reserved event types
+		if !input.AllowReservedEventTypes {
+			err = s.eventTypeValidator(getMeter.EventType)
+			if err != nil {
+				return models.NewGenericValidationError(fmt.Errorf("invalid event type: %w", err))
+			}
+		}
 
-	// Check if the meter has active entitlements
-	hasEntitlements, err := s.adapter.HasEntitlementForMeter(ctx, getMeter.Namespace, getMeter.ID)
-	if err != nil {
-		return fmt.Errorf("failed to check if meter has entitlements [namespace=%s, key=%s]: %w",
-			input.Namespace, getMeter.Key, err)
-	}
+		// Check if the meter has active features
+		hasFeatures, err := s.adapter.HasActiveFeatureForMeter(ctx, input.Namespace, getMeter.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check if meter has features [namespace=%s, key=%s]: %w",
+				input.Namespace, getMeter.Key, err)
+		}
 
-	if hasEntitlements {
-		return models.NewGenericConflictError(
-			fmt.Errorf("meter has active entitlements and cannot be deleted"),
-		)
-	}
+		if hasFeatures {
+			return models.NewGenericConflictError(
+				fmt.Errorf("meter has active features and cannot be deleted"),
+			)
+		}
 
-	// Delete the meter
-	err = s.adapter.DeleteMeter(ctx, getMeter)
-	if err != nil {
-		return err
-	}
+		// Check if the meter has active entitlements
+		hasEntitlements, err := s.adapter.HasEntitlementForMeter(ctx, getMeter.Namespace, getMeter.ID)
+		if err != nil {
+			return fmt.Errorf("failed to check if meter has entitlements [namespace=%s, key=%s]: %w",
+				input.Namespace, getMeter.Key, err)
+		}
 
-	// Get the deleted meter
-	deletedMeter, err := s.GetMeterByIDOrSlug(ctx, meter.GetMeterInput{
-		Namespace: input.Namespace,
-		IDOrSlug:  input.IDOrSlug,
+		if hasEntitlements {
+			return models.NewGenericConflictError(
+				fmt.Errorf("meter has active entitlements and cannot be deleted"),
+			)
+		}
+
+		// Delete the meter
+		err = s.adapter.DeleteMeter(ctx, getMeter)
+		if err != nil {
+			return err
+		}
+
+		// Get the deleted meter
+		deletedMeter, err := s.GetMeterByIDOrSlug(ctx, meter.GetMeterInput{
+			Namespace: input.Namespace,
+			IDOrSlug:  input.IDOrSlug,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Publish the meter deleted event
+		meterDeletedEvent := meter.NewMeterDeleteEvent(ctx, &deletedMeter)
+		if err := s.publisher.Publish(ctx, meterDeletedEvent); err != nil {
+			return fmt.Errorf("failed to publish meter deleted event: %w", err)
+		}
+
+		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	// Publish the meter deleted event
-	meterDeletedEvent := meter.NewMeterDeleteEvent(ctx, &deletedMeter)
-	if err := s.publisher.Publish(ctx, meterDeletedEvent); err != nil {
-		return fmt.Errorf("failed to publish meter deleted event: %w", err)
-	}
-
-	return nil
 }
 
 // UpdateMeter updates a meter

--- a/openmeter/meter/service/manage_test.go
+++ b/openmeter/meter/service/manage_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/meter/adapter"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/openmeter/watermill/marshaler"
+)
+
+type errorPublisher struct {
+	eventbus.Publisher
+	err error
+}
+
+func (p errorPublisher) Publish(context.Context, marshaler.Event) error {
+	return p.err
+}
+
+func TestDeleteMeterTransaction(t *testing.T) {
+	database := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
+	t.Cleanup(func() {
+		require.NoError(t, database.EntDriver.Close())
+		require.NoError(t, database.PGDriver.Close())
+	})
+
+	meterAdapter, err := adapter.New(adapter.Config{
+		Client: database.EntDriver.Client(),
+		Logger: testutils.NewDiscardLogger(t),
+	})
+	require.NoError(t, err)
+
+	t.Run("commits deletion after publishing the event", func(t *testing.T) {
+		// Given a meter that has no active features or entitlements.
+		namespace := ulid.Make().String()
+		createdMeter, err := meterAdapter.CreateMeter(t.Context(), meter.CreateMeterInput{
+			Namespace:   namespace,
+			Name:        "meter to delete",
+			Key:         "meter-to-delete",
+			Aggregation: meter.MeterAggregationCount,
+			EventType:   "test.meter",
+		})
+		require.NoError(t, err)
+
+		service := NewManage(meterAdapter, eventbus.NewMock(t), nil, nil)
+
+		// When the meter is deleted successfully.
+		err = service.DeleteMeter(t.Context(), meter.DeleteMeterInput{
+			Namespace: namespace,
+			IDOrSlug:  createdMeter.ID,
+		})
+
+		// Then the transaction commits the soft deletion.
+		require.NoError(t, err)
+		deletedMeter, err := meterAdapter.GetMeterByIDOrSlug(t.Context(), meter.GetMeterInput{
+			Namespace: namespace,
+			IDOrSlug:  createdMeter.ID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, deletedMeter.DeletedAt)
+	})
+
+	t.Run("rolls back deletion when publishing fails", func(t *testing.T) {
+		// Given a meter and a publisher that fails after the soft deletion.
+		namespace := ulid.Make().String()
+		createdMeter, err := meterAdapter.CreateMeter(t.Context(), meter.CreateMeterInput{
+			Namespace:   namespace,
+			Name:        "meter to preserve",
+			Key:         "meter-to-preserve",
+			Aggregation: meter.MeterAggregationCount,
+			EventType:   "test.meter",
+		})
+		require.NoError(t, err)
+
+		publishErr := errors.New("publish failed")
+		service := NewManage(meterAdapter, errorPublisher{
+			Publisher: eventbus.NewMock(t),
+			err:       publishErr,
+		}, nil, nil)
+
+		// When deletion reaches event publication.
+		err = service.DeleteMeter(t.Context(), meter.DeleteMeterInput{
+			Namespace: namespace,
+			IDOrSlug:  createdMeter.ID,
+		})
+
+		// Then the publication error rolls back the soft deletion.
+		require.ErrorIs(t, err, publishErr)
+		activeMeter, err := meterAdapter.GetMeterByIDOrSlug(t.Context(), meter.GetMeterInput{
+			Namespace: namespace,
+			IDOrSlug:  createdMeter.ID,
+		})
+		require.NoError(t, err)
+		require.Nil(t, activeMeter.DeletedAt)
+	})
+}


### PR DESCRIPTION
## Overview

Make meter delete to be atomic operation by running it in database transaction alongside the read operations used for lookup.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes meter deletion checks, soft deletion, and the post-delete lookup share one PostgreSQL transaction. It also adds integration coverage for successful commit and rollback when event publication fails, but publishing from inside the transaction permits an acknowledged event to outlive a later database commit failure.
- Makes `GetMeterByIDOrSlug` transaction-aware.
- Wraps the complete `DeleteMeter` service flow in a transaction.
- Adds commit and publisher-error rollback tests.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until deletion events are prevented from becoming externally visible before the corresponding database deletion is durably committed.

DeleteMeter now sends an acknowledged Kafka event from inside the transaction callback, so a later PostgreSQL commit failure leaves consumers with a deletion event for a meter that remains active.

**Files Needing Attention:** openmeter/meter/service/manage.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/meter/adapter/meter.go | Makes point lookups use the transaction-bound adapter when a transaction is present while preserving nontransactional behavior otherwise. |
| openmeter/meter/service/manage.go | Makes deletion database operations atomic, but publishes the deletion event before commit and can therefore emit a phantom deletion. |
| openmeter/meter/service/manage_test.go | Covers successful commit and rollback on publication failure, but not the irreconcilable successful-publication followed by failed-database-commit ordering. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as ManageService
    participant DB as PostgreSQL transaction
    participant K as Kafka
    participant C as Consumer
    S->>DB: Soft-delete meter
    S->>DB: Read deleted meter
    S->>K: Publish meter.deleted
    K-->>S: Acknowledge event
    K-->>C: Event becomes observable
    S->>DB: Commit transaction
    alt Commit fails
        DB-->>S: Rollback/error
        Note over K,C: Published event cannot be rolled back
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fmeter%2Fservice%2Fmanage.go%3A150-152%0A**Deletion%20event%20precedes%20commit**%0A%0AWhen%20Kafka%20acknowledges%20the%20deletion%20event%20but%20the%20enclosing%20database%20transaction%20subsequently%20fails%20to%20commit%2C%20consumers%20receive%20a%20deletion%20event%20for%20a%20meter%20that%20remains%20active%20in%20PostgreSQL.%20Publishing%20inside%20the%20transaction%20callback%20cannot%20make%20the%20Kafka%20message%20atomic%20with%20the%20later%20database%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4838&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22fix%2Fmeter-delete%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmeter-delete%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fmeter%2Fservice%2Fmanage.go%3A150-152%0A**Deletion%20event%20precedes%20commit**%0A%0AWhen%20Kafka%20acknowledges%20the%20deletion%20event%20but%20the%20enclosing%20database%20transaction%20subsequently%20fails%20to%20commit%2C%20consumers%20receive%20a%20deletion%20event%20for%20a%20meter%20that%20remains%20active%20in%20PostgreSQL.%20Publishing%20inside%20the%20transaction%20callback%20cannot%20make%20the%20Kafka%20message%20atomic%20with%20the%20later%20database%20commit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4838&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/meter/service/manage.go:150-152
**Deletion event precedes commit**

When Kafka acknowledges the deletion event but the enclosing database transaction subsequently fails to commit, consumers receive a deletion event for a meter that remains active in PostgreSQL. Publishing inside the transaction callback cannot make the Kafka message atomic with the later database commit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: meter delete in tx"](https://github.com/openmeterio/openmeter/commit/78ef4a9813ecd043e91af5202303b9f4e9f823fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49613643)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->