### PR TITLE
fix(billing): reject custom-currency manual charges

### DIFF
--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func (s *service) CreateCustomerCharge(ctx context.Context, input charges.CreateCustomerChargeInput) (charges.Charge, error) {
@@ -22,6 +23,10 @@ func (s *service) CreateCustomerCharge(ctx context.Context, input charges.Create
 	})
 	if err != nil {
 		return charges.Charge{}, fmt.Errorf("resolving currency: %w", err)
+	}
+
+	if currency.IsCustom() {
+		return charges.Charge{}, models.NewGenericValidationError(fmt.Errorf("currency: %w", meta.ErrCustomCurrencyNotSupported))
 	}
 
 	intent := meta.Intent{

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -4239,7 +4239,51 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 		customCurrency = s.createTestCustomCurrency(ctx, ns)
 	})
 
-	s.Run("#2 create credits-only flat fee", func() {
+	s.Run("#2 reject custom currency through the customer charge API", func() {
+		// given:
+		// - the same customer and custom currency used by the supported root charge flow below
+		servicePeriod := timeutil.ClosedPeriod{
+			From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+			To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+		}
+
+		// when:
+		// - a manual customer charge tries to use that custom currency
+		_, err := s.Charges.CreateCustomerCharge(ctx, charges.CreateCustomerChargeInput{
+			Namespace:    ns,
+			CustomerID:   customerID,
+			CurrencyCode: customCurrency.GetCode(),
+			FlatFee: &charges.CreateCustomerChargeFlatFeeInput{
+				IntentMutableFields: flatfee.IntentMutableFields{
+					IntentMutableFields: meta.IntentMutableFields{
+						Name:              "Unsupported custom currency charge",
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:             servicePeriod.From,
+					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+					AmountBeforeProration: alpacadecimal.NewFromInt(10),
+				},
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+			},
+		})
+
+		// then:
+		// - the API boundary rejects it before the supported root creation path is reached
+		s.Require().Error(err)
+		s.ErrorIs(err, meta.ErrCustomCurrencyNotSupported)
+		s.True(models.IsGenericValidationError(err))
+
+		persisted, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+			Namespace:   ns,
+			CustomerIDs: []string{customerID},
+		})
+		s.Require().NoError(err)
+		s.Empty(persisted.Items)
+	})
+
+	s.Run("#3 create credits-only flat fee through the root service", func() {
 		// given:
 		// - an immediately due flat fee in the custom currency
 		// - mocked ledger allocation and lineage callbacks
@@ -4349,7 +4393,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 		s.Empty(createdCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].CreditsApplied)
 	})
 
-	s.Run("#3 reload persisted charge", func() {
+	s.Run("#4 reload persisted charge", func() {
 		// when:
 		// - the flat-fee charge is loaded again from Postgres
 		// then:


### PR DESCRIPTION
## What changed

- reject resolved custom currencies at the manual customer-charge service boundary
- return the existing `ErrCustomCurrencyNotSupported` marker as a validation error before charge persistence
- add Postgres-backed service coverage asserting rejection and no persisted charge

## Why

The v3 manual customer-charge API resolved custom currencies and passed them into root charge creation. Root creation intentionally commits before auto-advance, while billing lineage still rejects custom currencies during advancement. An immediate charge could therefore remain persisted after a failed request, and a future-dated charge could be accepted and fail later in the worker.

The guard stays in `CreateCustomerCharge` so internal root charge APIs remain available for supported ledger/chargeadapter mechanics and future billing integration.

## Validation

- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service -run '^TestCustomerChargeAPI$' -count=1`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service ./api/v3/handlers/customers/charges`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Customer charges now reject unsupported custom currencies with a clear validation error.
  * Invalid charges are not saved or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents manual customer charges denominated in custom currencies from reaching charge persistence while preserving custom-currency support in the internal root service.
- Rejects resolved custom currencies at the `CreateCustomerCharge` boundary with the existing validation marker.
- Adds Postgres-backed coverage for error classification and absence of persisted charges.
- Retains coverage for successful custom-currency creation through the root charge service.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/service/api.go | Adds an early, correctly classified custom-currency rejection before root charge creation and persistence. |
| openmeter/billing/charges/service/invoicable_test.go | Verifies rejection, validation-error identity, no persisted manual charge, and continued root-service support. |

<sub>Reviews (2): Last reviewed commit: ["fix(billing): reject custom-currency man..."](https://github.com/openmeterio/openmeter/commit/655db03a22ab5f18fd088ea8aa99a71df678ca4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49635546)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->