### PR TITLE
feat(ledger): add credit_then_invoice custom currency fx support

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -195,7 +195,44 @@ separate settlement facts. A zero converted overage controls line omission and
 invoice bypass. A zero required transaction controls payment handling and does
 not by itself remove an otherwise billable line from the invoice.
 
-This is a charge-domain contract, not end-to-end support: current ledger-backed
-charge adapters reject custom currencies. Enabling them spans ledger route
-identity and persistence, charge realization, settlement rounding, corrections,
-balance queries, and historical migration.
+Ledger-backed charge adapters implement this boundary directly:
+
+- credit allocation and correction stay in the custom currency end to end
+  ([`credit_only`](#settlement-semantics) never leaves it)
+- `OnCustomCurrencyOverageAccrued` calls the charge-side conversion once to
+  get the authoritative rounded fiat amount, then books the overage exactly
+  like a credit purchase immediately consumed by the same charge: it
+  purchases the uncovered custom amount at the charge's persisted cost basis,
+  consumes that purchase through the identical route so it never becomes
+  spendable customer balance, and converts the resulting custom-currency
+  receivable into that fiat amount as the open invoice receivable - all in
+  one atomic transaction group. It never re-resolves a cost basis or performs
+  a second, independent FX conversion. Ledger history keeps the native
+  amount, cost basis, and fiat provenance on the accrued leg even though the
+  invoice and payment lifecycle are fiat-only.
+- the accrual group keeps the consumed amount on the native accrued route and
+  creates the authoritative fiat open receivable; invoice, authorization, and
+  settlement reuse that fiat amount and currency on the charge's persisted
+  cost-basis route rather than a fixed cost basis of 1. No spendable
+  custom-currency balance or open custom-currency receivable survives accrual
+- credit realization lineage tracks a managed currency's code plus its
+  namespace-scoped currency ID, not the display code alone, so two managed
+  currencies that reuse a code (e.g. after one is soft-deleted) never share
+  or contaminate each other's lineage. The mechanism itself - advance,
+  backfill, earnings-recognized segment transitions - is currency agnostic
+  and applies to custom currencies the same way it does to fiat.
+- `AdvanceCharges` recognizes earnings in the currency each charge actually
+  settles in: fiat charges recognize in their own currency, and custom
+  `credit_then_invoice` charges recognize in their resolved invoice fiat
+  currency (the recognizer never sees the native custom currency for them).
+  Custom `credit_only` has no invoice-fiat side and no accounting design yet
+  for recognizing native custom-currency consumption as revenue, so it is
+  omitted from recognition entirely rather than erroring or being mapped to
+  an invented currency; this is a deliberate, currently-open boundary, not an
+  oversight.
+
+Known limitation: converting the uncovered custom-currency overage can round
+to a zero fiat amount. The charge layer does not yet delete the resulting
+empty overage invoice line in every case (see the skipped cases in
+`usagebased_test.go`'s custom-currency lifecycle table); until that lands,
+zero-fiat-overage handling is incomplete, not implemented.

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -84,6 +84,13 @@ func (c ChargeBase) GetCurrency() currencies.Currency {
 	return c.Intent.GetCurrency()
 }
 
+// GetResolvedCostBasis returns the charge's persisted cost-basis snapshot, or
+// nil if the charge's currency is fiat or the dynamic cost basis has not been
+// resolved yet.
+func (c ChargeBase) GetResolvedCostBasis() *costbasis.State {
+	return c.State.ResolvedCostBasis
+}
+
 func (c ChargeBase) GetInvoiceCurrency() (currencyx.FiatCode, error) {
 	currency := c.GetCurrency()
 	if currency.IsFiat() {

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -234,8 +234,13 @@ type Handler interface {
 	// OnFlatFeeStandardInvoiceUsageAccrued is called when the remaining usage is sent to the customer on a standard invoice.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency flat-fee value is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency
+	// flat-fee value is accrued. From the ledger's point of view this is a
+	// credit purchase immediately consumed by the same charge: it purchases
+	// and consumes the uncovered amount in the native currency at the
+	// charge's persisted cost basis, then converts the resulting
+	// custom-currency receivable into the fiat amount the invoice collects.
+	// The purchased credit never becomes spendable customer balance.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.

--- a/openmeter/billing/charges/lineage/adapter/lineage.go
+++ b/openmeter/billing/charges/lineage/adapter/lineage.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/creditrealizationlineage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/creditrealizationlineagesegment"
-	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
@@ -73,7 +74,8 @@ func (a *adapter) CreateLineages(ctx context.Context, input lineage.CreateLineag
 				SetChargeID(input.ChargeID).
 				SetRootRealizationID(spec.RootRealizationID).
 				SetCustomerID(input.CustomerID).
-				SetCurrency(input.Currency).
+				SetCurrency(input.Currency.Code).
+				SetNillableCustomCurrencyID(input.Currency.CustomCurrencyID).
 				SetOriginKind(spec.OriginKind).
 				SetAdvanceFeatures(pq.StringArray(spec.AdvanceFeatures)),
 			)
@@ -101,7 +103,7 @@ func (a *adapter) LoadLineagesByCustomer(ctx context.Context, input lineage.Load
 			Where(
 				creditrealizationlineage.Namespace(input.Namespace),
 				creditrealizationlineage.CustomerIDEQ(input.CustomerID),
-				creditrealizationlineage.CurrencyEQ(input.Currency),
+				currencyIdentityPredicate(input.Currency),
 			).
 			WithSegments(func(q *entdb.CreditRealizationLineageSegmentQuery) {
 				q.Where(creditrealizationlineagesegment.ClosedAtIsNil()).
@@ -115,6 +117,24 @@ func (a *adapter) LoadLineagesByCustomer(ctx context.Context, input lineage.Load
 
 		return lo.Map(lineages, mapLineage), nil
 	})
+}
+
+// currencyIdentityPredicate matches a lineage's persisted currency identity:
+// the display code plus, for custom currencies, the exact managed currency
+// ID. Distinct managed currencies can reuse a code (e.g. after one is
+// soft-deleted), so matching on code alone would conflate their lineages.
+func currencyIdentityPredicate(ref currencies.CurrencyReference) predicate.CreditRealizationLineage {
+	if ref.CustomCurrencyID == nil {
+		return creditrealizationlineage.And(
+			creditrealizationlineage.CurrencyEQ(ref.Code),
+			creditrealizationlineage.CustomCurrencyIDIsNil(),
+		)
+	}
+
+	return creditrealizationlineage.And(
+		creditrealizationlineage.CurrencyEQ(ref.Code),
+		creditrealizationlineage.CustomCurrencyIDEQ(*ref.CustomCurrencyID),
+	)
 }
 
 func (a *adapter) LockCorrectionLineages(ctx context.Context, namespace string, realizationIDs []string) ([]lineage.Lineage, error) {
@@ -143,7 +163,7 @@ func (a *adapter) LockCorrectionLineages(ctx context.Context, namespace string, 
 	})
 }
 
-func (a *adapter) LockAdvanceLineagesForBackfill(ctx context.Context, namespace string, customerID string, currency currencyx.Code) ([]lineage.Lineage, error) {
+func (a *adapter) LockAdvanceLineagesForBackfill(ctx context.Context, namespace string, customerID string, currency currencies.CurrencyReference) ([]lineage.Lineage, error) {
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) ([]lineage.Lineage, error) {
 		if _, err := entutils.GetDriverFromContext(ctx); err != nil {
 			return nil, fmt.Errorf("lock advance lineages for backfill must be called in a transaction: %w", err)
@@ -153,7 +173,7 @@ func (a *adapter) LockAdvanceLineagesForBackfill(ctx context.Context, namespace 
 			Where(
 				creditrealizationlineage.Namespace(namespace),
 				creditrealizationlineage.CustomerIDEQ(customerID),
-				creditrealizationlineage.CurrencyEQ(currency),
+				currencyIdentityPredicate(currency),
 				creditrealizationlineage.HasSegmentsWith(
 					creditrealizationlineagesegment.ClosedAtIsNil(),
 					creditrealizationlineagesegment.StateEQ(creditrealization.LineageSegmentStateAdvanceUncovered),
@@ -172,7 +192,7 @@ func (a *adapter) LockAdvanceLineagesForBackfill(ctx context.Context, namespace 
 				ChargeID:          entry.ChargeID,
 				RootRealizationID: entry.RootRealizationID,
 				CustomerID:        entry.CustomerID,
-				Currency:          entry.Currency,
+				Currency:          currencies.CurrencyReference{Code: entry.Currency, CustomCurrencyID: entry.CustomCurrencyID},
 				OriginKind:        entry.OriginKind,
 				AdvanceFeatures:   []string(entry.AdvanceFeatures),
 			}
@@ -242,7 +262,7 @@ func mapLineage(entry *entdb.CreditRealizationLineage, _ int) lineage.Lineage {
 		ChargeID:          entry.ChargeID,
 		RootRealizationID: entry.RootRealizationID,
 		CustomerID:        entry.CustomerID,
-		Currency:          entry.Currency,
+		Currency:          currencies.CurrencyReference{Code: entry.Currency, CustomCurrencyID: entry.CustomCurrencyID},
 		OriginKind:        entry.OriginKind,
 		AdvanceFeatures:   []string(entry.AdvanceFeatures),
 		Segments: lo.Map(entry.Edges.Segments, func(segment *entdb.CreditRealizationLineageSegment, _ int) lineage.Segment {

--- a/openmeter/billing/charges/lineage/lineage_test.go
+++ b/openmeter/billing/charges/lineage/lineage_test.go
@@ -6,20 +6,15 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
-	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
+// TestBackfillAdvanceLineageSegmentsInputValidateCurrency documents that
+// advance-lineage backfill is currency agnostic: fiat and custom currencies
+// are tracked identically, since lineage only records credit provenance and
+// never performs currency-specific accounting itself.
 func TestBackfillAdvanceLineageSegmentsInputValidateCurrency(t *testing.T) {
-	customCurrency, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
-		WithCode(currencyx.Code("CREDITS")).
-		WithName("Credits").
-		Build()
-	require.NoError(t, err)
-
 	baseInput := BackfillAdvanceLineageSegmentsInput{
 		Namespace:                 "test-namespace",
 		CustomerID:                "test-customer",
@@ -36,12 +31,9 @@ func TestBackfillAdvanceLineageSegmentsInputValidateCurrency(t *testing.T) {
 
 	t.Run("custom currency", func(t *testing.T) {
 		input := baseInput
-		input.Currency = currencies.Currency{Currency: customCurrency}
+		input.Currency = currenciestestutils.NewCustomCurrency(t, "CREDITS", 2)
 
-		err := input.Validate()
-		require.Error(t, err)
-		require.ErrorIs(t, err, meta.ErrCustomCurrencyNotSupported)
-		require.ErrorContains(t, err, "advance lineage backfill")
+		require.NoError(t, input.Validate())
 	})
 
 	t.Run("missing currency", func(t *testing.T) {

--- a/openmeter/billing/charges/lineage/service.go
+++ b/openmeter/billing/charges/lineage/service.go
@@ -8,10 +8,8 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
-	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
@@ -32,7 +30,7 @@ type Adapter interface {
 	LoadActiveSegmentsByRealizationID(ctx context.Context, namespace string, realizationIDs []string) (ActiveSegmentsByRealizationID, error)
 	LoadLineagesByCustomer(ctx context.Context, input LoadLineagesByCustomerInput) ([]Lineage, error)
 	LockCorrectionLineages(ctx context.Context, namespace string, realizationIDs []string) ([]Lineage, error)
-	LockAdvanceLineagesForBackfill(ctx context.Context, namespace string, customerID string, currency currencyx.Code) ([]Lineage, error)
+	LockAdvanceLineagesForBackfill(ctx context.Context, namespace string, customerID string, currency currencies.CurrencyReference) ([]Lineage, error)
 	ListActiveSegments(ctx context.Context, input ListActiveSegmentsInput) ([]Segment, error)
 	CloseSegment(ctx context.Context, segmentID string, closedAt time.Time) error
 	CreateSegment(ctx context.Context, input CreateSegmentInput) error
@@ -61,10 +59,6 @@ func (i CreateInitialLineagesInput) Validate() error {
 	}
 	if err := i.Currency.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
-	}
-
-	if i.Currency.IsCustom() {
-		errs = append(errs, fmt.Errorf("create initial lineages: custom currency: %w", meta.ErrCustomCurrencyNotSupported))
 	}
 
 	if err := i.Realizations.Validate(); err != nil {
@@ -120,9 +114,6 @@ func (i BackfillAdvanceLineageSegmentsInput) Validate() error {
 	if err := i.Currency.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
 	}
-	if i.Currency.IsCustom() {
-		errs = append(errs, fmt.Errorf("advance lineage backfill: %w", meta.ErrCustomCurrencyNotSupported))
-	}
 	if !i.Amount.IsPositive() {
 		errs = append(errs, errors.New("amount must be positive"))
 	}
@@ -136,7 +127,7 @@ func (i BackfillAdvanceLineageSegmentsInput) Validate() error {
 type LoadLineagesByCustomerInput struct {
 	Namespace  string
 	CustomerID string
-	Currency   currencyx.Code
+	Currency   currencies.CurrencyReference
 }
 
 func (i LoadLineagesByCustomerInput) Validate() error {
@@ -159,7 +150,7 @@ type CreateLineagesInput struct {
 	Namespace  string
 	ChargeID   string
 	CustomerID string
-	Currency   currencyx.Code
+	Currency   currencies.CurrencyReference
 	Specs      []creditrealization.InitialLineageSpec
 }
 
@@ -234,7 +225,7 @@ type Lineage struct {
 	ChargeID          string
 	RootRealizationID string
 	CustomerID        string
-	Currency          currencyx.Code
+	Currency          currencies.CurrencyReference
 	OriginKind        creditrealization.LineageOriginKind
 	AdvanceFeatures   []string
 	Segments          []Segment

--- a/openmeter/billing/charges/lineage/service/service.go
+++ b/openmeter/billing/charges/lineage/service/service.go
@@ -63,7 +63,7 @@ func (s *service) CreateInitialLineages(ctx context.Context, input lineage.Creat
 			Namespace:  input.Namespace,
 			ChargeID:   input.ChargeID,
 			CustomerID: input.CustomerID,
-			Currency:   input.Currency.GetCode(),
+			Currency:   input.Currency.Reference(),
 			Specs:      specs,
 		})
 	})
@@ -181,7 +181,7 @@ func (s *service) BackfillAdvanceLineageSegments(ctx context.Context, input line
 	}
 
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		lineages, err := s.adapter.LockAdvanceLineagesForBackfill(ctx, input.Namespace, input.CustomerID, input.Currency.GetCode())
+		lineages, err := s.adapter.LockAdvanceLineagesForBackfill(ctx, input.Namespace, input.CustomerID, input.Currency.Reference())
 		if err != nil {
 			return fmt.Errorf("lock advance lineages for backfill: %w", err)
 		}

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -96,7 +96,7 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 			}
 		}
 
-		currencies, err := collectCurrencies(advancedCharges)
+		currencies, err := collectEarningsRecognitionCurrencies(advancedCharges)
 		if err != nil {
 			return nil, err
 		}
@@ -114,12 +114,35 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 	return advancedCharges, nil
 }
 
-func collectCurrencies(chargeList charges.Charges) ([]currencies.Currency, error) {
-	out, err := lo.MapErr(chargeList, func(c charges.Charge, _ int) (currencies.Currency, error) {
-		return c.GetCurrency()
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get currencies: %w", err)
+// collectEarningsRecognitionCurrencies resolves the currency each advanced
+// charge should recognize earnings in. Fiat charges recognize in their own
+// currency.
+//
+// Custom-currency charges are omitted regardless of settlement mode. Their
+// only recognizable (credit-backed) lineage is created by the shared
+// allocation path in the native custom currency - identically for
+// credit_only and credit_then_invoice, since both allocate covered usage the
+// same way. Recognizing in the invoice fiat currency instead would be a
+// silent no-op: credit_then_invoice never creates fiat-denominated lineage
+// for the overage (it books straight to receivable/accrued, bypassing
+// lineage entirely), so searching in fiat would find nothing while the real,
+// recognizable native-currency lineage goes unrecognized. Recognizing
+// native custom-currency consumption as revenue directly has no accounting
+// design yet, so it stays omitted rather than erroring or being substituted.
+func collectEarningsRecognitionCurrencies(chargeList charges.Charges) ([]currencies.Currency, error) {
+	out := make([]currencies.Currency, 0, len(chargeList))
+
+	for _, c := range chargeList {
+		chargeCurrency, err := c.GetCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("get currency: %w", err)
+		}
+
+		if chargeCurrency.IsCustom() {
+			continue
+		}
+
+		out = append(out, chargeCurrency)
 	}
 
 	return lo.UniqByErr(out, func(c currencies.Currency) (string, error) {

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -351,7 +351,7 @@ func TestCollectEarningsRecognitionCurrencies(t *testing.T) {
 	custom := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
-		FiatCurrency: lo.Must(currencyx.NewFiatCurrency("USD")),
+		FiatCurrency: lo.Must(currencyx.NewFiatCurrency("EUR")),
 		Rate:         alpacadecimal.NewFromFloat(0.25),
 	})
 

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -6,13 +6,19 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -26,6 +32,7 @@ type AdvanceChargesTestSuite struct {
 }
 
 func (s *AdvanceChargesTestSuite) SetupSuite() {
+	s.UseRealRecognizer = true
 	s.BaseSuite.SetupSuite()
 }
 
@@ -235,4 +242,138 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceUs
 	s.Equal(meta.ChargeStatusActive, meta.ChargeStatus(usageBasedCharge.Status))
 	s.NotNil(usageBasedCharge.State.AdvanceAfter)
 	s.True(servicePeriod.To.Equal(*usageBasedCharge.State.AdvanceAfter))
+}
+
+// usageBasedIntentServicePeriod is the fixed service period newUsageBasedIntent bakes
+// into every intent it builds.
+var usageBasedIntentServicePeriod = timeutil.ClosedPeriod{
+	From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+	To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+}
+
+// TestAdvanceChargesCustomCurrencyCreditThenInvoiceRecognitionIsOmittedNotFailed proves
+// that advancing a custom-currency credit_then_invoice charge reaches the real
+// (non-noop) recognizer without its native custom currency ever being passed
+// to it. Before the fix this call failed and rolled back the whole
+// AdvanceCharges transaction, because the recognizer explicitly rejects
+// custom currency. See TestCollectEarningsRecognitionCurrencies for why the
+// custom currency is omitted rather than substituted with the invoice fiat
+// currency.
+func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditThenInvoiceRecognitionIsOmittedNotFailed() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-advance-custom-cti")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	customCurrency := s.createTestCustomCurrency(ctx, ns)
+	featureMeters := s.createFeatureMeters(ctx, ns, "custom-cti-feature")
+
+	clock.FreezeTime(usageBasedIntentServicePeriod.From)
+	defer clock.UnFreeze()
+
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: s.newFiatCurrency("USD"),
+		Rate:         alpacadecimal.NewFromFloat(0.25),
+	})
+
+	_, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
+		Namespace: ns,
+		Intents: []usagebased.Intent{
+			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-cti", "custom-cti-feature", productcatalog.CreditThenInvoiceSettlementMode, &costBasisIntent),
+		},
+		FeatureMeters: featureMeters,
+	})
+	s.Require().NoError(err)
+
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(advancedCharges, 1)
+}
+
+// TestAdvanceChargesCustomCurrencyCreditOnlyRecognitionIsDeferredNotFailed documents
+// the deliberately deferred boundary: a custom-currency credit_only charge has
+// no invoice/fiat side and no accounting design yet for recognizing native
+// custom-currency consumption as revenue. Creating and advancing it must keep
+// succeeding - as it already does in production, per
+// TestFlatFeeCreditOnlyWithCustomCurrency and TestUsageBasedCreditOnlyWithCustomCurrency
+// in invoicable_test.go - rather than erroring or inventing a fiat currency
+// for it.
+func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditOnlyRecognitionIsDeferredNotFailed() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-advance-custom-credit-only")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	customCurrency := s.createTestCustomCurrency(ctx, ns)
+	featureMeters := s.createFeatureMeters(ctx, ns, "custom-credit-only-feature")
+
+	clock.FreezeTime(usageBasedIntentServicePeriod.From)
+	defer clock.UnFreeze()
+
+	_, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
+		Namespace: ns,
+		Intents: []usagebased.Intent{
+			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-credit-only", "custom-credit-only-feature", productcatalog.CreditOnlySettlementMode, nil),
+		},
+		FeatureMeters: featureMeters,
+	})
+	s.Require().NoError(err)
+
+	clock.SetTime(usageBasedIntentServicePeriod.To.Add(time.Second))
+
+	_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.Require().NoError(err)
+}
+
+// TestCollectEarningsRecognitionCurrencies proves the exact currency-selection
+// contract: a fiat charge contributes its own currency; a custom-currency
+// charge is always omitted, regardless of settlement mode. Recognizing
+// credit_then_invoice in its invoice fiat currency instead would be a silent
+// no-op - credit_then_invoice's covered usage creates real, recognizable
+// lineage in the native custom currency via the same allocation path
+// credit_only uses, and that lineage would never be found under the fiat
+// currency, while the overage itself never creates lineage at all (it books
+// straight to receivable/accrued). This test would fail loudly (by returning
+// the invoice fiat currency, or the raw custom currency) if that mistake were
+// reintroduced.
+func TestCollectEarningsRecognitionCurrencies(t *testing.T) {
+	usd := currenciestestutils.NewFiatCurrency(t, "USD")
+	custom := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: lo.Must(currencyx.NewFiatCurrency("USD")),
+		Rate:         alpacadecimal.NewFromFloat(0.25),
+	})
+
+	newUsageBasedCharge := func(currency currencies.Currency, settlementMode productcatalog.SettlementMode, costBasis *costbasis.Intent) charges.Charge {
+		return charges.NewCharge(usagebased.Charge{
+			ChargeBase: usagebased.ChargeBase{
+				Intent: usagebased.Intent{
+					Intent:         meta.Intent{Currency: currency},
+					FeatureKey:     "feature",
+					SettlementMode: settlementMode,
+					CostBasis:      costBasis,
+				}.AsOverridableIntent(),
+			},
+		})
+	}
+
+	result, err := collectEarningsRecognitionCurrencies(charges.Charges{
+		newUsageBasedCharge(usd, productcatalog.CreditThenInvoiceSettlementMode, nil),
+		newUsageBasedCharge(custom, productcatalog.CreditOnlySettlementMode, nil),
+		newUsageBasedCharge(custom, productcatalog.CreditThenInvoiceSettlementMode, &costBasisIntent),
+	})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, currencyx.Code("USD"), result[0].GetCode())
 }

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
@@ -25,6 +26,7 @@ import (
 	chargeslinerouter "github.com/openmeterio/openmeter/openmeter/billing/charges/linerouter"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/adapter"
 	usagebasedservice "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service"
@@ -35,8 +37,13 @@ import (
 	currencyservice "github.com/openmeterio/openmeter/openmeter/currencies/service"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
+	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	featurepkg "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/featuregate"
@@ -54,6 +61,14 @@ type BaseSuite struct {
 	// stack the suite builds. Defaults to false; a derived suite sets it in its own
 	// SetupSuite (before calling BaseSuite.SetupSuite) to exercise unit_config rating.
 	UnitConfigEnabled bool
+
+	// UseRealRecognizer wires a real, ledger-backed recognizer.Service instead of
+	// recognizer.NoopService{}. Defaults to false because most suites in this
+	// package drive charges through mock ledger handlers that never persist real
+	// customer/business ledger accounts; a derived suite that needs to observe
+	// actual recognition behavior sets it in its own SetupSuite (before calling
+	// BaseSuite.SetupSuite).
+	UseRealRecognizer bool
 
 	Charges                   *service
 	UsageBasedService         usagebased.Service
@@ -108,6 +123,24 @@ func (s *BaseSuite) SetupSuite() {
 	})
 	s.NoError(err)
 	s.LineageService = lineageService
+
+	var recognizerService recognizer.Service = recognizer.NoopService{}
+	if s.UseRealRecognizer {
+		ledgerDeps, err := ledgertestutils.InitDeps(s.DBClient, slog.Default())
+		s.NoError(err)
+
+		recognizerService, err = recognizer.NewService(recognizer.Config{
+			Ledger: ledgerDeps.HistoricalLedger,
+			Dependencies: transactions.ResolverDependencies{
+				AccountService: ledgerDeps.ResolversService,
+				AccountCatalog: ledgerDeps.AccountService,
+				BalanceQuerier: ledgerDeps.HistoricalLedger,
+			},
+			Lineage:            lineageService,
+			TransactionManager: enttx.NewCreator(s.DBClient),
+		})
+		s.NoError(err)
+	}
 
 	flatFeeAdapter, err := flatfeeadapter.New(flatfeeadapter.Config{
 		Client:      s.DBClient,
@@ -212,7 +245,7 @@ func (s *BaseSuite) SetupSuite() {
 		FlatFeeService:        flatFeeService,
 		CreditPurchaseService: creditPurchaseService,
 		UsageBasedService:     usageBasedService,
-		RecognizerService:     recognizer.NoopService{},
+		RecognizerService:     recognizerService,
 
 		BillingService:   s.BillingService,
 		TaxCodeService:   s.TaxCodeService,
@@ -439,6 +472,82 @@ func (s *BaseSuite) grantPromotionalCredits(ctx context.Context, customerID cust
 	s.Len(res, 1)
 
 	return res
+}
+
+func (s *BaseSuite) newFiatCurrency(code currencyx.Code) *currencyx.FiatCurrency {
+	s.T().Helper()
+
+	fiatCurrency, err := currencyx.NewFiatCurrency(code)
+	s.Require().NoError(err)
+
+	return fiatCurrency
+}
+
+func (s *BaseSuite) newUsageBasedIntent(
+	customerID string,
+	currency currencies.Currency,
+	taxCodeID string,
+	uniqueReferenceID string,
+	featureKey string,
+	settlementMode productcatalog.SettlementMode,
+	costBasis *costbasis.Intent,
+) usagebased.Intent {
+	s.T().Helper()
+
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return usagebased.Intent{
+		Intent: meta.Intent{
+			ManagedBy:         billing.ManuallyManagedLine,
+			CustomerID:        customerID,
+			Currency:          currency,
+			TaxConfig:         productcatalog.TaxCodeConfig{TaxCodeID: taxCodeID},
+			UniqueReferenceID: lo.ToPtr(uniqueReferenceID),
+		},
+		IntentMutableFields: usagebased.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              uniqueReferenceID,
+				ServicePeriod:     period,
+				FullServicePeriod: period,
+				BillingPeriod:     period,
+			},
+			InvoiceAt: period.To,
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromInt(1),
+			}),
+		},
+		SettlementMode: settlementMode,
+		FeatureKey:     featureKey,
+		CostBasis:      costBasis,
+	}
+}
+
+func (s *BaseSuite) createFeatureMeters(ctx context.Context, namespace, key string) featurepkg.FeatureMeterCollection {
+	s.T().Helper()
+
+	testMeter := newTestMeter(namespace, key+"-meter")
+	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{testMeter}))
+
+	feature, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: namespace,
+		Name:      key,
+		Key:       key,
+		MeterID:   lo.ToPtr(testMeter.ID),
+	})
+	s.Require().NoError(err)
+
+	featureMeter := featurepkg.FeatureMeter{
+		Feature: feature,
+		Meter:   &testMeter,
+	}
+
+	return featurepkg.FeatureMeterCollection{
+		ByKey: map[string]featurepkg.FeatureMeter{feature.Key: featureMeter},
+		ByID:  map[string]featurepkg.FeatureMeter{feature.ID: featureMeter},
+	}
 }
 
 func (s *BaseSuite) mustGetChargeByID(chargeID meta.ChargeID) charges.Charge {

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
@@ -274,7 +275,7 @@ func (s *CreditRealizationLineageTestSuite) TestLockAdvanceLineagesForBackfillRe
 	})
 	s.Require().NoError(err)
 
-	_, err = adapter.LockAdvanceLineagesForBackfill(ctx, ns, "customer-id", currencyx.Code(currency.USD))
+	_, err = adapter.LockAdvanceLineagesForBackfill(ctx, ns, "customer-id", currencies.NewCurrencyReference(currencyx.Code(currency.USD)))
 	s.Error(err)
 	s.ErrorContains(err, "must be called in a transaction")
 }
@@ -296,7 +297,7 @@ func (s *CreditRealizationLineageTestSuite) TestLockAdvanceLineagesForBackfillWo
 	})
 	s.Require().NoError(err)
 
-	lineages, err := adapter.LockAdvanceLineagesForBackfill(ctx, ns, "customer-id", currencyx.Code(currency.USD))
+	lineages, err := adapter.LockAdvanceLineagesForBackfill(ctx, ns, "customer-id", currencies.NewCurrencyReference(currencyx.Code(currency.USD)))
 	s.NoError(err)
 	s.Empty(lineages)
 }

--- a/openmeter/billing/charges/service/usagebased_costbasis_test.go
+++ b/openmeter/billing/charges/service/usagebased_costbasis_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -9,20 +8,15 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	dbchargeusagebasedcostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedcostbasis"
-	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	featurepkg "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestUsageBasedCostBasisCreate(t *testing.T) {
@@ -410,80 +404,4 @@ func (s *UsageBasedCostBasisCreateSuite) countCostBases(namespace string) int {
 	s.Require().NoError(err)
 
 	return count
-}
-
-func (s *UsageBasedCostBasisCreateSuite) createFeatureMeters(ctx context.Context, namespace, key string) featurepkg.FeatureMeterCollection {
-	s.T().Helper()
-
-	testMeter := newTestMeter(namespace, key+"-meter")
-	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{testMeter}))
-
-	feature, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
-		Namespace: namespace,
-		Name:      key,
-		Key:       key,
-		MeterID:   lo.ToPtr(testMeter.ID),
-	})
-	s.Require().NoError(err)
-
-	featureMeter := featurepkg.FeatureMeter{
-		Feature: feature,
-		Meter:   &testMeter,
-	}
-
-	return featurepkg.FeatureMeterCollection{
-		ByKey: map[string]featurepkg.FeatureMeter{feature.Key: featureMeter},
-		ByID:  map[string]featurepkg.FeatureMeter{feature.ID: featureMeter},
-	}
-}
-
-func (s *UsageBasedCostBasisCreateSuite) newFiatCurrency(code currencyx.Code) *currencyx.FiatCurrency {
-	s.T().Helper()
-
-	fiatCurrency, err := currencyx.NewFiatCurrency(code)
-	s.Require().NoError(err)
-
-	return fiatCurrency
-}
-
-func (s *UsageBasedCostBasisCreateSuite) newUsageBasedIntent(
-	customerID string,
-	currency currencies.Currency,
-	taxCodeID string,
-	uniqueReferenceID string,
-	featureKey string,
-	settlementMode productcatalog.SettlementMode,
-	costBasis *costbasis.Intent,
-) usagebased.Intent {
-	s.T().Helper()
-
-	period := timeutil.ClosedPeriod{
-		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
-		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
-	}
-
-	return usagebased.Intent{
-		Intent: meta.Intent{
-			ManagedBy:         billing.ManuallyManagedLine,
-			CustomerID:        customerID,
-			Currency:          currency,
-			TaxConfig:         productcatalog.TaxCodeConfig{TaxCodeID: taxCodeID},
-			UniqueReferenceID: lo.ToPtr(uniqueReferenceID),
-		},
-		IntentMutableFields: usagebased.IntentMutableFields{
-			IntentMutableFields: meta.IntentMutableFields{
-				Name:              uniqueReferenceID,
-				ServicePeriod:     period,
-				FullServicePeriod: period,
-				BillingPeriod:     period,
-			},
-			InvoiceAt: period.To,
-			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-				Amount: alpacadecimal.NewFromInt(1),
-			}),
-		},
-		SettlementMode: settlementMode,
-		FeatureKey:     featureKey,
-		CostBasis:      costBasis,
-	}
 }

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -85,6 +85,13 @@ func (c ChargeBase) GetCurrency() currencies.Currency {
 	return c.Intent.GetCurrency()
 }
 
