### PR TITLE
fix(billing): [OM-434] delete empty invoices during issuing

### DIFF
--- a/openmeter/app/sandbox/mock.go
+++ b/openmeter/app/sandbox/mock.go
@@ -30,10 +30,10 @@ type MockApp struct {
 	upsertInvoiceCalled   bool
 
 	finalizeInvoiceResponse mo.Option[*billing.FinalizeStandardInvoiceResult]
-	finalizeInvoiceCalled   bool
+	finalizeInvoiceCalls    int
 
 	deleteInvoiceResponse mo.Option[error]
-	deleteInvoiceCalled   bool
+	deleteInvoiceCalls    int
 }
 
 func NewMockApp(_ *testing.T) *MockApp {
@@ -91,7 +91,7 @@ func (m *MockApp) OnUpsertStandardInvoice(cb InvoiceUpsertCallback) {
 }
 
 func (m *MockApp) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
-	m.finalizeInvoiceCalled = true
+	m.finalizeInvoiceCalls++
 	return m.finalizeInvoiceResponse.MustGet(), nil
 }
 
@@ -99,13 +99,21 @@ func (m *MockApp) OnFinalizeStandardInvoice(result *billing.FinalizeStandardInvo
 	m.finalizeInvoiceResponse = mo.Some(result)
 }
 
+func (m *MockApp) FinalizeInvoiceCallCount() int {
+	return m.finalizeInvoiceCalls
+}
+
 func (m *MockApp) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
-	m.deleteInvoiceCalled = true
+	m.deleteInvoiceCalls++
 	return m.deleteInvoiceResponse.MustGet()
 }
 
 func (m *MockApp) OnDeleteStandardInvoice(err error) {
 	m.deleteInvoiceResponse = mo.Some(err)
+}
+
+func (m *MockApp) DeleteInvoiceCallCount() int {
+	return m.deleteInvoiceCalls
 }
 
 func (m *MockApp) Reset(t *testing.T) {
@@ -123,10 +131,10 @@ func (m *MockApp) Reset(t *testing.T) {
 	m.upsertInvoiceCalled = false
 
 	m.finalizeInvoiceResponse = mo.None[*billing.FinalizeStandardInvoiceResult]()
-	m.finalizeInvoiceCalled = false
+	m.finalizeInvoiceCalls = 0
 
 	m.deleteInvoiceResponse = mo.None[error]()
-	m.deleteInvoiceCalled = false
+	m.deleteInvoiceCalls = 0
 }
 
 func (m *MockApp) AssertExpectations(t *testing.T) {
@@ -144,11 +152,11 @@ func (m *MockApp) AssertExpectations(t *testing.T) {
 		t.Errorf("expected UpsertInvoice to be called")
 	}
 
-	if m.finalizeInvoiceResponse.IsPresent() && !m.finalizeInvoiceCalled {
+	if m.finalizeInvoiceResponse.IsPresent() && m.finalizeInvoiceCalls == 0 {
 		t.Errorf("expected FinalizeInvoice to be called")
 	}
 
-	if m.deleteInvoiceResponse.IsPresent() && !m.deleteInvoiceCalled {
+	if m.deleteInvoiceResponse.IsPresent() && m.deleteInvoiceCalls == 0 {
 		t.Errorf("expected DeleteInvoice to be called")
 	}
 }

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -93,8 +93,8 @@ The standard invoice state machine coordinates:
 When issuing starts, a standard invoice with no non-deleted lines is deleted
 instead of finalized. Billing records this as a system deletion, synchronizes
 the deletion with the invoicing app, and skips charge booking and payment. This
-decision is based on line presence rather than monetary totals: a visible line
-with a zero total still follows the normal issuing lifecycle.
+decision is based on line presence rather than monetary totals: a non-deleted
+line with a zero total still follows the normal issuing lifecycle.
 
 Critical validation issues stop advancement. External app and line-engine
 failures leave the invoice in an explicit failed state so the failed step can

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -90,6 +90,12 @@ The standard invoice state machine coordinates:
 4. approval and issuing
 5. charge booking and payment processing
 
+When issuing starts, a standard invoice with no non-deleted lines is deleted
+instead of finalized. Billing records this as a system deletion, synchronizes
+the deletion with the invoicing app, and skips charge booking and payment. This
+decision is based on line presence rather than monetary totals: a visible line
+with a zero total still follows the normal issuing lifecycle.
+
 Critical validation issues stop advancement. External app and line-engine
 failures leave the invoice in an explicit failed state so the failed step can
 be retried without replaying stable lifecycle states. Issuing and payment

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -475,6 +475,24 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				}
 
 				var err error
+				if test.expectLineDeleted {
+					mockApp := s.SandboxApp.EnableMock(s.T())
+					defer s.SandboxApp.DisableMock()
+					mockApp.OnDeleteStandardInvoice(nil)
+
+					invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+					s.Require().NoError(err)
+					s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+					s.NotNil(invoice.DeletedAt)
+					s.Equal(billing.ChangeSourceSystem, invoice.DeletionSource)
+					s.Nil(invoice.IssuedAt)
+					s.Equal(1, mockApp.DeleteInvoiceCallCount())
+					s.Zero(mockApp.FinalizeInvoiceCallCount())
+					mockApp.AssertExpectations(s.T())
+
+					return
+				}
+
 				invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
 				s.Require().NoError(err)
 				s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
@@ -525,11 +543,20 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 					Expand:  billing.StandardInvoiceExpandAll,
 				})
 				s.Require().NoError(err)
