### PR TITLE
refactor(credit): model invoice purchases with state machine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,12 @@
 - Do not hide type switching, validation, persistence mapping, or meaningful
   domain translation inside local closures. Use a named helper; reserve inline
   callbacks for obvious, tiny logic.
+- For non-trivial operations with multiple related parameters, define a named
+  `<Operation>Input` struct that implements `models.Validator` through
+  `Validate() error`. Put field and cross-field validation on the input and
+  validate it at the owning boundary. Prefer this over a multi-argument
+  operation paired with a separate `validate<Operation>(...)` helper. Do not
+  introduce input structs for trivial single-value operations.
 - For `Validate() error`, collect field errors and return
   `models.NewNillableGenericValidationError(errors.Join(errs...))`. Preserve
   field context with wrapped errors.

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -112,8 +112,15 @@ Credit purchases use a separate settlement union:
 
 - promotional grants credit without payment
 - external grants credit and tracks external authorization and settlement
-- invoice settlement is driven by billing hooks and the credit-purchase line
-  engine
+- invoice settlement is driven by billing hooks that fire invoice-created,
+  payment-authorized, and payment-settled triggers on the credit-purchase state
+  machine
+
+Payment-backed credit purchases grant credits before entering payment pending,
+then record authorization and settlement as separate state-machine transitions.
+Invoice settlement requires billing's authorization callback before settlement;
+external settlement additionally supports a direct-paid path that records both
+facts in order.
 
 A credit grant, payment authorization, and payment settlement are separate
 durable facts. A later state cannot be inferred from the presence of an earlier

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -252,58 +252,6 @@ func TestExternalCreditPurchaseAuthorizationUsesCostBasisForFiatCurrency(t *test
 	handler.AssertExpectations(t)
 }
 