+// GetResolvedCostBasis returns the charge's persisted cost-basis snapshot, or
+// nil if the charge's currency is fiat or the dynamic cost basis has not been
+// resolved yet.
+func (c ChargeBase) GetResolvedCostBasis() *costbasis.State {
+	return c.State.ResolvedCostBasis
+}
+
 func (c ChargeBase) GetInvoiceCurrency() (currencyx.FiatCode, error) {
 	currency := c.GetCurrency()
 	if currency.IsFiat() {

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -247,8 +247,13 @@ type Handler interface {
 	// OnPaymentSettled is called when an invoice-backed usage-based run payment is settled.
 	OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency usage is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency
+	// usage is accrued. From the ledger's point of view this is a credit
+	// purchase immediately consumed by the same charge: it purchases and
+	// consumes the uncovered amount in the native currency at the charge's
+	// persisted cost basis, then converts the resulting custom-currency
+	// receivable into the fiat amount the invoice collects. The purchased
+	// credit never becomes spendable customer balance.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.

--- a/openmeter/ent/db/creditrealizationlineage.go
+++ b/openmeter/ent/db/creditrealizationlineage.go
@@ -31,6 +31,8 @@ type CreditRealizationLineage struct {
 	CustomerID string `json:"customer_id,omitempty"`
 	// Currency holds the value of the "currency" field.
 	Currency currencyx.Code `json:"currency,omitempty"`
+	// CustomCurrencyID holds the value of the "custom_currency_id" field.
+	CustomCurrencyID *string `json:"custom_currency_id,omitempty"`
 	// OriginKind holds the value of the "origin_kind" field.
 	OriginKind creditrealization.LineageOriginKind `json:"origin_kind,omitempty"`
 	// AdvanceFeatures holds the value of the "advance_features" field.
@@ -81,7 +83,7 @@ func (*CreditRealizationLineage) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case creditrealizationlineage.FieldAdvanceFeatures:
 			values[i] = new(pq.StringArray)
-		case creditrealizationlineage.FieldID, creditrealizationlineage.FieldNamespace, creditrealizationlineage.FieldChargeID, creditrealizationlineage.FieldRootRealizationID, creditrealizationlineage.FieldCustomerID, creditrealizationlineage.FieldCurrency, creditrealizationlineage.FieldOriginKind:
+		case creditrealizationlineage.FieldID, creditrealizationlineage.FieldNamespace, creditrealizationlineage.FieldChargeID, creditrealizationlineage.FieldRootRealizationID, creditrealizationlineage.FieldCustomerID, creditrealizationlineage.FieldCurrency, creditrealizationlineage.FieldCustomCurrencyID, creditrealizationlineage.FieldOriginKind:
 			values[i] = new(sql.NullString)
 		case creditrealizationlineage.FieldCreatedAt:
 			values[i] = new(sql.NullTime)
@@ -135,6 +137,13 @@ func (_m *CreditRealizationLineage) assignValues(columns []string, values []any)
 				return fmt.Errorf("unexpected type %T for field currency", values[i])
 			} else if value.Valid {
 				_m.Currency = currencyx.Code(value.String)
+			}
+		case creditrealizationlineage.FieldCustomCurrencyID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field custom_currency_id", values[i])
+			} else if value.Valid {
+				_m.CustomCurrencyID = new(string)
+				*_m.CustomCurrencyID = value.String
 			}
 		case creditrealizationlineage.FieldOriginKind:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -214,6 +223,11 @@ func (_m *CreditRealizationLineage) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("currency=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Currency))
+	builder.WriteString(", ")
+	if v := _m.CustomCurrencyID; v != nil {
+		builder.WriteString("custom_currency_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("origin_kind=")
 	builder.WriteString(fmt.Sprintf("%v", _m.OriginKind))

--- a/openmeter/ent/db/creditrealizationlineage/creditrealizationlineage.go
+++ b/openmeter/ent/db/creditrealizationlineage/creditrealizationlineage.go
@@ -26,6 +26,8 @@ const (
 	FieldCustomerID = "customer_id"
 	// FieldCurrency holds the string denoting the currency field in the database.
 	FieldCurrency = "currency"
+	// FieldCustomCurrencyID holds the string denoting the custom_currency_id field in the database.
+	FieldCustomCurrencyID = "custom_currency_id"
 	// FieldOriginKind holds the string denoting the origin_kind field in the database.
 	FieldOriginKind = "origin_kind"
 	// FieldAdvanceFeatures holds the string denoting the advance_features field in the database.
@@ -62,6 +64,7 @@ var Columns = []string{
 	FieldRootRealizationID,
 	FieldCustomerID,
 	FieldCurrency,
+	FieldCustomCurrencyID,
 	FieldOriginKind,
 	FieldAdvanceFeatures,
 	FieldCreatedAt,
@@ -88,6 +91,8 @@ var (
 	CustomerIDValidator func(string) error
 	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	CurrencyValidator func(string) error
+	// CustomCurrencyIDValidator is a validator for the "custom_currency_id" field. It is called by the builders before save.
+	CustomCurrencyIDValidator func(string) error
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultID holds the default value on creation for the "id" field.
@@ -135,6 +140,11 @@ func ByCustomerID(opts ...sql.OrderTermOption) OrderOption {
 // ByCurrency orders the results by the currency field.
 func ByCurrency(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCurrency, opts...).ToFunc()
+}
+
+// ByCustomCurrencyID orders the results by the custom_currency_id field.
+func ByCustomCurrencyID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCustomCurrencyID, opts...).ToFunc()
 }
 
 // ByOriginKind orders the results by the origin_kind field.

--- a/openmeter/ent/db/creditrealizationlineage/where.go
+++ b/openmeter/ent/db/creditrealizationlineage/where.go
@@ -94,6 +94,11 @@ func Currency(v currencyx.Code) predicate.CreditRealizationLineage {
 	return predicate.CreditRealizationLineage(sql.FieldEQ(FieldCurrency, vc))
 }
 
+// CustomCurrencyID applies equality check predicate on the "custom_currency_id" field. It's identical to CustomCurrencyIDEQ.
+func CustomCurrencyID(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldEQ(FieldCustomCurrencyID, v))
+}
+
 // AdvanceFeatures applies equality check predicate on the "advance_features" field. It's identical to AdvanceFeaturesEQ.
 func AdvanceFeatures(v pq.StringArray) predicate.CreditRealizationLineage {
 	return predicate.CreditRealizationLineage(sql.FieldEQ(FieldAdvanceFeatures, v))
@@ -446,6 +451,81 @@ func CurrencyEqualFold(v currencyx.Code) predicate.CreditRealizationLineage {
 func CurrencyContainsFold(v currencyx.Code) predicate.CreditRealizationLineage {
 	vc := string(v)
 	return predicate.CreditRealizationLineage(sql.FieldContainsFold(FieldCurrency, vc))
+}
+
+// CustomCurrencyIDEQ applies the EQ predicate on the "custom_currency_id" field.
+func CustomCurrencyIDEQ(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldEQ(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDNEQ applies the NEQ predicate on the "custom_currency_id" field.
+func CustomCurrencyIDNEQ(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldNEQ(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDIn applies the In predicate on the "custom_currency_id" field.
+func CustomCurrencyIDIn(vs ...string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldIn(FieldCustomCurrencyID, vs...))
+}
+
+// CustomCurrencyIDNotIn applies the NotIn predicate on the "custom_currency_id" field.
+func CustomCurrencyIDNotIn(vs ...string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldNotIn(FieldCustomCurrencyID, vs...))
+}
+
+// CustomCurrencyIDGT applies the GT predicate on the "custom_currency_id" field.
+func CustomCurrencyIDGT(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldGT(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDGTE applies the GTE predicate on the "custom_currency_id" field.
+func CustomCurrencyIDGTE(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldGTE(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDLT applies the LT predicate on the "custom_currency_id" field.
+func CustomCurrencyIDLT(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldLT(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDLTE applies the LTE predicate on the "custom_currency_id" field.
+func CustomCurrencyIDLTE(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldLTE(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDContains applies the Contains predicate on the "custom_currency_id" field.
+func CustomCurrencyIDContains(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldContains(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDHasPrefix applies the HasPrefix predicate on the "custom_currency_id" field.
+func CustomCurrencyIDHasPrefix(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldHasPrefix(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDHasSuffix applies the HasSuffix predicate on the "custom_currency_id" field.
+func CustomCurrencyIDHasSuffix(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldHasSuffix(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDIsNil applies the IsNil predicate on the "custom_currency_id" field.
+func CustomCurrencyIDIsNil() predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldIsNull(FieldCustomCurrencyID))
+}
+
+// CustomCurrencyIDNotNil applies the NotNil predicate on the "custom_currency_id" field.
+func CustomCurrencyIDNotNil() predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldNotNull(FieldCustomCurrencyID))
+}
+
+// CustomCurrencyIDEqualFold applies the EqualFold predicate on the "custom_currency_id" field.
+func CustomCurrencyIDEqualFold(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldEqualFold(FieldCustomCurrencyID, v))
+}
+
+// CustomCurrencyIDContainsFold applies the ContainsFold predicate on the "custom_currency_id" field.
+func CustomCurrencyIDContainsFold(v string) predicate.CreditRealizationLineage {
+	return predicate.CreditRealizationLineage(sql.FieldContainsFold(FieldCustomCurrencyID, v))
 }
 
 // OriginKindEQ applies the EQ predicate on the "origin_kind" field.

--- a/openmeter/ent/db/creditrealizationlineage_create.go
+++ b/openmeter/ent/db/creditrealizationlineage_create.go
@@ -58,6 +58,20 @@ func (_c *CreditRealizationLineageCreate) SetCurrency(v currencyx.Code) *CreditR
 	return _c
 }
 
+// SetCustomCurrencyID sets the "custom_currency_id" field.
+func (_c *CreditRealizationLineageCreate) SetCustomCurrencyID(v string) *CreditRealizationLineageCreate {
+	_c.mutation.SetCustomCurrencyID(v)
+	return _c
+}
+
+// SetNillableCustomCurrencyID sets the "custom_currency_id" field if the given value is not nil.
+func (_c *CreditRealizationLineageCreate) SetNillableCustomCurrencyID(v *string) *CreditRealizationLineageCreate {
+	if v != nil {
+		_c.SetCustomCurrencyID(*v)
+	}
+	return _c
+}
+
 // SetOriginKind sets the "origin_kind" field.
 func (_c *CreditRealizationLineageCreate) SetOriginKind(v creditrealization.LineageOriginKind) *CreditRealizationLineageCreate {
 	_c.mutation.SetOriginKind(v)
@@ -205,6 +219,11 @@ func (_c *CreditRealizationLineageCreate) check() error {
 			return &ValidationError{Name: "currency", err: fmt.Errorf(`db: validator failed for field "CreditRealizationLineage.currency": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.CustomCurrencyID(); ok {
+		if err := creditrealizationlineage.CustomCurrencyIDValidator(v); err != nil {
+			return &ValidationError{Name: "custom_currency_id", err: fmt.Errorf(`db: validator failed for field "CreditRealizationLineage.custom_currency_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.OriginKind(); !ok {
 		return &ValidationError{Name: "origin_kind", err: errors.New(`db: missing required field "CreditRealizationLineage.origin_kind"`)}
 	}
@@ -270,6 +289,10 @@ func (_c *CreditRealizationLineageCreate) createSpec() (*CreditRealizationLineag
 	if value, ok := _c.mutation.Currency(); ok {
 		_spec.SetField(creditrealizationlineage.FieldCurrency, field.TypeString, value)
 		_node.Currency = value
+	}
+	if value, ok := _c.mutation.CustomCurrencyID(); ok {
+		_spec.SetField(creditrealizationlineage.FieldCustomCurrencyID, field.TypeString, value)
+		_node.CustomCurrencyID = &value
 	}
 	if value, ok := _c.mutation.OriginKind(); ok {
 		_spec.SetField(creditrealizationlineage.FieldOriginKind, field.TypeEnum, value)
@@ -399,6 +422,9 @@ func (u *CreditRealizationLineageUpsertOne) UpdateNewValues() *CreditRealization
 		}
 		if _, exists := u.create.mutation.Currency(); exists {
 			s.SetIgnore(creditrealizationlineage.FieldCurrency)
+		}
+		if _, exists := u.create.mutation.CustomCurrencyID(); exists {
+			s.SetIgnore(creditrealizationlineage.FieldCustomCurrencyID)
 		}
 		if _, exists := u.create.mutation.OriginKind(); exists {
 			s.SetIgnore(creditrealizationlineage.FieldOriginKind)
@@ -637,6 +663,9 @@ func (u *CreditRealizationLineageUpsertBulk) UpdateNewValues() *CreditRealizatio
 			}
 			if _, exists := b.mutation.Currency(); exists {
 				s.SetIgnore(creditrealizationlineage.FieldCurrency)
+			}
+			if _, exists := b.mutation.CustomCurrencyID(); exists {
+				s.SetIgnore(creditrealizationlineage.FieldCustomCurrencyID)
 			}
 			if _, exists := b.mutation.OriginKind(); exists {
 				s.SetIgnore(creditrealizationlineage.FieldOriginKind)

--- a/openmeter/ent/db/creditrealizationlineage_update.go
+++ b/openmeter/ent/db/creditrealizationlineage_update.go
@@ -116,6 +116,9 @@ func (_u *CreditRealizationLineageUpdate) sqlSave(ctx context.Context) (_node in
 			}
 		}
 	}
+	if _u.mutation.CustomCurrencyIDCleared() {
+		_spec.ClearField(creditrealizationlineage.FieldCustomCurrencyID, field.TypeString)
+	}
 	if _u.mutation.AdvanceFeaturesCleared() {
 		_spec.ClearField(creditrealizationlineage.FieldAdvanceFeatures, field.TypeOther)
 	}
@@ -301,6 +304,9 @@ func (_u *CreditRealizationLineageUpdateOne) sqlSave(ctx context.Context) (_node
 				ps[i](selector)
 			}
 		}
+	}
+	if _u.mutation.CustomCurrencyIDCleared() {
+		_spec.ClearField(creditrealizationlineage.FieldCustomCurrencyID, field.TypeString)
 	}
 	if _u.mutation.AdvanceFeaturesCleared() {
 		_spec.ClearField(creditrealizationlineage.FieldAdvanceFeatures, field.TypeOther)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3577,7 +3577,8 @@ var (
 		{Name: "namespace", Type: field.TypeString},
 		{Name: "root_realization_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
-		{Name: "currency", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(3)"}},
+		{Name: "currency", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(24)"}},
+		{Name: "custom_currency_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "origin_kind", Type: field.TypeEnum, Enums: []string{"real_credit", "advance"}},
 		{Name: "advance_features", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "text[]"}},
 		{Name: "created_at", Type: field.TypeTime},
@@ -3591,7 +3592,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "credit_realization_lineages_charges_credit_realization_lineages",
-				Columns:    []*schema.Column{CreditRealizationLineagesColumns[8]},
+				Columns:    []*schema.Column{CreditRealizationLineagesColumns[9]},
 				RefColumns: []*schema.Column{ChargesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3615,7 +3616,7 @@ var (
 			{
 				Name:    "creditrealizationlineage_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{CreditRealizationLineagesColumns[1], CreditRealizationLineagesColumns[8]},
+				Columns: []*schema.Column{CreditRealizationLineagesColumns[1], CreditRealizationLineagesColumns[9]},
 			},
 			{
 				Name:    "creditrealizationlineage_namespace_customer_id",

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -80073,6 +80073,7 @@ type CreditRealizationLineageMutation struct {
 	root_realization_id *string
 	customer_id         *string
 	currency            *currencyx.Code
+	custom_currency_id  *string
 	origin_kind         *creditrealization.LineageOriginKind
 	advance_features    *pq.StringArray
 	created_at          *time.Time
@@ -80371,6 +80372,55 @@ func (m *CreditRealizationLineageMutation) ResetCurrency() {
 	m.currency = nil
 }
 
+// SetCustomCurrencyID sets the "custom_currency_id" field.
+func (m *CreditRealizationLineageMutation) SetCustomCurrencyID(s string) {
+	m.custom_currency_id = &s
+}
+
+// CustomCurrencyID returns the value of the "custom_currency_id" field in the mutation.
+func (m *CreditRealizationLineageMutation) CustomCurrencyID() (r string, exists bool) {
+	v := m.custom_currency_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCustomCurrencyID returns the old "custom_currency_id" field's value of the CreditRealizationLineage entity.
+// If the CreditRealizationLineage object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CreditRealizationLineageMutation) OldCustomCurrencyID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCustomCurrencyID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCustomCurrencyID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCustomCurrencyID: %w", err)
+	}
+	return oldValue.CustomCurrencyID, nil
+}
+
+// ClearCustomCurrencyID clears the value of the "custom_currency_id" field.
+func (m *CreditRealizationLineageMutation) ClearCustomCurrencyID() {
+	m.custom_currency_id = nil
+	m.clearedFields[creditrealizationlineage.FieldCustomCurrencyID] = struct{}{}
+}
+
+// CustomCurrencyIDCleared returns if the "custom_currency_id" field was cleared in this mutation.
+func (m *CreditRealizationLineageMutation) CustomCurrencyIDCleared() bool {
+	_, ok := m.clearedFields[creditrealizationlineage.FieldCustomCurrencyID]
+	return ok
+}
+
+// ResetCustomCurrencyID resets all changes to the "custom_currency_id" field.
+func (m *CreditRealizationLineageMutation) ResetCustomCurrencyID() {
+	m.custom_currency_id = nil
+	delete(m.clearedFields, creditrealizationlineage.FieldCustomCurrencyID)
+}
+
 // SetOriginKind sets the "origin_kind" field.
 func (m *CreditRealizationLineageMutation) SetOriginKind(cok creditrealization.LineageOriginKind) {
 	m.origin_kind = &cok
@@ -80607,7 +80657,7 @@ func (m *CreditRealizationLineageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CreditRealizationLineageMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 9)
 	if m.namespace != nil {
 		fields = append(fields, creditrealizationlineage.FieldNamespace)
 	}
@@ -80622,6 +80672,9 @@ func (m *CreditRealizationLineageMutation) Fields() []string {
 	}
 	if m.currency != nil {
 		fields = append(fields, creditrealizationlineage.FieldCurrency)
+	}
+	if m.custom_currency_id != nil {
+		fields = append(fields, creditrealizationlineage.FieldCustomCurrencyID)
 	}
 	if m.origin_kind != nil {
 		fields = append(fields, creditrealizationlineage.FieldOriginKind)
@@ -80650,6 +80703,8 @@ func (m *CreditRealizationLineageMutation) Field(name string) (ent.Value, bool) 
 		return m.CustomerID()
 	case creditrealizationlineage.FieldCurrency:
 		return m.Currency()
+	case creditrealizationlineage.FieldCustomCurrencyID:
+		return m.CustomCurrencyID()
 	case creditrealizationlineage.FieldOriginKind:
 		return m.OriginKind()
 	case creditrealizationlineage.FieldAdvanceFeatures:
@@ -80675,6 +80730,8 @@ func (m *CreditRealizationLineageMutation) OldField(ctx context.Context, name st
 		return m.OldCustomerID(ctx)
 	case creditrealizationlineage.FieldCurrency:
 		return m.OldCurrency(ctx)
+	case creditrealizationlineage.FieldCustomCurrencyID:
+		return m.OldCustomCurrencyID(ctx)
 	case creditrealizationlineage.FieldOriginKind:
 		return m.OldOriginKind(ctx)
 	case creditrealizationlineage.FieldAdvanceFeatures:
@@ -80724,6 +80781,13 @@ func (m *CreditRealizationLineageMutation) SetField(name string, value ent.Value
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCurrency(v)
+		return nil
+	case creditrealizationlineage.FieldCustomCurrencyID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCustomCurrencyID(v)
 		return nil
 	case creditrealizationlineage.FieldOriginKind:
 		v, ok := value.(creditrealization.LineageOriginKind)
@@ -80776,6 +80840,9 @@ func (m *CreditRealizationLineageMutation) AddField(name string, value ent.Value
 // mutation.
 func (m *CreditRealizationLineageMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(creditrealizationlineage.FieldCustomCurrencyID) {
+		fields = append(fields, creditrealizationlineage.FieldCustomCurrencyID)
+	}
 	if m.FieldCleared(creditrealizationlineage.FieldAdvanceFeatures) {
 		fields = append(fields, creditrealizationlineage.FieldAdvanceFeatures)
 	}
@@ -80793,6 +80860,9 @@ func (m *CreditRealizationLineageMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *CreditRealizationLineageMutation) ClearField(name string) error {
 	switch name {
+	case creditrealizationlineage.FieldCustomCurrencyID:
+		m.ClearCustomCurrencyID()
+		return nil
 	case creditrealizationlineage.FieldAdvanceFeatures:
 		m.ClearAdvanceFeatures()
 		return nil
@@ -80818,6 +80888,9 @@ func (m *CreditRealizationLineageMutation) ResetField(name string) error {
 		return nil
 	case creditrealizationlineage.FieldCurrency:
 		m.ResetCurrency()
+		return nil
+	case creditrealizationlineage.FieldCustomCurrencyID:
+		m.ResetCustomCurrencyID()
 		return nil
 	case creditrealizationlineage.FieldOriginKind:
 		m.ResetOriginKind()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1903,8 +1903,12 @@ func init() {
 	creditrealizationlineageDescCurrency := creditrealizationlineageFields[3].Descriptor()
 	// creditrealizationlineage.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	creditrealizationlineage.CurrencyValidator = creditrealizationlineageDescCurrency.Validators[0].(func(string) error)
+	// creditrealizationlineageDescCustomCurrencyID is the schema descriptor for custom_currency_id field.
+	creditrealizationlineageDescCustomCurrencyID := creditrealizationlineageFields[4].Descriptor()
+	// creditrealizationlineage.CustomCurrencyIDValidator is a validator for the "custom_currency_id" field. It is called by the builders before save.
+	creditrealizationlineage.CustomCurrencyIDValidator = creditrealizationlineageDescCustomCurrencyID.Validators[0].(func(string) error)
 	// creditrealizationlineageDescCreatedAt is the schema descriptor for created_at field.
-	creditrealizationlineageDescCreatedAt := creditrealizationlineageFields[6].Descriptor()
+	creditrealizationlineageDescCreatedAt := creditrealizationlineageFields[7].Descriptor()
 	// creditrealizationlineage.DefaultCreatedAt holds the default value on creation for the created_at field.
 	creditrealizationlineage.DefaultCreatedAt = creditrealizationlineageDescCreatedAt.Default.(func() time.Time)
 	// creditrealizationlineageDescID is the schema descriptor for id field.

--- a/openmeter/ent/schema/creditrealizationlineage.go
+++ b/openmeter/ent/schema/creditrealizationlineage.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"time"
 
 	"entgo.io/ent"
@@ -57,8 +58,19 @@ func (CreditRealizationLineage) Fields() []ent.Field {
 			NotEmpty().
 			Immutable().
 			SchemaType(map[string]string{
-				dialect.Postgres: "varchar(3)",
+				dialect.Postgres: fmt.Sprintf("varchar(%d)", currencyx.CustomCurrencyCodeMaxLength),
 			}),
+		// custom_currency_id disambiguates managed custom currencies that reuse a
+		// display code (e.g. after one is soft-deleted). Nil for fiat currencies,
+		// whose code is globally unambiguous identity on its own.
+		field.String("custom_currency_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			NotEmpty().
+			Nillable().
+			Immutable(),
 		field.Enum("origin_kind").
 			GoType(creditrealization.LineageOriginKind("")).
 			Immutable(),

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -15,7 +15,6 @@ import (
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	ledgerbreakagerecorddb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerbreakagerecord"
-	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	ledgertransactiongroupdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransactiongroup"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
@@ -1150,7 +1149,7 @@ func (e *creditPurchaseHandlerTestEnv) requireAccountSourceSpendBucketAmounts(t 
 func (e *creditPurchaseHandlerTestEnv) requireTransactionGroupEntriesSourceCharge(t *testing.T, groupID string, sourceChargeID string) {
 	t.Helper()
 
-	entries := e.transactionGroupEntries(t, groupID)
+	entries := e.TransactionGroupEntries(t, groupID)
 	require.NotEmpty(t, entries)
 
 	expectedIdentityKey, _ := ledger.EntryIdentityParts{
@@ -1163,42 +1162,6 @@ func (e *creditPurchaseHandlerTestEnv) requireTransactionGroupEntriesSourceCharg
 		require.Nil(t, entry.SpendChargeID)
 		require.Equal(t, string(expectedIdentityKey), entry.IdentityKey)
 	}
-}
-
-func (e *creditPurchaseHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
-	t.Helper()
-
-	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
-		Where(
-			ledgertransactiondb.Namespace(e.Namespace),
-			ledgertransactiondb.GroupID(groupID),
-		).
-		Order(
-			ledgertransactiondb.ByCreatedAt(),
-			ledgertransactiondb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-	require.NotEmpty(t, ledgerTransactions)
-
-	transactionIDs := make([]string, 0, len(ledgerTransactions))
-	for _, transaction := range ledgerTransactions {
-		transactionIDs = append(transactionIDs, transaction.ID)
-	}
-
-	entries, err := e.DB.LedgerEntry.Query().
-		Where(
-			ledgerentrydb.Namespace(e.Namespace),
-			ledgerentrydb.TransactionIDIn(transactionIDs...),
-		).
-		Order(
-			ledgerentrydb.ByCreatedAt(),
-			ledgerentrydb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-
-	return entries
 }
 
 func sourceChargeBucketKey(sourceChargeID *string) string {

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -297,7 +297,7 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
 	}
 
-	costBasis, err := flatFeeInvoiceCostBasis(input.Charge)
+	costBasis, err := resolveInvoiceCostBasis(input.Charge)
 	if err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
 	}
@@ -364,7 +364,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
 	}
 
-	costBasis, err := flatFeeInvoiceCostBasis(input.Charge)
+	costBasis, err := resolveInvoiceCostBasis(input.Charge)
 	if err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
 	}
@@ -433,22 +433,3 @@ func validateSettlementMode(actual productcatalog.SettlementMode, allowed ...pro
 }
 
 var invoiceCostBasis = lo.ToPtr(alpacadecimal.NewFromInt(1))
-
-// flatFeeInvoiceCostBasis returns the cost-basis route the invoice payment
-// lifecycle must authorize and settle against. Fiat charges always settle at
-// par (cost basis 1). Custom-currency charges settle at the same persisted
-// rate the overage accrual already converted through: the fiat receivable
-// created by OnCustomCurrencyOverageAccrued lives on that rate's route, not
-// on the par route, so payment authorization/settlement must reference it
-// rather than re-resolving or recomputing a rate.
-func flatFeeInvoiceCostBasis(charge flatfee.Charge) (*alpacadecimal.Decimal, error) {
-	if !charge.Intent.GetCurrency().IsCustom() {
-		return invoiceCostBasis, nil
-	}
-
-	if charge.State.ResolvedCostBasis == nil {
-		return nil, fmt.Errorf("custom currency charge is missing a resolved cost basis")
-	}
-
-	return &charge.State.ResolvedCostBasis.CostBasis, nil
-}

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -288,9 +288,6 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 	}
 
 	intent := input.Charge.Intent
-	if intent.GetCurrency().IsCustom() {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", meta.ErrCustomCurrencyNotSupported)
-	}
 
 	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
 	if err != nil {
@@ -355,9 +352,6 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 	}
 
 	intent := input.Charge.Intent
-	if intent.GetCurrency().IsCustom() {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", meta.ErrCustomCurrencyNotSupported)
-	}
 
 	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
 	if err != nil {

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -8,14 +8,15 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/ledger/collector"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
 // flatFeeHandler maps charge lifecycle events to ledger transaction templates
@@ -156,13 +157,107 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 	}, nil
 }
 
+// OnCustomCurrencyOverageAccrued books uncovered custom-currency overage as a
+// credit purchase immediately consumed by the same charge: it purchases the
+// uncovered custom amount at the charge's persisted cost basis, consumes it
+// through the identical route so it never becomes spendable customer balance,
+// and converts the resulting custom-currency receivable into the
+// already-agreed, rounded fiat receivable the invoice will collect. This
+// keeps native amount, cost basis, and fiat provenance on the accrued leg
+// while the invoice and payment lifecycle stay entirely in fiat.
 func (h *flatFeeHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
 	if err := input.Validate(); err != nil {
 		return flatfee.OnCustomCurrencyOverageAccruedResult{}, err
 	}
 
-	// TODO[implement]: Book the fiat overage in the customer's outstanding account.
-	return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
+	fiatOverage, err := input.Charge.ConvertCustomCurrencyOverageToFiat(input.Run.Totals)
+	if err != nil {
+		return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+	}
+
+	costBasis, err := input.GetCostBasis()
+	if err != nil {
+		return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("get cost basis: %w", err)
+	}
+
+	intent := input.Charge.Intent
+	taxConfig := intent.GetTaxConfig()
+	customCurrency := input.CustomCurrency().Reference()
+	fiatCode := currencyx.Code(fiatOverage.Currency.GetFiatCode())
+	customAmount := input.GetCustomCurrencyAmountAccrued()
+
+	customerID := customer.CustomerID{
+		Namespace: input.Charge.Namespace,
+		ID:        intent.GetCustomerID(),
+	}
+	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
+	bookedAt := flatfee.UsageBookedAt(intent.GetEffectivePaymentTerm(), input.Run.ServicePeriod)
+
+	inputs, err := transactions.ResolveTransactions(
+		ctx,
+		h.deps,
+		transactions.ResolutionScope{
+			CustomerID: customerID,
+			Namespace:  input.Charge.Namespace,
+		},
+		// Purchase the uncovered custom amount at the charge's persisted cost basis.
+		transactions.IssueCustomerReceivableTemplate{
+			At:                bookedAt,
+			Amount:            customAmount,
+			Currency:          customCurrency,
+			CostBasisCurrency: &fiatCode,
+			CostBasis:         &costBasis,
+			SourceChargeID:    &input.Charge.ID,
+		},
+		// Immediately consume the purchase through the same charge, so it never
+		// becomes spendable customer balance.
+		transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
+			At:                bookedAt,
+			Amount:            customAmount,
+			Currency:          customCurrency,
+			TaxCode:           lo.ToPtr(taxConfig.TaxCodeID),
+			TaxBehavior:       (*ledger.TaxBehavior)(taxConfig.Behavior),
+			CostBasisCurrency: &fiatCode,
+			CostBasis:         &costBasis,
+			SourceChargeID:    &input.Charge.ID,
+			SpendChargeID:     &input.Charge.ID,
+		},
+		// Convert the purchase-backed custom receivable into the already-agreed,
+		// rounded fiat receivable the invoice will collect.
+		transactions.ConvertCurrencyTemplate{
+			At:             bookedAt,
+			SourceAmount:   fiatOverage.Amount,
+			TargetAmount:   customAmount,
+			CostBasis:      costBasis,
+			SourceCurrency: currencies.NewCurrencyReference(fiatCode),
+			TargetCurrency: customCurrency,
+		},
+	)
+	if err != nil {
+		return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("resolve transactions: %w", err)
+	}
+
+	for i, txInput := range inputs {
+		if txInput != nil {
+			inputs[i] = transactions.WithAnnotations(txInput, annotations)
+		}
+	}
+
+	transactionGroup, err := h.ledger.CommitGroup(ctx, transactions.GroupInputs(
+		input.Charge.Namespace,
+		annotations,
+		inputs...,
+	))
+	if err != nil {
+		return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("commit ledger transaction group: %w", err)
+	}
+
+	return flatfee.OnCustomCurrencyOverageAccruedResult{
+		TransactionGroup: ledgertransaction.GroupReference{
+			TransactionGroupID: transactionGroup.ID().ID,
+		},
+		TotalFiatAmount: fiatOverage.Amount,
+	}, nil
 }
 
 func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
@@ -197,11 +292,22 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", meta.ErrCustomCurrencyNotSupported)
 	}
 
+	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
+	}
+
+	costBasis, err := flatFeeInvoiceCostBasis(input.Charge)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
+	}
+
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
 		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
+	paymentIdentity := invoicePaymentIdentity(input.Charge.ID, intent.GetCurrency())
 
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
@@ -211,11 +317,12 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
-			At:            input.EventAt,
-			Amount:        input.FiatAmount,
-			Currency:      intent.GetCurrency().Reference(),
-			CostBasis:     invoiceCostBasis,
-			SpendChargeID: &input.Charge.ID,
+			At:             input.EventAt,
+			Amount:         input.FiatAmount,
+			Currency:       currencies.NewCurrencyReference(currencyx.Code(invoiceCurrency)),
+			CostBasis:      costBasis,
+			SourceChargeID: paymentIdentity.SourceChargeID,
+			SpendChargeID:  paymentIdentity.SpendChargeID,
 		},
 	)
 	if err != nil {
@@ -252,11 +359,22 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", meta.ErrCustomCurrencyNotSupported)
 	}
 
+	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
+	}
+
+	costBasis, err := flatFeeInvoiceCostBasis(input.Charge)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
+	}
+
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
 		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
+	paymentIdentity := invoicePaymentIdentity(input.Charge.ID, intent.GetCurrency())
 
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
@@ -266,11 +384,12 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
-			At:            input.EventAt,
-			Amount:        input.FiatAmount,
-			Currency:      intent.GetCurrency().Reference(),
-			CostBasis:     invoiceCostBasis,
-			SpendChargeID: &input.Charge.ID,
+			At:             input.EventAt,
+			Amount:         input.FiatAmount,
+			Currency:       currencies.NewCurrencyReference(currencyx.Code(invoiceCurrency)),
+			CostBasis:      costBasis,
+			SourceChargeID: paymentIdentity.SourceChargeID,
+			SpendChargeID:  paymentIdentity.SpendChargeID,
 		},
 	)
 	if err != nil {
@@ -314,3 +433,22 @@ func validateSettlementMode(actual productcatalog.SettlementMode, allowed ...pro
 }
 
 var invoiceCostBasis = lo.ToPtr(alpacadecimal.NewFromInt(1))
+
+// flatFeeInvoiceCostBasis returns the cost-basis route the invoice payment
+// lifecycle must authorize and settle against. Fiat charges always settle at
+// par (cost basis 1). Custom-currency charges settle at the same persisted
+// rate the overage accrual already converted through: the fiat receivable
+// created by OnCustomCurrencyOverageAccrued lives on that rate's route, not
+// on the par route, so payment authorization/settlement must reference it
+// rather than re-resolving or recomputing a rate.
+func flatFeeInvoiceCostBasis(charge flatfee.Charge) (*alpacadecimal.Decimal, error) {
+	if !charge.Intent.GetCurrency().IsCustom() {
+		return invoiceCostBasis, nil
+	}
+
+	if charge.State.ResolvedCostBasis == nil {
+		return nil, fmt.Errorf("custom currency charge is missing a resolved cost basis")
+	}
+
+	return &charge.State.ResolvedCostBasis.CostBasis, nil
+}

--- a/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
@@ -1,0 +1,416 @@
+package chargeadapter_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestOnFlatFeeCustomCurrencyOverageAccrued mirrors the usage-based boundary
+// as a credit-purchase-equivalent flow: 100 ACME rated, 60 ACME covered by
+// credits, 40 ACME uncovered overage is purchased at the persisted cost basis
+// (0.25 USD/ACME) and immediately consumed by the same charge, then the
+// resulting custom-currency receivable is converted once into a 10.00 USD
+// fiat receivable. No spendable custom-currency balance or open custom
+// receivable survives the accrual.
+func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
+	env := newFlatFeeHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	settlementCurrency := currencyx.Code("USD")
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+	run := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	})
+
+	result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    run,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.TransactionGroup.TransactionGroupID)
+	require.True(t, result.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(10)), "got %s", result.TotalFiatAmount)
+
+	// The purchase is immediately and fully consumed by the same charge: no
+	// spendable custom-currency FBO balance and no open custom receivable survive.
+	fboSubAccount := env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)
+	require.True(t, env.sumBalance(t, fboSubAccount).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+
+	// The consumed amount is accrued natively, preserving cost basis and fiat provenance.
+	accruedSubAccount := env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)
+	require.True(t, env.sumBalance(t, accruedSubAccount).Equal(alpacadecimal.NewFromInt(40)))
+
+	// The already-agreed, rounded fiat amount becomes the open invoice receivable.
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	// Brokerage carries the exact fiat and native legs of the conversion.
+	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForFlatFee(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(10)))
+	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForFlatFee(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-40)))
+
+	// The atomic group uses the same economic steps as a paid credit purchase,
+	// with the purchased credit consumed immediately before its receivable is
+	// converted into the invoice currency.
+	templateCodes := make([]string, 0, 3)
+	for _, txAnnotations := range env.transactionAnnotations(t, result.TransactionGroup.TransactionGroupID) {
+		require.Equal(t, charge.ID, txAnnotations[ledger.AnnotationChargeID], "transaction missing charge annotation: %v", txAnnotations)
+		templateCode, err := ledger.TransactionTemplateCodeFromAnnotations(txAnnotations)
+		require.NoError(t, err)
+		templateCodes = append(templateCodes, templateCode)
+	}
+	require.ElementsMatch(t, []string{
+		transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{}),
+		transactions.TemplateCode(transactions.TransferCustomerFBOAdvanceToAccruedTemplate{}),
+		transactions.TemplateCode(transactions.ConvertCurrencyTemplate{}),
+	}, templateCodes)
+
+	// Like a real credit purchase, issuance identifies only the credit source.
+	// Consumption adds the spend identity while preserving that source.
+	entries := env.transactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
+	fboEntries := env.entriesForSubAccount(entries, fboSubAccount)
+	require.Len(t, fboEntries, 2, "issue and immediate consumption must each post to the custom FBO route")
+	issueEntry := fboEntries[0]
+	consumeEntry := fboEntries[1]
+	if issueEntry.Amount.IsNegative() {
+		issueEntry, consumeEntry = consumeEntry, issueEntry
+	}
+	require.True(t, issueEntry.Amount.IsPositive())
+	require.NotNil(t, issueEntry.SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*issueEntry.SourceChargeID))
+	require.Nil(t, issueEntry.SpendChargeID)
+	require.True(t, consumeEntry.Amount.IsNegative())
+	require.NotNil(t, consumeEntry.SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SourceChargeID))
+	require.NotNil(t, consumeEntry.SpendChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SpendChargeID))
+
+	accruedEntries := env.entriesForSubAccount(entries, accruedSubAccount)
+	require.Len(t, accruedEntries, 1)
+	require.True(t, accruedEntries[0].Amount.Equal(alpacadecimal.NewFromInt(40)))
+	require.NotNil(t, accruedEntries[0].SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*accruedEntries[0].SourceChargeID))
+	require.NotNil(t, accruedEntries[0].SpendChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*accruedEntries[0].SpendChargeID))
+}
+
+// TestOnFlatFeeCustomCurrencyOverageAccrued_RejectsNonPositiveFiatOutcomes
+// mirrors the usage-based guarantee that neither a zero native overage nor an
+// overage that rounds to zero fiat ever produces a ledger transaction.
+func TestOnFlatFeeCustomCurrencyOverageAccrued_RejectsNonPositiveFiatOutcomes(t *testing.T) {
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+
+	t.Run("zero native overage", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+		charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.25))
+
+		result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+			Charge: charge,
+			Run:    env.newCustomOverageRun(totals.Totals{Amount: alpacadecimal.Zero, Total: alpacadecimal.Zero}),
+		})
+		require.Error(t, err)
+		require.Empty(t, result.TransactionGroup.TransactionGroupID)
+	})
+
+	t.Run("native overage rounds to zero fiat", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+		// 1 ACME at a 0.001 USD/ACME rate rounds to 0.00 USD at 2-decimal fiat
+		// precision: the native amount is positive, but there is nothing to book.
+		charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.001))
+
+		result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+			Charge: charge,
+			Run:    env.newCustomOverageRun(totals.Totals{Amount: alpacadecimal.NewFromInt(1), Total: alpacadecimal.NewFromInt(1)}),
+		})
+		require.Error(t, err)
+		require.Empty(t, result.TransactionGroup.TransactionGroupID)
+	})
+}
+
+// TestOnFlatFeeCustomCurrencyOverageAccrued_UsesPersistedCostBasis proves the
+// converted fiat amount is a pure function of the charge's persisted
+// ResolvedCostBasis snapshot, mirroring the usage-based guarantee.
+func TestOnFlatFeeCustomCurrencyOverageAccrued_UsesPersistedCostBasis(t *testing.T) {
+	env := newFlatFeeHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	overage := totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	}
+
+	historicalCharge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.25))
+	historicalResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+		Charge: historicalCharge,
+		Run:    env.newCustomOverageRun(overage),
+	})
+	require.NoError(t, err)
+	require.True(t, historicalResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(10)), "got %s", historicalResult.TotalFiatAmount)
+
+	// A later cost-basis change must not affect the amount computed from the
+	// already-persisted (historical) rate above.
+	laterRateCharge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.5))
+	laterResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+		Charge: laterRateCharge,
+		Run:    env.newCustomOverageRun(overage),
+	})
+	require.NoError(t, err)
+	require.True(t, laterResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(20)), "got %s", laterResult.TotalFiatAmount)
+	require.False(t, historicalResult.TotalFiatAmount.Equal(laterResult.TotalFiatAmount))
+}
+
+// TestOnFlatFeeCustomCurrencyPaymentLifecycle exercises accrual, authorization,
+// and settlement for the converted fiat overage, verifying the whole payment
+// lifecycle stays in the invoice fiat currency for a custom-currency charge,
+// using the charge's persisted cost basis rather than a fixed cost basis of 1.
+func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
+	env := newFlatFeeHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	settlementCurrency := currencyx.Code("USD")
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+	run := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	})
+
+	accrualResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), flatfee.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    run,
+	})
+	require.NoError(t, err)
+
+	fiatOverage := accrualResult.TotalFiatAmount
+
+	authorizeRef, err := env.handler.OnPaymentAuthorized(t.Context(), flatfee.OnPaymentAuthorizedInput{
+		Charge:     charge,
+		Run:        run,
+		EventAt:    env.Now(),
+		FiatAmount: fiatOverage,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, authorizeRef.TransactionGroupID)
+	for _, entry := range env.transactionGroupEntries(t, authorizeRef.TransactionGroupID) {
+		require.NotNil(t, entry.SourceChargeID)
+		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
+		require.Nil(t, entry.SpendChargeID)
+	}
+
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	settleRef, err := env.handler.OnPaymentSettled(t.Context(), flatfee.OnPaymentSettledInput{
+		Charge:     charge,
+		Run:        run,
+		EventAt:    env.Now(),
+		FiatAmount: fiatOverage,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, settleRef.TransactionGroupID)
+	for _, entry := range env.transactionGroupEntries(t, settleRef.TransactionGroupID) {
+		require.NotNil(t, entry.SourceChargeID)
+		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
+		require.Nil(t, entry.SpendChargeID)
+	}
+
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.WashSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	// Authorization and settlement never touch the custom-currency side: FBO
+	// stays empty, the custom receivable stays closed, and the purchased
+	// credit that was consumed at accrual time remains the only trace.
+	require.True(t, env.sumBalance(t, env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+}
+
+// newCustomCurrencyCreditThenInvoiceCharge builds a credit_then_invoice charge
+// with a manually resolved and persisted cost basis, the shape a real charge
+// has once its dynamic cost basis has been resolved and snapshotted.
+func (e *flatFeeHandlerTestEnv) newCustomCurrencyCreditThenInvoiceCharge(t *testing.T, customCurrencyValue currencies.Currency, costBasis alpacadecimal.Decimal) flatfee.Charge {
+	t.Helper()
+
+	usd, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: now.Add(-time.Hour),
+		To:   now,
+	}
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: usd,
+		Rate:         costBasis,
+	})
+
+	return flatfee.Charge{
+		ChargeBase: flatfee.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: e.Namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				ID: "flat-fee-charge-cc-cti",
+			},
+			Intent: flatfee.Intent{
+				Intent: meta.Intent{
+					ManagedBy:  billing.SystemManagedLine,
+					CustomerID: e.CustomerID.ID,
+					Currency:   customCurrencyValue,
+					TaxConfig: productcatalog.TaxCodeConfig{
+						TaxCodeID: testChargeTaxCodeID,
+					},
+				},
+				IntentMutableFields: flatfee.IntentMutableFields{
+					IntentMutableFields: meta.IntentMutableFields{
+						Name:              "Flat fee (custom currency, credit then invoice)",
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:             now,
+					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+					ProRating:             productcatalog.ProRatingConfig{},
+					AmountBeforeProration: alpacadecimal.NewFromInt(100),
+				},
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				CostBasis:      &costBasisIntent,
+			}.AsOverridableIntent(),
+			Status: flatfee.StatusActive,
+			State: flatfee.State{
+				AmountAfterProration: alpacadecimal.NewFromInt(100),
+				CostBasisID:          lo.ToPtr("cost-basis-1"),
+				ResolvedCostBasis: &costbasis.State{
+					CostBasis:  costBasis,
+					ResolvedAt: now,
+				},
+			},
+		},
+	}
+}
+
+// customFBOSubAccountForFlatFee is the spendable custom-currency FBO route a
+// purchase-backed overage issues into and then immediately consumes, at the
+// charge's known cost basis.
+func (e *flatFeeHandlerTestEnv) customFBOSubAccountForFlatFee(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
+		Currency:          customCurrency,
+		CostBasisCurrency: costBasisCurrency,
+		CostBasis:         &costBasis,
+		CreditPriority:    ledger.DefaultCustomerFBOPriority,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+// customOpenReceivableSubAccountForFlatFee is the open custom-currency
+// receivable route a purchase-backed overage issues into and then converts
+// away, at the charge's known cost basis.
+func (e *flatFeeHandlerTestEnv) customOpenReceivableSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.ReceivableAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerReceivableRouteParams{
+		Currency:                       customCurrency,
+		CostBasisCurrency:              costBasisCurrency,
+		CostBasis:                      &costBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *flatFeeHandlerTestEnv) customAccruedSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
+		Currency:          customCurrency,
+		CostBasisCurrency: costBasisCurrency,
+		TaxCode:           lo.ToPtr(testChargeTaxCodeID),
+		CostBasis:         costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *flatFeeHandlerTestEnv) fiatBrokerageSubAccountForFlatFee(t *testing.T, currency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
+		Currency:  currencies.NewCurrencyReference(currency),
+		CostBasis: &costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *flatFeeHandlerTestEnv) customBrokerageSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
+		Currency:          customCurrency,
+		CostBasisCurrency: &costBasisCurrency,
+		CostBasis:         &costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *flatFeeHandlerTestEnv) newCustomOverageRun(overageTotals totals.Totals) flatfee.RealizationRun {
+	now := time.Now().UTC()
+
+	return flatfee.RealizationRun{
+		RealizationRunBase: flatfee.RealizationRunBase{
+			ID: flatfee.RealizationRunID(models.NamespacedID{
+				Namespace: e.Namespace,
+				ID:        "run-1",
+			}),
+			ManagedModel: models.ManagedModel{
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			LineID:      lo.ToPtr("line-1"),
+			Type:        flatfee.RealizationRunTypeFinalRealization,
+			InitialType: flatfee.RealizationRunTypeFinalRealization,
+			ServicePeriod: timeutil.ClosedPeriod{
+				From: now.Add(-time.Hour),
+				To:   now,
+			},
+			AmountAfterProration: overageTotals.Amount,
+			Totals:               overageTotals,
+		},
+	}
+}

--- a/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
@@ -56,19 +56,19 @@ func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
 	// The purchase is immediately and fully consumed by the same charge: no
 	// spendable custom-currency FBO balance and no open custom receivable survive.
 	fboSubAccount := env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)
