### PR TITLE
fix: preserve invoice backend for zero-amount artifacts

### DIFF
--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
@@ -178,11 +178,16 @@ func (s *Service) diffItem(
 // non-billable targets behave as absent targets and naturally reconcile to
 // delete/no-op outcomes.
 //
-// The router decides which backend a target would use if it had to be created.
-// Only invoicing-backed targets are gated on GetExpectedLine(): if a target
-// does not realize to an invoice line, it should not be diffed as an invoice
-// artifact. Charge-backed targets are filtered by billability only.
-func filterInScopeLines(inScopeLines []targetstate.StateItem, patchCollections *patchCollectionRouter) ([]targetstate.StateItem, error) {
+// Existing artifacts retain their persisted backend; only new targets use the
+// default backend. Invoicing-backed targets are gated on GetExpectedLine(): if
+// a target does not realize to an invoice line, it should behave as absent and
+// naturally retire any existing invoice artifact. Charge-backed targets are
+// filtered by billability only.
+func filterInScopeLines(
+	inScopeLines []targetstate.StateItem,
+	persistedByUniqueID map[string]persistedstate.Item,
+	patchCollections *patchCollectionRouter,
+) ([]targetstate.StateItem, error) {
 	out := make([]targetstate.StateItem, 0, len(inScopeLines))
 
 	for _, line := range inScopeLines {
@@ -190,12 +195,18 @@ func filterInScopeLines(inScopeLines []targetstate.StateItem, patchCollections *
 			continue
 		}
 
-		defaultCollection, err := patchCollections.ResolveDefaultCollection(line)
+		var collection PatchCollection
+		var err error
+		if existing := persistedByUniqueID[line.UniqueID]; existing != nil {
+			collection, err = patchCollections.GetCollectionFor(existing)
+		} else {
+			collection, err = patchCollections.ResolveDefaultCollection(line)
+		}
 		if err != nil {
-			return nil, fmt.Errorf("resolving default patch collection for line[%s]: %w", line.UniqueID, err)
+			return nil, fmt.Errorf("resolving patch collection for line[%s]: %w", line.UniqueID, err)
 		}
 
-		if defaultCollection.GetLineEngineType().IsCharge() {
+		if collection.GetLineEngineType().IsCharge() {
 			out = append(out, line)
 			continue
 		}
@@ -242,11 +253,11 @@ func (s *Service) Plan(ctx context.Context, input PlanInput) (*Plan, error) {
 		return nil, fmt.Errorf("patchCollectionRouter is nil")
 	}
 
-	inScopeLines, err := filterInScopeLines(input.Target.Items, patchCollections)
+	persisted := input.Persisted
+	inScopeLines, err := filterInScopeLines(input.Target.Items, persisted.ByUniqueID, patchCollections)
 	if err != nil {
 		return nil, fmt.Errorf("filtering in-scope lines: %w", err)
 	}
-	persisted := input.Persisted
 
 	if len(inScopeLines) == 0 && len(persisted.ByUniqueID) == 0 {
 		return &Plan{

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -2461,14 +2461,15 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) TestMigratesProratedZeroAmountInvoiceLineToCharge() {
+func (s *CreditThenInvoiceTestSuite) TestRetiresProratedZeroAmountInvoiceLineWithoutMigratingBackend() {
 	// given:
 	// - a credit-then-invoice subscription was synchronized without a charges service, which falls back to invoice-backed storage
-	// - its in-advance flat fee is canceled early enough that the prorated USD amount rounds to zero
+	// - its in-advance flat fee is replaced quickly enough that the old version's prorated USD amount rounds to zero
 	// when:
 	// - the same subscription is synchronized with credit-then-invoice charge provisioning enabled
 	// then:
-	// - the invoice-backed line is deleted and a zero-amount charge takes ownership of the item
+	// - the zero-valued invoice-backed artifact is retired without migrating its backend ownership
+	// - the new item version is provisioned through the charge backend
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")
 	syncUntil := s.mustParseTime("2024-01-15T00:00:00Z")
@@ -2513,7 +2514,7 @@ func (s *CreditThenInvoiceTestSuite) TestMigratesProratedZeroAmountInvoiceLineTo
 								Key:  "users",
 								Name: "users",
 								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-									Amount:      alpacadecimal.NewFromFloat(0.01),
+									Amount:      alpacadecimal.NewFromInt(8),
 									PaymentTerm: productcatalog.InAdvancePaymentTerm,
 								}),
 							},
@@ -2525,7 +2526,7 @@ func (s *CreditThenInvoiceTestSuite) TestMigratesProratedZeroAmountInvoiceLineTo
 		},
 	})
 
-	clock.FreezeTime(start.Add(time.Minute))
+	clock.FreezeTime(start.Add(time.Second))
 	s.NoError(invoiceBackedService.SyncByView(ctx, subView, syncUntil))
 
 	invoiceBackedInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2539,32 +2540,67 @@ func (s *CreditThenInvoiceTestSuite) TestMigratesProratedZeroAmountInvoiceLineTo
 	childUniqueReferenceID := *invoiceBackedLine.ChildUniqueReferenceID
 	invoiceBackedPrice, err := invoiceBackedLine.Price.AsFlat()
 	s.NoError(err)
-	s.Equal(float64(0.01), invoiceBackedPrice.Amount.InexactFloat64())
+	s.Equal(float64(8), invoiceBackedPrice.Amount.InexactFloat64())
 
-	cancelAt := start.Add(24 * time.Hour)
-	clock.FreezeTime(cancelAt)
-	subscriptionModel, err := s.SubscriptionService.Cancel(ctx, subView.Subscription.NamespacedID, subscription.Timing{
-		Enum: lo.ToPtr(subscription.TimingImmediate),
+	editAt := start.Add(9 * time.Second)
+	clock.FreezeTime(editAt)
+	editedSubView, err := s.SubscriptionWorkflowService.EditRunning(ctx, subView.Subscription.NamespacedID, []subscription.Patch{
+		&patch.PatchRemoveItem{
+			PhaseKey: "default",
+			ItemKey:  "users",
+		},
+		(subscriptionAddItem{
+			PhaseKey: "default",
+			ItemKey:  "users",
+			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount:      alpacadecimal.NewFromInt(24),
+				PaymentTerm: productcatalog.InAdvancePaymentTerm,
+			}),
+			BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+		}).AsPatch(),
+	}, s.timingImmediate())
+	s.NoError(err)
+
+	usersVersions := editedSubView.Phases[0].ItemsByKey["users"]
+	s.Require().Len(usersVersions, 2)
+	s.Require().NotNil(usersVersions[0].SubscriptionItem.ActiveTo)
+	s.Equal(editAt, *usersVersions[0].SubscriptionItem.ActiveTo)
+
+	s.Require().NoError(s.Service.SyncByView(ctx, editedSubView, syncUntil))
+
+	retiredInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: invoiceBackedInvoice.GetInvoiceID(),
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+			billing.GatheringInvoiceExpandDeletedLines,
+		},
 	})
 	s.NoError(err)