-func TestInvoiceCreditPurchasePaymentPassesExactFiatAmount(t *testing.T) {
-	charge := newExternalStateMachineTestCharge(t, creditpurchase.StatusActivePaymentPending, alpacadecimal.NewFromFloat(0.5))
-	charge.Intent.Settlement = creditpurchase.NewSettlement(creditpurchase.InvoiceSettlement{
-		GenericSettlement: creditpurchase.GenericSettlement{
-			Currency:  currencyx.FiatCode("USD"),
-			CostBasis: alpacadecimal.NewFromFloat(0.5),
-		},
-	})
-	fiatAmount := alpacadecimal.RequireFromString("49.99")
-	line := &billing.StandardLine{}
-	line.ID = "line-1"
-	line.Totals.Total = fiatAmount
-	lineWithHeader := billing.StandardLineWithInvoiceHeader{
-		Line: line,
-		Invoice: billing.StandardInvoice{
-			StandardInvoiceBase: billing.StandardInvoiceBase{
-				ID: "invoice-1",
-			},
-		},
-	}
-	handler := &externalStateMachineHandler{}
-	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			input := args.Get(1).(creditpurchase.PaymentEventInput)
-			require.True(t, input.FiatAmount.Equal(fiatAmount))
-		}).
-		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
-		Once()
-	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			input := args.Get(1).(creditpurchase.PaymentEventInput)
-			require.True(t, input.FiatAmount.Equal(fiatAmount))
-		}).
-		Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
-		Once()
-	adapter := &externalStateMachineAdapter{}
-	svc := &service{
-		adapter: adapter,
-		handler: handler,
-	}
-
-	err := svc.PostInvoicePaymentAuthorized(t.Context(), charge, lineWithHeader)
-	require.NoError(t, err)
-	require.True(t, adapter.createdInvoicedPayment.FiatAmount.Equal(fiatAmount))
-
-	charge.Realizations.InvoiceSettlement = &adapter.createdInvoicedPayment
-	err = svc.PostInvoicePaymentSettled(t.Context(), charge, lineWithHeader)
-	require.NoError(t, err)
-	require.True(t, adapter.updatedInvoicedPayment.FiatAmount.Equal(fiatAmount))
-	handler.AssertExpectations(t)
-}
-
 func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 	for _, tc := range []struct {
 		name                     string
@@ -814,8 +762,10 @@ type externalStateMachineAdapter struct {
 	updateExternalPaymentCalls int
 	updatedExternalPayment     payment.External
 
-	createdInvoicedPayment payment.Invoiced
-	updatedInvoicedPayment payment.Invoiced
+	createInvoicedPaymentCalls int
+	createdInvoicedPayment     payment.Invoiced
+	updateInvoicedPaymentCalls int
+	updatedInvoicedPayment     payment.Invoiced
 }
 
 func (a *externalStateMachineAdapter) UpdateCharge(ctx context.Context, charge creditpurchase.ChargeBase) (creditpurchase.ChargeBase, error) {
@@ -863,6 +813,7 @@ func (a *externalStateMachineAdapter) UpdateExternalPayment(ctx context.Context,
 }
 
 func (a *externalStateMachineAdapter) CreateInvoicedPayment(_ context.Context, _ meta.ChargeID, input payment.InvoicedCreate) (payment.Invoiced, error) {
+	a.createInvoicedPaymentCalls++
 	a.createdInvoicedPayment = payment.Invoiced{
 		Payment: payment.Payment{
 			NamespacedID: models.NamespacedID{
@@ -879,6 +830,7 @@ func (a *externalStateMachineAdapter) CreateInvoicedPayment(_ context.Context, _
 }
 
 func (a *externalStateMachineAdapter) UpdateInvoicedPayment(_ context.Context, paymentSettlement payment.Invoiced) (payment.Invoiced, error) {
+	a.updateInvoicedPaymentCalls++
 	a.updatedInvoicedPayment = paymentSettlement
 	return paymentSettlement, nil
 }

--- a/openmeter/billing/charges/creditpurchase/service/invoice.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice.go
@@ -2,132 +2,287 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
-	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/statelessx"
 )
 
+type InvoiceCreditPurchaseStateMachine struct {
+	*stateMachine
+}
+
+func NewInvoiceCreditPurchaseStateMachine(config StateMachineConfig) (*InvoiceCreditPurchaseStateMachine, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+
+	if config.Realizations == nil {
+		return nil, errors.New("realizations service is required")
+	}
+
+	if config.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeInvoice {
+		return nil, fmt.Errorf("charge %s is not invoice settled", config.Charge.ID)
+	}
+
+	// TODO: Migrate existing invoice credit purchases from the legacy active status
+	// to their detailed status with an SQL migration, then remove this runtime mapping.
+	mappedCharge, err := mapLegacyInvoiceCreditPurchaseStatus(config.Charge)
+	if err != nil {
+		return nil, fmt.Errorf("map legacy invoice credit purchase status: %w", err)
+	}
+	config.Charge = mappedCharge
+
+	stateMachine, err := newStateMachineBase(config)
+	if err != nil {
+		return nil, fmt.Errorf("new invoice credit purchase state machine: %w", err)
+	}
+
+	out := &InvoiceCreditPurchaseStateMachine{
+		stateMachine: stateMachine,
+	}
+	out.configureStates()
+
+	return out, nil
+}
+
+func (s *InvoiceCreditPurchaseStateMachine) configureStates() {
+	s.Configure(creditpurchase.StatusCreated).
+		Permit(meta.TriggerInvoiceCreated, creditpurchase.StatusActiveInitialCreditGrant)
+
+	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
+		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).
+		OnActive(s.GrantCredits)
+
+	s.Configure(creditpurchase.StatusActivePaymentPending).
+		Permit(billing.TriggerAuthorized, creditpurchase.StatusActivePaymentAuthorized)
+
+	s.Configure(creditpurchase.StatusActivePaymentAuthorized).
+		Permit(billing.TriggerPaid, creditpurchase.StatusActivePaymentSettled).
+		OnEntryFrom(
+			billing.TriggerAuthorized,
+			statelessx.WithParameters(s.AuthorizeInvoicedPayment),
+		)
+
+	s.Configure(creditpurchase.StatusActivePaymentSettled).
+		Permit(meta.TriggerNext, creditpurchase.StatusFinal).
+		OnActive(s.SettleInvoicedPayment)
+
+	s.Configure(creditpurchase.StatusFinal)
+}
+
+// mapLegacyInvoiceCreditPurchaseStatus maps the generic active status used before
+// detailed invoice states from durable realization facts. The mapping is in-memory
+// so the next real lifecycle event persists its target without a synthetic transition.
+func mapLegacyInvoiceCreditPurchaseStatus(charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	if charge.Status != creditpurchase.StatusActive {
+		return charge, nil
+	}
+
+	creditGrant := charge.Realizations.CreditGrantRealization
+	if creditGrant == nil || creditGrant.TransactionGroupID == "" {
+		return creditpurchase.Charge{}, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("legacy active invoice credit purchase has no credit grant [charge_id=%s]", charge.ID),
+		)
+	}
+
+	invoicedPayment := charge.Realizations.InvoiceSettlement
+	if invoicedPayment == nil {
+		return charge.WithStatus(creditpurchase.StatusActivePaymentPending), nil
+	}
+
+	switch invoicedPayment.Status {
+	case payment.StatusAuthorized:
+		return charge.WithStatus(creditpurchase.StatusActivePaymentAuthorized), nil
+	case payment.StatusSettled:
+		return charge.WithStatus(creditpurchase.StatusFinal), nil
+	default:
+		return creditpurchase.Charge{}, fmt.Errorf(
+			"unsupported invoiced payment status %q [charge_id=%s]",
+			invoicedPayment.Status,
+			charge.ID,
+		)
+	}
+}
+
+func (s *InvoiceCreditPurchaseStateMachine) GrantCredits(ctx context.Context) error {
+	updatedCharge, err := s.Realizations.GrantCredits(ctx, s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge
+	return nil
+}
+
+func (s *InvoiceCreditPurchaseStateMachine) AuthorizeInvoicedPayment(ctx context.Context, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
+	updatedCharge, err := s.Realizations.AuthorizeInvoicedPayment(ctx, creditpurchaserealizations.AuthorizeInvoicedPaymentInput{
+		Charge:         s.Charge,
+		LineWithHeader: lineWithHeader,
+	})
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge
+	return nil
+}
+
+func (s *InvoiceCreditPurchaseStateMachine) SettleInvoicedPayment(ctx context.Context) error {
+	updatedCharge, err := s.Realizations.SettleInvoicedPayment(ctx, s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge
+	return nil
+}
+
+type HandleInvoiceLifecycleTriggerInput struct {
+	Charge         creditpurchase.Charge
+	Trigger        meta.Trigger
+	LineWithHeader billing.StandardLineWithInvoiceHeader
+}
+
+var _ models.Validator = HandleInvoiceLifecycleTriggerInput{}
+
+func (i HandleInvoiceLifecycleTriggerInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.GetChargeID().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	if i.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeInvoice {
+		errs = append(errs, fmt.Errorf("charge %s is not invoice settled", i.Charge.ID))
+	}
+
+	switch trigger := i.Trigger.(type) {
+	case nil:
+		errs = append(errs, errors.New("trigger is required"))
+	case string:
+		if !slices.ContainsFunc([]meta.Trigger{
+			meta.TriggerInvoiceCreated,
+			billing.TriggerAuthorized,
+			billing.TriggerPaid,
+		}, func(allowedTrigger meta.Trigger) bool {
+			return allowedTrigger == trigger
+		}) {
+			errs = append(errs, fmt.Errorf("unsupported trigger %q", trigger))
+		}
+	default:
+		errs = append(errs, fmt.Errorf("unsupported trigger %v", trigger))
+	}
+
+	if err := i.LineWithHeader.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("line with invoice header: %w", err))
+	}
+
+	line := i.LineWithHeader.Line
+	if i.LineWithHeader.Invoice.Namespace != i.Charge.Namespace {
+		errs = append(errs, errors.New("invoice namespace must match charge namespace"))
+	}
+
+	if line != nil {
+		if line.ChargeID == nil || *line.ChargeID != i.Charge.ID {
+			errs = append(errs, errors.New("line charge ID must match charge"))
+		}
+
+		if line.Namespace != i.Charge.Namespace {
+			errs = append(errs, errors.New("line namespace must match charge namespace"))
+		}
+
+		if line.InvoiceID != i.LineWithHeader.Invoice.ID {
+			errs = append(errs, errors.New("line invoice ID must match invoice"))
+		}
+	}
+
+	if invoicedPayment := i.Charge.Realizations.InvoiceSettlement; invoicedPayment != nil {
+		if line != nil && invoicedPayment.LineID != line.ID {
+			errs = append(errs, errors.New("payment line ID must match line"))
+		}
+
+		if invoicedPayment.InvoiceID != i.LineWithHeader.Invoice.ID {
+			errs = append(errs, errors.New("payment invoice ID must match invoice"))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (s *service) handleInvoiceLifecycleTrigger(ctx context.Context, input HandleInvoiceLifecycleTriggerInput) (creditpurchase.Charge, error) {
+	if err := input.Validate(); err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("validate invoice lifecycle trigger: %w", err)
+	}
+
+	stateMachine, err := NewInvoiceCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       input.Charge,
+		Adapter:      s.adapter,
+		Realizations: s.realizations,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("reconcile invoice credit purchase state: %w", err)
+	}
+
+	if err := stateMachine.FireAndActivate(ctx, input.Trigger, input.LineWithHeader); err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("fire invoice lifecycle trigger %s: %w", input.Trigger, err)
+	}
+
+	advancedCharge, err := stateMachine.AdvanceUntilStateStable(ctx)
+	if err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("advance invoice credit purchase after %s: %w", input.Trigger, err)
+	}
+
+	if advancedCharge != nil {
+		return *advancedCharge, nil
+	}
+
+	return stateMachine.GetCharge(), nil
+}
+
+// TODO: Move these invoice lifecycle hook adapters to the credit-purchase line engine
+// and remove the service entry points when the legacy standard invoice hook routing is retired.
 func (s *service) PostInvoiceDraftCreated(ctx context.Context, charge creditpurchase.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchaseInitiated(ctx, charge)
-		if err != nil {
-			return err
-		}
-
-		if _, err := s.adapter.CreateCreditGrant(ctx, charge.GetChargeID(), creditpurchase.CreateCreditGrantInput{
-			TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-			GrantedAt:          clock.Now(),
-		}); err != nil {
-			return err
-		}
-
-		if ledgerTransactionGroupReference.TransactionGroupID != "" {
-			if err := s.lineage.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
-				Namespace:                 charge.Namespace,
-				CustomerID:                charge.Intent.CustomerID,
-				Currency:                  charge.Intent.Currency,
-				Amount:                    charge.Intent.CreditAmount,
-				BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-				FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
-			}); err != nil {
-				return err
-			}
-		}
-
-		charge.Status = creditpurchase.StatusActive
-
-		_, err = s.adapter.UpdateCharge(ctx, charge.ChargeBase)
+		_, err := s.handleInvoiceLifecycleTrigger(ctx, HandleInvoiceLifecycleTriggerInput{
+			Charge:         charge,
+			Trigger:        meta.TriggerInvoiceCreated,
+			LineWithHeader: lineWithHeader,
+		})
 		return err
 	})
 }
 