-	require.True(t, env.sumBalance(t, fboSubAccount).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.Equal(t, 0.0, env.sumBalance(t, fboSubAccount).InexactFloat64())
+	require.Equal(t, 0.0, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
 
 	// The consumed amount is accrued natively, preserving cost basis and fiat provenance.
 	accruedSubAccount := env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)
-	require.True(t, env.sumBalance(t, accruedSubAccount).Equal(alpacadecimal.NewFromInt(40)))
+	require.Equal(t, 40.0, env.sumBalance(t, accruedSubAccount).InexactFloat64())
 
 	// The already-agreed, rounded fiat amount becomes the open invoice receivable.
-	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+	require.Equal(t, -10.0, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).InexactFloat64())
 
 	// Brokerage carries the exact fiat and native legs of the conversion.
-	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForFlatFee(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(10)))
-	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForFlatFee(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-40)))
+	require.Equal(t, 10.0, env.sumBalance(t, env.fiatBrokerageSubAccountForFlatFee(t, settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, -40.0, env.sumBalance(t, env.customBrokerageSubAccountForFlatFee(t, customCurrencyIdentity, settlementCurrency, costBasis)).InexactFloat64())
 
 	// The atomic group uses the same economic steps as a paid credit purchase,
 	// with the purchased credit consumed immediately before its receivable is
@@ -220,8 +220,8 @@ func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 		require.Nil(t, entry.SpendChargeID)
 	}
 
-	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.NewFromInt(-10)))
+	require.Equal(t, 0.0, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).InexactFloat64())
+	require.Equal(t, -10.0, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).InexactFloat64())
 
 	settleRef, err := env.handler.OnPaymentSettled(t.Context(), flatfee.OnPaymentSettledInput{
 		Charge:     charge,
@@ -237,15 +237,15 @@ func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 		require.Nil(t, entry.SpendChargeID)
 	}
 
-	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.WashSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+	require.Equal(t, 0.0, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).InexactFloat64())
+	require.Equal(t, -10.0, env.sumBalance(t, env.WashSubAccountWithCostBasis(t, &costBasis)).InexactFloat64())
 
 	// Authorization and settlement never touch the custom-currency side: FBO
 	// stays empty, the custom receivable stays closed, and the purchased
 	// credit that was consumed at accrual time remains the only trace.
