### PR TITLE
refactor: JSON_VALUE in clickhouse query

### DIFF
--- a/openmeter/streaming/clickhouse/connector_test.go
+++ b/openmeter/streaming/clickhouse/connector_test.go
@@ -85,6 +85,7 @@ func TestConnector_QueryMeter(t *testing.T) {
 	// Mock the SQL query and response
 	mockRows1 := NewMockRows()
 	mockCH.On("Query", mock.Anything, mock.AnythingOfType("string"), []interface{}{
+		"$.value",
 		"test-namespace",
 		"test-event",
 		from.Unix(),

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -313,7 +313,9 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 			}
 
 			whereExpr := stringFilterWhereExpr(column, filterString)
-			query = query.Where(query.Var(whereExpr))
+			if whereExpr != nil {
+				query = query.Where(query.Var(whereExpr))
+			}
 		}
 	}
 
@@ -404,15 +406,23 @@ func stringFilterWhereExpr(field sqlbuilder.Builder, f filter.FilterString) sqlb
 	case f.Or != nil:
 		return joinStringFilterWhereExprs(field, *f.Or, " OR ")
 	default:
-		return sqlbuilder.Buildf("")
+		return nil
 	}
 }
 
 func joinStringFilterWhereExprs(field sqlbuilder.Builder, filters []filter.FilterString, separator string) sqlbuilder.Builder {
-	format := "(" + strings.Join(lo.RepeatBy(len(filters), func(_ int) string { return "%v" }), separator) + ")"
-	args := lo.Map(filters, func(f filter.FilterString, _ int) any {
-		return stringFilterWhereExpr(field, f)
-	})
+	args := make([]any, 0, len(filters))
+	for _, filter := range filters {
+		if expr := stringFilterWhereExpr(field, filter); expr != nil {
+			args = append(args, expr)
+		}
+	}
+
+	if len(args) == 0 {
+		return nil
+	}
+
+	format := "(" + strings.Join(lo.RepeatBy(len(args), func(_ int) string { return "%v" }), separator) + ")"
 
 	return sqlbuilder.Buildf(format, args...)
 }

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -109,6 +109,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	tableName := getTableName(d.Database, d.EventsTableName)
 	getColumn := columnFactory(d.EventsTableName)
 	timeColumn := getColumn("time")
+	query := sqlbuilder.ClickHouse.NewSelectBuilder()
 
 	var selectColumns, groupByColumns []string
 
@@ -207,19 +208,19 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	case meterpkg.MeterAggregationCount:
 		selectColumns = append(selectColumns, fmt.Sprintf("%s(*) AS value", sqlAggregation))
 	case meterpkg.MeterAggregationUniqueCount:
-		selectColumns = append(selectColumns, fmt.Sprintf("%s(nullIf(JSON_VALUE(%s, '%s'), 'null')) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
+		selectColumns = append(selectColumns, fmt.Sprintf("%s(nullIf(JSON_VALUE(%s, %s), 'null')) AS value", sqlAggregation, getColumn("data"), query.Var(*d.Meter.ValueProperty)))
 	case meterpkg.MeterAggregationLatest:
 		if d.EnableDecimalPrecision {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, '%s'), 'null'), 19), %s) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty), timeColumn))
+			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, %s), 'null'), 19), %s) AS value", sqlAggregation, getColumn("data"), query.Var(*d.Meter.ValueProperty), timeColumn))
 		} else {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, '%s')), null), %s) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty), timeColumn))
+			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, %s)), null), %s) AS value", sqlAggregation, getColumn("data"), query.Var(*d.Meter.ValueProperty), timeColumn))
 		}
 	default:
 		if d.EnableDecimalPrecision {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, '%s'), 'null'), 19)) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
+			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, %s), 'null'), 19)) AS value", sqlAggregation, getColumn("data"), query.Var(*d.Meter.ValueProperty)))
 		} else {
 			// JSON_VALUE returns an empty string if the JSON Path is not found. With toFloat64OrNull we convert it to NULL so the aggregation function can handle it properly.
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, '%s')), null)) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
+			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, %s)), null)) AS value", sqlAggregation, getColumn("data"), query.Var(*d.Meter.ValueProperty)))
 		}
 	}
 