-// PostInvoicePaymentAuthorized is called when the invoice is approved/issued.
-// It's invoked from the billing service's PostUpdate hook, already within a transaction.
+// PostInvoicePaymentAuthorized is called when billing has authorized payment.
+// Billing invokes the hook inside the invoice lifecycle transaction.
 func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge creditpurchase.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
-	if charge.Realizations.InvoiceSettlement != nil {
-		return fmt.Errorf("invoice settlement already authorized - settlement already exists: %s", charge.Realizations.InvoiceSettlement.InvoiceID)
-	}
-
-	eventAt := clock.Now()
-	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
-		Charge:     charge,
-		EventAt:    eventAt,
-		FiatAmount: lineWithHeader.Line.Totals.Total,
+	_, err := s.handleInvoiceLifecycleTrigger(ctx, HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        billing.TriggerAuthorized,
+		LineWithHeader: lineWithHeader,
 	})
-	if err != nil {
-		return err
-	}
-
-	newPaymentSettlement := payment.InvoicedCreate{
-		Namespace: charge.Namespace,
-		Base: payment.Base{
-			ServicePeriod: charge.Intent.ServicePeriod,
-			FiatAmount:    lineWithHeader.Line.Totals.Total,
-			Authorized: &ledgertransaction.TimedGroupReference{
-				GroupReference: ledgerTransactionGroupReference,
-				Time:           eventAt,
-			},
-			Status: payment.StatusAuthorized,
-		},
-		InvoiceID: lineWithHeader.Invoice.ID,
-		LineID:    lineWithHeader.Line.ID,
-	}
-
-	_, err = s.adapter.CreateInvoicedPayment(ctx, charge.GetChargeID(), newPaymentSettlement)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
-// PostInvoicePaymentSettled is called when the invoice is paid.
-// It's invoked from the billing service's PostUpdate hook, already within a transaction.
+// PostInvoicePaymentSettled is called when billing has settled payment.
+// Billing invokes the hook inside the invoice lifecycle transaction.
 func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge creditpurchase.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