-	require.True(t, env.sumBalance(t, env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+	require.Equal(t, 0.0, env.sumBalance(t, env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 0.0, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 40.0, env.sumBalance(t, env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)).InexactFloat64())
 }
 
 // newCustomCurrencyCreditThenInvoiceCharge builds a credit_then_invoice charge

--- a/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_customcurrency_test.go
@@ -34,7 +34,6 @@ import (
 func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
 	env := newFlatFeeHandlerTestEnv(t)
 	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
-	customCurrency := customCurrencyValue.GetCode()
 	customCurrencyIdentity := customCurrencyValue.Reference()
 	settlementCurrency := currencyx.Code("USD")
 	costBasis := alpacadecimal.NewFromFloat(0.25)
@@ -55,20 +54,20 @@ func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
 
 	// The purchase is immediately and fully consumed by the same charge: no
 	// spendable custom-currency FBO balance and no open custom receivable survive.
-	fboSubAccount := env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)
+	fboSubAccount := env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)
 	require.Equal(t, 0.0, env.sumBalance(t, fboSubAccount).InexactFloat64())
-	require.Equal(t, 0.0, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 0.0, env.sumBalance(t, env.ReceivableSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
 
 	// The consumed amount is accrued natively, preserving cost basis and fiat provenance.
-	accruedSubAccount := env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)
+	accruedSubAccount := env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))
 	require.Equal(t, 40.0, env.sumBalance(t, accruedSubAccount).InexactFloat64())
 
 	// The already-agreed, rounded fiat amount becomes the open invoice receivable.
 	require.Equal(t, -10.0, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).InexactFloat64())
 
 	// Brokerage carries the exact fiat and native legs of the conversion.