+	retiredLine, found := lo.Find(retiredInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ID == invoiceBackedLine.ID
+	})
+	s.Require().True(found)
+	s.NotNil(retiredLine.DeletedAt)
 
-	canceledSubView, err := s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
-	s.NoError(err)
-
-	s.Require().NoError(s.Service.SyncByView(ctx, canceledSubView, syncUntil))
-
-	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	chargeList, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:       s.Namespace,
 		SubscriptionIDs: []string{subView.Subscription.ID},
 		IncludeDeleted:  true,
 	})
 	s.NoError(err)
-	s.Require().Len(chargeList.Items, 1)
-	s.Equal(chargesmeta.ChargeTypeFlatFee, chargeList.Items[0].Type())
-	chargeUniqueReferenceID, err := chargeList.Items[0].GetUniqueReferenceID()
-	s.NoError(err)
-	s.Equal(lo.ToPtr(childUniqueReferenceID), chargeUniqueReferenceID)
+	s.NotEmpty(chargeList.Items)
+	chargeUniqueReferenceIDs := make([]string, 0, len(chargeList.Items))
+	for _, charge := range chargeList.Items {
+		s.Equal(chargesmeta.ChargeTypeFlatFee, charge.Type())
+
+		chargeUniqueReferenceID, err := charge.GetUniqueReferenceID()
+		s.NoError(err)
+		s.Require().NotNil(chargeUniqueReferenceID)
+		chargeUniqueReferenceIDs = append(chargeUniqueReferenceIDs, *chargeUniqueReferenceID)
+	}
+
+	s.NotContains(chargeUniqueReferenceIDs, childUniqueReferenceID)
+	s.Contains(chargeUniqueReferenceIDs, fmt.Sprintf("%s/default/users/v[1]/period[0]", subView.Subscription.ID))
 }
 
 func (s *CreditThenInvoiceTestSuite) TestDefactoZeroPrices() {

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -2486,7 +2486,7 @@ func (s *CreditThenInvoiceTestSuite) TestRetiresProratedZeroAmountInvoiceLineWit
 			featuregate.CtxKeyCredits: string(featuregate.CtxKeyCredits),
 		}, map[featuregate.FeatureFlag]bool{featuregate.CtxKeyCredits: true}),
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	subView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
 		NamespacedModel: models.NamespacedModel{
@@ -2559,7 +2559,7 @@ func (s *CreditThenInvoiceTestSuite) TestRetiresProratedZeroAmountInvoiceLineWit
 			BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
 		}).AsPatch(),
 	}, s.timingImmediate())
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	usersVersions := editedSubView.Phases[0].ItemsByKey["users"]
 	s.Require().Len(usersVersions, 2)

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -2461,6 +2461,112 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 	})
 }
 
