### PR TITLE
fix(ledger): guard custom currency charge payments

### DIFF
--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -193,6 +193,9 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 	}
 
 	intent := input.Charge.Intent
+	if intent.GetCurrency().IsCustom() {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", meta.ErrCustomCurrencyNotSupported)
+	}
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
@@ -245,6 +248,9 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 	}
 
 	intent := input.Charge.Intent
+	if intent.GetCurrency().IsCustom() {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", meta.ErrCustomCurrencyNotSupported)
+	}
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -105,6 +105,9 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 	}
 
 	intent := input.Charge.Intent
+	if intent.GetCurrency().IsCustom() {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", meta.ErrCustomCurrencyNotSupported)
+	}
 
 	if err := validateSettlementMode(
 		intent.GetSettlementMode(),
@@ -182,6 +185,9 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 	}
 
 	intent := input.Charge.Intent
+	if intent.GetCurrency().IsCustom() {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", meta.ErrCustomCurrencyNotSupported)
+	}
 
 	if err := validateSettlementMode(
 		intent.GetSettlementMode(),


### PR DESCRIPTION
## Summary

- reject custom-currency payment authorization in the flat-fee and usage-based ledger adapters
- reject custom-currency payment settlement through the same explicit unsupported-currency error

## Behavioral change

Custom-currency overage accrual is not yet supported by the ledger adapters, but the payment handlers did not enforce the same boundary. If reached independently, they could attempt to resolve a custom-currency receivable using a fiat payment amount.

The payment handlers now return `ErrCustomCurrencyNotSupported` before resolving or committing a ledger transaction. Fiat charge payment behavior is unchanged. These guards are intentionally temporary and should be removed when OM-435 implements fiat settlement for custom-currency overage.

## Validation

```text
go test ./openmeter/ledger/chargeadapter
```

Ticket: OM-435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added clear validation when authorizing and settling flat-fee payments with custom currencies.
  - Added the same validation for usage-based payments.
  - Custom-currency transactions are now rejected early with a consistent, actionable error instead of proceeding through payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents unsupported custom-currency payment transactions from reaching ledger resolution or commit.
- Adds early custom-currency rejection to flat-fee payment authorization and settlement.
- Adds equivalent guards to usage-based payment authorization and settlement.
- Preserves existing fiat payment behavior and wraps the shared unsupported-currency sentinel for error inspection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with unsupported custom-currency payments rejected before ledger mutations while fiat behavior remains unchanged.

The four new checks return the shared unsupported-currency error before transaction resolution or commit, and current workflow ordering does not expose a conflicting reachable no-op path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/ledger/chargeadapter/flatfee.go | Adds correctly positioned custom-currency guards before flat-fee payment transaction resolution and ledger commits. |
| openmeter/ledger/chargeadapter/usagebased.go | Adds matching custom-currency guards to usage-based authorization and settlement; no currently reachable regression was identified. |

<sub>Reviews (1): Last reviewed commit: ["feat: guard custom currency payments"](https://github.com/openmeterio/openmeter/commit/a5636e45b5ad0afbf2186be60d0616409221cb4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50056710)</sub>

**Context used:**

- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->