-	require.Equal(t, 10.0, env.sumBalance(t, env.fiatBrokerageSubAccountForFlatFee(t, settlementCurrency, costBasis)).InexactFloat64())
-	require.Equal(t, -40.0, env.sumBalance(t, env.customBrokerageSubAccountForFlatFee(t, customCurrencyIdentity, settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 10.0, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, currencies.NewCurrencyReference(settlementCurrency), nil, costBasis)).InexactFloat64())
+	require.Equal(t, -40.0, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
 
 	// The atomic group uses the same economic steps as a paid credit purchase,
 	// with the purchased credit consumed immediately before its receivable is
@@ -88,8 +87,8 @@ func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
 
 	// Like a real credit purchase, issuance identifies only the credit source.
 	// Consumption adds the spend identity while preserving that source.
-	entries := env.transactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
-	fboEntries := env.entriesForSubAccount(entries, fboSubAccount)
+	entries := env.TransactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
+	fboEntries := env.EntriesForSubAccount(entries, fboSubAccount)
 	require.Len(t, fboEntries, 2, "issue and immediate consumption must each post to the custom FBO route")
 	issueEntry := fboEntries[0]
 	consumeEntry := fboEntries[1]
@@ -106,7 +105,7 @@ func TestOnFlatFeeCustomCurrencyOverageAccrued(t *testing.T) {
 	require.NotNil(t, consumeEntry.SpendChargeID)
 	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SpendChargeID))
 
-	accruedEntries := env.entriesForSubAccount(entries, accruedSubAccount)
+	accruedEntries := env.EntriesForSubAccount(entries, accruedSubAccount)
 	require.Len(t, accruedEntries, 1)
 	require.True(t, accruedEntries[0].Amount.Equal(alpacadecimal.NewFromInt(40)))
 	require.NotNil(t, accruedEntries[0].SourceChargeID)
@@ -187,7 +186,6 @@ func TestOnFlatFeeCustomCurrencyOverageAccrued_UsesPersistedCostBasis(t *testing
 func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 	env := newFlatFeeHandlerTestEnv(t)
 	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
-	customCurrency := customCurrencyValue.GetCode()
 	customCurrencyIdentity := customCurrencyValue.Reference()
 	settlementCurrency := currencyx.Code("USD")
 	costBasis := alpacadecimal.NewFromFloat(0.25)
@@ -214,7 +212,7 @@ func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, authorizeRef.TransactionGroupID)
-	for _, entry := range env.transactionGroupEntries(t, authorizeRef.TransactionGroupID) {
+	for _, entry := range env.TransactionGroupEntries(t, authorizeRef.TransactionGroupID) {
 		require.NotNil(t, entry.SourceChargeID)
 		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
 		require.Nil(t, entry.SpendChargeID)
@@ -231,7 +229,7 @@ func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, settleRef.TransactionGroupID)
-	for _, entry := range env.transactionGroupEntries(t, settleRef.TransactionGroupID) {
+	for _, entry := range env.TransactionGroupEntries(t, settleRef.TransactionGroupID) {
 		require.NotNil(t, entry.SourceChargeID)
 		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
 		require.Nil(t, entry.SpendChargeID)
@@ -243,9 +241,9 @@ func TestOnFlatFeeCustomCurrencyPaymentLifecycle(t *testing.T) {
 	// Authorization and settlement never touch the custom-currency side: FBO
 	// stays empty, the custom receivable stays closed, and the purchased
 	// credit that was consumed at accrual time remains the only trace.
-	require.Equal(t, 0.0, env.sumBalance(t, env.customFBOSubAccountForFlatFee(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
-	require.Equal(t, 0.0, env.sumBalance(t, env.customOpenReceivableSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
-	require.Equal(t, 40.0, env.sumBalance(t, env.customAccruedSubAccountForFlatFee(t, customCurrencyIdentity, &settlementCurrency, &costBasis)).InexactFloat64())
+	require.Equal(t, 0.0, env.sumBalance(t, env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 0.0, env.sumBalance(t, env.ReceivableSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).InexactFloat64())
+	require.Equal(t, 40.0, env.sumBalance(t, env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))).InexactFloat64())
 }
 
 // newCustomCurrencyCreditThenInvoiceCharge builds a credit_then_invoice charge
@@ -314,79 +312,6 @@ func (e *flatFeeHandlerTestEnv) newCustomCurrencyCreditThenInvoiceCharge(t *test
 			},
 		},
 	}
-}
-
-// customFBOSubAccountForFlatFee is the spendable custom-currency FBO route a
-// purchase-backed overage issues into and then immediately consumes, at the
-// charge's known cost basis.
-func (e *flatFeeHandlerTestEnv) customFBOSubAccountForFlatFee(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: costBasisCurrency,
-		CostBasis:         &costBasis,
-		CreditPriority:    ledger.DefaultCustomerFBOPriority,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-// customOpenReceivableSubAccountForFlatFee is the open custom-currency
-// receivable route a purchase-backed overage issues into and then converts
-// away, at the charge's known cost basis.
-func (e *flatFeeHandlerTestEnv) customOpenReceivableSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.ReceivableAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerReceivableRouteParams{
-		Currency:                       customCurrency,
-		CostBasisCurrency:              costBasisCurrency,
-		CostBasis:                      &costBasis,
-		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *flatFeeHandlerTestEnv) customAccruedSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: costBasisCurrency,
-		TaxCode:           lo.ToPtr(testChargeTaxCodeID),
-		CostBasis:         costBasis,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *flatFeeHandlerTestEnv) fiatBrokerageSubAccountForFlatFee(t *testing.T, currency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
-		Currency:  currencies.NewCurrencyReference(currency),
-		CostBasis: &costBasis,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *flatFeeHandlerTestEnv) customBrokerageSubAccountForFlatFee(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: &costBasisCurrency,
-		CostBasis:         &costBasis,
-	})
-	require.NoError(t, err)
-
-	return subAccount
 }
 
 func (e *flatFeeHandlerTestEnv) newCustomOverageRun(overageTotals totals.Totals) flatfee.RealizationRun {

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -1234,6 +1234,7 @@ func (e *flatFeeHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID st
 		).
 		All(t.Context())
 	require.NoError(t, err)
+	require.NotEmpty(t, entries)
 
 	return entries
 }

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
-	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
-	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	ledgertransactiongroupdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransactiongroup"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
@@ -528,7 +526,7 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
 			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
 		}
-		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+		for _, entry := range env.TransactionGroupEntries(t, ref.TransactionGroupID) {
 			require.Nil(t, entry.SourceChargeID)
 			require.NotNil(t, entry.SpendChargeID)
 			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
@@ -663,7 +661,7 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
 			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
 		}
-		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+		for _, entry := range env.TransactionGroupEntries(t, ref.TransactionGroupID) {
 			require.Nil(t, entry.SourceChargeID)
 			require.NotNil(t, entry.SpendChargeID)
 			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
@@ -1200,54 +1198,6 @@ func (e *flatFeeHandlerTestEnv) transactionGroupAnnotations(t *testing.T, groupI
 	require.NoError(t, err)
 
 	return group.Annotations
-}
-
-func (e *flatFeeHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
-	t.Helper()
-
-	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
-		Where(
-			ledgertransactiondb.Namespace(e.Namespace),
-			ledgertransactiondb.GroupID(groupID),
-		).
-		Order(
-			ledgertransactiondb.ByCreatedAt(),
-			ledgertransactiondb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-	require.NotEmpty(t, ledgerTransactions)
-
-	transactionIDs := make([]string, 0, len(ledgerTransactions))
-	for _, transaction := range ledgerTransactions {
-		transactionIDs = append(transactionIDs, transaction.ID)
-	}
-
-	entries, err := e.DB.LedgerEntry.Query().
-		Where(
-			ledgerentrydb.Namespace(e.Namespace),
-			ledgerentrydb.TransactionIDIn(transactionIDs...),
-		).
-		Order(
-			ledgerentrydb.ByCreatedAt(),
-			ledgerentrydb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-	require.NotEmpty(t, entries)
-
-	return entries
-}
-
-func (e *flatFeeHandlerTestEnv) entriesForSubAccount(entries []*entdb.LedgerEntry, subAccount ledger.SubAccount) []*entdb.LedgerEntry {
-	out := make([]*entdb.LedgerEntry, 0, len(entries))
-	for _, entry := range entries {
-		if entry.SubAccountID == subAccount.Address().SubAccountID() {
-			out = append(out, entry)
-		}
-	}
-
-	return out
 }
 
 func (e *flatFeeHandlerTestEnv) transactionBookedAtTimes(t *testing.T, groupID string) []time.Time {

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -1,6 +1,7 @@
 package chargeadapter_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	ledgertransactiongroupdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransactiongroup"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
@@ -525,6 +528,11 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
 			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
 		}
+		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+			require.Nil(t, entry.SourceChargeID)
+			require.NotNil(t, entry.SpendChargeID)
+			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
+		}
 	})
 
 	t.Run("credit_then_invoice mixed FBO and receivable only authorizes receivable", func(t *testing.T) {
@@ -654,6 +662,11 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
 			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
+		}
+		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+			require.Nil(t, entry.SourceChargeID)
+			require.NotNil(t, entry.SpendChargeID)
+			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
 		}
 	})
 
@@ -1189,6 +1202,53 @@ func (e *flatFeeHandlerTestEnv) transactionGroupAnnotations(t *testing.T, groupI
 	return group.Annotations
 }
 
+func (e *flatFeeHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
+	t.Helper()
+
+	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, ledgerTransactions)
+
+	transactionIDs := make([]string, 0, len(ledgerTransactions))
+	for _, transaction := range ledgerTransactions {
+		transactionIDs = append(transactionIDs, transaction.ID)
+	}
+
+	entries, err := e.DB.LedgerEntry.Query().
+		Where(
+			ledgerentrydb.Namespace(e.Namespace),
+			ledgerentrydb.TransactionIDIn(transactionIDs...),
+		).
+		Order(
+			ledgerentrydb.ByCreatedAt(),
+			ledgerentrydb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+
+	return entries
+}
+
+func (e *flatFeeHandlerTestEnv) entriesForSubAccount(entries []*entdb.LedgerEntry, subAccount ledger.SubAccount) []*entdb.LedgerEntry {
+	out := make([]*entdb.LedgerEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.SubAccountID == subAccount.Address().SubAccountID() {
+			out = append(out, entry)
+		}
+	}
+
+	return out
+}
+
 func (e *flatFeeHandlerTestEnv) transactionBookedAtTimes(t *testing.T, groupID string) []time.Time {
 	t.Helper()
 
@@ -1208,6 +1268,29 @@ func (e *flatFeeHandlerTestEnv) transactionBookedAtTimes(t *testing.T, groupID s
 	out := make([]time.Time, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.BookedAt)
+	}
+
+	return out
+}
+
+func (e *flatFeeHandlerTestEnv) transactionAnnotations(t *testing.T, groupID string) []models.Annotations {
+	t.Helper()
+
+	transactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+
+	out := make([]models.Annotations, 0, len(transactions))
+	for _, tx := range transactions {
+		out = append(out, tx.Annotations)
 	}
 
 	return out

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 )
@@ -32,4 +33,32 @@ func invoicePaymentIdentity(chargeID string, chargeCurrency currencies.Currency)
 	return ledger.EntryIdentityParts{
 		SpendChargeID: &chargeID,
 	}
+}
+
+// resolvedCostBasisCharge is satisfied by usagebased.Charge and flatfee.Charge:
+// both embed a ChargeBase exposing the charge's currency and persisted
+// dynamic cost-basis snapshot.
+type resolvedCostBasisCharge interface {
+	GetCurrency() currencies.Currency
+	GetResolvedCostBasis() *costbasis.State
+}
+
+// resolveInvoiceCostBasis returns the cost-basis route the invoice payment
+// lifecycle must authorize and settle against. Fiat charges always settle at
+// par (cost basis 1). Custom-currency charges settle at the same persisted
+// rate the overage accrual already converted through: the fiat receivable
+// created by OnCustomCurrencyOverageAccrued lives on that rate's route, not
+// on the par route, so payment authorization/settlement must reference it
+// rather than re-resolving or recomputing a rate.
+func resolveInvoiceCostBasis(charge resolvedCostBasisCharge) (*alpacadecimal.Decimal, error) {
+	if !charge.GetCurrency().IsCustom() {
+		return invoiceCostBasis, nil
+	}
+
+	resolved := charge.GetResolvedCostBasis()
+	if resolved == nil {
+		return nil, fmt.Errorf("custom currency charge is missing a resolved cost basis")
+	}
+
+	return &resolved.CostBasis, nil
 }

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 )
 
@@ -16,4 +17,19 @@ func settledBalanceForSubAccount(ctx context.Context, querier ledger.BalanceQuer
 	}
 
 	return balance, nil
+}
+
+// invoicePaymentIdentity keeps ordinary invoiced charges attributed as spend,
+// while custom-currency overage follows its credit-purchase invoice line and
+// attributes the fiat payment lifecycle to the synthetic credit source.
+func invoicePaymentIdentity(chargeID string, chargeCurrency currencies.Currency) ledger.EntryIdentityParts {
+	if chargeCurrency.IsCustom() {
+		return ledger.EntryIdentityParts{
+			SourceChargeID: &chargeID,
+		}
+	}
+
+	return ledger.EntryIdentityParts{
+		SpendChargeID: &chargeID,
+	}
 }

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -7,15 +7,16 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/ledger/collector"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
 // usageBasedHandler maps usage-based credit lifecycle events to ledger transaction templates.
@@ -116,13 +117,14 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
 	}
 
-	receivableReplenishment := alpacadecimal.Zero
-	if input.Run.InvoiceUsage != nil {
-		receivableReplenishment = input.Run.InvoiceUsage.Totals.Total
+	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
 	}
 
-	if receivableReplenishment.IsZero() {
-		return ledgertransaction.GroupReference{}, nil
+	costBasis, err := usageBasedInvoiceCostBasis(input.Charge)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
 	}
 
 	customerID := customer.CustomerID{
@@ -130,6 +132,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
+	paymentIdentity := invoicePaymentIdentity(input.Charge.ID, intent.GetCurrency())
 
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
@@ -139,11 +142,12 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
-			At:            input.EventAt,
-			Amount:        receivableReplenishment,
-			Currency:      intent.GetCurrency().Reference(),
-			CostBasis:     invoiceCostBasis,
-			SpendChargeID: &input.Charge.ID,
+			At:             input.EventAt,
+			Amount:         input.FiatAmount,
+			Currency:       currencies.NewCurrencyReference(currencyx.Code(invoiceCurrency)),
+			CostBasis:      costBasis,
+			SourceChargeID: paymentIdentity.SourceChargeID,
+			SpendChargeID:  paymentIdentity.SpendChargeID,
 		},
 	)
 	if err != nil {
@@ -170,13 +174,106 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 	}, nil
 }
 
+// OnCustomCurrencyOverageAccrued books uncovered custom-currency overage as a
+// credit purchase immediately consumed by the same charge: it purchases the
+// uncovered custom amount at the charge's persisted cost basis, consumes it
+// through the identical route so it never becomes spendable customer balance,
+// and converts the resulting custom-currency receivable into the
+// already-agreed, rounded fiat receivable the invoice will collect. This
+// keeps native amount, cost basis, and fiat provenance on the accrued leg
+// while the invoice and payment lifecycle stay entirely in fiat.
 func (h *usageBasedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
 	if err := input.Validate(); err != nil {
 		return usagebased.OnCustomCurrencyOverageAccruedResult{}, err
 	}
 
-	// TODO[implement]: Book the fiat overage in the customer's outstanding account.
-	return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
+	fiatOverage, err := input.Charge.ConvertCustomCurrencyOverageToFiat(input.Run.Totals)
+	if err != nil {
+		return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+	}
+
+	costBasis, err := input.GetCostBasis()
+	if err != nil {
+		return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("get cost basis: %w", err)
+	}
+
+	intent := input.Charge.Intent
+	taxConfig := intent.GetTaxConfig()
+	customCurrency := input.CustomCurrency().Reference()
+	fiatCode := currencyx.Code(fiatOverage.Currency.GetFiatCode())
+	customAmount := input.GetCustomCurrencyAmountAccrued()
+
+	customerID := customer.CustomerID{
+		Namespace: input.Charge.Namespace,
+		ID:        intent.GetCustomerID(),
+	}
+	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
+
+	inputs, err := transactions.ResolveTransactions(
+		ctx,
+		h.deps,
+		transactions.ResolutionScope{
+			CustomerID: customerID,
+			Namespace:  input.Charge.Namespace,
+		},
+		// Purchase the uncovered custom amount at the charge's persisted cost basis.
+		transactions.IssueCustomerReceivableTemplate{
+			At:                input.Run.ServicePeriodTo,
+			Amount:            customAmount,
+			Currency:          customCurrency,
+			CostBasisCurrency: &fiatCode,
+			CostBasis:         &costBasis,
+			SourceChargeID:    &input.Charge.ID,
+		},
+		// Immediately consume the purchase through the same charge, so it never
+		// becomes spendable customer balance.
+		transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
+			At:                input.Run.ServicePeriodTo,
+			Amount:            customAmount,
+			Currency:          customCurrency,
+			TaxCode:           lo.ToPtr(taxConfig.TaxCodeID),
+			TaxBehavior:       (*ledger.TaxBehavior)(taxConfig.Behavior),
+			CostBasisCurrency: &fiatCode,
+			CostBasis:         &costBasis,
+			SourceChargeID:    &input.Charge.ID,
+			SpendChargeID:     &input.Charge.ID,
+		},
+		// Convert the purchase-backed custom receivable into the already-agreed,
+		// rounded fiat receivable the invoice will collect.
+		transactions.ConvertCurrencyTemplate{
+			At:             input.Run.ServicePeriodTo,
+			SourceAmount:   fiatOverage.Amount,
+			TargetAmount:   customAmount,
+			CostBasis:      costBasis,
+			SourceCurrency: currencies.NewCurrencyReference(fiatCode),
+			TargetCurrency: customCurrency,
+		},
+	)
+	if err != nil {
+		return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("resolve transactions: %w", err)
+	}
+
+	for i, txInput := range inputs {
+		if txInput != nil {
+			inputs[i] = transactions.WithAnnotations(txInput, annotations)
+		}
+	}
+
+	transactionGroup, err := h.ledger.CommitGroup(ctx, transactions.GroupInputs(
+		input.Charge.Namespace,
+		annotations,
+		inputs...,
+	))
+	if err != nil {
+		return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("commit ledger transaction group: %w", err)
+	}
+
+	return usagebased.OnCustomCurrencyOverageAccruedResult{
+		TransactionGroup: ledgertransaction.GroupReference{
+			TransactionGroupID: transactionGroup.ID().ID,
+		},
+		TotalFiatAmount: fiatOverage.Amount,
+	}, nil
 }
 
 func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