+func (s *CreditThenInvoiceTestSuite) TestMigratesProratedZeroAmountInvoiceLineToCharge() {
+	// given:
+	// - a credit-then-invoice subscription was synchronized without a charges service, which falls back to invoice-backed storage
+	// - its in-advance flat fee is canceled early enough that the prorated USD amount rounds to zero
+	// when:
+	// - the same subscription is synchronized with credit-then-invoice charge provisioning enabled
+	// then:
+	// - the invoice-backed line is deleted and a zero-amount charge takes ownership of the item
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	syncUntil := s.mustParseTime("2024-01-15T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	invoiceBackedService, err := New(Config{
+		BillingService:          s.BillingService,
+		Logger:                  s.Service.logger,
+		Tracer:                  s.Service.tracer,
+		SubscriptionSyncAdapter: s.Adapter,
+		SubscriptionService:     s.SubscriptionService,
+		FeatureGate: featuregate.NewFeatureGateChecker(featuregate.NewNoop(), featuregate.Flags{
+			featuregate.CtxKeyCredits: string(featuregate.CtxKeyCredits),
+		}, map[featuregate.FeatureFlag]bool{featuregate.CtxKeyCredits: true}),
+	})
+	s.NoError(err)
+
+	subView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currencies.NewCurrencyReference(currencyx.Code(currency.USD)),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("default", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "users",
+								Name: "users",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(0.01),
+									PaymentTerm: productcatalog.InAdvancePaymentTerm,
+								}),
+							},
+							BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	clock.FreezeTime(start.Add(time.Minute))
+	s.NoError(invoiceBackedService.SyncByView(ctx, subView, syncUntil))
+
+	invoiceBackedInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	invoiceBackedLines := invoiceBackedInvoice.Lines.OrEmpty()
+	invoiceBackedLine, found := lo.Find(invoiceBackedLines, func(line billing.GatheringLine) bool {
+		return line.ServicePeriod.From.Equal(start)
+	})
+	s.Require().True(found)
+	s.Nil(invoiceBackedLine.ChargeID)
+	s.Require().NotNil(invoiceBackedLine.ChildUniqueReferenceID)
+	childUniqueReferenceID := *invoiceBackedLine.ChildUniqueReferenceID
+	invoiceBackedPrice, err := invoiceBackedLine.Price.AsFlat()
+	s.NoError(err)
+	s.Equal(float64(0.01), invoiceBackedPrice.Amount.InexactFloat64())
+
+	cancelAt := start.Add(24 * time.Hour)
+	clock.FreezeTime(cancelAt)
+	subscriptionModel, err := s.SubscriptionService.Cancel(ctx, subView.Subscription.NamespacedID, subscription.Timing{
+		Enum: lo.ToPtr(subscription.TimingImmediate),
+	})
+	s.NoError(err)
+
+	canceledSubView, err := s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
+	s.NoError(err)
+
+	s.Require().NoError(s.Service.SyncByView(ctx, canceledSubView, syncUntil))
+
+	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	chargeList, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:       s.Namespace,
+		SubscriptionIDs: []string{subView.Subscription.ID},
+		IncludeDeleted:  true,
+	})
+	s.NoError(err)
+	s.Require().Len(chargeList.Items, 1)
+	s.Equal(chargesmeta.ChargeTypeFlatFee, chargeList.Items[0].Type())
+	chargeUniqueReferenceID, err := chargeList.Items[0].GetUniqueReferenceID()
+	s.NoError(err)
+	s.Equal(lo.ToPtr(childUniqueReferenceID), chargeUniqueReferenceID)
+}
+
 func (s *CreditThenInvoiceTestSuite) TestDefactoZeroPrices() {
 	ctx := s.T().Context()
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))