-	// Idempotency check: if already settled, skip processing
-	if charge.Realizations.InvoiceSettlement == nil {
-		return fmt.Errorf("invoice settlement not found")
-	}
-
-	if charge.Realizations.InvoiceSettlement.Settled != nil {
-		return fmt.Errorf("invoice settlement already settled")
-	}
-
-	paymentSettlement := *charge.Realizations.InvoiceSettlement
-
-	eventAt := clock.Now()
-	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
-		Charge:     charge,
-		EventAt:    eventAt,
-		FiatAmount: paymentSettlement.FiatAmount,
+	_, err := s.handleInvoiceLifecycleTrigger(ctx, HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        billing.TriggerPaid,
+		LineWithHeader: lineWithHeader,
 	})
-	if err != nil {
-		return err
-	}
-
-	paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
-		GroupReference: ledgerTransactionGroupReference,
-		Time:           eventAt,
-	}
-
-	paymentSettlement.Status = payment.StatusSettled
-
-	if _, err := s.adapter.UpdateInvoicedPayment(ctx, paymentSettlement); err != nil {
-		return err
-	}
-
-	// Update charge status to final
-	charge.Status = creditpurchase.StatusFinal
-
-	if _, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase); err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/openmeter/billing/charges/creditpurchase/service/invoice_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice_test.go
@@ -1,0 +1,412 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestInvoiceCreditPurchaseStateMachineGrantsCreditsWhenInvoiceIsCreated(t *testing.T) {
+	// given:
+	// - a newly-created invoice-settled credit purchase
+	// when:
+	// - billing reports that its standard invoice was created
+	// then:
+	// - the machine grants credits before persisting payment-pending
+	charge := newInvoiceStateMachineTestCharge(t, creditpurchase.StatusCreated)
+	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
+	adapter := &externalStateMachineAdapter{}
+	handler := &externalStateMachineHandler{}
+	lineageService := &externalStateMachineLineage{}
+	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			inputCharge := args.Get(1).(creditpurchase.Charge)
+			require.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, inputCharge.Status)
+			require.Nil(t, inputCharge.Realizations.CreditGrantRealization)
+			require.Nil(t, inputCharge.Realizations.InvoiceSettlement)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+		Once()
+	lineageService.On("BackfillAdvanceLineageSegments", mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+
+	service := newInvoiceStateMachineTestService(t, adapter, handler, lineageService)
+
+	updatedCharge, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        meta.TriggerInvoiceCreated,
+		LineWithHeader: lineWithHeader,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusActivePaymentPending, updatedCharge.Status)
+	require.NotNil(t, updatedCharge.Realizations.CreditGrantRealization)
+	require.Equal(t, "initiated-ledger-tx", updatedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActiveInitialCreditGrant,
+		creditpurchase.StatusActivePaymentPending,
+	}, adapter.updatedBaseStatuses)
+	require.Equal(t, 1, adapter.createCreditGrantCalls)
+	handler.AssertExpectations(t)
+	lineageService.AssertExpectations(t)
+}
+
+func TestInvoiceCreditPurchaseStateMachineAuthorizesAndSettlesPayment(t *testing.T) {
+	// given:
+	// - an invoice-settled credit purchase with granted credits
+	// when:
+	// - billing authorizes and then settles its invoice payment
+	// then:
+	// - the exact invoice amount is persisted and the charge becomes final
+	charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActivePaymentPending)
+	fiatAmount := alpacadecimal.RequireFromString("49.99")
+	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, fiatAmount)
+	adapter := &externalStateMachineAdapter{}
+	handler := &externalStateMachineHandler{}
+	lineageService := &externalStateMachineLineage{}
+	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.NotNil(t, input.Charge.Realizations.CreditGrantRealization)
+			require.Nil(t, input.Charge.Realizations.InvoiceSettlement)
+			require.True(t, input.FiatAmount.Equal(fiatAmount))
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+		Once()
+	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentSettled, input.Charge.Status)
+			require.NotNil(t, input.Charge.Realizations.InvoiceSettlement)
+			require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.InvoiceSettlement.Status)
+			require.True(t, input.FiatAmount.Equal(fiatAmount))
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+		Once()
+
+	service := newInvoiceStateMachineTestService(t, adapter, handler, lineageService)
+
+	authorizedCharge, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        billing.TriggerAuthorized,
+		LineWithHeader: lineWithHeader,
+	})
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, authorizedCharge.Status)
+	require.NotNil(t, authorizedCharge.Realizations.InvoiceSettlement)
+	require.Equal(t, payment.StatusAuthorized, authorizedCharge.Realizations.InvoiceSettlement.Status)
+	require.True(t, authorizedCharge.Realizations.InvoiceSettlement.FiatAmount.Equal(fiatAmount))
+	require.Equal(t, lineWithHeader.Line.ID, authorizedCharge.Realizations.InvoiceSettlement.LineID)
+	require.Equal(t, lineWithHeader.Invoice.ID, authorizedCharge.Realizations.InvoiceSettlement.InvoiceID)
+
+	settledCharge, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+		Charge:         authorizedCharge,
+		Trigger:        billing.TriggerPaid,
+		LineWithHeader: lineWithHeader,
+	})
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusFinal, settledCharge.Status)
+	require.NotNil(t, settledCharge.Realizations.InvoiceSettlement)
+	require.Equal(t, payment.StatusSettled, settledCharge.Realizations.InvoiceSettlement.Status)
+	require.Equal(t, "settled-ledger-tx", settledCharge.Realizations.InvoiceSettlement.Settled.TransactionGroupID)
+	require.Equal(t, 1, adapter.createInvoicedPaymentCalls)
+	require.Equal(t, 1, adapter.updateInvoicedPaymentCalls)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActivePaymentAuthorized,
+		creditpurchase.StatusActivePaymentSettled,
+		creditpurchase.StatusFinal,
+	}, adapter.updatedBaseStatuses)
+	handler.AssertExpectations(t)
+}
+
+func TestInvoiceCreditPurchasePaymentPassesExactFiatAmount(t *testing.T) {
+	charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActivePaymentPending)
+	fiatAmount := alpacadecimal.RequireFromString("49.99")
+	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, fiatAmount)
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.True(t, input.FiatAmount.Equal(fiatAmount))
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+		Once()
+	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentSettled, input.Charge.Status)
+			require.True(t, input.FiatAmount.Equal(fiatAmount))
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+		Once()
+	adapter := &externalStateMachineAdapter{}
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, &externalStateMachineLineage{})
+	svc := &service{
+		adapter:      adapter,
+		handler:      handler,
+		realizations: realizationsService,
+	}
+
+	err := svc.PostInvoicePaymentAuthorized(t.Context(), charge, lineWithHeader)
+	require.NoError(t, err)
+	require.True(t, adapter.createdInvoicedPayment.FiatAmount.Equal(fiatAmount))
+
+	charge.Status = creditpurchase.StatusActivePaymentAuthorized
+	charge.Realizations.InvoiceSettlement = &adapter.createdInvoicedPayment
+	err = svc.PostInvoicePaymentSettled(t.Context(), charge, lineWithHeader)
+	require.NoError(t, err)
+	require.True(t, adapter.updatedInvoicedPayment.FiatAmount.Equal(fiatAmount))
+	handler.AssertExpectations(t)
+}
+
+func TestInvoiceCreditPurchaseStateMachineMapsLegacyActiveStatusAtConstruction(t *testing.T) {
+	t.Run("payment pending", func(t *testing.T) {
+		// given:
+		// - a historical active invoice credit purchase with a grant and no payment
+		// when:
+		// - billing authorizes payment
+		// then:
+		// - the machine maps payment-pending in memory and persists authorization directly
+		charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActive)
+		lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
+		adapter := &externalStateMachineAdapter{}
+		handler := &externalStateMachineHandler{}
+		handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+			Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+			Once()
+
+		service := newInvoiceStateMachineTestService(t, adapter, handler, &externalStateMachineLineage{})
+
+		updatedCharge, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+			Charge:         charge,
+			Trigger:        billing.TriggerAuthorized,
+			LineWithHeader: lineWithHeader,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, updatedCharge.Status)
+		require.Zero(t, adapter.createCreditGrantCalls)
+		require.Equal(t, []creditpurchase.Status{
+			creditpurchase.StatusActivePaymentAuthorized,
+		}, adapter.updatedBaseStatuses)
+		handler.AssertExpectations(t)
+	})
+
+	t.Run("payment authorized", func(t *testing.T) {
+		// given:
+		// - a historical active invoice credit purchase with an authorized payment
+		// when:
+		// - billing settles payment
+		// then:
+		// - the machine maps payment-authorized in memory and settles without reauthorizing
+		charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActive)
+		lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
+		charge.Realizations.InvoiceSettlement = newAuthorizedInvoiceStateMachinePayment(charge, lineWithHeader)
+		adapter := &externalStateMachineAdapter{}
+		handler := &externalStateMachineHandler{}
+		handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+			Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+			Once()
+
+		service := newInvoiceStateMachineTestService(t, adapter, handler, &externalStateMachineLineage{})
+
+		updatedCharge, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+			Charge:         charge,
+			Trigger:        billing.TriggerPaid,
+			LineWithHeader: lineWithHeader,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, creditpurchase.StatusFinal, updatedCharge.Status)
+		require.Zero(t, adapter.createInvoicedPaymentCalls)
+		require.Equal(t, 1, adapter.updateInvoicedPaymentCalls)
+		require.Equal(t, []creditpurchase.Status{
+			creditpurchase.StatusActivePaymentSettled,
+			creditpurchase.StatusFinal,
+		}, adapter.updatedBaseStatuses)
+		handler.AssertNotCalled(t, "OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything)
+		handler.AssertExpectations(t)
+	})
+}
+
+func TestInvoiceCreditPurchaseStateMachineRejectsLegacyActiveStatusWithoutGrant(t *testing.T) {
+	// given:
+	// - an inconsistent historical active invoice credit purchase without a grant
+	// when:
+	// - the machine attempts to reconcile it before authorization
+	// then:
+	// - it reports the missing durable fact instead of creating new credit
+	charge := newInvoiceStateMachineTestCharge(t, creditpurchase.StatusActive)
+	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
+	adapter := &externalStateMachineAdapter{}
+	handler := &externalStateMachineHandler{}
+
+	service := newInvoiceStateMachineTestService(t, adapter, handler, &externalStateMachineLineage{})
+
+	_, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        billing.TriggerAuthorized,
+		LineWithHeader: lineWithHeader,
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "has no credit grant")
+	require.Zero(t, adapter.createCreditGrantCalls)
+	require.Zero(t, adapter.createInvoicedPaymentCalls)
+	require.Zero(t, adapter.updateChargeCalls)
+}
+
+func TestInvoiceCreditPurchaseStateMachineRejectsMismatchedPaymentLine(t *testing.T) {
+	charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActivePaymentAuthorized)
+	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
+	charge.Realizations.InvoiceSettlement = newAuthorizedInvoiceStateMachinePayment(charge, lineWithHeader)
+	lineWithHeader.Line.ID = "different-line"
+	adapter := &externalStateMachineAdapter{}
+	handler := &externalStateMachineHandler{}
+
+	service := newInvoiceStateMachineTestService(t, adapter, handler, &externalStateMachineLineage{})
+
+	_, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{
+		Charge:         charge,
+		Trigger:        billing.TriggerPaid,
+		LineWithHeader: lineWithHeader,
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "payment line ID must match line")
+	require.Zero(t, adapter.updateInvoicedPaymentCalls)
+	require.Zero(t, adapter.updateChargeCalls)
+}
+
+func newInvoiceStateMachineTestService(
+	t *testing.T,
+	adapter *externalStateMachineAdapter,
+	handler *externalStateMachineHandler,
+	lineageService *externalStateMachineLineage,
+) *service {
+	t.Helper()
+
+	return &service{
+		adapter:      adapter,
+		realizations: newExternalStateMachineRealizations(t, adapter, handler, lineageService),
+	}
+}
+
+func newInvoiceStateMachineTestCharge(t *testing.T, status creditpurchase.Status) creditpurchase.Charge {
+	t.Helper()
+
+	charge := newExternalStateMachineTestCharge(t, status, alpacadecimal.NewFromFloat(0.5))
+	charge.Intent.Name = "test invoice credits"
+	charge.Intent.Settlement = creditpurchase.NewSettlement(creditpurchase.InvoiceSettlement{
+		GenericSettlement: creditpurchase.GenericSettlement{
+			Currency:  currencyx.FiatCode("USD"),
+			CostBasis: alpacadecimal.NewFromFloat(0.5),
+		},
+	})
+
+	return charge
+}
+
+func newGrantedInvoiceStateMachineTestCharge(t *testing.T, status creditpurchase.Status) creditpurchase.Charge {
+	t.Helper()
+
+	charge := newInvoiceStateMachineTestCharge(t, status)
+	charge.Realizations.CreditGrantRealization = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"},
+		Time:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return charge
+}
+
+func newInvoiceStateMachineTestLine(t *testing.T, charge creditpurchase.Charge, fiatAmount alpacadecimal.Decimal) billing.StandardLineWithInvoiceHeader {
+	t.Helper()
+
+	invoiceID := "invoice-1"
+	chargeID := charge.ID
+	createdAt := charge.Intent.ServicePeriod.From
+	line := &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: charge.Namespace},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: createdAt,
+					UpdatedAt: createdAt,
+				},
+				ID:   "line-1",
+				Name: "invoice credit purchase",
+			},
+			ManagedBy: billing.SystemManagedLine,
+			Engine:    billing.LineEngineTypeChargeCreditPurchase,
+			InvoiceID: invoiceID,
+			Currency:  currencyx.FiatCode("USD"),
+			Period:    charge.Intent.ServicePeriod,
+			InvoiceAt: createdAt,
+			ChargeID:  &chargeID,
+			Totals: totals.Totals{
+				Amount: fiatAmount,
+				Total:  fiatAmount,
+			},
+		},
+		UsageBased: &billing.UsageBasedLine{
+			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount:      fiatAmount,
+				PaymentTerm: productcatalog.InAdvancePaymentTerm,
+			}),
+			Quantity: lo.ToPtr(alpacadecimal.NewFromInt(1)),
+		},
+	}
+
+	lineWithHeader := billing.StandardLineWithInvoiceHeader{
+		Line: line,
+		Invoice: billing.StandardInvoice{
+			StandardInvoiceBase: billing.StandardInvoiceBase{
+				Namespace: charge.Namespace,
+				ID:        invoiceID,
+			},
+		},
+	}
+	require.NoError(t, lineWithHeader.Validate())
+
+	return lineWithHeader
+}
+
+func newAuthorizedInvoiceStateMachinePayment(charge creditpurchase.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) *payment.Invoiced {
+	return &payment.Invoiced{
+		Payment: payment.Payment{
+			NamespacedID: models.NamespacedID{Namespace: charge.Namespace, ID: "invoice-payment-1"},
+			ManagedModel: models.ManagedModel{
+				CreatedAt: charge.Intent.ServicePeriod.From,
+				UpdatedAt: charge.Intent.ServicePeriod.From,
+			},
+			Base: payment.Base{
+				ServicePeriod: charge.Intent.ServicePeriod,
+				Status:        payment.StatusAuthorized,
+				FiatAmount:    lineWithHeader.Line.Totals.Total,
+				Authorized: &ledgertransaction.TimedGroupReference{
+					GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"},
+					Time:           charge.Intent.ServicePeriod.From,
+				},
+			},
+		},
+		LineID:    lineWithHeader.Line.ID,
+		InvoiceID: lineWithHeader.Invoice.ID,
+	}
+}

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
@@ -58,17 +59,16 @@ func New(config Config) (*Service, error) {
 }
 
 func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