@@ -196,8 +293,14 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
 	}
 
-	if input.Run.InvoiceUsage == nil || !input.Run.InvoiceUsage.Totals.Total.IsPositive() {
-		return ledgertransaction.GroupReference{}, nil
+	invoiceCurrency, err := input.Charge.GetInvoiceCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
+	}
+
+	costBasis, err := usageBasedInvoiceCostBasis(input.Charge)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
 	}
 
 	customerID := customer.CustomerID{
@@ -205,6 +308,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
+	paymentIdentity := invoicePaymentIdentity(input.Charge.ID, intent.GetCurrency())
 
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
@@ -214,11 +318,12 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
-			At:            input.EventAt,
-			Amount:        input.Run.InvoiceUsage.Totals.Total,
-			Currency:      intent.GetCurrency().Reference(),
-			CostBasis:     invoiceCostBasis,
-			SpendChargeID: &input.Charge.ID,
+			At:             input.EventAt,
+			Amount:         input.FiatAmount,
+			Currency:       currencies.NewCurrencyReference(currencyx.Code(invoiceCurrency)),
+			CostBasis:      costBasis,
+			SourceChargeID: paymentIdentity.SourceChargeID,
+			SpendChargeID:  paymentIdentity.SpendChargeID,
 		},
 	)
 	if err != nil {
@@ -316,4 +421,23 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Cont
 		Corrections:                  input.Corrections,
 		LineageSegmentsByRealization: input.LineageSegmentsByRealization,
 	})
+}
+
+// usageBasedInvoiceCostBasis returns the cost-basis route the invoice payment
+// lifecycle must authorize and settle against. Fiat charges always settle at
+// par (cost basis 1). Custom-currency charges settle at the same persisted
+// rate the overage accrual already converted through: the fiat receivable
+// created by OnCustomCurrencyOverageAccrued lives on that rate's route, not
+// on the par route, so payment authorization/settlement must reference it
+// rather than re-resolving or recomputing a rate.
+func usageBasedInvoiceCostBasis(charge usagebased.Charge) (*alpacadecimal.Decimal, error) {
+	if !charge.Intent.GetCurrency().IsCustom() {
+		return invoiceCostBasis, nil
+	}
+
+	if charge.State.ResolvedCostBasis == nil {
+		return nil, fmt.Errorf("custom currency charge is missing a resolved cost basis")
+	}
+
+	return &charge.State.ResolvedCostBasis.CostBasis, nil
 }

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -122,7 +121,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
 	}
 
-	costBasis, err := usageBasedInvoiceCostBasis(input.Charge)
+	costBasis, err := resolveInvoiceCostBasis(input.Charge)
 	if err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
 	}
@@ -298,7 +297,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 		return ledgertransaction.GroupReference{}, fmt.Errorf("get invoice currency: %w", err)
 	}
 
-	costBasis, err := usageBasedInvoiceCostBasis(input.Charge)
+	costBasis, err := resolveInvoiceCostBasis(input.Charge)
 	if err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
 	}
@@ -421,23 +420,4 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Cont
 		Corrections:                  input.Corrections,
 		LineageSegmentsByRealization: input.LineageSegmentsByRealization,
 	})
-}
-
-// usageBasedInvoiceCostBasis returns the cost-basis route the invoice payment
-// lifecycle must authorize and settle against. Fiat charges always settle at
-// par (cost basis 1). Custom-currency charges settle at the same persisted
-// rate the overage accrual already converted through: the fiat receivable
-// created by OnCustomCurrencyOverageAccrued lives on that rate's route, not
-// on the par route, so payment authorization/settlement must reference it
-// rather than re-resolving or recomputing a rate.
-func usageBasedInvoiceCostBasis(charge usagebased.Charge) (*alpacadecimal.Decimal, error) {
-	if !charge.Intent.GetCurrency().IsCustom() {
-		return invoiceCostBasis, nil
-	}
-
-	if charge.State.ResolvedCostBasis == nil {
-		return nil, fmt.Errorf("custom currency charge is missing a resolved cost basis")
-	}
-
-	return &charge.State.ResolvedCostBasis.CostBasis, nil
 }

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -105,9 +105,6 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 	}
 
 	intent := input.Charge.Intent
-	if intent.GetCurrency().IsCustom() {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", meta.ErrCustomCurrencyNotSupported)
-	}
 
 	if err := validateSettlementMode(
 		intent.GetSettlementMode(),
@@ -281,9 +278,6 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 	}
 
 	intent := input.Charge.Intent
-	if intent.GetCurrency().IsCustom() {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", meta.ErrCustomCurrencyNotSupported)
-	}
 
 	if err := validateSettlementMode(
 		intent.GetSettlementMode(),

--- a/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
@@ -1,16 +1,23 @@
 package chargeadapter_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	chargeusagebased "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -20,6 +27,299 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+// TestOnUsageBasedCustomCurrencyOverageAccrued exercises the credit_then_invoice
+// boundary as a credit-purchase-equivalent flow, per the product decision that
+// custom-currency overage "happen[s] exactly like a creditpurchase": 100 ACME
+// rated, 60 ACME covered by credits, 40 ACME uncovered overage is purchased at
+// the persisted cost basis (0.25 USD/ACME) and immediately consumed by the
+// same charge, then the resulting custom-currency receivable is converted
+// once into a 10.00 USD fiat receivable. No spendable custom-currency balance
+// or open custom receivable survives the accrual.
+func TestOnUsageBasedCustomCurrencyOverageAccrued(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	settlementCurrency := currencyx.Code("USD")
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+	run := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	})
+
+	result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    run,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.TransactionGroup.TransactionGroupID)
+	require.True(t, result.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(10)), "got %s", result.TotalFiatAmount)
+
+	// The purchase is immediately and fully consumed by the same charge: no
+	// spendable custom-currency FBO balance and no open custom receivable survive.
+	fboSubAccount := env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)
+	require.True(t, env.sumBalance(t, fboSubAccount).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+
+	// The consumed amount is accrued natively, preserving cost basis and fiat provenance.
+	accruedSubAccount := env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)
+	require.True(t, env.sumBalance(t, accruedSubAccount).Equal(alpacadecimal.NewFromInt(40)))
+
+	// The already-agreed, rounded fiat amount becomes the open invoice receivable.
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	// Brokerage carries the exact fiat and native legs of the conversion.
+	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForUsageBased(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(10)))
+	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForUsageBased(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-40)))
+
+	// The atomic group uses the same economic steps as a paid credit purchase,
+	// with the purchased credit consumed immediately before its receivable is
+	// converted into the invoice currency.
+	templateCodes := make([]string, 0, 3)
+	for _, txAnnotations := range env.transactionAnnotations(t, result.TransactionGroup.TransactionGroupID) {
+		require.Equal(t, charge.ID, txAnnotations[ledger.AnnotationChargeID], "transaction missing charge annotation: %v", txAnnotations)
+		templateCode, err := ledger.TransactionTemplateCodeFromAnnotations(txAnnotations)
+		require.NoError(t, err)
+		templateCodes = append(templateCodes, templateCode)
+	}
+	require.ElementsMatch(t, []string{
+		transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{}),
+		transactions.TemplateCode(transactions.TransferCustomerFBOAdvanceToAccruedTemplate{}),
+		transactions.TemplateCode(transactions.ConvertCurrencyTemplate{}),
+	}, templateCodes)
+
+	// Like a real credit purchase, issuance identifies only the credit source.
+	// Consumption adds the spend identity while preserving that source.
+	entries := env.transactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
+	fboEntries := env.entriesForSubAccount(entries, fboSubAccount)
+	require.Len(t, fboEntries, 2, "issue and immediate consumption must each post to the custom FBO route")
+	issueEntry := fboEntries[0]
+	consumeEntry := fboEntries[1]
+	if issueEntry.Amount.IsNegative() {
+		issueEntry, consumeEntry = consumeEntry, issueEntry
+	}
+	require.True(t, issueEntry.Amount.IsPositive())
+	require.NotNil(t, issueEntry.SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*issueEntry.SourceChargeID))
+	require.Nil(t, issueEntry.SpendChargeID)
+	require.True(t, consumeEntry.Amount.IsNegative())
+	require.NotNil(t, consumeEntry.SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SourceChargeID))
+	require.NotNil(t, consumeEntry.SpendChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SpendChargeID))
+
+	accruedEntries := env.entriesForSubAccount(entries, accruedSubAccount)
+	require.Len(t, accruedEntries, 1)
+	require.True(t, accruedEntries[0].Amount.Equal(alpacadecimal.NewFromInt(40)))
+	require.NotNil(t, accruedEntries[0].SourceChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*accruedEntries[0].SourceChargeID))
+	require.NotNil(t, accruedEntries[0].SpendChargeID)
+	require.Equal(t, charge.ID, strings.TrimSpace(*accruedEntries[0].SpendChargeID))
+}
+
+// TestOnUsageBasedCustomCurrencyOverageAccrued_RejectsNonPositiveFiatOutcomes
+// proves neither a zero native overage nor an overage that rounds to zero
+// fiat ever produces a ledger transaction: both fail before any transaction
+// group is committed, matching the pre-existing no-op contract the run-level
+// caller (BookAccruedInvoiceUsage) already relies on when it skips calling
+// this handler for a zero invoice line total.
+func TestOnUsageBasedCustomCurrencyOverageAccrued_RejectsNonPositiveFiatOutcomes(t *testing.T) {
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+
+	t.Run("zero native overage", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+		charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.25))
+
+		result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+			Charge: charge,
+			Run: env.newCustomOverageRun(totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(60),
+				CreditsTotal: alpacadecimal.NewFromInt(60),
+				Total:        alpacadecimal.Zero,
+			}),
+		})
+		require.Error(t, err)
+		require.Empty(t, result.TransactionGroup.TransactionGroupID)
+	})
+
+	t.Run("native overage rounds to zero fiat", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+		// 1 ACME at a 0.001 USD/ACME rate rounds to 0.00 USD at 2-decimal fiat
+		// precision: the native amount is positive, but there is nothing to book.
+		charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.001))
+
+		result, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+			Charge: charge,
+			Run: env.newCustomOverageRun(totals.Totals{
+				Amount: alpacadecimal.NewFromInt(1),
+				Total:  alpacadecimal.NewFromInt(1),
+			}),
+		})
+		require.Error(t, err)
+		require.Empty(t, result.TransactionGroup.TransactionGroupID)
+	})
+}
+
+// TestOnUsageBasedCustomCurrencyOverageAccrued_UsesPersistedCostBasis proves the
+// converted fiat amount is a pure function of the charge's persisted
+// ResolvedCostBasis snapshot: two charges with the same custom-currency
+// overage but different persisted rates produce different fiat amounts, and
+// neither call re-resolves a "current" rate.
+func TestOnUsageBasedCustomCurrencyOverageAccrued_UsesPersistedCostBasis(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	overage := totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	}
+
+	historicalCharge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.25))
+	historicalResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: historicalCharge,
+		Run:    env.newCustomOverageRun(overage),
+	})
+	require.NoError(t, err)
+	require.True(t, historicalResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(10)), "got %s", historicalResult.TotalFiatAmount)
+
+	// A later cost-basis change must not affect the amount computed from the
+	// already-persisted (historical) rate above.
+	laterRateCharge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, alpacadecimal.NewFromFloat(0.5))
+	laterResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: laterRateCharge,
+		Run:    env.newCustomOverageRun(overage),
+	})
+	require.NoError(t, err)
+	require.True(t, laterResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(20)), "got %s", laterResult.TotalFiatAmount)
+	require.False(t, historicalResult.TotalFiatAmount.Equal(laterResult.TotalFiatAmount))
+}
+
+// TestOnUsageBasedCustomCurrencyOverageAccrued_ProgressiveRuns proves that two
+// sequential overage runs against the same persisted cost basis (progressive
+// billing) each purchase, consume, and convert only their own newly uncovered
+// increment, accumulating without double rounding or double booking. This
+// also demonstrates route stability: a later run against the same charge and
+// persisted cost basis lands on the exact same purchase route.
+func TestOnUsageBasedCustomCurrencyOverageAccrued_ProgressiveRuns(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	settlementCurrency := currencyx.Code("USD")
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+
+	firstRun := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	})
+	firstResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    firstRun,
+	})
+	require.NoError(t, err)
+	require.True(t, firstResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(10)), "got %s", firstResult.TotalFiatAmount)
+
+	// Second run represents only the incremental delta accrued afterwards.
+	secondRun := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(20),
+		CreditsTotal: alpacadecimal.Zero,
+		Total:        alpacadecimal.NewFromInt(20),
+	})
+	secondResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    secondRun,
+	})
+	require.NoError(t, err)
+	require.True(t, secondResult.TotalFiatAmount.Equal(alpacadecimal.NewFromFloat(5)), "got %s", secondResult.TotalFiatAmount)
+	require.NotEqual(t, firstResult.TransactionGroup.TransactionGroupID, secondResult.TransactionGroup.TransactionGroupID)
+
+	// Both runs purchase-and-consume on the same route: FBO and the open custom
+	// receivable stay at zero cumulatively, never accumulating spendable credit.
+	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(60)))
+
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-15)))
+	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForUsageBased(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(15)))
+	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForUsageBased(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-60)))
+}
+
+// TestOnUsageBasedCustomCurrencyPaymentLifecycle exercises accrual, authorization,
+// and settlement for the converted fiat overage, verifying the whole payment
+// lifecycle stays in the invoice fiat currency for a custom-currency charge,
+// using the charge's persisted cost basis rather than a fixed cost basis of 1.
+func TestOnUsageBasedCustomCurrencyPaymentLifecycle(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	settlementCurrency := currencyx.Code("USD")
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+	run := env.newCustomOverageRun(totals.Totals{
+		Amount:       alpacadecimal.NewFromInt(100),
+		CreditsTotal: alpacadecimal.NewFromInt(60),
+		Total:        alpacadecimal.NewFromInt(40),
+	})
+
+	accrualResult, err := env.handler.OnCustomCurrencyOverageAccrued(t.Context(), chargeusagebased.OnCustomCurrencyOverageAccruedInput{
+		Charge: charge,
+		Run:    run,
+	})
+	require.NoError(t, err)
+
+	fiatOverage := accrualResult.TotalFiatAmount
+	run.LineID = lo.ToPtr("line-1")
+
+	authorizeRef, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
+		Charge:     charge,
+		Run:        run,
+		EventAt:    env.Now(),
+		FiatAmount: fiatOverage,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, authorizeRef.TransactionGroupID)
+	for _, entry := range env.transactionGroupEntries(t, authorizeRef.TransactionGroupID) {
+		require.NotNil(t, entry.SourceChargeID)
+		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
+		require.Nil(t, entry.SpendChargeID)
+	}
+
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	settleRef, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
+		Charge:     charge,
+		Run:        run,
+		EventAt:    env.Now(),
+		FiatAmount: fiatOverage,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, settleRef.TransactionGroupID)
+	for _, entry := range env.transactionGroupEntries(t, settleRef.TransactionGroupID) {
+		require.NotNil(t, entry.SourceChargeID)
+		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
+		require.Nil(t, entry.SpendChargeID)
+	}
+
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasisAndStatus(t, &costBasis, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.WashSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
+
+	// Authorization and settlement never touch the custom-currency side: FBO
+	// stays empty, the custom receivable stays closed, and the purchased
+	// credit that was consumed at accrual time remains the only trace.
+	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+
+	// No custom-currency receivable or payment exposure is ever created for the overage.
+	require.True(t, env.sumBalance(t, env.customReceivableSubAccountForUsageBasedFeature(t, customCurrencyValue.GetCode(), customCurrencyValue.Reference(), "api_requests")).Equal(alpacadecimal.Zero))
+}
 
 // TestOnUsageBasedCreditsOnlyUsageAccrued_CustomCurrency exercises credit_only
 // usage collection in a custom currency through the real collector: first
@@ -118,6 +418,157 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection_CustomCurrency(t *testing
 	require.True(t, env.sumBalance(t, env.customUnknownAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity)).Equal(alpacadecimal.Zero))
 }
 
