### PR TITLE
refactor(subscription): plan sync by materialized nodes

### DIFF
--- a/openmeter/subscription/service/README.md
+++ b/openmeter/subscription/service/README.md
@@ -24,17 +24,17 @@ updated subscription graph.
 
 ## Reconciliation model
 
-An update compares the current `SubscriptionView` with the complete target
-spec. Materialization proceeds in three passes:
-
-1. remove phases and item versions that disappeared or whose persisted shape
-   no longer matches the target
-2. recreate changed phases and item versions that still exist in the target
-3. create phases and item versions that are new to the target
+An update indexes the current `SubscriptionView` and complete target spec by
+logical path. Phase, item-version, and entitlement nodes compare their own
+materialized shape and produce an ordered archive/create plan. Archives run
+from derived resources toward their parents; creates run from parents toward
+derived resources so generated references are available when needed.
 
 Phase keys identify logical phases. Within a phase, item key and slice position
 identify a logical item version. When a phase changes, its items are
-rematerialized with it.
+rematerialized with it. Items and their derived entitlements are also one
+replacement group because the persisted item references the generated
+entitlement ID.
 
 Changed rows are deleted and recreated rather than updated field by field.
 Their database IDs—and the IDs of entitlements derived from them—are therefore

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -160,7 +160,7 @@ func (s *service) Create(ctx context.Context, namespace string, spec subscriptio
 				return def, fmt.Errorf("failed to get phase cadence: %w", err)
 			}
 
-			if _, err := s.createPhase(ctx, *cus, *phase, sub, phaseCadence); err != nil {
+			if _, err := s.createPhaseWithChildren(ctx, *cus, *phase, sub, phaseCadence); err != nil {
 				return def, err
 			}
 		}