-	externalSettlement, err := charge.Intent.Settlement.AsExternalSettlement()
-	if err != nil {
+	if err := charge.Intent.Settlement.Validate(); err != nil {
 		return creditpurchase.Charge{}, err
 	}
 
-	if err := externalSettlement.Validate(); err != nil {
-		return creditpurchase.Charge{}, err
+	if charge.Intent.Settlement.Type() == creditpurchase.SettlementTypePromotional {
+		return creditpurchase.Charge{}, fmt.Errorf("promotional credit purchases do not use payment-backed credit grants")
 	}
 
 	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {
-		return creditpurchase.Charge{}, fmt.Errorf("external credit grant already realized [charge_id=%s, transaction_group_id=%s]", charge.ID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
+		return creditpurchase.Charge{}, fmt.Errorf("credit grant already realized [charge_id=%s, transaction_group_id=%s]", charge.ID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
 	}
 
 	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchaseInitiated(ctx, charge)
@@ -98,6 +98,132 @@ func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge
 			return creditpurchase.Charge{}, err
 		}
 	}
+
+	return charge, nil
+}
+
+type AuthorizeInvoicedPaymentInput struct {
+	Charge         creditpurchase.Charge
+	LineWithHeader billing.StandardLineWithInvoiceHeader
+}
+
+var _ models.Validator = AuthorizeInvoicedPaymentInput{}
+
+func (i AuthorizeInvoicedPaymentInput) Validate() error {
+	var errs []error
+
+	if _, err := i.Charge.Intent.Settlement.AsInvoiceSettlement(); err != nil {
+		errs = append(errs, fmt.Errorf("invoice settlement: %w", err))
+	}
+
+	if err := i.LineWithHeader.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("line with invoice header: %w", err))
+	}
+
+	line := i.LineWithHeader.Line
+	if i.LineWithHeader.Invoice.Namespace != i.Charge.Namespace {
+		errs = append(errs, errors.New("invoice namespace must match charge namespace"))
+	}
+
+	if line != nil {
+		if line.ChargeID == nil || *line.ChargeID != i.Charge.ID {
+			errs = append(errs, errors.New("line charge ID must match charge"))
+		}
+
+		if line.Namespace != i.Charge.Namespace {
+			errs = append(errs, errors.New("line namespace must match charge namespace"))
+		}
+
+		if line.InvoiceID != i.LineWithHeader.Invoice.ID {
+			errs = append(errs, errors.New("line invoice ID must match invoice"))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (s *Service) AuthorizeInvoicedPayment(ctx context.Context, input AuthorizeInvoicedPaymentInput) (creditpurchase.Charge, error) {
+	if err := input.Validate(); err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("validate authorize invoiced payment: %w", err)
+	}
+
+	charge := input.Charge
+	lineWithHeader := input.LineWithHeader
+
+	if charge.Realizations.InvoiceSettlement != nil {
+		return creditpurchase.Charge{}, payment.ErrPaymentAlreadyAuthorized.
+			WithAttrs(charge.ErrorAttributes()).
+			WithAttrs(charge.Realizations.InvoiceSettlement.ErrorAttributes())
+	}
+
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
+		Charge:     charge,
+		EventAt:    eventAt,
+		FiatAmount: lineWithHeader.Line.Totals.Total,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	paymentSettlement, err := s.adapter.CreateInvoicedPayment(ctx, charge.GetChargeID(), payment.InvoicedCreate{
+		Namespace: charge.Namespace,
+		Base: payment.Base{
+			ServicePeriod: charge.Intent.ServicePeriod,
+			FiatAmount:    lineWithHeader.Line.Totals.Total,
+			Authorized: &ledgertransaction.TimedGroupReference{
+				GroupReference: ledgerTransactionGroupReference,
+				Time:           eventAt,
+			},
+			Status: payment.StatusAuthorized,
+		},
+		InvoiceID: lineWithHeader.Invoice.ID,
+		LineID:    lineWithHeader.Line.ID,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.InvoiceSettlement = &paymentSettlement
+
+	return charge, nil
+}
+
+func (s *Service) SettleInvoicedPayment(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	if charge.Realizations.InvoiceSettlement == nil {
+		return creditpurchase.Charge{}, payment.ErrCannotSettleNotAuthorizedPayment.
+			WithAttrs(charge.ErrorAttributes())
+	}
+
+	paymentSettlement := *charge.Realizations.InvoiceSettlement
+	if paymentSettlement.Status != payment.StatusAuthorized {
+		return creditpurchase.Charge{}, payment.ErrPaymentAlreadySettled.
+			WithAttrs(charge.ErrorAttributes()).
+			WithAttrs(paymentSettlement.ErrorAttributes())
+	}
+
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
+		Charge:     charge,
+		EventAt:    eventAt,
+		FiatAmount: paymentSettlement.FiatAmount,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgerTransactionGroupReference,
+		Time:           eventAt,
+	}
+	paymentSettlement.Status = payment.StatusSettled
+
+	paymentSettlement, err = s.adapter.UpdateInvoicedPayment(ctx, paymentSettlement)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.InvoiceSettlement = &paymentSettlement
 
 	return charge, nil
 }

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -866,7 +866,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 
 		s.Equal(1, initatedCallback.nrInvocations)
 		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
-		s.Equal(creditpurchase.StatusActive, creditPurchaseCharge.Status)
+		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status)
 
 		chargeID = creditPurchaseCharge.GetChargeID()
 		initatedTrnsID = initatedCallback.id
@@ -885,7 +885,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
 			assert.Nil(t, charge.Realizations.InvoiceSettlement)
-			assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 		})
 
 		invoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