### PR DESCRIPTION
## What changed

Subscription reconciliation now determines zero-amount filtering from the backend that already owns the persisted artifact. A target backed by a legacy invoice line must still pass invoice-line realization; when proration rounds that target to zero, it behaves as absent and the legacy artifact is retired instead of being implicitly migrated to a charge.

Default charge routing remains unchanged for genuinely new subscription-sync identities.

## Root cause

`filterInScopeLines` resolved every target through the current default backend before diff planning. If charge provisioning became available after an invoice-backed artifact had already been created, the target was classified as charge-backed and bypassed invoice-line realization. A prorated amount that rounded to zero could therefore survive filtering, causing reconciliation to delete the legacy line and create a zero-amount charge for the same identity.

## Regression coverage

The integration test reproduces the transition with the production billing, subscription, charge, ledger, and PostgreSQL fixture stack:

1. synchronize a credit-then-invoice subscription while only invoice-backed persistence is available;
2. replace the flat-fee item shortly afterward so the old version prorates to zero;
3. synchronize with charge provisioning enabled;
4. verify the legacy invoice line is retired, no charge takes its identity, and the new item version is provisioned through charges.

## Impact

This preserves stable backend ownership for existing subscription-sync artifacts and prevents an implicit invoice-to-charge migration when a legacy artifact recalculates to zero.

## Validation

- `make test-nocache`: 6791 tests passed, 9 skipped
- reconciler package tests
- focused credit-then-invoice regression
- `git diff --check`

No Jira ticket: maintenance/reliability fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing backend assignments during subscription reconciliation.
  * Correctly applied expected-line filtering to invoice-backed items.
  * Removed obsolete zero-value prorated invoice lines without creating unintended charges.
  * Ensured replacement subscription versions are provisioned with the correct flat-fee charge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Subscription reconciliation now selects the backend already associated with a persisted artifact while retaining default routing for new identities.
- Resolves existing targets through their persisted patch collection before zero-amount filtering.
- Retires a zero-valued legacy invoice line without migrating its identity to a charge.
- Adds integration coverage for replacing an invoice-backed flat-fee item after charge provisioning becomes available.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go | Preserves persisted backend ownership during target filtering and uses default routing only for new reconciliation identities. |
| openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go | Adds end-to-end coverage for retiring a prorated legacy invoice line without creating a charge under the same identity. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  T[Subscription target] --> P{Persisted artifact exists?}
  P -->|Yes| E[Use persisted backend]
  P -->|No| D[Resolve default backend]
  E --> B{Backend type}
  D --> B
  B -->|Invoice| R[Realize expected invoice line]
  B -->|Charge| C[Keep billable target]
  R -->|Zero or absent| X[Treat target as absent and retire legacy line]
  R -->|Present| I[Reconcile invoice line]
  C --> Q[Reconcile charge]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: require dependent subscription syn..."](https://github.com/openmeterio/openmeter/commit/fb76334ba29dfaea266f592a2aabbddb2f19ef66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50780271)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->