### PR TITLE
feat(credit): add usage snapshot schema

### DIFF
--- a/openmeter/credit/balance/balance.go
+++ b/openmeter/credit/balance/balance.go
@@ -78,8 +78,19 @@ func (s SnapshottedUsage) IsZero() bool {
 	return s.Usage == 0.0 && s.Since.IsZero()
 }
 
+// UsageSnapshot is the cumulative usage state for the usage period containing
+// the snapshot.
+type UsageSnapshot struct {
+	Usage           float64 `json:"usage"`
+	TotalGrantUsage float64 `json:"totalGrantUsage"`
+}
+
 type Snapshot struct {
-	Usage    SnapshottedUsage
+	Usage SnapshottedUsage
+	// UsageSnapshot is nil for snapshots created without complete usage-period
+	// state.
+	UsageSnapshot *UsageSnapshot
+
 	Balances Map
 	Overage  float64
 	At       time.Time

--- a/openmeter/ent/db/balancesnapshot.go
+++ b/openmeter/ent/db/balancesnapshot.go
@@ -35,6 +35,8 @@ type BalanceSnapshot struct {
 	GrantBalances balance.Map `json:"grant_balances,omitempty"`
 	// Usage holds the value of the "usage" field.
 	Usage *balance.SnapshottedUsage `json:"usage,omitempty"`
+	// UsageSnapshot holds the value of the "usage_snapshot" field.
+	UsageSnapshot *balance.UsageSnapshot `json:"usage_snapshot,omitempty"`
 	// Balance holds the value of the "balance" field.
 	Balance float64 `json:"balance,omitempty"`
 	// Overage holds the value of the "overage" field.
@@ -74,7 +76,7 @@ func (*BalanceSnapshot) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case balancesnapshot.FieldGrantBalances, balancesnapshot.FieldUsage:
+		case balancesnapshot.FieldGrantBalances, balancesnapshot.FieldUsage, balancesnapshot.FieldUsageSnapshot:
 			values[i] = new([]byte)
 		case balancesnapshot.FieldBalance, balancesnapshot.FieldOverage:
 			values[i] = new(sql.NullFloat64)
@@ -152,6 +154,14 @@ func (_m *BalanceSnapshot) assignValues(columns []string, values []any) error {
 			} else if value != nil && len(*value) > 0 {
 				if err := json.Unmarshal(*value, &_m.Usage); err != nil {
 					return fmt.Errorf("unmarshal field usage: %w", err)
+				}
+			}
+		case balancesnapshot.FieldUsageSnapshot:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field usage_snapshot", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.UsageSnapshot); err != nil {
+					return fmt.Errorf("unmarshal field usage_snapshot: %w", err)
 				}
 			}
 		case balancesnapshot.FieldBalance:
@@ -241,6 +251,9 @@ func (_m *BalanceSnapshot) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("usage=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Usage))
+	builder.WriteString(", ")
+	builder.WriteString("usage_snapshot=")
+	builder.WriteString(fmt.Sprintf("%v", _m.UsageSnapshot))
 	builder.WriteString(", ")
 	builder.WriteString("balance=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Balance))

--- a/openmeter/ent/db/balancesnapshot/balancesnapshot.go
+++ b/openmeter/ent/db/balancesnapshot/balancesnapshot.go
@@ -30,6 +30,8 @@ const (
 	FieldGrantBalances = "grant_balances"
 	// FieldUsage holds the string denoting the usage field in the database.
 	FieldUsage = "usage"
+	// FieldUsageSnapshot holds the string denoting the usage_snapshot field in the database.
+	FieldUsageSnapshot = "usage_snapshot"
 	// FieldBalance holds the string denoting the balance field in the database.
 	FieldBalance = "balance"
 	// FieldOverage holds the string denoting the overage field in the database.
@@ -61,6 +63,7 @@ var Columns = []string{
 	FieldOwnerID,
 	FieldGrantBalances,
 	FieldUsage,
+	FieldUsageSnapshot,
 	FieldBalance,
 	FieldOverage,
 	FieldAt,

--- a/openmeter/ent/db/balancesnapshot/where.go
+++ b/openmeter/ent/db/balancesnapshot/where.go
@@ -365,6 +365,16 @@ func UsageNotNil() predicate.BalanceSnapshot {
 	return predicate.BalanceSnapshot(sql.FieldNotNull(FieldUsage))
 }
 
+// UsageSnapshotIsNil applies the IsNil predicate on the "usage_snapshot" field.
+func UsageSnapshotIsNil() predicate.BalanceSnapshot {
+	return predicate.BalanceSnapshot(sql.FieldIsNull(FieldUsageSnapshot))
+}
+
+// UsageSnapshotNotNil applies the NotNil predicate on the "usage_snapshot" field.
+func UsageSnapshotNotNil() predicate.BalanceSnapshot {
+	return predicate.BalanceSnapshot(sql.FieldNotNull(FieldUsageSnapshot))
+}
+
 // BalanceEQ applies the EQ predicate on the "balance" field.
 func BalanceEQ(v float64) predicate.BalanceSnapshot {
 	return predicate.BalanceSnapshot(sql.FieldEQ(FieldBalance, v))

--- a/openmeter/ent/db/balancesnapshot_create.go
+++ b/openmeter/ent/db/balancesnapshot_create.go
@@ -91,6 +91,12 @@ func (_c *BalanceSnapshotCreate) SetUsage(v *balance.SnapshottedUsage) *BalanceS
 	return _c
 }
 
+// SetUsageSnapshot sets the "usage_snapshot" field.
+func (_c *BalanceSnapshotCreate) SetUsageSnapshot(v *balance.UsageSnapshot) *BalanceSnapshotCreate {
+	_c.mutation.SetUsageSnapshot(v)
+	return _c
+}
+
 // SetBalance sets the "balance" field.
 func (_c *BalanceSnapshotCreate) SetBalance(v float64) *BalanceSnapshotCreate {
 	_c.mutation.SetBalance(v)
@@ -264,6 +270,10 @@ func (_c *BalanceSnapshotCreate) createSpec() (*BalanceSnapshot, *sqlgraph.Creat
 		_spec.SetField(balancesnapshot.FieldUsage, field.TypeJSON, value)
 		_node.Usage = value
 	}
+	if value, ok := _c.mutation.UsageSnapshot(); ok {
+		_spec.SetField(balancesnapshot.FieldUsageSnapshot, field.TypeJSON, value)
+		_node.UsageSnapshot = value
+	}
 	if value, ok := _c.mutation.Balance(); ok {
 		_spec.SetField(balancesnapshot.FieldBalance, field.TypeFloat64, value)
 		_node.Balance = value
@@ -408,6 +418,9 @@ func (u *BalanceSnapshotUpsertOne) UpdateNewValues() *BalanceSnapshotUpsertOne {
 		}
 		if _, exists := u.create.mutation.Usage(); exists {
 			s.SetIgnore(balancesnapshot.FieldUsage)
+		}
+		if _, exists := u.create.mutation.UsageSnapshot(); exists {
+			s.SetIgnore(balancesnapshot.FieldUsageSnapshot)
 		}
 		if _, exists := u.create.mutation.Balance(); exists {
 			s.SetIgnore(balancesnapshot.FieldBalance)
@@ -680,6 +693,9 @@ func (u *BalanceSnapshotUpsertBulk) UpdateNewValues() *BalanceSnapshotUpsertBulk
 			}
 			if _, exists := b.mutation.Usage(); exists {
 				s.SetIgnore(balancesnapshot.FieldUsage)
+			}
+			if _, exists := b.mutation.UsageSnapshot(); exists {
+				s.SetIgnore(balancesnapshot.FieldUsageSnapshot)
 			}
 			if _, exists := b.mutation.Balance(); exists {
 				s.SetIgnore(balancesnapshot.FieldBalance)

--- a/openmeter/ent/db/balancesnapshot_update.go
+++ b/openmeter/ent/db/balancesnapshot_update.go
@@ -127,6 +127,9 @@ func (_u *BalanceSnapshotUpdate) sqlSave(ctx context.Context) (_node int, err er
 	if _u.mutation.UsageCleared() {
 		_spec.ClearField(balancesnapshot.FieldUsage, field.TypeJSON)
 	}
+	if _u.mutation.UsageSnapshotCleared() {
+		_spec.ClearField(balancesnapshot.FieldUsageSnapshot, field.TypeJSON)
+	}
 	if _u.mutation.UnitConfigCleared() {
 		_spec.ClearField(balancesnapshot.FieldUnitConfig, field.TypeString)
 	}
@@ -278,6 +281,9 @@ func (_u *BalanceSnapshotUpdateOne) sqlSave(ctx context.Context) (_node *Balance
 	}
 	if _u.mutation.UsageCleared() {
 		_spec.ClearField(balancesnapshot.FieldUsage, field.TypeJSON)
+	}
+	if _u.mutation.UsageSnapshotCleared() {
+		_spec.ClearField(balancesnapshot.FieldUsageSnapshot, field.TypeJSON)
 	}
 	if _u.mutation.UnitConfigCleared() {
 		_spec.ClearField(balancesnapshot.FieldUnitConfig, field.TypeString)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -478,6 +478,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "grant_balances", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "usage", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "usage_snapshot", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "balance", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "overage", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "at", Type: field.TypeTime},
@@ -492,7 +493,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "balance_snapshots_entitlements_balance_snapshot",
-				Columns:    []*schema.Column{BalanceSnapshotsColumns[11]},
+				Columns:    []*schema.Column{BalanceSnapshotsColumns[12]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -506,7 +507,7 @@ var (
 			{
 				Name:    "balancesnapshot_namespace_owner_id_at",
 				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[11], BalanceSnapshotsColumns[9]},
+				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[12], BalanceSnapshotsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -9323,6 +9323,7 @@ type BalanceSnapshotMutation struct {
 	deleted_at         *time.Time
 	grant_balances     *balance.Map
 	usage              **balance.SnapshottedUsage
+	usage_snapshot     **balance.UsageSnapshot
 	balance            *float64
 	addbalance         *float64
 	overage            *float64
@@ -9713,6 +9714,55 @@ func (m *BalanceSnapshotMutation) ResetUsage() {
 	delete(m.clearedFields, balancesnapshot.FieldUsage)
 }
 
+// SetUsageSnapshot sets the "usage_snapshot" field.
+func (m *BalanceSnapshotMutation) SetUsageSnapshot(bs *balance.UsageSnapshot) {
+	m.usage_snapshot = &bs
+}
+
+// UsageSnapshot returns the value of the "usage_snapshot" field in the mutation.
+func (m *BalanceSnapshotMutation) UsageSnapshot() (r *balance.UsageSnapshot, exists bool) {
+	v := m.usage_snapshot
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUsageSnapshot returns the old "usage_snapshot" field's value of the BalanceSnapshot entity.
+// If the BalanceSnapshot object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BalanceSnapshotMutation) OldUsageSnapshot(ctx context.Context) (v *balance.UsageSnapshot, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUsageSnapshot is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUsageSnapshot requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUsageSnapshot: %w", err)
+	}
+	return oldValue.UsageSnapshot, nil
+}
+
+// ClearUsageSnapshot clears the value of the "usage_snapshot" field.
+func (m *BalanceSnapshotMutation) ClearUsageSnapshot() {
+	m.usage_snapshot = nil
+	m.clearedFields[balancesnapshot.FieldUsageSnapshot] = struct{}{}
+}
+
+// UsageSnapshotCleared returns if the "usage_snapshot" field was cleared in this mutation.
+func (m *BalanceSnapshotMutation) UsageSnapshotCleared() bool {
+	_, ok := m.clearedFields[balancesnapshot.FieldUsageSnapshot]
+	return ok
+}
+
+// ResetUsageSnapshot resets all changes to the "usage_snapshot" field.
+func (m *BalanceSnapshotMutation) ResetUsageSnapshot() {
+	m.usage_snapshot = nil
+	delete(m.clearedFields, balancesnapshot.FieldUsageSnapshot)
+}
+
 // SetBalance sets the "balance" field.
 func (m *BalanceSnapshotMutation) SetBalance(f float64) {
 	m.balance = &f
@@ -9984,7 +10034,7 @@ func (m *BalanceSnapshotMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BalanceSnapshotMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.namespace != nil {
 		fields = append(fields, balancesnapshot.FieldNamespace)
 	}
@@ -10005,6 +10055,9 @@ func (m *BalanceSnapshotMutation) Fields() []string {
 	}
 	if m.usage != nil {
 		fields = append(fields, balancesnapshot.FieldUsage)
+	}
+	if m.usage_snapshot != nil {
+		fields = append(fields, balancesnapshot.FieldUsageSnapshot)
 	}
 	if m.balance != nil {
 		fields = append(fields, balancesnapshot.FieldBalance)
@@ -10040,6 +10093,8 @@ func (m *BalanceSnapshotMutation) Field(name string) (ent.Value, bool) {
 		return m.GrantBalances()
 	case balancesnapshot.FieldUsage:
 		return m.Usage()
+	case balancesnapshot.FieldUsageSnapshot:
+		return m.UsageSnapshot()
 	case balancesnapshot.FieldBalance:
 		return m.Balance()
 	case balancesnapshot.FieldOverage:
@@ -10071,6 +10126,8 @@ func (m *BalanceSnapshotMutation) OldField(ctx context.Context, name string) (en
 		return m.OldGrantBalances(ctx)
 	case balancesnapshot.FieldUsage:
 		return m.OldUsage(ctx)
+	case balancesnapshot.FieldUsageSnapshot:
+		return m.OldUsageSnapshot(ctx)
 	case balancesnapshot.FieldBalance:
 		return m.OldBalance(ctx)
 	case balancesnapshot.FieldOverage:
@@ -10136,6 +10193,13 @@ func (m *BalanceSnapshotMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUsage(v)
+		return nil
+	case balancesnapshot.FieldUsageSnapshot:
+		v, ok := value.(*balance.UsageSnapshot)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUsageSnapshot(v)
 		return nil
 	case balancesnapshot.FieldBalance:
 		v, ok := value.(float64)
@@ -10228,6 +10292,9 @@ func (m *BalanceSnapshotMutation) ClearedFields() []string {
 	if m.FieldCleared(balancesnapshot.FieldUsage) {
 		fields = append(fields, balancesnapshot.FieldUsage)
 	}
+	if m.FieldCleared(balancesnapshot.FieldUsageSnapshot) {
+		fields = append(fields, balancesnapshot.FieldUsageSnapshot)
+	}
 	if m.FieldCleared(balancesnapshot.FieldUnitConfig) {
 		fields = append(fields, balancesnapshot.FieldUnitConfig)
 	}
@@ -10250,6 +10317,9 @@ func (m *BalanceSnapshotMutation) ClearField(name string) error {
 		return nil
 	case balancesnapshot.FieldUsage:
 		m.ClearUsage()
+		return nil
+	case balancesnapshot.FieldUsageSnapshot:
+		m.ClearUsageSnapshot()
 		return nil
 	case balancesnapshot.FieldUnitConfig:
 		m.ClearUnitConfig()
@@ -10282,6 +10352,9 @@ func (m *BalanceSnapshotMutation) ResetField(name string) error {
 		return nil
 	case balancesnapshot.FieldUsage:
 		m.ResetUsage()
+		return nil
+	case balancesnapshot.FieldUsageSnapshot:
+		m.ResetUsageSnapshot()
 		return nil
 	case balancesnapshot.FieldBalance:
 		m.ResetBalance()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -451,7 +451,7 @@ func init() {
 	// balancesnapshot.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	balancesnapshot.UpdateDefaultUpdatedAt = balancesnapshotDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// balancesnapshotDescUnitConfig is the schema descriptor for unit_config field.
-	balancesnapshotDescUnitConfig := balancesnapshotFields[6].Descriptor()
+	balancesnapshotDescUnitConfig := balancesnapshotFields[7].Descriptor()
 	balancesnapshot.ValueScanner.UnitConfig = balancesnapshotDescUnitConfig.ValueScanner.(field.TypeValueScanner[*unitconfig.UnitConfig])
 	billingcustomerlockMixin := schema.BillingCustomerLock{}.Mixin()
 	billingcustomerlockMixinFields0 := billingcustomerlockMixin[0].Fields()

--- a/openmeter/ent/schema/balance_snapshot.go
+++ b/openmeter/ent/schema/balance_snapshot.go
@@ -32,7 +32,12 @@ func (BalanceSnapshot) Fields() []ent.Field {
 		field.JSON("grant_balances", balance.Map{}).Immutable().SchemaType(map[string]string{
 			dialect.Postgres: "jsonb",
 		}),
+		// usage stores the legacy Since-relative representation during the
+		// rolling migration to complete usage-period snapshots.
 		field.JSON("usage", &balance.SnapshottedUsage{}).Immutable().Optional().SchemaType(map[string]string{
+			dialect.Postgres: "jsonb",
+		}),
+		field.JSON("usage_snapshot", &balance.UsageSnapshot{}).Immutable().Optional().SchemaType(map[string]string{
 			dialect.Postgres: "jsonb",
 		}),
 		field.Float("balance").Immutable().SchemaType(map[string]string{

--- a/tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.down.sql
+++ b/tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" DROP COLUMN "usage_snapshot";

--- a/tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.up.sql
+++ b/tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.up.sql
@@ -1,0 +1,2 @@
+-- modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" ADD COLUMN "usage_snapshot" jsonb NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+I8wD+JBHyBLuhkJINMZuTN7uH32QFaSsDnCCPa7d7s=
+h1:0iXhmu5OGhnWljKLNuibztsenOLI+wGnqCPt/LeDgcY=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -248,3 +248,4 @@ h1:+I8wD+JBHyBLuhkJINMZuTN7uH32QFaSsDnCCPa7d7s=
 20260728100841_product_catalog_currency_references.up.sql h1:q7A61W3rAITxk2BYED3y717t1y5nKUHDLinxne/8O/M=
 20260728103546_product_catalog_currency_constraints.up.sql h1:58Q5V4nRCgUv5CE9U38oWC43/Rs+lhK6bBPTkdoVenM=
 20260728160000_add_ledger_custom_currency_support.up.sql h1:5hOQM4caCMA4RQ4qqXsZ2X/Wl70Mn+aDOLJcGY3s/p0=
+20260803135655_add_balance_snapshot_usage_snapshot.up.sql h1:5sc9bKOEFg+IcahxNZI4K4b6g499R7C2I4UFjDcyAsI=


### PR DESCRIPTION
## What

- expose the complete usage-period snapshot type
- add an optional `usage_snapshot` JSONB field to balance snapshots
- include the generated Ent changes and migration

## Why

This is the schema-first half of the entitlement balance snapshot fix in #4846. Landing and deploying the additive persistence shape first keeps the follow-up runtime change zero-downtime and leaves room for a snapshot warmup job if needed.

## Impact

Additive and inert: this PR does not read, write, or select the new field at runtime.

## Validation

- generated schema and migration are unchanged from the previously validated #4846 stack
- `git diff --check`
- follow-up credit engine and balance tests pass on the stacked branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage snapshot information to balance snapshots, including cumulative period usage and total grant usage.
  * Usage snapshot data is optional when complete usage-period details are unavailable.
  * Added database support for storing usage snapshots in balance records.

* **Migration**
  * Added upgrade and rollback support for the new usage snapshot data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the persistence shape needed for complete usage-period snapshots while leaving runtime behavior unchanged.

- Adds the exported `UsageSnapshot` domain type and an optional pointer on balance snapshots.
- Adds the nullable immutable `usage_snapshot` JSONB field to the Ent schema and generated client.
- Adds the corresponding additive PostgreSQL migration and Atlas checksum.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge as an additive schema-first change with no active runtime behavior.

The nullable column, generated Ent artifacts, positional schema references, and migration are internally consistent, while existing rows remain compatible through a nil usage snapshot.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/credit/balance/balance.go | Adds the complete usage-period snapshot shape as an optional, backward-compatible domain field. |
| openmeter/ent/schema/balance_snapshot.go | Declares a nullable, immutable JSONB field consistent with the schema-first rollout. |
| openmeter/ent/db/migrate/schema.go | Updates generated migration metadata with correctly shifted field, foreign-key, and index positions. |
| openmeter/ent/db/balancesnapshot.go | Adds generated scanning, unmarshalling, and model support for nullable usage snapshots. |
| tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.up.sql | Applies an additive nullable JSONB column without rewriting existing snapshot data. |
| tools/migrate/migrations/20260803135655_add_balance_snapshot_usage_snapshot.down.sql | Removes the newly introduced column when rolling back the migration. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Domain[balance.UsageSnapshot] --> Ent[Ent usage_snapshot field]
  Ent --> DB[(balance_snapshots.usage_snapshot JSONB)]
  Runtime[Follow-up runtime integration] -. deferred .-> Domain
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(credit): add usage snapshot schema"](https://github.com/openmeterio/openmeter/commit/b78b4ad00f51f61b081869b26b1aa2e684d530b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50005279)</sub>

**Context used:**

- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)

<!-- /greptile_comment -->