@@ -239,14 +240,13 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 
 		// Group by columns need to be parsed from the JSON data
 		groupByColumn := sqlbuilder.Escape(groupByKey)
-		groupByJSONPath := escapeJSONPathLiteral(d.Meter.GroupBy[groupByKey])
-		selectColumn := fmt.Sprintf("JSON_VALUE(%s, '%s') as %s", getColumn("data"), groupByJSONPath, groupByColumn)
+		groupByJSONPath := query.Var(d.Meter.GroupBy[groupByKey])
+		selectColumn := fmt.Sprintf("JSON_VALUE(%s, %s) as %s", getColumn("data"), groupByJSONPath, groupByColumn)
 
 		selectColumns = append(selectColumns, selectColumn)
 		groupByColumns = append(groupByColumns, groupByColumn)
 	}
 
-	query := sqlbuilder.ClickHouse.NewSelectBuilder()
 	query.Select(selectColumns...)
 	query.From(tableName)
 
@@ -298,22 +298,22 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 				)
 			}
 
-			// Determine the column name
-			column := fmt.Sprintf("JSON_VALUE(%s, '%s')", dataColumn, escapeJSONPathLiteral(groupByJSONPath))
+			// Determine the column expression. Build the JSON_VALUE call as a nested
+			// builder so both the JSONPath and filter values remain query parameters.
+			column := sqlbuilder.Buildf("JSON_VALUE(%s, %v)", sqlbuilder.Raw(dataColumn), groupByJSONPath)
 
 			// Subject is a special case
 			if groupByKey == "subject" {
-				column = "subject"
+				column = sqlbuilder.Buildf("%s", sqlbuilder.Raw("subject"))
 			}
 
 			// Customer ID is a special case
 			if groupByKey == "customer_id" {
-				column = "customer_id"
+				column = sqlbuilder.Buildf("%s", sqlbuilder.Raw("customer_id"))
 			}
 
-			// Use the filter's SelectWhereExpr method to generate the WHERE clause
-			whereExpr := filterString.SelectWhereExpr(column, query)
-			query = query.Where(whereExpr)
+			whereExpr := stringFilterWhereExpr(column, filterString)
+			query = query.Where(query.Var(whereExpr))
 		}
 	}
 
@@ -359,6 +359,62 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	}
 
 	return sql, args, nil
+}
+
+// stringFilterWhereExpr builds a string filter around a SQL expression while
+// preserving parameters owned by that expression. FilterString.SelectWhereExpr
+// accepts a raw field string, which cannot carry a nested JSONPath parameter.
+func stringFilterWhereExpr(field sqlbuilder.Builder, f filter.FilterString) sqlbuilder.Builder {
+	switch {
+	case f.Eq != nil:
+		return sqlbuilder.Buildf("%v = %v", field, *f.Eq)
+	case f.Ne != nil:
+		return sqlbuilder.Buildf("%v <> %v", field, *f.Ne)
+	case f.Exists != nil:
+		if *f.Exists {
+			return sqlbuilder.Buildf("%v IS NOT NULL", field)
+		}
+		return sqlbuilder.Buildf("%v IS NULL", field)
+	case f.In != nil:
+		return sqlbuilder.Buildf("%v IN (%v)", field, *f.In)
+	case f.Nin != nil:
+		return sqlbuilder.Buildf("%v NOT IN (%v)", field, *f.Nin)
+	case f.Like != nil:
+		return sqlbuilder.Buildf("%v LIKE %v", field, *f.Like)
+	case f.Nlike != nil:
+		return sqlbuilder.Buildf("%v NOT LIKE %v", field, *f.Nlike)
+	case f.Ilike != nil:
+		return sqlbuilder.Buildf("LOWER(%v) LIKE LOWER(%v)", field, *f.Ilike)
+	case f.Nilike != nil:
+		return sqlbuilder.Buildf("LOWER(%v) NOT LIKE LOWER(%v)", field, *f.Nilike)
+	case f.Contains != nil:
+		return sqlbuilder.Buildf("LOWER(%v) LIKE LOWER(%v)", field, filter.ContainsPattern(*f.Contains))
+	case f.Ncontains != nil:
+		return sqlbuilder.Buildf("LOWER(%v) NOT LIKE LOWER(%v)", field, filter.ContainsPattern(*f.Ncontains))
+	case f.Gt != nil:
+		return sqlbuilder.Buildf("%v > %v", field, *f.Gt)
+	case f.Gte != nil:
+		return sqlbuilder.Buildf("%v >= %v", field, *f.Gte)
+	case f.Lt != nil:
+		return sqlbuilder.Buildf("%v < %v", field, *f.Lt)
+	case f.Lte != nil:
+		return sqlbuilder.Buildf("%v <= %v", field, *f.Lte)
+	case f.And != nil:
+		return joinStringFilterWhereExprs(field, *f.And, " AND ")
+	case f.Or != nil:
+		return joinStringFilterWhereExprs(field, *f.Or, " OR ")
+	default:
+		return sqlbuilder.Buildf("")
+	}
+}
+
+func joinStringFilterWhereExprs(field sqlbuilder.Builder, filters []filter.FilterString, separator string) sqlbuilder.Builder {
+	format := "(" + strings.Join(lo.RepeatBy(len(filters), func(_ int) string { return "%v" }), separator) + ")"
+	args := lo.Map(filters, func(f filter.FilterString, _ int) any {
+		return stringFilterWhereExpr(field, f)
+	})
+
+	return sqlbuilder.Buildf(format, args...)
 }
 
 // whereByOrderedColumns applies the where clause to the query for columns that are ordered by the event table.