@@ -277,7 +277,7 @@ func (s *service) Delete(ctx context.Context, subscriptionID models.NamespacedID
 	return transaction.RunWithNoValue(ctx, s.TransactionManager, func(ctx context.Context) error {
 		// First, let's delete all phases
 		for _, phase := range view.Phases {
-			if err := s.deletePhase(ctx, phase); err != nil {
+			if err := s.deletePhaseWithChildren(ctx, phase); err != nil {
 				return fmt.Errorf("failed to delete phase: %w", err)
 			}
 		}

--- a/openmeter/subscription/service/sync.go
+++ b/openmeter/subscription/service/sync.go
@@ -4,375 +4,58 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
-
-	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
-	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-// Sync manages the synchronization of a subscription with a new spec.
-// It consists of 3 steps:
-// 1. Remove anything that's changed or got removed
-// 2. Create anything that's been changed
-// 3. Create anything that's new
-//
-// Some remarks:
-// 1. Change comparison is done on the relevant create inputs.
-// 2. Things being deleted are marked via a `touched` map.
-//
-// TODO: localize error so phase and item keys are always included (alongside subscription reference)
-// TODO (OM-1074): clean up this control flow
 func (s *service) sync(ctx context.Context, view subscription.SubscriptionView, newSpec subscription.SubscriptionSpec) (subscription.Subscription, error) {
 	return transaction.Run(ctx, s.TransactionManager, func(ctx context.Context) (subscription.Subscription, error) {
 		var def subscription.Subscription
 
-		// Some sanity checks for good measure
-		if view.Subscription.CustomerId != newSpec.CustomerId {
-			return def, fmt.Errorf("cannot change customer id")
-		}
-		if !view.Subscription.PlanRef.NilEqual(newSpec.Plan) {
-			return def, fmt.Errorf("cannot change plan")
-		}
-		if !view.Subscription.ActiveFrom.Equal(newSpec.ActiveFrom) {
-			return def, fmt.Errorf("cannot change subscription start")
-		}
-		if view.Subscription.SettlementMode != newSpec.SettlementMode {
-			return def, fmt.Errorf("cannot change settlement mode")
+		if err := validateSyncTarget(view, newSpec); err != nil {
+			return def, err
 		}
 
-		dirty := make(touched)
+		plan, err := newSyncPlan(view, newSpec)
+		if err != nil {
+			return def, fmt.Errorf("failed to plan subscription sync: %w", err)
+		}
 
-		// Let's make sure the Subscription Cadence is up to date
-		if !view.Subscription.CadencedModel.Equal(models.CadencedModel{ActiveFrom: newSpec.ActiveFrom, ActiveTo: newSpec.ActiveTo}) {
-			_, err := s.SubscriptionRepo.SetEndOfCadence(ctx, view.Subscription.NamespacedID, newSpec.ActiveTo)
-			if err != nil {
+		if !view.Subscription.CadencedModel.Equal(models.CadencedModel{
+			ActiveFrom: newSpec.ActiveFrom,
+			ActiveTo:   newSpec.ActiveTo,
+		}) {
+			if _, err := s.SubscriptionRepo.SetEndOfCadence(
+				ctx,
+				view.Subscription.NamespacedID,
+				newSpec.ActiveTo,
+			); err != nil {
 				return def, fmt.Errorf("failed to set end of cadence: %w", err)
 			}
 		}
 
-		// 1. Let's remove anything that's changed or got removed
-		newSortedPhaseSpecs := newSpec.GetSortedPhases()
-		for _, currentPhaseView := range view.Phases {
-			// Let's try find a matching phase in the new spec
-			matchingPhaseFromNewSpec, found := lo.Find(newSortedPhaseSpecs, func(s *subscription.SubscriptionPhaseSpec) bool {
-				return s.PhaseKey == currentPhaseView.SubscriptionPhase.Key
-			})
-
-			// If there's no equivalent found in the current spec, we need to delete the phase
-			if !found {
-				if err := s.deletePhase(ctx, currentPhaseView); err != nil {
-					return def, fmt.Errorf("failed to delete phase: %w", err)
-				}
-
-				dirty.mark(subscription.NewPhasePath(currentPhaseView.SubscriptionPhase.Key))
-
-				// There's nothing more to be done for this phase, so lets skip to the next one
-				continue
-			}
-
-			// sanity check
-			if matchingPhaseFromNewSpec == nil {
-				return def, fmt.Errorf("failed to find matching phase in new spec but no error was returned")
-			}
-
-			// Let's get the cadence of the current phase
-			cadenceOfCurrentPhaseBasedOnSpec, err := view.Spec.GetPhaseCadence(currentPhaseView.SubscriptionPhase.Key)
-			if err != nil {
-				return def, fmt.Errorf("failed to get cadence for current phase %s: %w", currentPhaseView.SubscriptionPhase.Key, err)
-			}
-
-			// Let's get the cadence of the new phase
-			cadenceOfNewPhaseBasedOnSpec, err := newSpec.GetPhaseCadence(matchingPhaseFromNewSpec.PhaseKey)
-			if err != nil {
-				return def, fmt.Errorf("failed to get cadence for new phase %s: %w", matchingPhaseFromNewSpec.PhaseKey, err)
-			}
-
-			// Lets figure out when the new phase should start
-			newPhaseStartTime, _ := matchingPhaseFromNewSpec.StartAfter.AddTo(view.Subscription.ActiveFrom)
-
-			curr := currentPhaseView.Spec.ToCreateSubscriptionPhaseEntityInput(view.Subscription, currentPhaseView.SubscriptionPhase.ActiveFrom)
-			new := matchingPhaseFromNewSpec.ToCreateSubscriptionPhaseEntityInput(view.Subscription, newPhaseStartTime)
-
-			// If the phase has any changes, we need to recreate it. That means also all sub-resources of it have to be relinked.
-			if !curr.Equal(new) {
-				// This means deleting the phase with all its sub-resources
-				if err := s.deletePhase(ctx, currentPhaseView); err != nil {
-					return def, fmt.Errorf("failed to delete phase: %w", err)
-				}
-
-				dirty.mark(subscription.NewPhasePath(currentPhaseView.SubscriptionPhase.Key))
-
-				// The phase is deleted, there's nothing more to be done
-				continue
-			}
-
-			// Sanity check, the current phase cannot be dirty
-			if dirty.isTouched(subscription.NewPhasePath(currentPhaseView.SubscriptionPhase.Key)) {
-				return def, fmt.Errorf("current phase is dirty but should not be")
-			}
-
-			// Now let's iterate through all items in the phase
-			for currentItemViewsKey, currentItemViews := range currentPhaseView.ItemsByKey {
-				// Let's try find a matching item in the new spec
-				// Here as we do an update, we rely on the previously verified integrity of both view and spec
-				// Due to this, we use a simple matching based on the index of the item under the given key
-				matchingItemsByKeyFromNewSpec, found := matchingPhaseFromNewSpec.ItemsByKey[currentItemViewsKey]
-
-				// If no matching key is found in the new spec lets delete everything
-				if !found || len(matchingItemsByKeyFromNewSpec) == 0 {
-					for _, currentItemView := range currentItemViews {
-						if err := s.deleteItem(ctx, currentItemView); err != nil {
-							return def, fmt.Errorf("failed to delete item: %w", err)
-						}
-
-						dirty.mark(subscription.NewItemPath(currentItemView.Spec.PhaseKey, currentItemView.Spec.ItemKey))
-					}
-
-					// There's nothing more to be done for this item(key), so lets skip to the next one
-					continue
-				}
-
-				for currentItemIdx, currentItemView := range currentItemViews {
-					// Let's get the item with the same index from the new spec
-					if currentItemIdx >= len(matchingItemsByKeyFromNewSpec) {
-						// Let's delete the item as it's not present in the new spec
-
-						if err := s.deleteItem(ctx, currentItemView); err != nil {
-							return def, fmt.Errorf("failed to delete item: %w", err)
-						}
-
-						dirty.mark(subscription.NewItemVersionPath(currentItemView.Spec.PhaseKey, currentItemView.Spec.ItemKey, currentItemIdx))
-
-						// There's nothing more to be done for this item, so lets skip to the next one
-						continue
-					}
-
-					matchingItemFromNewSpec := matchingItemsByKeyFromNewSpec[currentItemIdx]
-
-					// First, let's check if the item itself needs to be changed
-					curr, err := currentItemView.Spec.ToCreateSubscriptionItemEntityInput(
-						currentPhaseView.SubscriptionPhase.NamespacedID,
-						cadenceOfCurrentPhaseBasedOnSpec,
-						convert.SafeDeRef(currentItemView.Entitlement, func(s subscription.SubscriptionEntitlement) *entitlement.Entitlement {
-							return &s.Entitlement.Entitlement
-						}),
-					)
-					if err != nil {
-						return def, fmt.Errorf("failed to convert item to entity input: %w", err)
-					}
-
-					// Here we don't preamptively know all the properties but fortunately all we need to know is whether they'd change or not
-					// We're prepopulating changing fields with invalid values, which is a lie and a bad method, but it's necessary for now due to the hard linking
-
-					newPhaseID := currentPhaseView.SubscriptionPhase.NamespacedID
-					if dirty.isTouched(subscription.NewPhasePath(currentPhaseView.SubscriptionPhase.Key)) {
-						newPhaseID = impossibleNamespacedId
-					}
-
-					newOnlyForComparisonWithInvalidProperties, err := matchingItemFromNewSpec.ToCreateSubscriptionItemEntityInput(
-						newPhaseID,
-						cadenceOfNewPhaseBasedOnSpec,
-						// Without the "new" entitlement already present we cannot properly compare the two create inputs.
-						// To work around this, we'll reuse the current entitlement for comparison.
-						// This won't cause an issue as all relevant properties of the entitlement are specced on the Item (as part of RateCard)
-						// FIXME: This is a lie
-						convert.SafeDeRef(currentItemView.Entitlement, func(s subscription.SubscriptionEntitlement) *entitlement.Entitlement {
-							return &s.Entitlement.Entitlement
-						}),
-					)
-					if err != nil {
-						return def, fmt.Errorf("failed to convert item to entity input: %w", err)
-					}
-
-					doesItemNeedToBeChanged := !curr.Equal(newOnlyForComparisonWithInvalidProperties)
-
-					if doesItemNeedToBeChanged {
-						// This means deleting the item with all its sub-resources
-						if err := s.deleteItem(ctx, currentItemView); err != nil {
-							return def, fmt.Errorf("failed to delete item: %w", err)
-						}
-
-						dirty.mark(subscription.NewItemVersionPath(currentItemView.Spec.PhaseKey, currentItemView.Spec.ItemKey, currentItemIdx))
-
-						// There's nothing more to be done here, so lets skip to the next one
-						continue
-					}
-				}
-			}
+		if err := plan.Execute(ctx, s, view.Customer); err != nil {
+			return def, err
 		}
 
-		// 2. Let's create anything that's been changed
-		for _, currentPhaseView := range view.Phases {
-			// Let's try find a matching phase in the new spec
-			matchingPhaseFromNewSpec, found := lo.Find(newSortedPhaseSpecs, func(s *subscription.SubscriptionPhaseSpec) bool {
-				return s.PhaseKey == currentPhaseView.SubscriptionPhase.Key
-			})
-
-			if !found {
-				// If the phase wasn't found there's nothing to create
-				continue
-			}
-
-			// Sanity check
-			if matchingPhaseFromNewSpec == nil {
-				return def, fmt.Errorf("failed to find matching phase in new spec but no error was returned")
-			}
-
-			newPhaseCadence, err := newSpec.GetPhaseCadence(matchingPhaseFromNewSpec.PhaseKey)
-			if err != nil {
-				return def, fmt.Errorf("failed to get cadence for phase %s: %w", matchingPhaseFromNewSpec.PhaseKey, err)
-			}
-
-			// If the phase got deleted, we can create it as a whole
-			if dirty.isTouched(subscription.NewPhasePath(currentPhaseView.SubscriptionPhase.Key)) {
-				if _, err := s.createPhase(ctx, view.Customer, *matchingPhaseFromNewSpec, view.Subscription, newPhaseCadence); err != nil {
-					return def, fmt.Errorf("failed to create phase: %w", err)
-				}
-
-				// There's nothing more to be done for this phase, so lets skip to the next one
-				continue
-			}
-
-			// Now let's check each of the items in the phase
-			for currentItemViewsKey, currentItemViews := range currentPhaseView.ItemsByKey {
-				// Let's try find a matching item in the new spec
-				// Here as we do an update, we rely on the previously verified integrity of both view and spec
-				// Due to this, we use a simple matching based on the index of the item under the given key
-				matchingItemsByKeyFromNewSpec, found := matchingPhaseFromNewSpec.ItemsByKey[currentItemViewsKey]
-				if !found {
-					// If the item wasn't found there's nothing to create
-					continue
-				}
-
-				for currentItemIdx, currentItemView := range currentItemViews {
-					// Let's get the item with the same index from the new spec
-					if currentItemIdx >= len(matchingItemsByKeyFromNewSpec) {
-						// We went out of bounds, these items are not present in the new spec so we can just break
-
-						break
-					}
-
-					matchingItemFromNewSpec := matchingItemsByKeyFromNewSpec[currentItemIdx]
-
-					// If the item got deleted, we can create it as a whole
-					if dirty.isTouched(subscription.NewItemVersionPath(currentItemView.Spec.PhaseKey, currentItemView.Spec.ItemKey, currentItemIdx)) {
-						if _, err := s.createItem(ctx, createItemOptions{
-							cust:         view.Customer,
-							sub:          view.Subscription,
-							phase:        currentPhaseView.SubscriptionPhase,
-							phaseCadence: newPhaseCadence,
-							itemSpec:     *matchingItemFromNewSpec,
-						}); err != nil {
-							return def, fmt.Errorf("failed to create item: %w", err)
-						}
-
-						// There's nothing more to be done for this item, so lets skip to the next one
-						continue
-					}
-				}
-			}
-		}
-
-		// 3. Finally, let's create anything that's new
-		for _, phase := range newSpec.GetSortedPhases() {
-			// Sanity check
-			if phase == nil {
-				return def, fmt.Errorf("phase is nil")
-			}
-
-			// Let's see if the phase was present in the current view
-			matchingPhaseInCurrentView, foundMatchingPhaseInCurrentView := lo.Find(view.Phases, func(p subscription.SubscriptionPhaseView) bool {
-				return p.SubscriptionPhase.Key == phase.PhaseKey
-			})
-
-			if !foundMatchingPhaseInCurrentView {
-				phaseCadence, err := newSpec.GetPhaseCadence(phase.PhaseKey)
-				if err != nil {
-					return def, fmt.Errorf("failed to get cadence for phase %s: %w", phase.PhaseKey, err)
-				}
-
-				if _, err := s.createPhase(ctx, view.Customer, *phase, view.Subscription, phaseCadence); err != nil {
-					return def, fmt.Errorf("failed to create phase: %w", err)
-				}
-				continue
-			}
-
-			// Now lets check all the items in the phase
-			for key, itemsByKey := range phase.ItemsByKey {
-				matchingItemsByKeyInCurrentView, foundMatchingItemsByKeyInCurrentView := matchingPhaseInCurrentView.ItemsByKey[key]
-
-				for itemIdx, item := range itemsByKey {
-					phaseCadence, err := newSpec.GetPhaseCadence(phase.PhaseKey)
-					if err != nil {
-						return def, fmt.Errorf("failed to get cadence for phase %s: %w", phase.PhaseKey, err)
-					}
-
-					// If we didn't find a matching key in the current view, we need to create the item
-					if !foundMatchingItemsByKeyInCurrentView {
-						if _, err := s.createItem(ctx, createItemOptions{
-							cust:         view.Customer,
-							sub:          view.Subscription,
-							phase:        matchingPhaseInCurrentView.SubscriptionPhase,
-							phaseCadence: phaseCadence,
-							itemSpec:     *item,
-						}); err != nil {
-							return def, fmt.Errorf("failed to create item: %w", err)
-						}
-
-						// There's nothing left to do for this item
-						continue
-					} else if itemIdx >= len(matchingItemsByKeyInCurrentView) {
-						// If there's a matching key, then in the previous step we've taken care of all indexes
-						// present in the current phase
-
-						// The rest we create
-						if _, err := s.createItem(ctx, createItemOptions{
-							cust:         view.Customer,
-							sub:          view.Subscription,
-							phase:        matchingPhaseInCurrentView.SubscriptionPhase,
-							phaseCadence: phaseCadence,
-							itemSpec:     *item,
-						}); err != nil {
-							return def, fmt.Errorf("failed to create item: %w", err)
-						}
-					}
-				}
-			}
-		}
-
-		// 4. Finally we're done with syncing everything, we should just re-fetch the subscription
 		return s.Get(ctx, view.Subscription.NamespacedID)
 	})
 }
 
-// touched is a map of touched paths (honoring sub-resource relationships)
-type touched map[subscription.SpecPath]bool
-
-// Mark a given path as touched
-func (t touched) mark(key subscription.SpecPath) {
-	t[key] = true
-}
-
-// Check if a given path has been touched
-// If path X has been touched, then all sub-resources of X have been touched
-func (t touched) isTouched(key subscription.SpecPath) bool {
-	for k := range t {
-		// IsParentOf check returns true for identity as well
-		if k.IsParentOf(key) {
-			return true
-		}
+func validateSyncTarget(view subscription.SubscriptionView, newSpec subscription.SubscriptionSpec) error {
+	if view.Subscription.CustomerId != newSpec.CustomerId {
+		return fmt.Errorf("cannot change customer id")
 	}
-	return false
-}
+	if !view.Subscription.PlanRef.NilEqual(newSpec.Plan) {
+		return fmt.Errorf("cannot change plan")
+	}
+	if !view.Subscription.ActiveFrom.Equal(newSpec.ActiveFrom) {
+		return fmt.Errorf("cannot change subscription start")
+	}
+	if view.Subscription.SettlementMode != newSpec.SettlementMode {
+		return fmt.Errorf("cannot change settlement mode")
+	}
 
-// NewItemVersionPath returns an invalid PatchPath thats still usable for IsParentOf checks
-// FIXME: this is a hack. For instance, is featureKey were to contain `/` it would completely break (though that exact scenario is otherwise prohibited)
-
-// an ID that can never occur in normal control flow
-var impossibleNamespacedId = models.NamespacedID{
-	ID:        "impossible",
-	Namespace: "impossible",
+	return nil
 }

--- a/openmeter/subscription/service/sync_test.go
+++ b/openmeter/subscription/service/sync_test.go
@@ -53,8 +53,38 @@ func TestEdit(t *testing.T) {
 				sub, err := deps.Service.Create(ctx, deps.Customer.Namespace, spec)
 				require.Nil(t, err)
 
+				before, err := deps.Service.GetView(ctx, sub.NamespacedID)
+				require.NoError(t, err)
+
 				_, err = deps.Service.Update(ctx, sub.NamespacedID, spec)
 				require.Nil(t, err)
+
+				after, err := deps.Service.GetView(ctx, sub.NamespacedID)
+				require.NoError(t, err)
+				require.Len(t, after.Phases, len(before.Phases))
+
+				for phaseIdx, beforePhase := range before.Phases {
+					afterPhase := after.Phases[phaseIdx]
+					require.Equal(t, beforePhase.SubscriptionPhase.ID, afterPhase.SubscriptionPhase.ID)
+
+					for itemKey, beforeItems := range beforePhase.ItemsByKey {
+						afterItems := afterPhase.ItemsByKey[itemKey]
+						require.Len(t, afterItems, len(beforeItems))
+
+						for itemIdx, beforeItem := range beforeItems {
+							afterItem := afterItems[itemIdx]
+							require.Equal(t, beforeItem.SubscriptionItem.ID, afterItem.SubscriptionItem.ID)
+
+							if beforeItem.Entitlement == nil {
+								require.Nil(t, afterItem.Entitlement)
+								continue
+							}
+
+							require.NotNil(t, afterItem.Entitlement)
+							require.Equal(t, beforeItem.Entitlement.Entitlement.ID, afterItem.Entitlement.Entitlement.ID)
+						}
+					}
+				}
 			},
 		},
 		{

--- a/openmeter/subscription/service/sync_test.go
+++ b/openmeter/subscription/service/sync_test.go
@@ -137,6 +137,29 @@ func TestEdit(t *testing.T) {
 			},
 		},
 		{
+			Name: "Should error if settlement mode changes",
+			Handler: func(t *testing.T, deps TDeps) {
+				ctx := t.Context()
+
+				spec, err := subscription.NewSpecFromPlan(deps.ExamplePlan, subscription.CreateSubscriptionCustomerInput{
+					Name:          "Test",
+					CustomerId:    deps.Customer.ID,
+					Currency:      currencyx.Code("USD"),
+					ActiveFrom:    deps.CurrentTime,
+					BillingAnchor: deps.CurrentTime,
+				})
+				require.NoError(t, err)
+
+				sub, err := deps.Service.Create(ctx, deps.Customer.Namespace, spec)
+				require.NoError(t, err)
+
+				spec.SettlementMode = productcatalog.CreditOnlySettlementMode
+
+				_, err = deps.Service.Update(ctx, sub.NamespacedID, spec)
+				require.ErrorContains(t, err, "cannot change settlement mode")
+			},
+		},
+		{
 			Name: "Should update contents of future phases when phase start changes",
 			Handler: func(t *testing.T, deps TDeps) {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -378,6 +401,298 @@ func TestEdit(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestSyncReconciliation(t *testing.T) {
+	const (
+		firstPhaseKey  = "test_phase_1"
+		secondPhaseKey = "test_phase_2"
+		thirdPhaseKey  = "test_phase_3"
+		addedPhaseKey  = "added_phase"
+	)
+
+	type testCase struct {
+		name    string
+		prepare func(t *testing.T, spec *subscription.SubscriptionSpec)
+		mutate  func(t *testing.T, spec *subscription.SubscriptionSpec)
+		assert  func(t *testing.T, before, after subscription.SubscriptionView)
+	}
+
+	tests := []testCase{
+		{
+			name: "changing a phase persists its properties and child links",
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				spec.Phases[firstPhaseKey].Name = "Changed phase"
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				beforePhase := requireSyncPhase(t, before, firstPhaseKey)
+				afterPhase := requireSyncPhase(t, after, firstPhaseKey)
+
+				require.Equal(t, "Changed phase", afterPhase.SubscriptionPhase.Name)
+				require.Len(t, afterPhase.ItemsByKey, len(beforePhase.ItemsByKey))
+				for _, items := range afterPhase.ItemsByKey {
+					for _, item := range items {
+						require.Equal(t, afterPhase.SubscriptionPhase.ID, item.SubscriptionItem.PhaseId)
+					}
+				}
+			},
+		},
+		{
+			name: "removing a phase deletes it and reconciles the preceding phase cadence",
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				delete(spec.Phases, thirdPhaseKey)
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				require.Len(t, after.Phases, len(before.Phases)-1)
+				_, found := lo.Find(after.Phases, func(phase subscription.SubscriptionPhaseView) bool {
+					return phase.SubscriptionPhase.Key == thirdPhaseKey
+				})
+				require.False(t, found)
+
+				phase := requireSyncPhase(t, after, secondPhaseKey)
+				cadence, err := after.Spec.GetPhaseCadence(secondPhaseKey)
+				require.NoError(t, err)
+				require.Nil(t, cadence.ActiveTo)
+				for _, items := range phase.ItemsByKey {
+					for _, item := range items {
+						require.Nil(t, item.SubscriptionItem.ActiveTo)
+						if item.Entitlement != nil {
+							require.Nil(t, item.Entitlement.Cadence.ActiveTo)
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "adding a phase creates it and reconciles the preceding phase cadence",
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				rateCard := subscriptiontestutils.ExampleRateCard2.Clone()
+				itemKey := rateCard.Key()
+				spec.Phases[addedPhaseKey] = &subscription.SubscriptionPhaseSpec{
+					CreateSubscriptionPhasePlanInput: subscription.CreateSubscriptionPhasePlanInput{
+						PhaseKey:   addedPhaseKey,
+						StartAfter: datetime.MustParseDuration(t, "P4M"),
+						Name:       "Added phase",
+					},
+					ItemsByKey: map[string][]*subscription.SubscriptionItemSpec{
+						itemKey: {
+							{
+								CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+									CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+										PhaseKey: addedPhaseKey,
+										ItemKey:  itemKey,
+										RateCard: rateCard,
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				require.Len(t, after.Phases, len(before.Phases)+1)
+				addedPhase := requireSyncPhase(t, after, addedPhaseKey)
+				require.Equal(t, "Added phase", addedPhase.SubscriptionPhase.Name)
+				require.Len(t, requireSyncItems(t, addedPhase, subscriptiontestutils.ExampleRateCard2.Key()), 1)
+
+				precedingPhase := requireSyncPhase(t, after, thirdPhaseKey)
+				precedingCadence, err := after.Spec.GetPhaseCadence(thirdPhaseKey)
+				require.NoError(t, err)
+				require.NotNil(t, precedingCadence.ActiveTo)
+				require.True(t, precedingCadence.ActiveTo.Equal(addedPhase.SubscriptionPhase.ActiveFrom))
+				for _, items := range precedingPhase.ItemsByKey {
+					for _, item := range items {
+						require.NotNil(t, item.SubscriptionItem.ActiveTo)
+						require.True(t, item.SubscriptionItem.ActiveTo.Equal(addedPhase.SubscriptionPhase.ActiveFrom))
+						if item.Entitlement != nil {
+							require.NotNil(t, item.Entitlement.Cadence.ActiveTo)
+							require.True(t, item.Entitlement.Cadence.ActiveTo.Equal(addedPhase.SubscriptionPhase.ActiveFrom))
+						}
+					}
+				}
+			},
+		},
+		{
+			name: "removing an item key deletes every version and keeps sibling items",
+			prepare: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				rateCard := subscriptiontestutils.ExampleRateCard2.Clone()
+				itemKey := rateCard.Key()
+				spec.Phases[firstPhaseKey].ItemsByKey[itemKey] = []*subscription.SubscriptionItemSpec{{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							PhaseKey: firstPhaseKey,
+							ItemKey:  itemKey,
+							RateCard: rateCard,
+						},
+					},
+				}}
+			},
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				delete(spec.Phases[firstPhaseKey].ItemsByKey, subscriptiontestutils.ExampleFeatureKey)
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				beforePhase := requireSyncPhase(t, before, firstPhaseKey)
+				afterPhase := requireSyncPhase(t, after, firstPhaseKey)
+				require.Len(t, beforePhase.ItemsByKey, 2)
+				require.Len(t, afterPhase.ItemsByKey, 1)
+
+				_, found := afterPhase.ItemsByKey[subscriptiontestutils.ExampleFeatureKey]
+				require.False(t, found)
+				require.Len(t, requireSyncItems(t, afterPhase, subscriptiontestutils.ExampleRateCard2.Key()), 1)
+			},
+		},
+		{
+			name: "adding an item key creates it and keeps existing items",
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				rateCard := subscriptiontestutils.ExampleRateCard2.Clone()
+				itemKey := rateCard.Key()
+				spec.Phases[firstPhaseKey].ItemsByKey[itemKey] = []*subscription.SubscriptionItemSpec{{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							PhaseKey: firstPhaseKey,
+							ItemKey:  itemKey,
+							RateCard: rateCard,
+						},
+					},
+				}}
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				beforePhase := requireSyncPhase(t, before, firstPhaseKey)
+				afterPhase := requireSyncPhase(t, after, firstPhaseKey)
+				require.Len(t, beforePhase.ItemsByKey, 1)
+				require.Len(t, afterPhase.ItemsByKey, 2)
+				require.Len(t, requireSyncItems(t, afterPhase, subscriptiontestutils.ExampleFeatureKey), 1)
+
+				addedItems := requireSyncItems(t, afterPhase, subscriptiontestutils.ExampleRateCard2.Key())
+				require.Len(t, addedItems, 1)
+				require.Nil(t, addedItems[0].Entitlement)
+			},
+		},
+		{
+			name: "adding a trailing item version creates contiguous item and entitlement cadences",
+			prepare: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				activeTo := datetime.MustParseDuration(t, "P15D")
+				spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey][0].ActiveToOverrideRelativeToPhaseStart = &activeTo
+			},
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				items := spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey]
+				activeFrom := datetime.MustParseDuration(t, "P15D")
+				secondVersion := *items[0]
+				secondVersion.RateCard = items[0].RateCard.Clone()
+				secondVersion.ActiveFromOverrideRelativeToPhaseStart = &activeFrom
+				secondVersion.ActiveToOverrideRelativeToPhaseStart = nil
+				spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey] = append(items, &secondVersion)
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				beforeItems := requireSyncItems(t, requireSyncPhase(t, before, firstPhaseKey), subscriptiontestutils.ExampleFeatureKey)
+				afterItems := requireSyncItems(t, requireSyncPhase(t, after, firstPhaseKey), subscriptiontestutils.ExampleFeatureKey)
+				require.Len(t, beforeItems, 1)
+				require.Len(t, afterItems, 2)
+
+				require.NotNil(t, afterItems[0].SubscriptionItem.ActiveTo)
+				require.Equal(t, *afterItems[0].SubscriptionItem.ActiveTo, afterItems[1].SubscriptionItem.ActiveFrom)
+				require.NotNil(t, afterItems[0].Entitlement)
+				require.NotNil(t, afterItems[1].Entitlement)
+				require.NotNil(t, afterItems[0].Entitlement.Cadence.ActiveTo)
+				require.Equal(t, *afterItems[0].Entitlement.Cadence.ActiveTo, afterItems[1].Entitlement.Cadence.ActiveFrom)
+			},
+		},
+		{
+			name: "removing a trailing item version leaves only the earlier cadence",
+			prepare: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				items := spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey]
+				boundary := datetime.MustParseDuration(t, "P15D")
+				items[0].ActiveToOverrideRelativeToPhaseStart = &boundary
+
+				secondVersion := *items[0]
+				secondVersion.RateCard = items[0].RateCard.Clone()
+				secondVersion.ActiveFromOverrideRelativeToPhaseStart = &boundary
+				secondVersion.ActiveToOverrideRelativeToPhaseStart = nil
+				spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey] = append(items, &secondVersion)
+			},
+			mutate: func(t *testing.T, spec *subscription.SubscriptionSpec) {
+				items := spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey]
+				spec.Phases[firstPhaseKey].ItemsByKey[subscriptiontestutils.ExampleFeatureKey] = items[:1]
+			},
+			assert: func(t *testing.T, before, after subscription.SubscriptionView) {
+				beforeItems := requireSyncItems(t, requireSyncPhase(t, before, firstPhaseKey), subscriptiontestutils.ExampleFeatureKey)
+				afterItems := requireSyncItems(t, requireSyncPhase(t, after, firstPhaseKey), subscriptiontestutils.ExampleFeatureKey)
+				require.Len(t, beforeItems, 2)
+				require.Len(t, afterItems, 1)
+				require.NotNil(t, afterItems[0].SubscriptionItem.ActiveTo)
+				require.NotNil(t, afterItems[0].Entitlement)
+				require.Equal(t, afterItems[0].SubscriptionItem.ActiveTo, afterItems[0].Entitlement.Cadence.ActiveTo)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given a fully materialized subscription built from the example plan.
+			currentTime := testutils.GetRFC3339Time(t, "2021-01-01T00:00:00Z")
+			clock.FreezeTime(currentTime)
+			defer clock.UnFreeze()
+
+			dbDeps := subscriptiontestutils.SetupDBDeps(t)
+			defer dbDeps.Cleanup(t)
+
+			deps := subscriptiontestutils.NewService(t, dbDeps)
+			cust := deps.CustomerAdapter.CreateExampleCustomer(t)
+			require.NotNil(t, cust)
+			_ = deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+			plan := deps.PlanHelper.CreatePlan(t, subscriptiontestutils.GetExamplePlanInput(t))
+
+			spec, err := subscription.NewSpecFromPlan(plan, subscription.CreateSubscriptionCustomerInput{
+				Name:          "Test",
+				CustomerId:    cust.ID,
+				Currency:      currencyx.Code("USD"),
+				ActiveFrom:    currentTime,
+				BillingAnchor: currentTime,
+			})
+			require.NoError(t, err)
+
+			if tt.prepare != nil {
+				tt.prepare(t, &spec)
+			}
+
+			sub, err := deps.SubscriptionService.Create(t.Context(), cust.Namespace, spec)
+			require.NoError(t, err)
+			beforeView, err := deps.SubscriptionService.GetView(t.Context(), sub.NamespacedID)
+			require.NoError(t, err)
+			subscriptiontestutils.ValidateSpecAndView(t, spec, beforeView)
+
+			// When the complete target spec changes one reconciliation boundary.
+			tt.mutate(t, &spec)
+			_, err = deps.SubscriptionService.Update(t.Context(), sub.NamespacedID, spec)
+			require.NoError(t, err)
+
+			// Then the persisted graph and derived entitlements exactly match the target.
+			afterView, err := deps.SubscriptionService.GetView(t.Context(), sub.NamespacedID)
+			require.NoError(t, err)
+			tt.assert(t, beforeView, afterView)
+			subscriptiontestutils.ValidateSpecAndView(t, spec, afterView)
+		})
+	}
+}
+
+func requireSyncPhase(t *testing.T, view subscription.SubscriptionView, phaseKey string) subscription.SubscriptionPhaseView {
+	t.Helper()
+
+	phase, found := lo.Find(view.Phases, func(phase subscription.SubscriptionPhaseView) bool {
+		return phase.SubscriptionPhase.Key == phaseKey
+	})
+	require.True(t, found, "phase %s not found", phaseKey)
+
+	return phase
+}
+
+func requireSyncItems(t *testing.T, phase subscription.SubscriptionPhaseView, itemKey string) []subscription.SubscriptionItemView {
+	t.Helper()
+
+	items, found := phase.ItemsByKey[itemKey]
+	require.True(t, found, "item %s not found in phase %s", itemKey, phase.SubscriptionPhase.Key)
+
+	return items
 }
 
 func TestDeleteScheduledDowngradeCanExpandDeletedSubscriptionForSync(t *testing.T) {

--- a/openmeter/subscription/service/synchelpers.go
+++ b/openmeter/subscription/service/synchelpers.go
@@ -8,11 +8,12 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func (s *service) createPhase(
+func (s *service) createPhaseWithChildren(
 	ctx context.Context,
 	cust customer.Customer,
 	phaseSpec subscription.SubscriptionPhaseSpec,
@@ -26,7 +27,7 @@ func (s *service) createPhase(
 		}
 
 		// First, let's create the phase itself
-		phase, err := s.SubscriptionPhaseRepo.Create(ctx, phaseSpec.ToCreateSubscriptionPhaseEntityInput(sub, cadence.ActiveFrom))
+		phase, err := s.createPhase(ctx, phaseSpec, sub, cadence)
 		if err != nil {
 			return res, fmt.Errorf("failed to create phase: %w", err)
 		}
@@ -37,7 +38,7 @@ func (s *service) createPhase(
 		for key, itemSpecs := range phaseSpec.ItemsByKey {
 			itemsByKey := make([]subscription.SubscriptionItemView, 0, len(itemSpecs))
 			for _, itemSpec := range itemSpecs {
-				item, err := s.createItem(ctx, createItemOptions{
+				item, err := s.createItemWithEntitlement(ctx, createItemOptions{
 					cust:         cust,
 					sub:          sub,
 					phase:        phase,
@@ -61,6 +62,15 @@ func (s *service) createPhase(
 	})
 }
 
+func (s *service) createPhase(
+	ctx context.Context,
+	phaseSpec subscription.SubscriptionPhaseSpec,
+	sub subscription.Subscription,
+	cadence models.CadencedModel,
+) (subscription.SubscriptionPhase, error) {
+	return s.SubscriptionPhaseRepo.Create(ctx, phaseSpec.ToCreateSubscriptionPhaseEntityInput(sub, cadence.ActiveFrom))
+}
+
 type createItemOptions struct {
 	cust         customer.Customer
 	sub          subscription.Subscription
@@ -69,7 +79,7 @@ type createItemOptions struct {
 	itemSpec     subscription.SubscriptionItemSpec
 }
 
-func (s *service) createItem(
+func (s *service) createItemWithEntitlement(
 	ctx context.Context,
 	opts createItemOptions,
 ) (subscription.SubscriptionItemView, error) {
@@ -78,55 +88,26 @@ func (s *service) createItem(
 			Spec: opts.itemSpec,
 		}
 
-		itemCadence := opts.itemSpec.GetCadence(opts.phaseCadence)
-
 		// First, let's see if we need to create an entitlement
-		entInput, hasEnt, err := opts.itemSpec.ToScheduleSubscriptionEntitlementInput(
-			subscription.ToScheduleSubscriptionEntitlementInputOptions{
-				Customer:             opts.cust,
-				Cadence:              itemCadence,
-				PhaseStart:           opts.phaseCadence.ActiveFrom,
-				AlignedBillingAnchor: opts.sub.BillingAnchor,
-			},
-		)
+		entInput, hasEnt, err := getItemEntitlementInput(opts)
 		if err != nil {
 			return res, fmt.Errorf("failed to determine entitlement input for item %s: %w", opts.itemSpec.ItemKey, err)
 		}
 
-		var newEnt *entitlement.Entitlement
+		var newEnt *subscription.SubscriptionEntitlement
 
 		if hasEnt {
-			ent, err := s.EntitlementAdapter.ScheduleEntitlement(ctx, entInput, models.Annotations{
-				subscription.AnnotationSubscriptionID: opts.sub.NamespacedID.ID,
-			})
+			ent, err := s.createItemEntitlement(ctx, opts.sub, entInput)
 			if err != nil {
 				return res, fmt.Errorf("failed to create entitlement: %w", err)
 			}
 
 			res.Entitlement = ent
-			newEnt = &ent.Entitlement.Entitlement
-		}
-
-		// Resolve tax code on the spec's RateCard before deriving the entity input so
-		// that the enrichment is applied to the source of truth (opts.itemSpec) rather
-		// than relying on the implicit pointer sharing between opts.itemSpec.RateCard
-		// and itemEntityInput.RateCard. If ToCreateSubscriptionItemEntityInput ever
-		// clones the rate card, the current order would silently stop updating the spec.
-		if err := s.resolveTaxCode(ctx, opts.sub.Namespace, opts.itemSpec.RateCard); err != nil {
-			return res, fmt.Errorf("failed to resolve tax code: %w", err)
+			newEnt = ent
 		}
 
 		// Second, let's create the item itself
-		itemEntityInput, err := opts.itemSpec.ToCreateSubscriptionItemEntityInput(
-			opts.phase.NamespacedID,
-			opts.phaseCadence,
-			newEnt,
-		)
-		if err != nil {
-			return res, fmt.Errorf("failed to get item entity input: %w", err)
-		}
-
-		item, err := s.SubscriptionItemRepo.Create(ctx, itemEntityInput)
+		item, err := s.createItem(ctx, opts, newEnt)
 		if err != nil {
 			return res, fmt.Errorf("failed to create item: %w", err)
 		}
@@ -137,20 +118,69 @@ func (s *service) createItem(
 	})
 }
 
-func (s *service) deletePhase(ctx context.Context, phase subscription.SubscriptionPhaseView) error {
+func getItemEntitlementInput(opts createItemOptions) (subscription.ScheduleSubscriptionEntitlementInput, bool, error) {
+	return opts.itemSpec.ToScheduleSubscriptionEntitlementInput(
+		subscription.ToScheduleSubscriptionEntitlementInputOptions{
+			Customer:             opts.cust,
+			Cadence:              opts.itemSpec.GetCadence(opts.phaseCadence),
+			PhaseStart:           opts.phaseCadence.ActiveFrom,
+			AlignedBillingAnchor: opts.sub.BillingAnchor,
+		},
+	)
+}
+
+func (s *service) createItemEntitlement(
+	ctx context.Context,
+	sub subscription.Subscription,
+	input subscription.ScheduleSubscriptionEntitlementInput,
+) (*subscription.SubscriptionEntitlement, error) {
+	return s.EntitlementAdapter.ScheduleEntitlement(ctx, input, models.Annotations{
+		subscription.AnnotationSubscriptionID: sub.NamespacedID.ID,
+	})
+}
+
+func (s *service) createItem(
+	ctx context.Context,
+	opts createItemOptions,
+	ent *subscription.SubscriptionEntitlement,
+) (subscription.SubscriptionItem, error) {
+	// Resolve tax code on the spec's RateCard before deriving the entity input so
+	// that the enrichment is applied to the source of truth (opts.itemSpec) rather
+	// than relying on the implicit pointer sharing between opts.itemSpec.RateCard
+	// and itemEntityInput.RateCard. If ToCreateSubscriptionItemEntityInput ever
+	// clones the rate card, the current order would silently stop updating the spec.
+	if err := s.resolveTaxCode(ctx, opts.sub.Namespace, opts.itemSpec.RateCard); err != nil {
+		return subscription.SubscriptionItem{}, fmt.Errorf("failed to resolve tax code: %w", err)
+	}
+
+	itemEntityInput, err := opts.itemSpec.ToCreateSubscriptionItemEntityInput(
+		opts.phase.NamespacedID,
+		opts.phaseCadence,
+		convert.SafeDeRef(ent, func(s subscription.SubscriptionEntitlement) *entitlement.Entitlement {
+			return &s.Entitlement.Entitlement
+		}),
+	)
+	if err != nil {
+		return subscription.SubscriptionItem{}, fmt.Errorf("failed to get item entity input: %w", err)
+	}
+
+	return s.SubscriptionItemRepo.Create(ctx, itemEntityInput)
+}
+
+func (s *service) deletePhaseWithChildren(ctx context.Context, phase subscription.SubscriptionPhaseView) error {
 	_, err := transaction.Run(ctx, s.TransactionManager, func(ctx context.Context) (any, error) {
 		// To delete the phase, we need to delete all sub-resources of it.
 		// Because deleting them is specific to the type of resource, we'll do it individually
 		for _, items := range phase.ItemsByKey {
 			for _, item := range items {
-				if err := s.deleteItem(ctx, item); err != nil {
+				if err := s.deleteItemWithEntitlement(ctx, item); err != nil {
 					return nil, fmt.Errorf("failed to delete item: %w", err)
 				}
 			}
 		}
 
 		// Let's delete the phase itself
-		if err := s.SubscriptionPhaseRepo.Delete(ctx, phase.SubscriptionPhase.NamespacedID); err != nil {
+		if err := s.deletePhase(ctx, phase.SubscriptionPhase); err != nil {
 			return nil, fmt.Errorf("failed to delete phase: %w", err)
 		}
 
@@ -159,23 +189,35 @@ func (s *service) deletePhase(ctx context.Context, phase subscription.Subscripti
 	return err
 }
 
-func (s *service) deleteItem(ctx context.Context, item subscription.SubscriptionItemView) error {
+func (s *service) deletePhase(ctx context.Context, phase subscription.SubscriptionPhase) error {
+	return s.SubscriptionPhaseRepo.Delete(ctx, phase.NamespacedID)
+}
+
+func (s *service) deleteItemWithEntitlement(ctx context.Context, item subscription.SubscriptionItemView) error {
 	_, err := transaction.Run(ctx, s.TransactionManager, func(ctx context.Context) (any, error) {
 		// If there's an entitlement let's delete it
 		if item.Entitlement != nil {
-			if err := s.EntitlementAdapter.DeleteByItemID(ctx, item.SubscriptionItem.NamespacedID); err != nil {
+			if err := s.deleteItemEntitlement(ctx, item.SubscriptionItem); err != nil {
 				return nil, fmt.Errorf("failed to delete entitlement: %w", err)
 			}
 		}
 
 		// Let's delete the item itself
-		if err := s.SubscriptionItemRepo.Delete(ctx, item.SubscriptionItem.NamespacedID); err != nil {
+		if err := s.deleteItem(ctx, item.SubscriptionItem); err != nil {
 			return nil, fmt.Errorf("failed to delete item: %w", err)
 		}
 
 		return nil, nil
 	})
 	return err
+}
+
+func (s *service) deleteItemEntitlement(ctx context.Context, item subscription.SubscriptionItem) error {
+	return s.EntitlementAdapter.DeleteByItemID(ctx, item.NamespacedID)
+}
+
+func (s *service) deleteItem(ctx context.Context, item subscription.SubscriptionItem) error {
+	return s.SubscriptionItemRepo.Delete(ctx, item.NamespacedID)
 }
 
 // resolveTaxCode ensures that a RateCard with a Stripe tax code in its TaxConfig

--- a/openmeter/subscription/service/syncnode.go
+++ b/openmeter/subscription/service/syncnode.go
@@ -1,0 +1,347 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type syncNodeKind string
+
+const (
+	syncNodeKindPhase       syncNodeKind = "phase"
+	syncNodeKindEntitlement syncNodeKind = "entitlement"
+	syncNodeKindItem        syncNodeKind = "item"
+)
+
+// syncNodeRef identifies one materialized resource. Items and entitlements
+// intentionally share a spec path, so Kind distinguishes those two nodes.
+type syncNodeRef struct {
+	Path subscription.SpecPath
+	Kind syncNodeKind
+}
+
+type syncNodeChange uint8
+
+const (
+	syncNodeChangeUnchanged syncNodeChange = iota
+	syncNodeChangeCreate
+	syncNodeChangeArchive
+	syncNodeChangeReplace
+)
+
+// syncNode pairs the optional current and desired state of one materialized
+// resource. Compare classifies the transition; Archive and Create apply it.
+type syncNode interface {
+	Ref() syncNodeRef
+	Compare() (syncNodeChange, error)
+	HasCurrent() bool
+	HasDesired() bool
+	forceChange() syncNodeChange
+	Archive(context.Context, *syncExecution) error
+	Create(context.Context, *syncExecution) error
+}
+
+type phaseSyncNode struct {
+	ref            syncNodeRef
+	subscription   subscription.Subscription
+	current        *subscription.SubscriptionPhaseView
+	desired        *subscription.SubscriptionPhaseSpec
+	desiredCadence models.CadencedModel
+}
+
+func (n *phaseSyncNode) Ref() syncNodeRef {
+	return n.ref
+}
+
+func (n *phaseSyncNode) HasCurrent() bool {
+	return n.current != nil
+}
+
+func (n *phaseSyncNode) HasDesired() bool {
+	return n.desired != nil
+}
+
+func (n *phaseSyncNode) forceChange() syncNodeChange {
+	switch {
+	case n.HasCurrent() && n.HasDesired():
+		return syncNodeChangeReplace
+	case n.HasCurrent():
+		return syncNodeChangeArchive
+	case n.HasDesired():
+		return syncNodeChangeCreate
+	default:
+		return syncNodeChangeUnchanged
+	}
+}
+
+func (n *phaseSyncNode) Compare() (syncNodeChange, error) {
+	return compareSyncNodePresence(n.HasCurrent(), n.HasDesired(), func() (bool, error) {
+		current := n.current.Spec.ToCreateSubscriptionPhaseEntityInput(
+			n.subscription,
+			n.current.SubscriptionPhase.ActiveFrom,
+		)
+		desired := n.desired.ToCreateSubscriptionPhaseEntityInput(
+			n.subscription,
+			n.desiredCadence.ActiveFrom,
+		)
+
+		// StartAfter is source-spec timing. The persisted phase materializes its
+		// absolute ActiveFrom, and rebuilding a view may express the same offset
+		// with a different but equivalent ISO duration.
+		current.StartAfter = desired.StartAfter
+
+		return current.Equal(desired), nil
+	})
+}
+
+func (n *phaseSyncNode) Archive(ctx context.Context, execution *syncExecution) error {
+	if n.current == nil {
+		return fmt.Errorf("phase has no current state")
+	}
+
+	if err := execution.service.deletePhase(ctx, n.current.SubscriptionPhase); err != nil {
+		return err
+	}
+
+	delete(execution.refState.phases, n.Ref().Path)
+	return nil
+}
+
+func (n *phaseSyncNode) Create(ctx context.Context, execution *syncExecution) error {
+	if n.desired == nil {
+		return fmt.Errorf("phase has no desired state")
+	}
+
+	phase, err := execution.service.createPhase(ctx, *n.desired, n.subscription, n.desiredCadence)
+	if err != nil {
+		return err
+	}
+
+	execution.refState.phases[n.Ref().Path] = phase
+	return nil
+}
+
+type itemSyncNode struct {
+	ref                 syncNodeRef
+	phasePath           subscription.SpecPath
+	subscription        subscription.Subscription
+	current             *subscription.SubscriptionItemView
+	desired             *subscription.SubscriptionItemSpec
+	currentPhaseCadence models.CadencedModel
+	desiredPhaseCadence models.CadencedModel
+}
+
+func (n *itemSyncNode) Ref() syncNodeRef {
+	return n.ref
+}
+
+func (n *itemSyncNode) HasCurrent() bool {
+	return n.current != nil
+}
+
+func (n *itemSyncNode) HasDesired() bool {
+	return n.desired != nil
+}
+
+func (n *itemSyncNode) forceChange() syncNodeChange {
+	switch {
+	case n.HasCurrent() && n.HasDesired():
+		return syncNodeChangeReplace
+	case n.HasCurrent():
+		return syncNodeChangeArchive
+	case n.HasDesired():
+		return syncNodeChangeCreate
+	default:
+		return syncNodeChangeUnchanged
+	}
+}
+
+func (n *itemSyncNode) Compare() (syncNodeChange, error) {
+	return compareSyncNodePresence(n.HasCurrent(), n.HasDesired(), func() (bool, error) {
+		comparisonPhaseID := models.NamespacedID{Namespace: n.subscription.Namespace}
+
+		current, err := n.current.Spec.ToCreateSubscriptionItemEntityInput(
+			comparisonPhaseID,
+			n.currentPhaseCadence,
+			nil,
+		)
+		if err != nil {
+			return false, fmt.Errorf("failed to derive current item state: %w", err)
+		}
+
+		desired, err := n.desired.ToCreateSubscriptionItemEntityInput(
+			comparisonPhaseID,
+			n.desiredPhaseCadence,
+			nil,
+		)
+		if err != nil {
+			return false, fmt.Errorf("failed to derive desired item state: %w", err)
+		}
+
+		return current.Equal(desired), nil
+	})
+}
+
+func (n *itemSyncNode) Archive(ctx context.Context, execution *syncExecution) error {
+	if n.current == nil {
+		return fmt.Errorf("item has no current state")
+	}
+
+	if err := execution.service.deleteItem(ctx, n.current.SubscriptionItem); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *itemSyncNode) Create(ctx context.Context, execution *syncExecution) error {
+	if n.desired == nil {
+		return fmt.Errorf("item has no desired state")
+	}
+
+	phase, ok := execution.refState.phases[n.phasePath]
+	if !ok {
+		return fmt.Errorf("phase reference %s is not materialized", n.phasePath)
+	}
+
+	entitlement := execution.refState.entitlements[n.Ref().Path]
+	_, err := execution.service.createItem(ctx, createItemOptions{
+		cust:         execution.customer,
+		sub:          n.subscription,
+		phase:        phase,
+		phaseCadence: n.desiredPhaseCadence,
+		itemSpec:     *n.desired,
+	}, entitlement)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type entitlementSyncNode struct {
+	ref          syncNodeRef
+	subscription subscription.Subscription
+	currentItem  *subscription.SubscriptionItemView
+	current      *subscription.SubscriptionEntitlement
+	desired      *subscription.ScheduleSubscriptionEntitlementInput
+}
+
+func (n *entitlementSyncNode) Ref() syncNodeRef {
+	return n.ref
+}
+
+func (n *entitlementSyncNode) HasCurrent() bool {
+	return n.current != nil
+}
+
+func (n *entitlementSyncNode) HasDesired() bool {
+	return n.desired != nil
+}
+
+func (n *entitlementSyncNode) forceChange() syncNodeChange {
+	switch {
+	case n.HasCurrent() && n.HasDesired():
+		return syncNodeChangeReplace
+	case n.HasCurrent():
+		return syncNodeChangeArchive
+	case n.HasDesired():
+		return syncNodeChangeCreate
+	default:
+		return syncNodeChangeUnchanged
+	}
+}
+
+func (n *entitlementSyncNode) Compare() (syncNodeChange, error) {
+	return compareSyncNodePresence(n.HasCurrent(), n.HasDesired(), func() (bool, error) {
+		current := normalizeEntitlementInput(
+			n.current.ToScheduleSubscriptionEntitlementInput(),
+			n.subscription.ID,
+		)
+		desired := normalizeEntitlementInput(*n.desired, n.subscription.ID)
+
+		return current.Equal(desired), nil
+	})
+}
+
+func (n *entitlementSyncNode) Archive(ctx context.Context, execution *syncExecution) error {
+	if n.current == nil || n.currentItem == nil {
+		return fmt.Errorf("entitlement has no current item state")
+	}
+
+	if err := execution.service.deleteItemEntitlement(ctx, n.currentItem.SubscriptionItem); err != nil {
+		return err
+	}
+
+	delete(execution.refState.entitlements, n.Ref().Path)
+	return nil
+}
+
+func (n *entitlementSyncNode) Create(ctx context.Context, execution *syncExecution) error {
+	if n.desired == nil {
+		return fmt.Errorf("entitlement has no desired state")
+	}
+
+	entitlement, err := execution.service.createItemEntitlement(ctx, n.subscription, *n.desired)
+	if err != nil {
+		return err
+	}
+
+	execution.refState.entitlements[n.Ref().Path] = entitlement
+	return nil
+}
+
+func normalizeEntitlementInput(
+	input subscription.ScheduleSubscriptionEntitlementInput,
+	subscriptionID string,
+) subscription.ScheduleSubscriptionEntitlementInput {
+	input.FeatureID = nil
+	input.SubscriptionManaged = true
+	input.Annotations = maps.Clone(input.Annotations)
+	if input.Annotations == nil {
+		input.Annotations = models.Annotations{}
+	}
+	input.Annotations[subscription.AnnotationSubscriptionID] = subscriptionID
+
+	// Entitlement persistence stores the recurrence as effective from
+	// MeasureUsageFrom, while the desired input carries its billing anchor.
+	if input.UsagePeriod != nil && input.MeasureUsageFrom != nil {
+		usagePeriod := entitlement.NewStartingUsagePeriodInput(
+			input.UsagePeriod.GetValue(),
+			input.MeasureUsageFrom.Get(),
+		)
+		input.UsagePeriod = &usagePeriod
+	}
+
+	return input
+}
+
+func compareSyncNodePresence(
+	hasCurrent bool,
+	hasDesired bool,
+	equal func() (bool, error),
+) (syncNodeChange, error) {
+	switch {
+	case !hasCurrent && hasDesired:
+		return syncNodeChangeCreate, nil
+	case hasCurrent && !hasDesired:
+		return syncNodeChangeArchive, nil
+	case !hasCurrent:
+		return syncNodeChangeUnchanged, nil
+	}
+
+	isEqual, err := equal()
+	if err != nil {
+		return syncNodeChangeUnchanged, err
+	}
+	if isEqual {
+		return syncNodeChangeUnchanged, nil
+	}
+
+	return syncNodeChangeReplace, nil
+}

--- a/openmeter/subscription/service/syncplan.go
+++ b/openmeter/subscription/service/syncplan.go
@@ -1,0 +1,365 @@
+package service
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type syncAction string
+
+const (
+	syncActionArchive syncAction = "archive"
+	syncActionCreate  syncAction = "create"
+)
+
+type syncCommand struct {
+	action syncAction
+	node   syncNode
+}
+
+func (c syncCommand) rank() int {
+	if c.action == syncActionArchive {
+		// Archive children before their parents.
+		switch c.node.Ref().Kind {
+		case syncNodeKindEntitlement:
+			return 0
+		case syncNodeKindItem:
+			return 1
+		case syncNodeKindPhase:
+			return 2
+		}
+	}
+
+	// Create parents before their children. Entitlements precede items because
+	// the item stores the entitlement reference.
+	switch c.node.Ref().Kind {
+	case syncNodeKindPhase:
+		return 0
+	case syncNodeKindEntitlement:
+		return 1
+	case syncNodeKindItem:
+		return 2
+	default:
+		return 3
+	}
+}
+
+type syncPlan struct {
+	commands []syncCommand
+	refState syncReferences
+}
+
+func (p syncPlan) Execute(ctx context.Context, service *service, customer customer.Customer) error {
+	execution := &syncExecution{
+		service:  service,
+		customer: customer,
+		refState: syncReferences{
+			phases:       maps.Clone(p.refState.phases),
+			entitlements: maps.Clone(p.refState.entitlements),
+		},
+	}
+
+	for _, command := range p.commands {
+		ref := command.node.Ref()
+
+		var err error
+		switch command.action {
+		case syncActionArchive:
+			err = command.node.Archive(ctx, execution)
+		case syncActionCreate:
+			err = command.node.Create(ctx, execution)
+		default:
+			err = fmt.Errorf("unknown sync action %q", command.action)
+		}
+		if err != nil {
+			return fmt.Errorf(
+				"failed to %s %s at %s: %w",
+				command.action,
+				ref.Kind,
+				ref.Path,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func newSyncPlan(
+	view subscription.SubscriptionView,
+	desiredSpec subscription.SubscriptionSpec,
+) (syncPlan, error) {
+	nodes, refState, err := buildSyncNodes(view, desiredSpec)
+	if err != nil {
+		return syncPlan{}, err
+	}
+
+	changes := make(map[syncNodeRef]syncNodeChange, len(nodes))
+	for ref, node := range nodes {
+		change, err := node.Compare()
+		if err != nil {
+			return syncPlan{}, fmt.Errorf("failed to compare %s at %s: %w", ref.Kind, ref.Path, err)
+		}
+		changes[ref] = change
+	}
+
+	// A replaced parent invalidates its descendants' persisted references.
+	propagatePhaseChanges(nodes, changes)
+	// Items persist entitlement references, so either changing replaces both.
+	propagateItemEntitlementChanges(nodes, changes)
+
+	commands := make([]syncCommand, 0, len(changes)*2)
+	for ref, change := range changes {
+		node := nodes[ref]
+		switch change {
+		case syncNodeChangeCreate:
+			commands = append(commands, syncCommand{action: syncActionCreate, node: node})
+		case syncNodeChangeArchive:
+			commands = append(commands, syncCommand{action: syncActionArchive, node: node})
+		case syncNodeChangeReplace:
+			commands = append(commands,
+				syncCommand{action: syncActionArchive, node: node},
+				syncCommand{action: syncActionCreate, node: node},
+			)
+		}
+	}
+
+	sortSyncCommands(commands)
+
+	return syncPlan{
+		commands: commands,
+		refState: refState,
+	}, nil
+}
+
+func buildSyncNodes(
+	view subscription.SubscriptionView,
+	desiredSpec subscription.SubscriptionSpec,
+) (map[syncNodeRef]syncNode, syncReferences, error) {
+	nodes := map[syncNodeRef]syncNode{}
+	refState := syncReferences{
+		phases:       map[subscription.SpecPath]subscription.SubscriptionPhase{},
+		entitlements: map[subscription.SpecPath]*subscription.SubscriptionEntitlement{},
+	}
+	currentPhases := make(map[string]*subscription.SubscriptionPhaseView, len(view.Phases))
+	for i := range view.Phases {
+		phase := &view.Phases[i]
+		currentPhases[phase.SubscriptionPhase.Key] = phase
+	}
+
+	phaseKeys := make(map[string]struct{}, len(currentPhases)+len(desiredSpec.Phases))
+	for key := range currentPhases {
+		phaseKeys[key] = struct{}{}
+	}
+	for key := range desiredSpec.Phases {
+		phaseKeys[key] = struct{}{}
+	}
+
+	for phaseKey := range phaseKeys {
+		currentPhase := currentPhases[phaseKey]
+		desiredPhase := desiredSpec.Phases[phaseKey]
+		phasePath := subscription.NewPhasePath(phaseKey)
+		phaseRef := syncNodeRef{Path: phasePath, Kind: syncNodeKindPhase}
+
+		var currentCadence models.CadencedModel
+		if currentPhase != nil {
+			var err error
+			currentCadence, err = view.Spec.GetPhaseCadence(phaseKey)
+			if err != nil {
+				return nil, syncReferences{}, fmt.Errorf("failed to get current cadence for phase %s: %w", phaseKey, err)
+			}
+			refState.phases[phasePath] = currentPhase.SubscriptionPhase
+		}
+
+		var desiredCadence models.CadencedModel
+		if desiredPhase != nil {
+			var err error
+			desiredCadence, err = desiredSpec.GetPhaseCadence(phaseKey)
+			if err != nil {
+				return nil, syncReferences{}, fmt.Errorf("failed to get desired cadence for phase %s: %w", phaseKey, err)
+			}
+		}
+
+		nodes[phaseRef] = &phaseSyncNode{
+			ref:            phaseRef,
+			subscription:   view.Subscription,
+			current:        currentPhase,
+			desired:        desiredPhase,
+			desiredCadence: desiredCadence,
+		}
+
+		itemKeys := map[string]struct{}{}
+		if currentPhase != nil {
+			for key := range currentPhase.ItemsByKey {
+				itemKeys[key] = struct{}{}
+			}
+		}
+		if desiredPhase != nil {
+			for key := range desiredPhase.ItemsByKey {
+				itemKeys[key] = struct{}{}
+			}
+		}
+
+		for itemKey := range itemKeys {
+			var currentItems []subscription.SubscriptionItemView
+			if currentPhase != nil {
+				currentItems = currentPhase.ItemsByKey[itemKey]
+			}
+
+			var desiredItems []*subscription.SubscriptionItemSpec
+			if desiredPhase != nil {
+				desiredItems = desiredPhase.ItemsByKey[itemKey]
+			}
+
+			itemCount := max(len(currentItems), len(desiredItems))
+			for itemIdx := range itemCount {
+				var currentItem *subscription.SubscriptionItemView
+				if itemIdx < len(currentItems) {
+					currentItem = &currentItems[itemIdx]
+				}
+
+				var desiredItem *subscription.SubscriptionItemSpec
+				if itemIdx < len(desiredItems) {
+					desiredItem = desiredItems[itemIdx]
+				}
+
+				itemPath := subscription.NewItemVersionPath(phaseKey, itemKey, itemIdx)
+				itemRef := syncNodeRef{Path: itemPath, Kind: syncNodeKindItem}
+				nodes[itemRef] = &itemSyncNode{
+					ref:                 itemRef,
+					phasePath:           phasePath,
+					subscription:        view.Subscription,
+					current:             currentItem,
+					desired:             desiredItem,
+					currentPhaseCadence: currentCadence,
+					desiredPhaseCadence: desiredCadence,
+				}
+
+				var currentEntitlement *subscription.SubscriptionEntitlement
+				if currentItem != nil {
+					currentEntitlement = currentItem.Entitlement
+				}
+
+				var desiredEntitlement *subscription.ScheduleSubscriptionEntitlementInput
+				if desiredItem != nil {
+					input, hasEntitlement, err := getItemEntitlementInput(createItemOptions{
+						cust:         view.Customer,
+						sub:          view.Subscription,
+						phaseCadence: desiredCadence,
+						itemSpec:     *desiredItem,
+					})
+					if err != nil {
+						return nil, syncReferences{}, fmt.Errorf("failed to derive entitlement for item %s: %w", itemPath, err)
+					}
+					if hasEntitlement {
+						desiredEntitlement = &input
+					}
+				}
+
+				if currentEntitlement != nil || desiredEntitlement != nil {
+					entitlementRef := syncNodeRef{Path: itemPath, Kind: syncNodeKindEntitlement}
+					nodes[entitlementRef] = &entitlementSyncNode{
+						ref:          entitlementRef,
+						subscription: view.Subscription,
+						currentItem:  currentItem,
+						current:      currentEntitlement,
+						desired:      desiredEntitlement,
+					}
+					if currentEntitlement != nil {
+						refState.entitlements[itemPath] = currentEntitlement
+					}
+				}
+			}
+		}
+	}
+
+	return nodes, refState, nil
+}
+
+func propagatePhaseChanges(
+	nodes map[syncNodeRef]syncNode,
+	changes map[syncNodeRef]syncNodeChange,
+) {
+	for ref, change := range changes {
+		if ref.Kind != syncNodeKindPhase || change != syncNodeChangeReplace {
+			continue
+		}
+
+		for childRef, child := range nodes {
+			if childRef == ref || !ref.Path.IsParentOf(childRef.Path) {
+				continue
+			}
+			changes[childRef] = child.forceChange()
+		}
+	}
+}
+
+func propagateItemEntitlementChanges(
+	nodes map[syncNodeRef]syncNode,
+	changes map[syncNodeRef]syncNodeChange,
+) {
+	for ref := range nodes {
+		if ref.Kind != syncNodeKindItem {
+			continue
+		}
+
+		entitlementRef := syncNodeRef{Path: ref.Path, Kind: syncNodeKindEntitlement}
+		entitlementNode, hasEntitlement := nodes[entitlementRef]
+		if !hasEntitlement {
+			continue
+		}
+
+		if changes[ref] == syncNodeChangeUnchanged && changes[entitlementRef] == syncNodeChangeUnchanged {
+			continue
+		}
+
+		changes[ref] = nodes[ref].forceChange()
+		changes[entitlementRef] = entitlementNode.forceChange()
+	}
+}
+
+func sortSyncCommands(commands []syncCommand) {
+	slices.SortStableFunc(commands, func(left, right syncCommand) int {
+		if left.action != right.action {
+			if left.action == syncActionArchive {
+				return -1
+			}
+
+			return 1
+		}
+
+		if rank := cmp.Compare(left.rank(), right.rank()); rank != 0 {
+			return rank
+		}
+
+		leftRef := left.node.Ref()
+		rightRef := right.node.Ref()
+		if path := cmp.Compare(leftRef.Path, rightRef.Path); path != 0 {
+			return path
+		}
+
+		return cmp.Compare(leftRef.Kind, rightRef.Kind)
+	})
+}
+
+type syncReferences struct {
+	phases       map[subscription.SpecPath]subscription.SubscriptionPhase
+	entitlements map[subscription.SpecPath]*subscription.SubscriptionEntitlement
+}
+
+// syncExecution is mutable state for reference tracking during an update.
+type syncExecution struct {
+	// service applies the persistence operations represented by commands.
+	service *service
+	// customer supplies customer data needed when materializing items.
+	customer customer.Customer
+	// refState tracks the latest materialized phase and entitlement references.
+	refState syncReferences
+}


### PR DESCRIPTION
## what

- refactor subscription sync into an ordered phase/item/entitlement node plan
- preserve the API and existing materialization behavior
- add reconciliation and no-op identity coverage

## test

- all Go tests except `e2e`
- subscription service tests after rebasing onto `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subscription updates now reconcile phases, items, and entitlements independently.
  - Changes are applied in dependency order, ensuring related resources are safely replaced or retained.
  - Cadence and derived entitlement updates are handled automatically.

- **Bug Fixes**
  - No-op updates preserve existing phase, item, and entitlement identifiers.
  - Invalid changes to customer, plan, start time, or settlement mode are rejected with validation errors.
  - Subscription creation and deletion now consistently include child resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces imperative subscription synchronization with a materialized-node reconciliation plan while preserving the existing service API.
- Models phases, item versions, and entitlements as independently comparable synchronization nodes.
- Orders archival from children to parents and creation from parents to derived resources.
- Propagates phase and item/entitlement replacements to keep generated references consistent.
- Adds reconciliation and no-op identity coverage and documents the new synchronization model.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failure identified.

The node planner preserves the existing logical identity model, coordinates item and entitlement replacement, and orders dependent archive and creation operations consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/subscription/service/sync.go | Replaces the prior multi-pass synchronization implementation with target validation, plan construction, cadence update, and transactional plan execution. |
| openmeter/subscription/service/syncnode.go | Introduces phase, item, and entitlement node comparison and materialization operations with normalized equality semantics. |
| openmeter/subscription/service/syncplan.go | Builds reconciliation nodes, propagates dependent replacements, and deterministically orders archive/create commands. |
| openmeter/subscription/service/synchelpers.go | Splits composite phase/item lifecycle helpers into reusable parent, child, entitlement, and entity operations. |
| openmeter/subscription/service/service.go | Updates create and delete flows to call the renamed composite lifecycle helpers. |
| openmeter/subscription/service/sync_test.go | Adds no-op identity assertions and reconciliation coverage for phase, item-key, and trailing item-version changes. |
| openmeter/subscription/service/README.md | Documents node-based reconciliation ordering and item-entitlement replacement grouping. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  View[Current SubscriptionView] --> Build[Build phase, item, and entitlement nodes]
  Spec[Desired SubscriptionSpec] --> Build
  Build --> Compare[Compare current and desired materialized state]
  Compare --> Propagate[Propagate phase and item-entitlement replacements]
  Propagate --> Archive[Archive entitlements, items, then phases]
  Archive --> Create[Create phases, entitlements, then items]
  Create --> Fetch[Fetch reconciled subscription]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(subscription): plan sync by mat..."](https://github.com/openmeterio/openmeter/commit/bff226d260ac9ea8187df43e4dc80c7f4429bfaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49693481)</sub>

**Context used:**

- Knowledge Base — [Subscription](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription.md)

<!-- /greptile_comment -->