+				expectedInvoiceStatus := billing.StandardInvoiceStatusPaid
+				if test.expectLineDeleted {
+					expectedInvoiceStatus = billing.StandardInvoiceStatusDeleted
+				}
+				s.Equal(expectedInvoiceStatus, activeInvoice.Status)
 				s.Equal(currencyx.FiatCode(USD), activeInvoice.Currency)
 				s.RequireTotals(test.expectInvoiceTotals, activeInvoice.Totals)
 				if test.expectLineDeleted {
+					s.NotNil(activeInvoice.DeletedAt)
+					s.Equal(billing.ChangeSourceSystem, activeInvoice.DeletionSource)
+					s.Nil(activeInvoice.IssuedAt)
 					s.Empty(activeInvoice.Lines.OrEmpty())
 				} else {
+					s.Nil(activeInvoice.DeletedAt)
 					s.Require().Len(activeInvoice.Lines.OrEmpty(), 1)
 				}
 
@@ -550,9 +577,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 						line:             line,
 						expectFiatTotals: test.expectInvoiceTotals,
 					})
-
-					// TODO: delete the standard invoice when zero overage removes its only line.
-					s.Nil(invoiceWithDeletedLines.DeletedAt)
+					s.NotNil(invoiceWithDeletedLines.DeletedAt)
+					s.Equal(billing.StandardInvoiceStatusDeleted, invoiceWithDeletedLines.Status)
+					s.Equal(billing.ChangeSourceSystem, invoiceWithDeletedLines.DeletionSource)
+					s.Nil(invoiceWithDeletedLines.IssuedAt)
 				} else {
 					s.requireCustomCurrencyOverageLine(requireCustomCurrencyOverageLineInput{
 						line:               line,

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -647,15 +647,30 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					})
 				}
 
+				if test.expectLineDeleted {
+					mockApp := s.SandboxApp.EnableMock(s.T())
+					defer s.SandboxApp.DisableMock()
+					mockApp.OnDeleteStandardInvoice(nil)
+
+					invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+					s.Require().NoError(err)
+					s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+					s.NotNil(invoice.DeletedAt)
+					s.Equal(billing.ChangeSourceSystem, invoice.DeletionSource)
+					s.Nil(invoice.IssuedAt)
+					s.Nil(invoice.CollectionAt)
+					s.Equal(1, mockApp.DeleteInvoiceCallCount())
+					s.Zero(mockApp.FinalizeInvoiceCallCount())
+					mockApp.AssertExpectations(s.T())
+
+					return
+				}
+
 				invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
 				s.Require().NoError(err)
 				s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
-				if test.expectLineDeleted {
-					s.Nil(invoice.CollectionAt)
-				} else {
-					s.Require().NotNil(invoice.CollectionAt)
-					s.True(realizationVariant.expectedCollectionEnd.Equal(*invoice.CollectionAt))
-				}
+				s.Require().NotNil(invoice.CollectionAt)
+				s.True(realizationVariant.expectedCollectionEnd.Equal(*invoice.CollectionAt))
 			})
 
 			s.Run("reload realized charge and invoice state", func() {
@@ -698,8 +713,16 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					Expand:  billing.StandardInvoiceExpandAll,
 				})
 				s.Require().NoError(err)