@@ -916,7 +916,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 		// Payment authorization is no longer persisted at pending.
 		s.Equal(0, authorizedCallback.nrInvocations)
 		s.Nil(creditPurchaseCharge.Realizations.InvoiceSettlement)
-		s.Equal(creditpurchase.StatusActive, creditPurchaseCharge.Status, "charge status should be active")
+		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status, "charge status should be payment pending")
 
 		// validate the standard line
 		lines := invoice.Lines.OrEmpty()
@@ -960,7 +960,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 
 			// Authorized transaction group ID should still be set from the authorized phase
 			assert.Equal(t, authorizedCallback.id, charge.Realizations.InvoiceSettlement.Authorized.TransactionGroupID)
-			assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+			assert.Equal(t, creditpurchase.StatusActivePaymentSettled, charge.Status, "charge status should be payment settled")
 		})
 
 		// First verify the invoice is in the expected state

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -131,7 +131,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedCreatesInvoiceArtifacts() 
 	})
 	s.Require().NoError(err)
 	s.Equal(creditpurchase.SettlementTypeInvoice, grant.Intent.Settlement.Type())
-	s.Equal(creditpurchase.StatusActive, grant.Status)
+	s.Equal(creditpurchase.StatusActivePaymentPending, grant.Status)
 	s.NotNil(grant.Realizations.CreditGrantRealization)
 
 	standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