@@ -479,31 +535,4 @@ func (queryMeter queryMeter) scanRows(rows driver.Rows) ([]meterpkg.MeterQueryRo
 	}
 
 	return values, nil
-}
-
-// escapeJSONPathLiteral escapes a string so it can be safely embedded
-// inside a single-quoted ClickHouse string literal (i.e. '…').
-//
-// It handles backslashes, single quotes, and double quotes.
-func escapeJSONPathLiteral(s string) string {
-	var sb strings.Builder
-	// Reserve approximate capacity
-	sb.Grow(len(s) * 2)
-
-	for _, r := range s {
-		switch r {
-		case '\\':
-			sb.WriteString(`\\`)
-		case '\'':
-			// Use backslash-escape for single quote (\' ), or you could also use ''
-			sb.WriteString(`\'`)
-		case '"':
-			// Escape double quotes (optional, depending on JSON path syntax)
-			sb.WriteString(`\"`)
-		default:
-			// For other runes, just write them
-			sb.WriteRune(r)
-		}
-	}
-	return sb.String()
 }

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -857,6 +857,75 @@ func TestQueryMeter(t *testing.T) {
 	}
 }
 
+func TestQueryMeterOmitsEmptyLogicalFilterExpressions(t *testing.T) {
+	baseSQL := "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, count(*) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?"
+	equalValue := "group-value"
+	emptyAnd := []filter.FilterString{}
+	emptyOr := []filter.FilterString{}
+	mixedAnd := []filter.FilterString{
+		{
+			Or: &[]filter.FilterString{
+				{},
+				{Eq: &equalValue},
+			},
+		},
+		{And: &emptyAnd},
+		{},
+	}
+
+	tests := []struct {
+		name     string
+		filter   filter.FilterString
+		wantSQL  string
+		wantArgs []interface{}
+	}{
+		{
+			name:     "empty and",
+			filter:   filter.FilterString{And: &emptyAnd},
+			wantSQL:  baseSQL,
+			wantArgs: []interface{}{"my_namespace", "event1"},
+		},
+		{
+			name:     "empty or",
+			filter:   filter.FilterString{Or: &emptyOr},
+			wantSQL:  baseSQL,
+			wantArgs: []interface{}{"my_namespace", "event1"},
+		},
+		{
+			name:     "nested mixed operands",
+			filter:   filter.FilterString{And: &mixedAnd},
+			wantSQL:  baseSQL + " AND ((JSON_VALUE(om_events.data, ?) = ?))",
+			wantArgs: []interface{}{"my_namespace", "event1", "$.group", "group-value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := queryMeter{
+				Database:        "openmeter",
+				EventsTableName: "om_events",
+				Namespace:       "my_namespace",
+				Meter: meter.Meter{
+					Key:         "meter1",
+					EventType:   "event1",
+					Aggregation: meter.MeterAggregationCount,
+					GroupBy: map[string]string{
+						"group": "$.group",
+					},
+				},
+				FilterGroupBy: map[string]filter.FilterString{
+					"group": tt.filter,
+				},
+			}
+
+			gotSQL, gotArgs, err := query.toSQL()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantSQL, gotSQL)
+			assert.Equal(t, tt.wantArgs, gotArgs)
+		})
+	}
+}
+
 func TestQueryMeterBindsJSONPaths(t *testing.T) {
 	valuePath := "$.value'), (SELECT sleep(3)), ('"
 	groupPath := "$.group'), (SELECT sleep(3)), ('"

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -50,8 +50,8 @@ func TestQueryMeter(t *testing.T) {
 				GroupBy:       []string{"subject", "group1", "group2"},
 				WindowSize:    &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, ?) as group1, JSON_VALUE(om_events.data, ?) as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "$.group1", "$.group2", "my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix()},
 		},
 		{
 			name: "basic query with decimal precision",
@@ -76,8 +76,8 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:             &windowSize,
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19)) AS value, om_events.subject, JSON_VALUE(om_events.data, ?) as group1, JSON_VALUE(om_events.data, ?) as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "$.group1", "$.group2", "my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix()},
 		},
 		{
 			name: "basic query with decimal stored at offset",
@@ -107,8 +107,8 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:             &windowSize,
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? AND om_events.stored_at < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix(), storedAtOffset.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19)) AS value, om_events.subject, JSON_VALUE(om_events.data, ?) as group1, JSON_VALUE(om_events.data, ?) as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? AND om_events.stored_at < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "$.group1", "$.group2", "my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix(), storedAtOffset.Unix()},
 		},
 		{
 			name: "Aggregate all available data",
@@ -127,8 +127,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with count aggregation",
@@ -186,8 +186,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, uniqExact(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, uniqExact(nullIf(JSON_VALUE(om_events.data, ?), 'null')) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with unique count aggregation with decimal precision",
@@ -207,8 +207,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, uniqExact(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, uniqExact(nullIf(JSON_VALUE(om_events.data, ?), 'null')) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with AVG aggregation",
@@ -227,8 +227,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, avg(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, avg(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with AVG aggregation with decimal precision",
@@ -248,8 +248,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, avg(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, avg(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with MIN aggregation",
@@ -268,8 +268,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, min(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, min(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with MIN aggregation with decimal precision",
@@ -289,8 +289,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, min(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, min(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with MAX aggregation",
@@ -309,8 +309,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, max(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, max(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with MAX aggregation with decimal precision",
@@ -330,8 +330,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, max(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, max(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with LATEST aggregation",
@@ -350,8 +350,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, argMax(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null), om_events.time) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, argMax(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null), om_events.time) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate with LATEST aggregation with decimal precision",
@@ -371,8 +371,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnableDecimalPrecision: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, argMax(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, argMax(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, ?), 'null'), 19), om_events.time) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate data from start",
@@ -392,8 +392,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				From: &from,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix()},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix()},
 		},
 		{
 			name: "Aggregate data between period",
@@ -414,8 +414,8 @@ func TestQueryMeter(t *testing.T) {
 				From: &from,
 				To:   &to,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ?",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{
 			name: "Aggregate data between period, groupped by window size",
@@ -437,8 +437,8 @@ func TestQueryMeter(t *testing.T) {
 				To:         &to,
 				WindowSize: &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{
 			name: "Aggregate data between period in a different timezone, groupped by window size",
@@ -461,8 +461,8 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:     &windowSize,
 				WindowTimeZone: tz,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{
 			name: "Aggregate data between period, groupped by DAY window size",
@@ -484,8 +484,8 @@ func TestQueryMeter(t *testing.T) {
 				To:         &to,
 				WindowSize: lo.ToPtr(meter.WindowSizeDay),
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalDay(1), 'UTC') AS windowstart, windowstart + toIntervalDay(1) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalDay(1), 'UTC') AS windowstart, windowstart + toIntervalDay(1) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{
 			name: "Aggregate data between period in a different timezone, groupped by DAY window size",
@@ -508,8 +508,8 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:     lo.ToPtr(meter.WindowSizeDay),
 				WindowTimeZone: tz,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalDay(1), 'Asia/Shanghai') AS windowstart, windowstart + toIntervalDay(1) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
-			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalDay(1), 'Asia/Shanghai') AS windowstart, windowstart + toIntervalDay(1) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{
 			name: "Aggregate data for a single subject",
@@ -530,8 +530,8 @@ func TestQueryMeter(t *testing.T) {
 				FilterSubject: []string{subject},
 				GroupBy:       []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", []string{"subject1"}},
 		},
 		{
 			name: "Aggregate data for a single subject and group by additional fields",
@@ -552,8 +552,8 @@ func TestQueryMeter(t *testing.T) {
 				FilterSubject: []string{subject},
 				GroupBy:       []string{"subject", "group1", "group2"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject, group1, group2",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, ?) as group1, JSON_VALUE(om_events.data, ?) as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject, group1, group2",
+			wantArgs: []interface{}{"$.value", "$.group1", "$.group2", "my_namespace", "event1", []string{"subject1"}},
 		},
 		{
 			name: "Aggregate data for a multiple subjects",
@@ -574,8 +574,8 @@ func TestQueryMeter(t *testing.T) {
 				FilterSubject: []string{subject, "subject2"},
 				GroupBy:       []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1", "subject2"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", []string{"subject1", "subject2"}},
 		},
 		{
 			name: "Select customer ID",
@@ -615,8 +615,9 @@ func TestQueryMeter(t *testing.T) {
 				},
 				GroupBy: []string{"customer_id"},
 			},
-			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, mapFromArrays(?, ?)[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY customer_id",
+			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, mapFromArrays(?, ?)[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY customer_id",
 			wantArgs: []interface{}{
+				"$.value",
 				[]string{"subject1", "subject2"},
 				[]string{"customer1", "customer2"},
 				"my_namespace",
@@ -662,8 +663,8 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?)",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{
+			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?)",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", []string{
 				// Only the first customer has a key
 				"customer-key-1",
 				// Usage attribution subjects of the first customer
@@ -700,8 +701,9 @@ func TestQueryMeter(t *testing.T) {
 				FilterSubject: []string{"subject1"},
 				GroupBy:       []string{"customer_id"},
 			},
-			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, mapFromArrays(?, ?)[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.subject IN (?) GROUP BY customer_id",
+			wantSQL: "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value, mapFromArrays(?, ?)[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.subject IN (?) GROUP BY customer_id",
 			wantArgs: []interface{}{
+				"$.value",
 				[]string{"subject1", "subject2"},
 				[]string{"customer1", "customer1"},
 				"my_namespace",
@@ -728,8 +730,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string]filter.FilterString{"g1": {Eq: lo.ToPtr("g1v1")}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, '$.group1') = ?",
-			wantArgs: []interface{}{"my_namespace", "event1", "g1v1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, ?) = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", "$.group1", "g1v1"},
 		},
 		{
 			name: "Aggregate data with filtering for a single group and multiple values",
@@ -749,8 +751,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string]filter.FilterString{"g1": {In: lo.ToPtr([]string{"g1v1", "g1v2"})}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, '$.group1') IN (?)",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"g1v1", "g1v2"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, ?) IN (?)",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", "$.group1", []string{"g1v1", "g1v2"}},
 		},
 		{
 			name: "Aggregate data with filtering for multiple groups and multiple values",
@@ -773,8 +775,8 @@ func TestQueryMeter(t *testing.T) {
 					"g2": {In: lo.ToPtr([]string{"g2v1", "g2v2"})},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, '$.group1') IN (?) AND JSON_VALUE(om_events.data, '$.group2') IN (?)",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"g1v1", "g1v2"}, []string{"g2v1", "g2v2"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND JSON_VALUE(om_events.data, ?) IN (?) AND JSON_VALUE(om_events.data, ?) IN (?)",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", "$.group1", []string{"g1v1", "g1v2"}, "$.group2", []string{"g2v1", "g2v2"}},
 		},
 		{
 			name: "Aggregate all available data, prewhere enabled (should not move anything to prewhere)",
@@ -794,8 +796,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				EnablePrewhere: true,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 		{
 			name: "Aggregate data with with filtering for multiple groups and multiple values prewhere enabled",
@@ -819,8 +821,8 @@ func TestQueryMeter(t *testing.T) {
 					"g2": {In: lo.ToPtr([]string{"g2v1", "g2v2"})},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE JSON_VALUE(om_events.data, '$.group1') IN (?) AND JSON_VALUE(om_events.data, '$.group2') IN (?) SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
-			wantArgs: []interface{}{"my_namespace", "event1", []string{"g1v1", "g1v2"}, []string{"g2v1", "g2v2"}},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE JSON_VALUE(om_events.data, ?) IN (?) AND JSON_VALUE(om_events.data, ?) IN (?) SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1", "$.group1", []string{"g1v1", "g1v2"}, "$.group2", []string{"g2v1", "g2v2"}},
 		},
 		{
 			name: "Add query settings",
@@ -836,8 +838,8 @@ func TestQueryMeter(t *testing.T) {
 				},
 				QuerySettings: map[string]string{"foo": "1"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? SETTINGS foo = 1",
-			wantArgs: []interface{}{"my_namespace", "event1"},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, ?)), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? SETTINGS foo = 1",
+			wantArgs: []interface{}{"$.value", "my_namespace", "event1"},
 		},
 	}
 
@@ -853,4 +855,37 @@ func TestQueryMeter(t *testing.T) {
 			assert.Equal(t, tt.wantArgs, gotArgs)
 		})
 	}
+}
+
+func TestQueryMeterBindsJSONPaths(t *testing.T) {
+	valuePath := "$.value'), (SELECT sleep(3)), ('"
+	groupPath := "$.group'), (SELECT sleep(3)), ('"
+
+	query := queryMeter{
+		Database:        "openmeter",
+		EventsTableName: "om_events",
+		Namespace:       "my_namespace",
+		Meter: meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: &valuePath,
+			GroupBy: map[string]string{
+				"group": groupPath,
+			},
+		},
+		GroupBy: []string{"group"},
+		FilterGroupBy: map[string]filter.FilterString{
+			"group": {Eq: lo.ToPtr("group-value")},
+		},
+	}
+
+	gotSQL, gotArgs, err := query.toSQL()
+	assert.NoError(t, err)
+	assert.NotContains(t, gotSQL, valuePath)
+	assert.NotContains(t, gotSQL, groupPath)
+	assert.Equal(t,
+		[]interface{}{valuePath, groupPath, "my_namespace", "event1", groupPath, "group-value"},
+		gotArgs,
+	)
 }


### PR DESCRIPTION
## Overview

Bind meter value-property and group-by JSONPaths as ClickHouse query parameters instead of interpolating them into SQL. This prevents crafted meter configuration from altering generated queries while preserving aggregation, grouping, and filtering behavior. Tests now verify injection-shaped JSONPaths remain bound values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse meter queries by safely binding JSON paths as parameters.
  * Added support for nested group-by filters and all filter string operators.
  * Prevented potentially malicious JSON paths from being embedded directly in generated SQL.
  * Omitted empty logical filter expressions from generated queries.

* **Tests**
  * Expanded coverage for filtering, grouping, aggregation, time windows, customer queries, and query settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens ClickHouse meter queries by binding value-property and group-by JSONPaths rather than interpolating them into SQL.
- Moves JSONPath values into ClickHouse query arguments across aggregation, grouping, and group-by filtering.
- Adds a nested string-filter expression builder that preserves bound parameters and omits empty logical expressions.
- Expands SQL-generation and connector tests for parameter ordering, nested filters, and injection-shaped JSONPaths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/streaming/clickhouse/meter_query.go | Replaces interpolated JSONPath literals with bound parameters and introduces parameter-preserving string-filter expression builders. |
| openmeter/streaming/clickhouse/meter_query_test.go | Updates expected SQL and arguments and adds coverage for empty logical filters and injection-shaped JSONPaths. |
| openmeter/streaming/clickhouse/connector_test.go | Updates the connector mock expectation to include the newly bound value-property JSONPath. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[Meter configuration] --> Q[queryMeter.toSQL]
  Q --> S[SELECT aggregation and grouping]
  Q --> F[Group-by filter expressions]
  S --> P[Bound JSONPath parameters]
  F --> P
  P --> CH[ClickHouse query execution]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: empty filters"](https://github.com/openmeterio/openmeter/commit/c0af7ba7614fc406a9d3d23fad9a3833884dd5ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50054766)</sub>

**Context used:**

- Knowledge Base — [Ingest, Dedupe, and Metering Flow](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/ingest-metering.md)

<!-- /greptile_comment -->