+				expectedInvoiceStatus := billing.StandardInvoiceStatusPaid
+				if test.expectLineDeleted {
+					expectedInvoiceStatus = billing.StandardInvoiceStatusDeleted
+				}
+				s.Equal(expectedInvoiceStatus, activeInvoice.Status)
 
 				if test.expectLineDeleted {
+					s.NotNil(activeInvoice.DeletedAt)
+					s.Equal(billing.ChangeSourceSystem, activeInvoice.DeletionSource)
+					s.Nil(activeInvoice.IssuedAt)
 					s.Nil(activeInvoice.CollectionAt)
 					s.Empty(activeInvoice.Lines.OrEmpty())
 
@@ -717,10 +740,12 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 						line:             deletedLine,
 						expectFiatTotals: test.onCollectionComplete.expectInvoiceTotals,
 					})
-
-					// TODO: delete the standard invoice when zero overage removes its only line.
-					s.Nil(invoiceWithDeletedLine.DeletedAt)
+					s.NotNil(invoiceWithDeletedLine.DeletedAt)
+					s.Equal(billing.StandardInvoiceStatusDeleted, invoiceWithDeletedLine.Status)
+					s.Equal(billing.ChangeSourceSystem, invoiceWithDeletedLine.DeletionSource)
+					s.Nil(invoiceWithDeletedLine.IssuedAt)
 				} else {
+					s.Nil(activeInvoice.DeletedAt)
 					s.Require().NotNil(activeInvoice.CollectionAt)
 					s.True(realizationVariant.expectedCollectionEnd.Equal(*activeInvoice.CollectionAt))
 					s.Require().Len(activeInvoice.Lines.OrEmpty(), 1)

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -177,7 +177,7 @@ func allocateStateMachine() *InvoiceStateMachine {
 		Permit(billing.TriggerUpdated, billing.StandardInvoiceStatusDraftUpdating)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusDraftReadyToIssue).
-		Permit(billing.TriggerNext, billing.StandardInvoiceStatusIssuingSyncing).
+		PermitDynamic(billing.TriggerNext, out.resolveStateAfterDraftReadyToIssue).
 		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerUpdated, billing.StandardInvoiceStatusDraftUpdating)
 
@@ -212,7 +212,10 @@ func allocateStateMachine() *InvoiceStateMachine {
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleteSyncing).
 		Permit(billing.TriggerNext, billing.StandardInvoiceStatusDeleted).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusDeleteFailed).
-		OnActive(out.syncDeletedInvoice)
+		OnActive(statelessx.AllOf(
+			out.ensureEmptyInvoiceDeletionPrepared,
+			out.syncDeletedInvoice,
+		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleteFailed).
 		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress)
@@ -870,6 +873,36 @@ func (m *InvoiceStateMachine) syncDeletedInvoice(ctx context.Context) error {
 		}
 
 		return nil, app.DeleteStandardInvoice(ctx, clonedInvoice)