@@ -495,7 +495,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigTo
 		},
 	})
 	s.Require().NoError(err)
-	s.Equal(creditpurchase.StatusActive, grant.Status)
+	s.Equal(creditpurchase.StatusActivePaymentPending, grant.Status)
 
 	standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
 		Namespaces: []string{ns},

--- a/test/credits/voidgrant_test.go
+++ b/test/credits/voidgrant_test.go
@@ -740,7 +740,7 @@ func (s *VoidGrantTestSuite) setupInvoiceFundedVoidGrant(ctx context.Context, ns
 		},
 	})
 	s.Require().NoError(err)
-	s.Equal(creditpurchase.StatusActive, grant.Status)
+	s.Equal(creditpurchase.StatusActivePaymentPending, grant.Status)
 	s.Require().NotNil(grant.Realizations.CreditGrantRealization)
 
 	standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{


### PR DESCRIPTION
## Summary

- model invoice-settled credit purchases with the same stateless lifecycle pattern used by charge state machines
- separate credit granting, invoice payment authorization, settlement, and finalization into explicit detailed states
- move payment and grant mechanics into the realization service with validated operation inputs
- map legacy generic active charges from their persisted realization facts at state-machine construction time
- update domain documentation and lifecycle coverage, including PostgreSQL-backed credit grant scenarios

## Why

This is a refactor that establishes the lifecycle boundary needed before implementing cost-basis pinning.

Ticket: OM-436

## Impact

Invoice-settled credit purchases now expose detailed payment lifecycle statuses instead of the generic active status. Existing active charges are mapped at runtime without replaying ledger effects; a follow-up SQL migration is documented in code.

## Validation

- `nix develop --impure .#ci -c make lint`
- `nix develop --impure .#ci -c make test` — 6,785 tests passed, 9 skipped
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/credits`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice-funded credit purchases now follow distinct payment stages: pending, authorized, and settled.
  * Credits are granted when an invoice is created, before payment authorization.
  * External direct-paid purchases can record authorization and settlement sequentially.
* **Bug Fixes**
  * Improved validation for invoice, payment, and charge relationships.
  * Prevented mismatched payment lines and incomplete credit grants from advancing.
* **Documentation**
  * Updated billing guidance to reflect invoice creation, authorization, and settlement workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refactors invoice-settled credit purchases onto the stateless charge lifecycle and derives detailed states for legacy active purchases.
- Separates credit granting, payment authorization, settlement, and finalization into explicit transitions.
- Moves invoice payment realization logic behind validated realization-service operations.
- Adds lifecycle, legacy-state mapping, exact-amount, and PostgreSQL-backed credit-grant coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The new lifecycle preserves transactional persistence on billing hook paths, maps legacy states from durable realization facts, and validates charge, invoice, line, and payment relationships before performing effects.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/creditpurchase/service/invoice.go | Introduces the invoice credit-purchase state machine, legacy-state mapping, validated lifecycle dispatch, and billing-hook adapters; no actionable defect was established. |
| openmeter/billing/charges/creditpurchase/service/realizations/service.go | Generalizes credit granting across payment-backed settlements and adds validated invoice authorization and settlement realization operations. |
| openmeter/billing/charges/creditpurchase/service/invoice_test.go | Covers grant, authorization, settlement, fiat amount preservation, legacy mappings, and invalid realization relationships. |
| openmeter/billing/charges/README.md | Documents the new invoice-backed credit-purchase lifecycle and durable realization facts. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Created[Created] -->|Invoice created| Grant[Active: initial credit grant]
  Grant -->|Grant credits / next| Pending[Active: payment pending]
  Pending -->|Payment authorized| Authorized[Active: payment authorized]
  Authorized -->|Payment paid| Settled[Active: payment settled]
  Settled -->|Finalize / next| Final[Final]
  Legacy[Legacy active] -. Grant only .-> Pending
  Legacy -. Authorized payment .-> Authorized
  Legacy -. Settled payment .-> Final
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(credit): model invoice purchase..."](https://github.com/openmeterio/openmeter/commit/8b83c37400025f645fcb5a44d65df8d27d545079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50728082)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->