+// TestOnUsageBasedCreditThenInvoiceCreditAllocationCorrection_CustomCurrency
+// proves that correcting a credit_then_invoice charge's native credit
+// allocation stays entirely in the custom currency: the correction never
+// touches the fiat overage side (accrual, receivable, or payment routes),
+// matching the domain rule that only the uncovered overage - never the
+// credit allocation itself - crosses the fiat boundary.
+func TestOnUsageBasedCreditThenInvoiceCreditAllocationCorrection_CustomCurrency(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	settlementCurrency := currencyx.Code("USD")
+	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	customCurrency := customCurrencyValue.GetCode()
+	customCurrencyIdentity := customCurrencyValue.Reference()
+	costBasis := alpacadecimal.NewFromFloat(0.25)
+	charge := env.newCustomCurrencyCreditThenInvoiceCharge(t, customCurrencyValue, costBasis)
+
+	// credit_then_invoice only allocates from already-funded credit; unlike
+	// credit_only it never advances an uncovered amount into an unknown bucket.
+	env.fundCustomFBO(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis, alpacadecimal.NewFromInt(60))
+
+	run := env.newRun()
+	allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
+		Charge:           charge,
+		Run:              run,
+		BookedAt:         env.Now(),
+		AmountToAllocate: alpacadecimal.NewFromInt(60),
+	})
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.True(t, allocations[0].Amount.Equal(alpacadecimal.NewFromInt(60)))
+
+	run.CreditsAllocated = env.realizationsFromAllocations(allocations)
+
+	correctionsRequest, err := run.CreditsAllocated.CreateCorrectionRequest(alpacadecimal.NewFromInt(-20), customCurrencyValue)
+	require.NoError(t, err)
+
+	corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
+		Charge:      charge,
+		Run:         run,
+		BookedAt:    env.Now(),
+		Corrections: correctionsRequest,
+	})
+	require.NoError(t, err)
+	require.Len(t, corrections, 1)
+	require.True(t, corrections[0].Amount.Equal(alpacadecimal.NewFromInt(-20)))
+
+	// The correction only moves 20 ACME back into FBO out of the custom-currency
+	// accrued bucket; it never creates or touches a fiat receivable/accrued/payment route.
+	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(20)))
+	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+	require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
+}
+
+// TestCreateInitialLineages_CustomCurrency proves that credit realization
+// lineage tracking - the advance/backfill/earnings-recognized provenance used
+// by both credit_only and credit_then_invoice credit allocation - is currency
+// agnostic and works for a custom currency the same way it does for fiat, and
+// that two managed custom currencies sharing a display code (e.g. after one
+// is soft-deleted and the code reused) never contaminate each other's
+// lineage: loading and backfilling are scoped by managed currency ID, not
+// code alone.
+func TestCreateInitialLineages_CustomCurrency(t *testing.T) {
+	env := newUsageBasedHandlerTestEnv(t)
+	firstCurrency := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	secondCurrency := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+	require.Equal(t, firstCurrency.GetCode(), secondCurrency.GetCode())
+	require.NotEqual(t, firstCurrency.ID, secondCurrency.ID)
+
+	firstChargeID := ulid.Make().String()
+	secondChargeID := ulid.Make().String()
+	env.ensureCharge(t, firstChargeID)
+	env.ensureCharge(t, secondChargeID)
+
+	firstRealizationID := env.createAdvanceLineage(t, firstChargeID, firstCurrency, alpacadecimal.NewFromInt(30))
+	secondRealizationID := env.createAdvanceLineage(t, secondChargeID, secondCurrency, alpacadecimal.NewFromInt(50))
+
+	firstLineages, err := env.lineage.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{
+		Namespace:  env.Namespace,
+		CustomerID: env.CustomerID.ID,
+		Currency:   firstCurrency.Reference(),
+	})
+	require.NoError(t, err)
+	require.Len(t, firstLineages, 1)
+	require.True(t, firstLineages[0].Currency.Equal(firstCurrency.Reference()))
+	require.Equal(t, firstChargeID, firstLineages[0].ChargeID)
+
+	secondLineages, err := env.lineage.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{
+		Namespace:  env.Namespace,
+		CustomerID: env.CustomerID.ID,
+		Currency:   secondCurrency.Reference(),
+	})
+	require.NoError(t, err)
+	require.Len(t, secondLineages, 1)
+	require.True(t, secondLineages[0].Currency.Equal(secondCurrency.Reference()))
+	require.Equal(t, secondChargeID, secondLineages[0].ChargeID)
+
+	// Backfilling the first managed currency's uncovered advance must not touch
+	// the second managed currency's lineage, even though both share "ACME".
+	err = env.lineage.BackfillAdvanceLineageSegments(t.Context(), lineage.BackfillAdvanceLineageSegmentsInput{
+		Namespace:                 env.Namespace,
+		CustomerID:                env.CustomerID.ID,
+		Currency:                  firstCurrency,
+		Amount:                    alpacadecimal.NewFromInt(30),
+		BackingTransactionGroupID: ulid.Make().String(),
+	})
+	require.NoError(t, err)
+
+	firstSegments, err := env.lineage.LoadActiveSegmentsByRealizationID(t.Context(), env.Namespace, []string{firstRealizationID})
+	require.NoError(t, err)
+	require.Len(t, firstSegments[firstRealizationID], 1)
+	require.Equal(t, creditrealization.LineageSegmentStateAdvanceBackfilled, firstSegments[firstRealizationID][0].State)
+
+	secondSegments, err := env.lineage.LoadActiveSegmentsByRealizationID(t.Context(), env.Namespace, []string{secondRealizationID})
+	require.NoError(t, err)
+	require.Len(t, secondSegments[secondRealizationID], 1)
+	require.Equal(t, creditrealization.LineageSegmentStateAdvanceUncovered, secondSegments[secondRealizationID][0].State,
+		"backfilling the first managed currency must not touch the second managed currency's lineage")
+}
+
+func (e *usageBasedHandlerTestEnv) createAdvanceLineage(t *testing.T, chargeID string, currency currencies.Currency, amount alpacadecimal.Decimal) string {
+	t.Helper()
+
+	now := time.Now().UTC()
+	realizationID := ulid.Make().String()
+	realizations := creditrealization.Realizations{
+		{
+			NamespacedModel: models.NamespacedModel{Namespace: e.Namespace},
+			ManagedModel:    models.ManagedModel{CreatedAt: now, UpdatedAt: now},
+			CreateInput: creditrealization.CreateInput{
+				ID:                realizationID,
+				Annotations:       creditrealization.LineageAnnotations(creditrealization.LineageOriginKindAdvance),
+				ServicePeriod:     timeutil.ClosedPeriod{From: now.Add(-time.Hour), To: now},
+				LedgerTransaction: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+				Amount:            amount,
+				Type:              creditrealization.TypeAllocation,
+			},
+		},
+	}
+
+	err := e.lineage.CreateInitialLineages(t.Context(), lineage.CreateInitialLineagesInput{
+		Namespace:    e.Namespace,
+		ChargeID:     chargeID,
+		CustomerID:   e.CustomerID.ID,
+		Currency:     currency,
+		Realizations: realizations,
+	})
+	require.NoError(t, err)
+
+	return realizationID
+}
+
 func (e *usageBasedHandlerTestEnv) newCustomCurrencyCreditsOnlyCharge(t *testing.T, customCurrencyValue currencies.Currency) chargeusagebased.Charge {
 	t.Helper()
 
@@ -168,6 +619,80 @@ func (e *usageBasedHandlerTestEnv) newCustomCurrencyCreditsOnlyCharge(t *testing
 			},
 		},
 	}
+}
+
+// newCustomCurrencyCreditThenInvoiceCharge builds a credit_then_invoice charge
+// with a manually resolved and persisted cost basis, the shape a real charge
+// has once ResolveDynamicCostBasis has run and snapshotted a rate.
+func (e *usageBasedHandlerTestEnv) newCustomCurrencyCreditThenInvoiceCharge(t *testing.T, customCurrencyValue currencies.Currency, costBasis alpacadecimal.Decimal) chargeusagebased.Charge {
+	t.Helper()
+
+	usd, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	featureID := "feature-api-requests"
+	servicePeriod := timeutil.ClosedPeriod{
+		From: now.Add(-time.Hour),
+		To:   now,
+	}
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: usd,
+		Rate:         costBasis,
+	})
+
+	return chargeusagebased.Charge{
+		ChargeBase: chargeusagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: e.Namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				ID: "usage-based-charge-cc-cti",
+			},
+			Intent: chargeusagebased.Intent{
+				Intent: meta.Intent{
+					ManagedBy:  billing.SystemManagedLine,
+					CustomerID: e.CustomerID.ID,
+					Currency:   customCurrencyValue,
+					TaxConfig: productcatalog.TaxCodeConfig{
+						TaxCodeID: testChargeTaxCodeID,
+					},
+				},
+				IntentMutableFields: chargeusagebased.IntentMutableFields{
+					IntentMutableFields: meta.IntentMutableFields{
+						Name:          "Usage based (custom currency, credit then invoice)",
+						ServicePeriod: servicePeriod,
+						BillingPeriod: servicePeriod,
+					},
+					InvoiceAt: now,
+					Price:     *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				},
+				FeatureKey:     "api_requests",
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				CostBasis:      &costBasisIntent,
+			}.AsOverridableIntent(),
+			Status: chargeusagebased.StatusActiveRealizationProcessing,
+			State: chargeusagebased.State{
+				FeatureID:    featureID,
+				RatingEngine: chargeusagebased.RatingEngineDelta,
+				CostBasisID:  lo.ToPtr("cost-basis-1"),
+				ResolvedCostBasis: &costbasis.State{
+					CostBasis:  costBasis,
+					ResolvedAt: now,
+				},
+			},
+		},
+	}
+}
+
+func (e *usageBasedHandlerTestEnv) newCustomOverageRun(overageTotals totals.Totals) chargeusagebased.RealizationRun {
+	run := e.newRun()
+	run.Totals = overageTotals
+	return run
 }
 
 // fundCustomFBO books a known-cost-basis, fiat-sourced custom currency FBO
@@ -257,6 +782,51 @@ func (e *usageBasedHandlerTestEnv) customReceivableSubAccountForUsageBasedFeatur
 		CostBasis:                      nil,
 		Features:                       []string{featureKey},
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+// customOpenReceivableSubAccountForUsageBased is the open custom-currency
+// receivable route a purchase-backed overage issues into and then converts
+// away, at the charge's known cost basis. Unlike
+// customReceivableSubAccountForUsageBasedFeature (credit_only's unknown-cost-
+// basis, feature-scoped advance route), overage purchases are not partitioned
+// by feature.
+func (e *usageBasedHandlerTestEnv) customOpenReceivableSubAccountForUsageBased(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.ReceivableAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerReceivableRouteParams{
+		Currency:                       customCurrency,
+		CostBasisCurrency:              costBasisCurrency,
+		CostBasis:                      &costBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *usageBasedHandlerTestEnv) fiatBrokerageSubAccountForUsageBased(t *testing.T, currency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
+		Currency:  currencies.NewCurrencyReference(currency),
+		CostBasis: &costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+func (e *usageBasedHandlerTestEnv) customBrokerageSubAccountForUsageBased(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
+		Currency:          customCurrency,
+		CostBasisCurrency: &costBasisCurrency,
+		CostBasis:         &costBasis,
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
@@ -39,7 +39,6 @@ import (
 func TestOnUsageBasedCustomCurrencyOverageAccrued(t *testing.T) {
 	env := newUsageBasedHandlerTestEnv(t)
 	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
-	customCurrency := customCurrencyValue.GetCode()
 	customCurrencyIdentity := customCurrencyValue.Reference()
 	settlementCurrency := currencyx.Code("USD")
 	costBasis := alpacadecimal.NewFromFloat(0.25)
@@ -60,20 +59,20 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued(t *testing.T) {
 
 	// The purchase is immediately and fully consumed by the same charge: no
 	// spendable custom-currency FBO balance and no open custom receivable survive.
-	fboSubAccount := env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)
+	fboSubAccount := env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)
 	require.True(t, env.sumBalance(t, fboSubAccount).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
 
 	// The consumed amount is accrued natively, preserving cost basis and fiat provenance.
-	accruedSubAccount := env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)
+	accruedSubAccount := env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))
 	require.True(t, env.sumBalance(t, accruedSubAccount).Equal(alpacadecimal.NewFromInt(40)))
 
 	// The already-agreed, rounded fiat amount becomes the open invoice receivable.
 	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-10)))
 
 	// Brokerage carries the exact fiat and native legs of the conversion.
-	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForUsageBased(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(10)))
-	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForUsageBased(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-40)))
+	require.True(t, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, currencies.NewCurrencyReference(settlementCurrency), nil, costBasis)).Equal(alpacadecimal.NewFromInt(10)))
+	require.True(t, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-40)))
 
 	// The atomic group uses the same economic steps as a paid credit purchase,
 	// with the purchased credit consumed immediately before its receivable is
@@ -93,8 +92,8 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued(t *testing.T) {
 
 	// Like a real credit purchase, issuance identifies only the credit source.
 	// Consumption adds the spend identity while preserving that source.
-	entries := env.transactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
-	fboEntries := env.entriesForSubAccount(entries, fboSubAccount)
+	entries := env.TransactionGroupEntries(t, result.TransactionGroup.TransactionGroupID)
+	fboEntries := env.EntriesForSubAccount(entries, fboSubAccount)
 	require.Len(t, fboEntries, 2, "issue and immediate consumption must each post to the custom FBO route")
 	issueEntry := fboEntries[0]
 	consumeEntry := fboEntries[1]
@@ -111,7 +110,7 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued(t *testing.T) {
 	require.NotNil(t, consumeEntry.SpendChargeID)
 	require.Equal(t, charge.ID, strings.TrimSpace(*consumeEntry.SpendChargeID))
 
-	accruedEntries := env.entriesForSubAccount(entries, accruedSubAccount)
+	accruedEntries := env.EntriesForSubAccount(entries, accruedSubAccount)
 	require.Len(t, accruedEntries, 1)
 	require.True(t, accruedEntries[0].Amount.Equal(alpacadecimal.NewFromInt(40)))
 	require.NotNil(t, accruedEntries[0].SourceChargeID)
@@ -206,7 +205,6 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued_UsesPersistedCostBasis(t *test
 func TestOnUsageBasedCustomCurrencyOverageAccrued_ProgressiveRuns(t *testing.T) {
 	env := newUsageBasedHandlerTestEnv(t)
 	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
-	customCurrency := customCurrencyValue.GetCode()
 	customCurrencyIdentity := customCurrencyValue.Reference()
 	settlementCurrency := currencyx.Code("USD")
 	costBasis := alpacadecimal.NewFromFloat(0.25)
@@ -240,13 +238,13 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued_ProgressiveRuns(t *testing.T) 
 
 	// Both runs purchase-and-consume on the same route: FBO and the open custom
 	// receivable stay at zero cumulatively, never accumulating spendable credit.
-	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(60)))
+	require.True(t, env.sumBalance(t, env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))).Equal(alpacadecimal.NewFromInt(60)))
 
 	require.True(t, env.sumBalance(t, env.ReceivableSubAccountWithCostBasis(t, &costBasis)).Equal(alpacadecimal.NewFromInt(-15)))
-	require.True(t, env.sumBalance(t, env.fiatBrokerageSubAccountForUsageBased(t, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(15)))
-	require.True(t, env.sumBalance(t, env.customBrokerageSubAccountForUsageBased(t, customCurrencyIdentity, settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-60)))
+	require.True(t, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, currencies.NewCurrencyReference(settlementCurrency), nil, costBasis)).Equal(alpacadecimal.NewFromInt(15)))
+	require.True(t, env.sumBalance(t, env.BrokerageSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(-60)))
 }
 
 // TestOnUsageBasedCustomCurrencyPaymentLifecycle exercises accrual, authorization,
@@ -256,7 +254,6 @@ func TestOnUsageBasedCustomCurrencyOverageAccrued_ProgressiveRuns(t *testing.T) 
 func TestOnUsageBasedCustomCurrencyPaymentLifecycle(t *testing.T) {
 	env := newUsageBasedHandlerTestEnv(t)
 	customCurrencyValue := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
-	customCurrency := customCurrencyValue.GetCode()
 	customCurrencyIdentity := customCurrencyValue.Reference()
 	settlementCurrency := currencyx.Code("USD")
 	costBasis := alpacadecimal.NewFromFloat(0.25)
@@ -284,7 +281,7 @@ func TestOnUsageBasedCustomCurrencyPaymentLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, authorizeRef.TransactionGroupID)
-	for _, entry := range env.transactionGroupEntries(t, authorizeRef.TransactionGroupID) {
+	for _, entry := range env.TransactionGroupEntries(t, authorizeRef.TransactionGroupID) {
 		require.NotNil(t, entry.SourceChargeID)
 		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
 		require.Nil(t, entry.SpendChargeID)
@@ -301,7 +298,7 @@ func TestOnUsageBasedCustomCurrencyPaymentLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, settleRef.TransactionGroupID)
-	for _, entry := range env.transactionGroupEntries(t, settleRef.TransactionGroupID) {
+	for _, entry := range env.TransactionGroupEntries(t, settleRef.TransactionGroupID) {
 		require.NotNil(t, entry.SourceChargeID)
 		require.Equal(t, charge.ID, strings.TrimSpace(*entry.SourceChargeID))
 		require.Nil(t, entry.SpendChargeID)
@@ -313,9 +310,9 @@ func TestOnUsageBasedCustomCurrencyPaymentLifecycle(t *testing.T) {
 	// Authorization and settlement never touch the custom-currency side: FBO
 	// stays empty, the custom receivable stays closed, and the purchased
 	// credit that was consumed at accrual time remains the only trace.
-	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customOpenReceivableSubAccountForUsageBased(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+	require.True(t, env.sumBalance(t, env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.ReceivableSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))).Equal(alpacadecimal.NewFromInt(40)))
 
 	// No custom-currency receivable or payment exposure is ever created for the overage.
 	require.True(t, env.sumBalance(t, env.customReceivableSubAccountForUsageBasedFeature(t, customCurrencyValue.GetCode(), customCurrencyValue.Reference(), "api_requests")).Equal(alpacadecimal.Zero))
@@ -348,8 +345,8 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued_CustomCurrency(t *testing.T) {
 		require.Len(t, realizations, 1)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(30)))
 
-		require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
-		require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(30)))
+		require.True(t, env.sumBalance(t, env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))).Equal(alpacadecimal.NewFromInt(30)))
 	})
 
 	t.Run("credit_only advances an uncovered custom currency amount", func(t *testing.T) {
@@ -465,8 +462,8 @@ func TestOnUsageBasedCreditThenInvoiceCreditAllocationCorrection_CustomCurrency(
 
 	// The correction only moves 20 ACME back into FBO out of the custom-currency
 	// accrued bucket; it never creates or touches a fiat receivable/accrued/payment route.
-	require.True(t, env.sumBalance(t, env.customFBOSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(20)))
-	require.True(t, env.sumBalance(t, env.customAccruedSubAccountForUsageBased(t, customCurrency, customCurrencyIdentity, &settlementCurrency, &costBasis)).Equal(alpacadecimal.NewFromInt(40)))
+	require.True(t, env.sumBalance(t, env.FBOSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, costBasis)).Equal(alpacadecimal.NewFromInt(20)))
+	require.True(t, env.sumBalance(t, env.AccruedSubAccountForCurrency(t, customCurrencyIdentity, &settlementCurrency, &costBasis, lo.ToPtr(testChargeTaxCodeID))).Equal(alpacadecimal.NewFromInt(40)))
 	require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
 	require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 }
@@ -728,38 +725,10 @@ func (e *usageBasedHandlerTestEnv) fundCustomFBO(t *testing.T, currency currency
 	require.NoError(t, err)
 }
 
-func (e *usageBasedHandlerTestEnv) customFBOSubAccountForUsageBased(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: costBasisCurrency,
-		CostBasis:         &costBasis,
-		CreditPriority:    ledger.DefaultCustomerFBOPriority,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *usageBasedHandlerTestEnv) customAccruedSubAccountForUsageBased(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: costBasisCurrency,
-		TaxCode:           lo.ToPtr(testChargeTaxCodeID),
-		CostBasis:         costBasis,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
 func (e *usageBasedHandlerTestEnv) customUnknownAccruedSubAccountForUsageBased(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference) ledger.SubAccount {
 	t.Helper()
 
-	return e.customAccruedSubAccountForUsageBased(t, currency, customCurrency, nil, nil)
+	return e.AccruedSubAccountForCurrency(t, customCurrency, nil, nil, lo.ToPtr(testChargeTaxCodeID))
 }
 
 func (e *usageBasedHandlerTestEnv) customUnknownFboSubAccountForUsageBased(t *testing.T, currency currencyx.Code, customCurrency currencies.CurrencyReference) ledger.SubAccount {
@@ -782,51 +751,6 @@ func (e *usageBasedHandlerTestEnv) customReceivableSubAccountForUsageBasedFeatur
 		CostBasis:                      nil,
 		Features:                       []string{featureKey},
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-// customOpenReceivableSubAccountForUsageBased is the open custom-currency
-// receivable route a purchase-backed overage issues into and then converts
-// away, at the charge's known cost basis. Unlike
-// customReceivableSubAccountForUsageBasedFeature (credit_only's unknown-cost-
-// basis, feature-scoped advance route), overage purchases are not partitioned
-// by feature.
-func (e *usageBasedHandlerTestEnv) customOpenReceivableSubAccountForUsageBased(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.CustomerAccounts.ReceivableAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerReceivableRouteParams{
-		Currency:                       customCurrency,
-		CostBasisCurrency:              costBasisCurrency,
-		CostBasis:                      &costBasis,
-		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *usageBasedHandlerTestEnv) fiatBrokerageSubAccountForUsageBased(t *testing.T, currency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
-		Currency:  currencies.NewCurrencyReference(currency),
-		CostBasis: &costBasis,
-	})
-	require.NoError(t, err)
-
-	return subAccount
-}
-
-func (e *usageBasedHandlerTestEnv) customBrokerageSubAccountForUsageBased(t *testing.T, customCurrency currencies.CurrencyReference, costBasisCurrency currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
-	t.Helper()
-
-	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
-		Currency:          customCurrency,
-		CostBasisCurrency: &costBasisCurrency,
-		CostBasis:         &costBasis,
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -1,6 +1,7 @@
 package chargeadapter_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +22,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -439,6 +442,11 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
 			requireLedgerBookedAtNotEqual(t, charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
+		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+			require.Nil(t, entry.SourceChargeID)
+			require.NotNil(t, entry.SpendChargeID)
+			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
+		}
 	})
 
 	t.Run("zero fiat amount is rejected", func(t *testing.T) {
@@ -518,6 +526,11 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
 			requireLedgerBookedAtNotEqual(t, settledCharge.Intent.GetEffectiveInvoiceAt(), bookedAt)
+		}
+		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+			require.Nil(t, entry.SourceChargeID)
+			require.NotNil(t, entry.SpendChargeID)
+			require.Equal(t, settledCharge.ID, strings.TrimSpace(*entry.SpendChargeID))
 		}
 	})
 
