### PR TITLE
fix(entitlement): invalidate snapshots after reset

### DIFF
--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -316,6 +316,10 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 			return nil, fmt.Errorf("failed to lock owner %s: %w", ownerID.ID, err)
 		}
 
+		if err := m.BalanceSnapshotService.InvalidateAfter(ctx, ownerID, at); err != nil {
+			return nil, fmt.Errorf("failed to invalidate snapshots after %s: %w", at, err)
+		}
+
 		// Let's save the snapshot
 		snap, err = m.saveSnapshot(ctx, snapshotParams{
 			grants:     grants,

--- a/openmeter/entitlement/metered/reset_test.go
+++ b/openmeter/entitlement/metered/reset_test.go
@@ -248,8 +248,15 @@ func TestResetEntitlementUsage(t *testing.T) {
 		{
 			name: "Should invalidate snapshots after the reset time",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
-				ctx := context.Background()
+				ctx := t.Context()
 				startTime := getAnchor(t)
+
+				// given:
+				// - a balance snapshot exists after the requested reset time
+				// when:
+				// - usage is reset with a backdated effective time
+				// then:
+				// - the later snapshot is invalidated and the reset snapshot becomes the latest valid one
 
 				randName := testutils.NameGenerator.Generate()
 
@@ -317,7 +324,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 						At: resetTime,
 					})
 
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
+				snap, err = deps.balanceSnapshotService.GetLatestValidAt(ctx, owner, queryTime)
+				require.NoError(t, err)
+				assert.Equal(t, resetTime, snap.At)
 			},
 		},
 		{


### PR DESCRIPTION
## Overview

Backdated entitlement resets can land before an already-persisted balance snapshot. Because that snapshot represents derived state from before the reset, reusing it would skip the reset and return a stale balance.

This change invalidates snapshots after the reset's effective time before saving the replacement reset snapshot. The reset test now verifies that subsequent balance calculations resume from the reset snapshot instead of a stale later one.

## Notes for reviewer

- Invalidation runs after the owner lock and in the same transaction as saving the reset snapshot and ending the usage period.
- The existing test already claimed this lifecycle behavior; it now asserts the resulting snapshot selection.

## Validation

- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/entitlement/metered -run 'TestResetEntitlementUsage/Should_invalidate_snapshots_after_the_reset_time$' -count=1`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/entitlement/metered -run '^TestResetEntitlementUsage$' -count=1`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/entitlement/metered -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage resets so outdated balance snapshots are invalidated.
  * Ensured recalculated balances correctly reflect backdated resets and subsequent usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->