+	})
+}
+
+func (m *InvoiceStateMachine) resolveStateAfterDraftReadyToIssue(_ context.Context, _ ...any) (stateless.State, error) {
+	if m.Invoice.Lines.IsPresent() && m.Invoice.Lines.NonDeletedLineCount() == 0 {
+		return billing.StandardInvoiceStatusDeleteSyncing, nil
+	}
+
+	return billing.StandardInvoiceStatusIssuingSyncing, nil
+}
+
+// ensureEmptyInvoiceDeletionPrepared starts a system deletion when issuing
+// discovers that every invoice line has already been deleted. Explicit
+// deletions have already been prepared in delete.in_progress and require no
+// further work.
+func (m *InvoiceStateMachine) ensureEmptyInvoiceDeletionPrepared(ctx context.Context) error {
+	if m.Invoice.DeletedAt != nil {
+		return nil
+	}
+
+	if !m.Invoice.Lines.IsPresent() {
+		return errors.New("invoice lines must be expanded before preparing empty invoice deletion")
+	}
+
+	if m.Invoice.Lines.NonDeletedLineCount() != 0 {
+		return errors.New("cannot prepare empty invoice deletion: invoice has non-deleted lines")
+	}
+
+	return m.deleteInvoice(ctx, billing.DeleteInvoiceTriggerInput{
+		Source: billing.ChangeSourceSystem,
 	})
 }
 

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -43,7 +43,6 @@ func allocateStateMachine() *InvoiceStateMachine {
 	out := &InvoiceStateMachine{}
 
 	// TODO[OM-979]: Tax is not captured here for now, as it would require the DB schema too
-	// TODO[OM-988]: Delete invoice is not implemented yet
 
 	stateMachine := stateless.NewStateMachineWithExternalStorage(
 		func(ctx context.Context) (stateless.State, error) {

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1416,6 +1416,228 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 	}
 }
 
+func (s *InvoicingTestSuite) TestEmptyInvoiceIsDeletedInsteadOfIssued() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("empty-invoice-deleted-when-issuing")
+
+	// Given a manual-approval invoice whose only line has been deleted.
+	invoice := s.createManualApprovalInvoice(ctx, namespace, billing.Discounts{})
+	invoice = s.deleteAllInvoiceLinesBySystem(ctx, invoice)
+
+	s.Require().NotNil(invoice.StatusDetails.AvailableActions.Approve)
+	s.Equal(
+		billing.StandardInvoiceStatusDeleted,
+		invoice.StatusDetails.AvailableActions.Approve.ResultingState,
+	)
+
+	activeInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.Require().NoError(err)
+	s.Empty(activeInvoice.Lines.OrEmpty())
+
+	invoiceWithDeletedLines, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll.With(billing.StandardInvoiceExpandDeletedLines),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoiceWithDeletedLines.Lines.OrEmpty(), 1)
+	s.NotNil(invoiceWithDeletedLines.Lines.OrEmpty()[0].DeletedAt)
+
+	mockApp := s.SandboxApp.EnableMock(s.T())
+	defer s.SandboxApp.DisableMock()
+	mockApp.OnDeleteStandardInvoice(nil)
+
+	// When the invoice is approved and issuing begins.
+	invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.Require().NoError(err)
+
+	// Then billing system-deletes the invoice and synchronizes the app deletion.
+	s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+	s.NotNil(invoice.DeletedAt)
+	s.Equal(billing.ChangeSourceSystem, invoice.DeletionSource)
+	s.Nil(invoice.IssuedAt)
+	s.Empty(invoice.ValidationIssues)
+	s.Equal(1, mockApp.DeleteInvoiceCallCount())
+	s.Zero(mockApp.FinalizeInvoiceCallCount())
+	mockApp.AssertExpectations(s.T())
+
+	activeInvoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleted, activeInvoice.Status)
+	s.Empty(activeInvoice.Lines.OrEmpty())
+
+	invoiceWithDeletedLines, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll.With(billing.StandardInvoiceExpandDeletedLines),
+	})
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleted, invoiceWithDeletedLines.Status)
+	s.Require().Len(invoiceWithDeletedLines.Lines.OrEmpty(), 1)
+	s.NotNil(invoiceWithDeletedLines.Lines.OrEmpty()[0].DeletedAt)
+}
+
+func (s *InvoicingTestSuite) TestEmptyInvoiceDeletionFailureCanBeRetried() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("empty-invoice-deletion-failure")
+
+	// Given an empty invoice whose invoicing app rejects deletion.
+	invoice := s.createManualApprovalInvoice(ctx, namespace, billing.Discounts{})
+	invoice = s.deleteAllInvoiceLinesBySystem(ctx, invoice)
+
+	mockApp := s.SandboxApp.EnableMock(s.T())
+	defer s.SandboxApp.DisableMock()
+	deleteErr := billing.NewValidationError("delete-failed", "invoice cannot be deleted")
+	mockApp.OnDeleteStandardInvoice(deleteErr)
+
+	// When approval starts issuing and attempts the automatic deletion.
+	invoice, err := s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.Require().NoError(err)
+
+	// Then the invoice records a retryable deletion failure without being issued.
+	s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+	s.Require().NotNil(invoice.DeletedAt)
+	deletedAt := *invoice.DeletedAt
+	s.Equal(billing.ChangeSourceSystem, invoice.DeletionSource)
+	s.Nil(invoice.IssuedAt)
+	s.Require().Len(invoice.ValidationIssues, 1)
+	s.Equal(deleteErr.Code, invoice.ValidationIssues[0].Code)
+	s.Equal(deleteErr.Message, invoice.ValidationIssues[0].Message)
+	s.Equal("app.sandbox.invoiceCustomers.delete", string(invoice.ValidationIssues[0].Component))
+	s.Equal(1, mockApp.DeleteInvoiceCallCount())
+	s.Zero(mockApp.FinalizeInvoiceCallCount())
+
+	mockApp.Reset(s.T())
+	mockApp.OnDeleteStandardInvoice(nil)
+
+	// When deletion is retried after the app recovers.
+	invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        invoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceSystem,
+	})
+	s.Require().NoError(err)
+
+	// Then the invoice reaches deleted without replacing its deletion timestamp.
+	s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+	s.Require().NotNil(invoice.DeletedAt)
+	s.Equal(deletedAt, *invoice.DeletedAt)
+	s.Equal(billing.ChangeSourceSystem, invoice.DeletionSource)
+	s.Empty(invoice.ValidationIssues)
+	s.Equal(1, mockApp.DeleteInvoiceCallCount())
+	s.Zero(mockApp.FinalizeInvoiceCallCount())
+	mockApp.AssertExpectations(s.T())
+}
+
+func (s *InvoicingTestSuite) TestZeroTotalInvoiceWithActiveLineIsIssued() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("zero-total-invoice-with-active-line")
+
+	// Given an invoice with an active line discounted to a zero monetary total.
+	invoice := s.createManualApprovalInvoice(ctx, namespace, billing.Discounts{
+		Percentage: &billing.PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{
+				Percentage: models.NewPercentage(100),
+			},
+		},
+	})
+	s.Zero(invoice.Totals.Total.InexactFloat64())
+	s.Require().Len(invoice.Lines.OrEmpty(), 1)
+	s.Nil(invoice.Lines.OrEmpty()[0].DeletedAt)
+
+	mockApp := s.SandboxApp.EnableMock(s.T())
+	defer s.SandboxApp.DisableMock()
+	mockApp.OnFinalizeStandardInvoice(nil)
+
+	// When the invoice is approved and issuing begins.
+	invoice, err := s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.Require().NoError(err)
+
+	// Then the active line keeps the invoice on the normal issuing path.
+	s.NotEqual(billing.StandardInvoiceStatusDeleted, invoice.Status)
+	s.Nil(invoice.DeletedAt)
+	s.NotNil(invoice.IssuedAt)
+	s.Zero(mockApp.DeleteInvoiceCallCount())
+	s.Equal(1, mockApp.FinalizeInvoiceCallCount())
+	mockApp.AssertExpectations(s.T())
+}
+
+func (s *InvoicingTestSuite) createManualApprovalInvoice(
+	ctx context.Context,
+	namespace string,
+	discounts billing.Discounts,
+) billing.StandardInvoice {
+	s.T().Helper()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithManualApproval())
+	customerEntity := s.CreateTestCustomer(namespace, "test-customer")
+
+	now := clock.Now().UTC()
+	period := timeutil.ClosedPeriod{
+		From: now.Add(-2 * time.Hour),
+		To:   now.Add(-time.Hour),
+	}
+
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: []billing.GatheringLine{
+			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+				Namespace:         namespace,
+				Period:            period,
+				InvoiceAt:         now.Add(-time.Second),
+				ManagedBy:         billing.ManuallyManagedLine,
+				Name:              "Test item",
+				PerUnitAmount:     alpacadecimal.NewFromInt(100),
+				Currency:          currencyx.FiatCode(currency.USD),
+				PaymentTerm:       productcatalog.InArrearsPaymentTerm,
+				RateCardDiscounts: discounts,
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pendingLines.Lines, 1)
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customerEntity.GetID(),
+		AsOf:     lo.ToPtr(now),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoices[0].Status)
+	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+
+	return invoices[0]
+}
+
+func (s *InvoicingTestSuite) deleteAllInvoiceLinesBySystem(
+	ctx context.Context,
+	invoice billing.StandardInvoice,
+) billing.StandardInvoice {
+	s.T().Helper()
+
+	updatedInvoice, err := s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
+		Invoice:      invoice.GetInvoiceID(),
+		ChangeSource: billing.ChangeSourceSystem,
+		EditFn: func(invoice *billing.StandardInvoice) error {
+			for _, line := range invoice.Lines.OrEmpty() {
+				line.DeletedAt = lo.ToPtr(clock.Now())
+			}
+
+			return nil
+		},
+		IncludeDeletedLines: true,
+	})
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, updatedInvoice.Status)
+
+	return updatedInvoice
+}
+
 func (s *InvoicingTestSuite) TestBillingProfileChange() {
 	namespace := "ns-billing-profile-default-change"
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

When issuing begins, billing now deletes a standard invoice if it has no non-deleted lines. The deletion is recorded as a system change and synchronized to the configured invoicing app instead of finalizing the invoice.

This is stacked on #4843, where custom-currency overage lines can be deleted after credits fully cover the charge or the resulting fiat amount rounds to zero. Those invoices now complete their lifecycle as deleted rather than remaining as empty drafts.

## Behavioral changes

- An invoice with zero non-deleted lines transitions into the deletion lifecycle when issuing starts.
- Billing calls the invoicing app's delete operation and skips finalization, charge booking, and payment processing.
- If app deletion fails, the invoice enters `delete.failed` and can be retried without replacing the original deletion timestamp.
- The decision is based on line presence, not invoice totals. A zero-total invoice with an active line still follows the normal issuing lifecycle.
- Invoice action details report `deleted` as the approval result when the expanded invoice is empty.

## Validation

- Added generic billing lifecycle coverage for successful empty-invoice deletion, app deletion failure and retry, and zero-total invoices with active lines.
- Extended #4843's flat-fee and usage-based lifecycle cases to assert persisted invoice status, system deletion metadata, invoicing app deletion, and absence of finalization.
- Covered both progressive and non-progressive usage-based lifecycles.
- Ran the targeted billing and charge-service test suites with PostgreSQL.
- Ran `make lint-go-fast` in the repository's Nix development shell.

Jira: OM-434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty invoices are now automatically deleted instead of issued.
  * Deletion is synchronized with the invoicing system, while charge booking and payment are skipped.
  * Failed invoice deletions can be retried safely.
  * Invoices with active zero-value lines continue through the normal issuing process.
  * Invoice status, deletion timestamps, and deletion details are preserved consistently.
  * Deleted invoice lines are handled consistently when viewing invoice details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes standard invoices with no active lines through the existing deletion lifecycle when issuing begins, preserving normal issuing for zero-total invoices that still contain an active line.

- Dynamically selects deletion or issuing after `draft.ready_to_issue`.
- Records system deletion metadata before synchronizing deletion to the invoicing app.
- Adds successful deletion, failed synchronization, retry, and zero-total lifecycle coverage.
- Extends the sandbox mock with finalize and delete call counts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/service/stdinvoicestate.go | Adds line-presence-based routing from ready-to-issue into the existing deletion lifecycle and prepares system deletion metadata before app synchronization. |
| openmeter/app/sandbox/mock.go | Replaces Boolean finalize/delete tracking with call counters used to verify lifecycle behavior. |
| test/billing/invoice_test.go | Covers empty-invoice deletion, failed app deletion and retry, timestamp preservation, and zero-total invoices with active lines. |
| openmeter/billing/charges/service/invoicable_test.go | Updates flat-fee lifecycle expectations for invoices whose only line is deleted. |
| openmeter/billing/charges/service/usagebased_test.go | Updates usage-based lifecycle expectations and verifies deletion synchronization without finalization. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Ready["draft.ready_to_issue"] --> Check{"Any non-deleted lines?"}
  Check -->|Yes| SyncIssue["issuing.syncing"]
  SyncIssue --> Finalize["Finalize through invoicing app"]
  Check -->|No| Prepare["Prepare system deletion"]
  Prepare --> SyncDelete["delete.syncing"]
  SyncDelete --> AppDelete["Delete through invoicing app"]
  AppDelete -->|Success| Deleted["deleted"]
  AppDelete -->|Failure| DeleteFailed["delete.failed"]
  DeleteFailed -->|Retry| SyncDelete
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(billing): address invoice deletion..."](https://github.com/openmeterio/openmeter/commit/ad95170d4e98a60f0bb2f9bbccf3d2cdc265d80a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50003908)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [App Framework (Marketplace Integrations)](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/app.md)

<!-- /greptile_comment -->