@@ -885,6 +898,53 @@ func (e *usageBasedHandlerTestEnv) transactionAnnotations(t *testing.T, groupID 
 	out := make([]models.Annotations, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.Annotations)
+	}
+
+	return out
+}
+
+func (e *usageBasedHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
+	t.Helper()
+
+	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, ledgerTransactions)
+
+	transactionIDs := make([]string, 0, len(ledgerTransactions))
+	for _, transaction := range ledgerTransactions {
+		transactionIDs = append(transactionIDs, transaction.ID)
+	}
+
+	entries, err := e.DB.LedgerEntry.Query().
+		Where(
+			ledgerentrydb.Namespace(e.Namespace),
+			ledgerentrydb.TransactionIDIn(transactionIDs...),
+		).
+		Order(
+			ledgerentrydb.ByCreatedAt(),
+			ledgerentrydb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+
+	return entries
+}
+
+func (e *usageBasedHandlerTestEnv) entriesForSubAccount(entries []*entdb.LedgerEntry, subAccount ledger.SubAccount) []*entdb.LedgerEntry {
+	out := make([]*entdb.LedgerEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.SubAccountID == subAccount.Address().SubAccountID() {
+			out = append(out, entry)
+		}
 	}
 
 	return out

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
-	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
-	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -442,7 +440,7 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
 			requireLedgerBookedAtNotEqual(t, charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
-		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+		for _, entry := range env.TransactionGroupEntries(t, ref.TransactionGroupID) {
 			require.Nil(t, entry.SourceChargeID)
 			require.NotNil(t, entry.SpendChargeID)
 			require.Equal(t, charge.ID, strings.TrimSpace(*entry.SpendChargeID))
@@ -527,7 +525,7 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
 			requireLedgerBookedAtNotEqual(t, settledCharge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
-		for _, entry := range env.transactionGroupEntries(t, ref.TransactionGroupID) {
+		for _, entry := range env.TransactionGroupEntries(t, ref.TransactionGroupID) {
 			require.Nil(t, entry.SourceChargeID)
 			require.NotNil(t, entry.SpendChargeID)
 			require.Equal(t, settledCharge.ID, strings.TrimSpace(*entry.SpendChargeID))
@@ -898,54 +896,6 @@ func (e *usageBasedHandlerTestEnv) transactionAnnotations(t *testing.T, groupID 
 	out := make([]models.Annotations, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.Annotations)
-	}
-
-	return out
-}
-
-func (e *usageBasedHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
-	t.Helper()
-
-	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
-		Where(
-			ledgertransactiondb.Namespace(e.Namespace),
-			ledgertransactiondb.GroupID(groupID),
-		).
-		Order(
-			ledgertransactiondb.ByCreatedAt(),
-			ledgertransactiondb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-	require.NotEmpty(t, ledgerTransactions)
-
-	transactionIDs := make([]string, 0, len(ledgerTransactions))
-	for _, transaction := range ledgerTransactions {
-		transactionIDs = append(transactionIDs, transaction.ID)
-	}
-
-	entries, err := e.DB.LedgerEntry.Query().
-		Where(
-			ledgerentrydb.Namespace(e.Namespace),
-			ledgerentrydb.TransactionIDIn(transactionIDs...),
-		).
-		Order(
-			ledgerentrydb.ByCreatedAt(),
-			ledgerentrydb.ByID(),
-		).
-		All(t.Context())
-	require.NoError(t, err)
-	require.NotEmpty(t, entries)
-
-	return entries
-}
-
-func (e *usageBasedHandlerTestEnv) entriesForSubAccount(entries []*entdb.LedgerEntry, subAccount ledger.SubAccount) []*entdb.LedgerEntry {
-	out := make([]*entdb.LedgerEntry, 0, len(entries))
-	for _, entry := range entries {
-		if entry.SubAccountID == subAccount.Address().SubAccountID() {
-			out = append(out, entry)
-		}
 	}
 
 	return out

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -935,6 +935,7 @@ func (e *usageBasedHandlerTestEnv) transactionGroupEntries(t *testing.T, groupID
 		).
 		All(t.Context())
 	require.NoError(t, err)
+	require.NotEmpty(t, entries)
 
 	return entries
 }

--- a/openmeter/ledger/recognizer/recognize.go
+++ b/openmeter/ledger/recognizer/recognize.go
@@ -38,7 +38,7 @@ func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInp
 		lineages, err := s.lnge.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{
 			Namespace:  in.CustomerID.Namespace,
 			CustomerID: in.CustomerID.ID,
-			Currency:   in.Currency.GetCode(),
+			Currency:   in.Currency.Reference(),
 		})
 		if err != nil {
 			return RecognizeEarningsResult{}, fmt.Errorf("load lineages: %w", err)

--- a/openmeter/ledger/recognizer/service_test.go
+++ b/openmeter/ledger/recognizer/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
@@ -214,7 +215,7 @@ func TestRecognizeEarnings_DeterministicAllocationAndSegmentTransition(t *testin
 	lineages, err := env.lineage.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{
 		Namespace:  env.Namespace,
 		CustomerID: env.CustomerID.ID,
-		Currency:   env.Currency,
+		Currency:   currencies.NewCurrencyReference(env.Currency),
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ledger/testutils/integration.go
+++ b/openmeter/ledger/testutils/integration.go
@@ -13,6 +13,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
+	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	omtestutils "github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -257,4 +259,122 @@ func (e *IntegrationEnv) SumBalance(t *testing.T, subAccount ledger.SubAccount) 
 	require.NoError(t, err)
 
 	return sum
+}
+
+// TransactionGroupEntries returns every ledger entry posted by the
+// transactions in a committed group, ordered by creation.
+func (e *IntegrationEnv) TransactionGroupEntries(t *testing.T, groupID string) []*entdb.LedgerEntry {
+	t.Helper()
+
+	ledgerTransactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, ledgerTransactions)
+
+	transactionIDs := make([]string, 0, len(ledgerTransactions))
+	for _, transaction := range ledgerTransactions {
+		transactionIDs = append(transactionIDs, transaction.ID)
+	}
+
+	entries, err := e.DB.LedgerEntry.Query().
+		Where(
+			ledgerentrydb.Namespace(e.Namespace),
+			ledgerentrydb.TransactionIDIn(transactionIDs...),
+		).
+		Order(
+			ledgerentrydb.ByCreatedAt(),
+			ledgerentrydb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	return entries
+}
+
+// EntriesForSubAccount filters a set of ledger entries down to the ones
+// posted against a specific sub-account.
+func (e *IntegrationEnv) EntriesForSubAccount(entries []*entdb.LedgerEntry, subAccount ledger.SubAccount) []*entdb.LedgerEntry {
+	out := make([]*entdb.LedgerEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.SubAccountID == subAccount.Address().SubAccountID() {
+			out = append(out, entry)
+		}
+	}
+
+	return out
+}
+
+// FBOSubAccountForCurrency is the explicit-currency counterpart of
+// FBOSubAccount, for tests that operate on a currency other than the env's
+// own (e.g. a custom currency alongside its fiat cost-basis currency).
+func (e *IntegrationEnv) FBOSubAccountForCurrency(t *testing.T, currency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
+		Currency:          currency,
+		CostBasisCurrency: costBasisCurrency,
+		CostBasis:         &costBasis,
+		CreditPriority:    ledger.DefaultCustomerFBOPriority,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+// AccruedSubAccountForCurrency is the explicit-currency counterpart of
+// AccruedSubAccountWithCostBasisAndTaxCode.
+func (e *IntegrationEnv) AccruedSubAccountForCurrency(t *testing.T, currency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis *alpacadecimal.Decimal, taxCode *string) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
+		Currency:          currency,
+		CostBasisCurrency: costBasisCurrency,
+		TaxCode:           taxCode,
+		CostBasis:         costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+// ReceivableSubAccountForCurrency is the explicit-currency, open-status
+// counterpart of ReceivableSubAccountWithCostBasis.
+func (e *IntegrationEnv) ReceivableSubAccountForCurrency(t *testing.T, currency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.CustomerAccounts.ReceivableAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerReceivableRouteParams{
+		Currency:                       currency,
+		CostBasisCurrency:              costBasisCurrency,
+		CostBasis:                      &costBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
+	})
+	require.NoError(t, err)
+
+	return subAccount
+}
+
+// BrokerageSubAccountForCurrency is the explicit-currency counterpart of
+// BrokerageSubAccount. Passing a nil costBasisCurrency serves a fiat
+// brokerage route; passing the fiat cost-basis currency alongside a custom
+// currency reference serves that custom currency's brokerage route.
+func (e *IntegrationEnv) BrokerageSubAccountForCurrency(t *testing.T, currency currencies.CurrencyReference, costBasisCurrency *currencyx.Code, costBasis alpacadecimal.Decimal) ledger.SubAccount {
+	t.Helper()
+
+	subAccount, err := e.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
+		Currency:          currency,
+		CostBasisCurrency: costBasisCurrency,
+		CostBasis:         &costBasis,
+	})
+	require.NoError(t, err)
+
+	return subAccount
 }

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -268,18 +268,29 @@ func costBasisKey(costBasis *alpacadecimal.Decimal) string {
 	return costBasis.String()
 }
 
-// TransferCustomerFBOAdvanceToAccruedTemplate moves value from the synthetic advance-backed
-// customer FBO route into the matching accrued route.
+// TransferCustomerFBOAdvanceToAccruedTemplate moves value out of a customer FBO
+// route directly into the matching accrued route without going through the
+// prioritized multi-source collection path in the collector package.
+//
+// It has two callers with different cost-basis shapes:
+//   - credit_only's uncovered-shortfall advance: CostBasis and CostBasisCurrency
+//     are nil (the source is not yet attributed to a known rate).
+//   - immediate purchase-and-consumption of custom-currency overage: CostBasis
+//     and CostBasisCurrency are the charge's persisted, already-known rate, and
+//     SourceChargeID is set so the accrued leg keeps purchase provenance
+//     alongside the spend that consumed it.
 type TransferCustomerFBOAdvanceToAccruedTemplate struct {
-	At             time.Time
-	Amount         alpacadecimal.Decimal
-	Currency       currencies.CurrencyReference
-	TaxCode        *string
-	TaxBehavior    *ledger.TaxBehavior
-	CostBasis      *alpacadecimal.Decimal
-	Features       []string
-	SpendChargeID  *string
-	CreditPriority *int
+	At                time.Time
+	Amount            alpacadecimal.Decimal
+	Currency          currencies.CurrencyReference
+	TaxCode           *string
+	TaxBehavior       *ledger.TaxBehavior
+	CostBasisCurrency *currencyx.Code
+	CostBasis         *alpacadecimal.Decimal
+	Features          []string
+	SourceChargeID    *string
+	SpendChargeID     *string
+	CreditPriority    *int
 }
 
 func (t TransferCustomerFBOAdvanceToAccruedTemplate) Validate() error {
@@ -299,6 +310,10 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) Validate() error {
 		if err := ledger.ValidateCostBasis(*t.CostBasis); err != nil {
 			return fmt.Errorf("cost basis: %w", err)
 		}
+	}
+
+	if err := ledger.ValidateCostBasisCurrency(t.Currency.Code, t.CostBasisCurrency, t.CostBasis); err != nil {
+		return fmt.Errorf("cost basis currency: %w", err)
 	}
 
 	if t.CreditPriority != nil {
@@ -388,20 +403,22 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 	}
 
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
-		Currency:       t.Currency,
-		CostBasis:      t.CostBasis,
-		Features:       t.Features,
-		CreditPriority: priority,
+		Currency:          t.Currency,
+		CostBasisCurrency: t.CostBasisCurrency,
+		CostBasis:         t.CostBasis,
+		Features:          t.Features,
+		CreditPriority:    priority,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get FBO sub-account: %w", err)
 	}
 
 	accrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:    t.Currency,
-		TaxCode:     t.TaxCode,
-		TaxBehavior: t.TaxBehavior,
-		CostBasis:   t.CostBasis,
+		Currency:          t.Currency,
+		CostBasisCurrency: t.CostBasisCurrency,
+		TaxCode:           t.TaxCode,
+		TaxBehavior:       t.TaxBehavior,
+		CostBasis:         t.CostBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accrued sub-account: %w", err)
@@ -414,14 +431,16 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 				address: fbo.Address(),
 				amount:  t.Amount.Neg(),
 				identity: ledger.EntryIdentityParts{
-					SpendChargeID: t.SpendChargeID,
+					SourceChargeID: t.SourceChargeID,
+					SpendChargeID:  t.SpendChargeID,
 				},
 			},
 			{
 				address: accrued.Address(),
 				amount:  t.Amount,
 				identity: ledger.EntryIdentityParts{
-					SpendChargeID: t.SpendChargeID,
+					SourceChargeID: t.SourceChargeID,
+					SpendChargeID:  t.SpendChargeID,
 				},
 			},
 		},

--- a/tools/migrate/migrations/20260807162052_add_lineage_custom_currency_identity.down.sql
+++ b/tools/migrate/migrations/20260807162052_add_lineage_custom_currency_identity.down.sql
@@ -1,0 +1,9 @@
+-- reverse: modify "credit_realization_lineages" table
+--
+-- The added "custom_currency_id" column is dropped, but the widened
+-- "currency" column is intentionally left at varchar(24) rather than
+-- narrowed back to varchar(3). Narrowing is lossy and would fail outright
+-- once any row stores a custom currency code longer than 3 characters.
+-- Application code from before this migration only ever writes 3-character
+-- fiat codes, so it remains fully compatible with the wider column.
+ALTER TABLE "credit_realization_lineages" DROP COLUMN "custom_currency_id";

--- a/tools/migrate/migrations/20260807162052_add_lineage_custom_currency_identity.up.sql
+++ b/tools/migrate/migrations/20260807162052_add_lineage_custom_currency_identity.up.sql
@@ -1,0 +1,2 @@
+-- modify "credit_realization_lineages" table
+ALTER TABLE "credit_realization_lineages" ALTER COLUMN "currency" TYPE character varying(24), ADD COLUMN "custom_currency_id" character(26) NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:knTp4LnCav59r5ke+cRxNcBBuyVaTl/mFrYz1j394ac=
+h1:6mZJ+3vJi82Nq90K62OhOxYCQGRQz6ssQ/X83+8fv1M=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -258,3 +258,4 @@ h1:knTp4LnCav59r5ke+cRxNcBBuyVaTl/mFrYz1j394ac=
 20260806163516_credit_purchase_cost_basis_bridge.up.sql h1:kRNpFRMflhq66wJbSnXkTlMDtcRNaxG1Pr56BNBW7Mw=
 20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql h1:k/byyaoUMzatU0fEugM3xNMyy607xkxlXEC1lAUMeDs=
 20260807145338_enforce_charge_cost_basis_relationships.up.sql h1:+eRqMO8jr7BRn3MW1zJCgjr/+kzx1hSDYrfuTguO/ZI=
+20260807162052_add_lineage_custom_currency_identity.up.sql h1:HjTSssdNPzr8KtxawvH7JLHshZohI7XvW5mJeaTExmo=


### PR DESCRIPTION
## Summary

  Implement ledger-side FX handling for custom-currency `credit_then_invoice` charges.

  The uncovered custom-currency overage is now booked using the same accounting semantics as a credit purchase:

  1. issue the uncovered custom amount as purchased credit
  2. immediately consume that credit through the originating charge
  3. convert the resulting custom receivable into the authoritative fiat invoice amount

  All three operations are committed in one atomic ledger transaction group.

  ## Why

  Custom-currency overage invoice lines represent credit purchases. Previously, the ledger implementation did not fully preserve the corresponding credit-purchase source/spend attribution.

  The ledger flow must therefore behave like an actual credit purchase while ensuring that the temporary custom-currency balance never becomes spendable.

  ## Implementation

  - Added custom-currency overage accrual for usage-based and flat-fee charges.
  - Uses the charge's persisted cost basis; it is not resolved or recalculated again.
  - Converts the post-allocation overage exactly once.
  - Preserves the native custom amount, cost basis, and charge provenance on the accrued route.
  - Leaves no spendable custom-currency FBO balance or open custom receivable after accrual.
  - Books the authoritative rounded amount as a fiat receivable.
  - Authorizes and settles payments in the invoice fiat currency.
  - Uses credit-purchase-compatible identity semantics:
    - purchase issuance: `SourceChargeID`
    - immediate consumption: `SourceChargeID` and `SpendChargeID`
    - custom-currency invoice payment: `SourceChargeID`
  - Preserves the existing `SpendChargeID` behavior for ordinary fiat charges.

  ## Test coverage

  Added PostgreSQL-backed flow coverage for both usage-based and flat-fee charges:

  - purchase → immediate consumption → fiat conversion transaction sequence
  - source/spend charge lineage
  - native and fiat ledger balances
  - persisted cost-basis usage
  - progressive usage-based realization runs
  - payment authorization and settlement
  - non-positive fiat conversion outcomes
  - regression coverage for existing fiat payment behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom-currency support for usage-based and flat-fee charge processing.
  * Custom-currency overages convert to fiat invoice receivables using the persisted cost basis.
  * Payment authorization and settlement follow the invoice’s fiat currency.
  * Credit and realization records retain complete custom-currency identity and lineage.

* **Bug Fixes**
  * Custom currencies no longer fail lineage validation.
  * Overages are not left as spendable balances.
  * Earnings recognition excludes custom-currency credit-only charges.
  * Invalid or zero-value fiat conversions are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds ledger-side handling for custom-currency `credit_then_invoice` overages while preserving native credit lineage and settling the resulting invoice in fiat.
- Books purchase, immediate consumption, and FX conversion in one transaction group.
- Routes payment authorization and settlement using the charge’s persisted cost basis.
- Extends credit-realization lineage identity with the managed custom-currency ID.
- Adds PostgreSQL-backed coverage for flat-fee, usage-based, progressive accrual, and payment flows.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/ledger/chargeadapter/usagebased.go | Adds atomic custom-currency overage purchase, consumption, FX conversion, and fiat payment routing for usage-based charges. |
| openmeter/ledger/chargeadapter/flatfee.go | Implements the equivalent custom-currency accrual and payment lifecycle for flat-fee charges. |
| openmeter/ledger/chargeadapter/helpers.go | Centralizes persisted invoice cost-basis resolution and custom-versus-fiat payment identity. |
| openmeter/ledger/transactions/accrual.go | Extends accrual transaction templates to preserve custom-currency charge identity and conversion routing. |
| openmeter/billing/charges/lineage/adapter/lineage.go | Persists and queries lineage using both currency code and custom-currency ID. |
| openmeter/billing/charges/service/advance.go | Omits custom currencies from earnings recognition while retaining recognition for fiat charges. |
| openmeter/ent/schema/creditrealizationlineage.go | Adds nullable custom-currency identity to credit-realization lineage persistence. |
| tools/migrate/migrations/20260807162052_add_lineage_custom_currency_identity.up.sql | Migrates the lineage table to store and index custom-currency identity. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Charge as Custom-currency charge
  participant Ledger
  participant Native as Native custom accounts
  participant Fiat as Fiat receivable
  participant Payment
  Charge->>Ledger: Accrue uncovered custom amount
  Ledger->>Native: Issue purchased credit
  Ledger->>Native: Immediately consume credit
  Ledger->>Fiat: Convert native receivable to rounded fiat amount
  Charge->>Payment: Authorize invoice amount in fiat
  Payment->>Ledger: Settle fiat receivable
```
</details>

<sub>Reviews (11): Last reviewed commit: ["fix: remove guards"](https://github.com/openmeterio/openmeter/commit/273d3e31bc6395d9ab4e03f02e206b176bef6820) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50087695)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)
</details>

<!-- /greptile_comment -->