### PR TITLE
feat: backfill credit purchases to cost basis schema level 2

### DIFF
--- a/tools/migrate/credit_purchase_cost_basis_backfill_test.go
+++ b/tools/migrate/credit_purchase_cost_basis_backfill_test.go
@@ -1,0 +1,303 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+const creditPurchaseCostBasisSchemaLevel2Migration = "20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql"
+
+func TestMigrateCreditPurchaseCostBasisSchemaLevel2(t *testing.T) {
+	withCreditPurchaseCostBasisBackfillTables(t, func(db *sql.DB) {
+		createdAt := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+		_, err := db.ExecContext(t.Context(), `
+			INSERT INTO charge_credit_purchases (
+				id, namespace, created_at, currency, custom_currency_id, settlement, schema_level,
+				fiat_cost_basis, settlement_type, initial_payment_settlement_status
+			) VALUES
+				('promotional', 'default', $1, 'USD', NULL, '{"type":"promotional"}', 1, NULL, NULL, NULL),
+				('invoice-fiat', 'default', $1, 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"0.5"}', 1, NULL, NULL, NULL),
+				('external-custom', 'default', $1, NULL, 'custom-1', '{"type":"external","currency":"EUR","costBasis":"1.25","status":"authorized"}', 1, NULL, NULL, NULL),
+				('native-level-2', 'default', $1, 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"2"}', 2, 2, 'invoice', NULL)
+		`, createdAt)
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(t.Context(), readMigration(t, creditPurchaseCostBasisSchemaLevel2Migration))
+		require.NoError(t, err)
+
+		var schemaLevel int
+		var settlementType string
+		var fiatCostBasis, costBasisID, initialStatus sql.NullString
+
+		err = db.QueryRowContext(t.Context(), `
+			SELECT schema_level, settlement_type, fiat_cost_basis::text, cost_basis_id, initial_payment_settlement_status
+			FROM charge_credit_purchases
+			WHERE id = 'promotional'
+		`).Scan(&schemaLevel, &settlementType, &fiatCostBasis, &costBasisID, &initialStatus)
+		require.NoError(t, err)
+		require.Equal(t, 2, schemaLevel)
+		require.Equal(t, "promotional", settlementType)
+		require.False(t, fiatCostBasis.Valid)
+		require.False(t, costBasisID.Valid)
+		require.False(t, initialStatus.Valid)
+
+		err = db.QueryRowContext(t.Context(), `
+			SELECT schema_level, settlement_type, fiat_cost_basis::text, cost_basis_id, initial_payment_settlement_status
+			FROM charge_credit_purchases
+			WHERE id = 'invoice-fiat'
+		`).Scan(&schemaLevel, &settlementType, &fiatCostBasis, &costBasisID, &initialStatus)
+		require.NoError(t, err)
+		require.Equal(t, 2, schemaLevel)
+		require.Equal(t, "invoice", settlementType)
+		require.Equal(t, "0.5", fiatCostBasis.String)
+		require.False(t, costBasisID.Valid)
+		require.False(t, initialStatus.Valid)
+
+		err = db.QueryRowContext(t.Context(), `
+			SELECT schema_level, settlement_type, fiat_cost_basis::text, cost_basis_id, initial_payment_settlement_status
+			FROM charge_credit_purchases
+			WHERE id = 'external-custom'
+		`).Scan(&schemaLevel, &settlementType, &fiatCostBasis, &costBasisID, &initialStatus)
+		require.NoError(t, err)
+		require.Equal(t, 2, schemaLevel)
+		require.Equal(t, "external", settlementType)
+		require.False(t, fiatCostBasis.Valid)
+		require.True(t, costBasisID.Valid)
+		require.Equal(t, "authorized", initialStatus.String)
+
+		var mode, fiatCurrency, manualRate, resolvedCostBasis, namespace, currencyID string
+		var resolvedAt time.Time
+		var currencyCostBasisID, resolvedCostBasisID sql.NullString
+		err = db.QueryRowContext(t.Context(), `
+			SELECT
+				mode, fiat_currency, manual_rate::text, resolved_cost_basis::text, resolved_at,
+				namespace, currency_id, currency_cost_basis_id, resolved_cost_basis_id
+			FROM charge_credit_purchase_cost_bases
+			WHERE id = $1
+		`, costBasisID.String).Scan(
+			&mode,
+			&fiatCurrency,
+			&manualRate,
+			&resolvedCostBasis,
+			&resolvedAt,
+			&namespace,
+			&currencyID,
+			&currencyCostBasisID,
+			&resolvedCostBasisID,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "manual", mode)
+		require.Equal(t, "EUR", fiatCurrency)
+		require.Equal(t, "1.25", manualRate)
+		require.Equal(t, "1.25", resolvedCostBasis)
+		require.Equal(t, createdAt, resolvedAt.UTC())
+		require.Equal(t, "default", namespace)
+		require.Equal(t, "custom-1", currencyID)
+		require.False(t, currencyCostBasisID.Valid)
+		require.False(t, resolvedCostBasisID.Valid)
+
+		var nativeFiatCostBasis string
+		err = db.QueryRowContext(t.Context(), `
+			SELECT schema_level, fiat_cost_basis::text
+			FROM charge_credit_purchases
+			WHERE id = 'native-level-2'
+		`).Scan(&schemaLevel, &nativeFiatCostBasis)
+		require.NoError(t, err)
+		require.Equal(t, 2, schemaLevel)
+		require.Equal(t, "2", nativeFiatCostBasis)
+
+		var legacyRows int
+		err = db.QueryRowContext(t.Context(), `SELECT count(*) FROM charge_credit_purchases WHERE schema_level = 1`).Scan(&legacyRows)
+		require.NoError(t, err)
+		require.Zero(t, legacyRows)
+	})
+}
+
+func TestMigrateCreditPurchaseCostBasisSchemaLevel2WaitsForLockedRows(t *testing.T) {
+	withCreditPurchaseCostBasisBackfillTables(t, func(db *sql.DB) {
+		_, err := db.ExecContext(t.Context(), `
+			INSERT INTO charge_credit_purchases (
+				id, namespace, created_at, currency, settlement, schema_level
+			) VALUES (
+				'locked-row', 'default', NOW(), 'USD',
+				'{"type":"invoice","currency":"USD","costBasis":"1"}', 1
+			)
+		`)
+		require.NoError(t, err)
+
+		lockTx, err := db.BeginTx(t.Context(), nil)
+		require.NoError(t, err)
+		defer func() {
+			_ = lockTx.Rollback()
+		}()
+
+		_, err = lockTx.ExecContext(t.Context(), `
+			SELECT id
+			FROM charge_credit_purchases
+			WHERE id = 'locked-row'
+			FOR UPDATE
+		`)
+		require.NoError(t, err)
+
+		migrationConn, err := db.Conn(t.Context())
+		require.NoError(t, err)
+		defer migrationConn.Close()
+
+		_, err = migrationConn.ExecContext(t.Context(), `SET statement_timeout = '250ms'`)
+		require.NoError(t, err)
+
+		_, err = migrationConn.ExecContext(t.Context(), readMigration(t, creditPurchaseCostBasisSchemaLevel2Migration))
+		require.ErrorContains(t, err, "canceling statement due to statement timeout")
+
+		_, err = migrationConn.ExecContext(t.Context(), `ROLLBACK`)
+		require.NoError(t, err)
+		require.NoError(t, lockTx.Rollback())
+
+		var schemaLevel int
+		err = db.QueryRowContext(t.Context(), `SELECT schema_level FROM charge_credit_purchases WHERE id = 'locked-row'`).Scan(&schemaLevel)
+		require.NoError(t, err)
+		require.Equal(t, 1, schemaLevel)
+	})
+}
+
+func TestMigrateCreditPurchaseCostBasisSchemaLevel2RejectsInvalidRows(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		insert  string
+		wantErr string
+	}{
+		{
+			name:    "unsupported settlement type",
+			insert:  `('invalid-type', 'default', NOW(), 'USD', NULL, '{"type":"unknown"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "unsupported settlement types",
+		},
+		{
+			name:    "dedicated state on legacy row",
+			insert:  `('dedicated-state', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"1"}', 1, 1, NULL, NULL, NULL)`,
+			wantErr: "dedicated schema-level state",
+		},
+		{
+			name:    "missing cost basis",
+			insert:  `('missing-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "zero cost basis",
+			insert:  `('zero-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"0"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "negative cost basis",
+			insert:  `('negative-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"-1"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "NaN cost basis",
+			insert:  `('nan-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"NaN"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "infinite cost basis",
+			insert:  `('infinite-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"Infinity"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "malformed cost basis",
+			insert:  `('malformed-rate', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"USD","costBasis":"not-a-number"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid cost basis",
+		},
+		{
+			name:    "mismatched fiat settlement currency",
+			insert:  `('currency-mismatch', 'default', NOW(), 'USD', NULL, '{"type":"invoice","currency":"EUR","costBasis":"1"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid settlement currency",
+		},
+		{
+			name:    "missing custom currency",
+			insert:  `('missing-custom-currency', 'default', NOW(), NULL, NULL, '{"type":"invoice","currency":"EUR","costBasis":"1"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid settlement currency",
+		},
+		{
+			name:    "missing external status",
+			insert:  `('missing-status', 'default', NOW(), 'USD', NULL, '{"type":"external","currency":"USD","costBasis":"1"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid settlement compatibility fields",
+		},
+		{
+			name:    "promotional payment fields",
+			insert:  `('promotional-fields', 'default', NOW(), 'USD', NULL, '{"type":"promotional","currency":"USD"}', 1, NULL, NULL, NULL, NULL)`,
+			wantErr: "invalid settlement compatibility fields",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withCreditPurchaseCostBasisBackfillTables(t, func(db *sql.DB) {
+				_, err := db.ExecContext(t.Context(), `
+					INSERT INTO charge_credit_purchases (
+						id, namespace, created_at, currency, custom_currency_id, settlement, schema_level,
+						fiat_cost_basis, cost_basis_id, settlement_type, initial_payment_settlement_status
+					) VALUES `+tc.insert)
+				require.NoError(t, err)
+
+				_, err = db.ExecContext(t.Context(), readMigration(t, creditPurchaseCostBasisSchemaLevel2Migration))
+				require.ErrorContains(t, err, tc.wantErr)
+			})
+		})
+	}
+}
+
+func withCreditPurchaseCostBasisBackfillTables(t *testing.T, action func(db *sql.DB)) {
+	t.Helper()
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	defer testDB.PGDriver.Close()
+
+	db := testDB.PGDriver.DB()
+	_, err := db.ExecContext(t.Context(), `
+		CREATE SEQUENCE om_test_ulid_sequence;
+
+		CREATE FUNCTION om_func_generate_ulid()
+		RETURNS text
+		LANGUAGE sql
+		VOLATILE
+		AS $$
+			SELECT lpad(nextval('om_test_ulid_sequence')::text, 26, '0')
+		$$;
+
+		CREATE TABLE charge_credit_purchases (
+			id text PRIMARY KEY,
+			namespace text NOT NULL,
+			created_at timestamptz NOT NULL,
+			currency varchar(3) NULL,
+			custom_currency_id text NULL,
+			settlement jsonb NOT NULL,
+			schema_level smallint NOT NULL,
+			fiat_cost_basis numeric NULL,
+			settlement_type text NULL,
+			initial_payment_settlement_status text NULL,
+			cost_basis_id text NULL
+		);
+
+		CREATE TABLE charge_credit_purchase_cost_bases (
+			id text PRIMARY KEY,
+			mode text NOT NULL,
+			fiat_currency varchar(3) NOT NULL,
+			manual_rate numeric NULL,
+			resolved_cost_basis numeric NULL,
+			resolved_at timestamptz NULL,
+			namespace text NOT NULL,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL,
+			deleted_at timestamptz NULL,
+			currency_cost_basis_id text NULL,
+			resolved_cost_basis_id text NULL,
+			currency_id text NOT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	action(db)
+}

--- a/tools/migrate/credit_purchase_cost_basis_backfill_test.go
+++ b/tools/migrate/credit_purchase_cost_basis_backfill_test.go
@@ -1,6 +1,7 @@
 package migrate_test
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -149,14 +150,11 @@ func TestMigrateCreditPurchaseCostBasisSchemaLevel2WaitsForLockedRows(t *testing
 		require.NoError(t, err)
 		defer migrationConn.Close()
 
-		_, err = migrationConn.ExecContext(t.Context(), `SET statement_timeout = '250ms'`)
-		require.NoError(t, err)
+		migrationContext, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		_, err = migrationConn.ExecContext(migrationContext, readMigration(t, creditPurchaseCostBasisSchemaLevel2Migration))
+		cancel()
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 
-		_, err = migrationConn.ExecContext(t.Context(), readMigration(t, creditPurchaseCostBasisSchemaLevel2Migration))
-		require.ErrorContains(t, err, "canceling statement due to statement timeout")
-
-		_, err = migrationConn.ExecContext(t.Context(), `ROLLBACK`)
-		require.NoError(t, err)
 		require.NoError(t, lockTx.Rollback())
 
 		var schemaLevel int

--- a/tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.down.sql
+++ b/tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.down.sql
@@ -1,0 +1,3 @@
+-- Intentionally no-op. The migration preserves the legacy settlement shadow,
+-- but deleting the new authoritative state would make rows unreadable by the
+-- schema-level-2 application and could discard later writes.

--- a/tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql
+++ b/tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql
@@ -1,0 +1,263 @@
+BEGIN;
+
+-- The application uses the same row lock when lazily upgrading a legacy charge.
+-- Locking in ID order makes the two upgrade paths serialize deterministically.
+DO $migration$
+BEGIN
+  PERFORM "id"
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+  ORDER BY "id"
+  FOR UPDATE;
+END
+$migration$;
+
+DO $migration$
+DECLARE
+  invalid_ids TEXT;
+BEGIN
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+    AND COALESCE("settlement"->>'type', '') NOT IN ('invoice', 'external', 'promotional');
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot migrate credit purchases with unsupported settlement types [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+    AND (
+      "fiat_cost_basis" IS NOT NULL
+      OR "cost_basis_id" IS NOT NULL
+      OR "settlement_type" IS NOT NULL
+      OR "initial_payment_settlement_status" IS NOT NULL
+    );
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot migrate legacy credit purchases with dedicated schema-level state [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+    AND "settlement"->>'type' IN ('invoice', 'external')
+    AND CASE
+      WHEN "settlement"->>'costBasis' IS NULL THEN TRUE
+      WHEN "settlement"->>'costBasis' !~ '^[0-9]+(\.[0-9]+)?$' THEN TRUE
+      ELSE ("settlement"->>'costBasis')::numeric <= 0
+    END;
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot migrate credit purchases with an invalid cost basis [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+    AND "settlement"->>'type' IN ('invoice', 'external')
+    AND (
+      COALESCE("settlement"->>'currency', '') !~ '^[A-Z]{3}$'
+      OR ("currency" IS NULL) = ("custom_currency_id" IS NULL)
+      OR (
+        "custom_currency_id" IS NULL
+        AND "settlement"->>'currency' IS DISTINCT FROM "currency"
+      )
+    );
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot migrate credit purchases with an invalid settlement currency [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" = 1
+    AND (
+      (
+        "settlement"->>'type' = 'external'
+        AND COALESCE("settlement"->>'status', '') NOT IN ('created', 'authorized', 'settled')
+      )
+      OR (
+        "settlement"->>'type' = 'invoice'
+        AND "settlement" ? 'status'
+      )
+      OR (
+        "settlement"->>'type' = 'promotional'
+        AND (
+          "settlement" ? 'currency'
+          OR "settlement" ? 'costBasis'
+          OR "settlement" ? 'status'
+        )
+      )
+    );
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'cannot migrate credit purchases with invalid settlement compatibility fields [ids=%]', invalid_ids;
+  END IF;
+END
+$migration$;
+
+CREATE TEMP TABLE "om_credit_purchase_cost_basis_backfill" (
+  "charge_id" text PRIMARY KEY,
+  "cost_basis_id" character(26) NOT NULL UNIQUE
+) ON COMMIT DROP;
+
+INSERT INTO "om_credit_purchase_cost_basis_backfill" ("charge_id", "cost_basis_id")
+SELECT "id", om_func_generate_ulid()
+FROM "charge_credit_purchases"
+WHERE "schema_level" = 1
+  AND "settlement"->>'type' IN ('invoice', 'external')
+  AND "custom_currency_id" IS NOT NULL
+ORDER BY "id";
+
+INSERT INTO "charge_credit_purchase_cost_bases" (
+  "id",
+  "mode",
+  "fiat_currency",
+  "manual_rate",
+  "resolved_cost_basis",
+  "resolved_at",
+  "namespace",
+  "created_at",
+  "updated_at",
+  "deleted_at",
+  "currency_cost_basis_id",
+  "resolved_cost_basis_id",
+  "currency_id"
+)
+SELECT
+  "backfill"."cost_basis_id",
+  'manual',
+  "credit_purchase"."settlement"->>'currency',
+  ("credit_purchase"."settlement"->>'costBasis')::numeric,
+  ("credit_purchase"."settlement"->>'costBasis')::numeric,
+  "credit_purchase"."created_at",
+  "credit_purchase"."namespace",
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  NULL,
+  NULL,
+  NULL,
+  "credit_purchase"."custom_currency_id"
+FROM "om_credit_purchase_cost_basis_backfill" AS "backfill"
+JOIN "charge_credit_purchases" AS "credit_purchase"
+  ON "credit_purchase"."id" = "backfill"."charge_id";
+
+UPDATE "charge_credit_purchases" AS "credit_purchase"
+SET "cost_basis_id" = "backfill"."cost_basis_id"
+FROM "om_credit_purchase_cost_basis_backfill" AS "backfill"
+WHERE "credit_purchase"."id" = "backfill"."charge_id"
+  AND "credit_purchase"."schema_level" = 1;
+
+-- schema_level is the commit marker and is set only after the authoritative
+-- cost-basis representation has been populated.
+UPDATE "charge_credit_purchases"
+SET
+  "fiat_cost_basis" = CASE
+    WHEN "settlement"->>'type' IN ('invoice', 'external')
+      AND "custom_currency_id" IS NULL
+    THEN ("settlement"->>'costBasis')::numeric
+    ELSE NULL
+  END,
+  "settlement_type" = "settlement"->>'type',
+  "initial_payment_settlement_status" = CASE
+    WHEN "settlement"->>'type' = 'external' THEN "settlement"->>'status'
+    ELSE NULL
+  END,
+  "schema_level" = 2
+WHERE "schema_level" = 1;
+
+DO $migration$
+DECLARE
+  invalid_ids TEXT;
+BEGIN
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "schema_level" <> 2;
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'credit purchase cost-basis migration left rows below schema level 2 [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE "settlement_type" IS DISTINCT FROM "settlement"->>'type'
+    OR "initial_payment_settlement_status" IS DISTINCT FROM CASE
+      WHEN "settlement"->>'type' = 'external' THEN "settlement"->>'status'
+      ELSE NULL
+    END;
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'credit purchase settlement state does not match its compatibility shadow [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases"
+  WHERE (
+      "settlement_type" = 'promotional'
+      AND ("fiat_cost_basis" IS NOT NULL OR "cost_basis_id" IS NOT NULL)
+    )
+    OR (
+      "settlement_type" IN ('invoice', 'external')
+      AND "custom_currency_id" IS NULL
+      AND (
+        "fiat_cost_basis" IS DISTINCT FROM ("settlement"->>'costBasis')::numeric
+        OR "cost_basis_id" IS NOT NULL
+        OR "currency" IS DISTINCT FROM "settlement"->>'currency'
+      )
+    );
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'credit purchase fiat cost basis does not match its compatibility shadow [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("credit_purchase"."id"::text, ', ' ORDER BY "credit_purchase"."id")
+  INTO invalid_ids
+  FROM "charge_credit_purchases" AS "credit_purchase"
+  LEFT JOIN "charge_credit_purchase_cost_bases" AS "cost_basis"
+    ON "cost_basis"."id" = "credit_purchase"."cost_basis_id"
+  WHERE "credit_purchase"."settlement_type" IN ('invoice', 'external')
+    AND "credit_purchase"."custom_currency_id" IS NOT NULL
+    AND (
+      "credit_purchase"."fiat_cost_basis" IS NOT NULL
+      OR "credit_purchase"."cost_basis_id" IS NULL
+      OR "cost_basis"."id" IS NULL
+      OR "cost_basis"."namespace" IS DISTINCT FROM "credit_purchase"."namespace"
+      OR "cost_basis"."currency_id" IS DISTINCT FROM "credit_purchase"."custom_currency_id"
+      OR "cost_basis"."fiat_currency" IS DISTINCT FROM "credit_purchase"."settlement"->>'currency'
+      OR "cost_basis"."resolved_cost_basis" IS DISTINCT FROM ("credit_purchase"."settlement"->>'costBasis')::numeric
+    );
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'credit purchase custom-currency cost basis does not match its compatibility shadow [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("credit_purchase"."id"::text, ', ' ORDER BY "credit_purchase"."id")
+  INTO invalid_ids
+  FROM "om_credit_purchase_cost_basis_backfill" AS "backfill"
+  JOIN "charge_credit_purchases" AS "credit_purchase"
+    ON "credit_purchase"."id" = "backfill"."charge_id"
+  JOIN "charge_credit_purchase_cost_bases" AS "cost_basis"
+    ON "cost_basis"."id" = "backfill"."cost_basis_id"
+  WHERE "cost_basis"."mode" <> 'manual'
+    OR "cost_basis"."manual_rate" IS DISTINCT FROM ("credit_purchase"."settlement"->>'costBasis')::numeric
+    OR "cost_basis"."resolved_at" IS DISTINCT FROM "credit_purchase"."created_at"
+    OR "cost_basis"."currency_cost_basis_id" IS NOT NULL
+    OR "cost_basis"."resolved_cost_basis_id" IS NOT NULL;
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'migrated custom-currency cost basis is not a resolved manual cost basis [ids=%]', invalid_ids;
+  END IF;
+END
+$migration$;
+
+COMMIT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GNZ2ACihcSIraTFssDqhn3CEFuInz1FCJsuU3yxLAOQ=
+h1:8gxLlLOMzBrWA6o3y0GrqlrpAqmba9YCCwW9dVC0fEU=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -256,3 +256,4 @@ h1:GNZ2ACihcSIraTFssDqhn3CEFuInz1FCJsuU3yxLAOQ=
 20260806133101_create_charge_overage_credit_allocations.up.sql h1:NcoU7vOQ65Hqur1/Sg/r2zDgZtzBGuYfFXjSvcxiw7A=
 20260806141309_add_charge_run_detailed_line_amount_discounts.up.sql h1:tgLzJPz7ntYq5dmkuVINnkT8yvqmgIIV8m+8ppb+c9A=
 20260806163516_credit_purchase_cost_basis_bridge.up.sql h1:kRNpFRMflhq66wJbSnXkTlMDtcRNaxG1Pr56BNBW7Mw=
+20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql h1:k/byyaoUMzatU0fEugM3xNMyy607xkxlXEC1lAUMeDs=


### PR DESCRIPTION
## Summary

- migrate all remaining legacy credit purchases from cost-basis schema level 1 to level 2
- backfill fiat purchases into the dedicated scalar field
- materialize legacy custom-currency purchases as resolved manual cost-basis records
- preserve promotional purchases without cost-basis state and retain all legacy settlement JSON shadows
- add migration coverage for mapping, corruption rejection, and blocking row-lock behavior

## Why

This is deployment 2 of the credit-purchase cost-basis persistence rollout. Once the compatibility bridge is fully deployed, this migration moves untouched legacy rows onto the authoritative schema-level-2 representation so later work can remove the level-1 compatibility path.

The change is intentionally stacked on the persistence bridge in #4870.

## Deployment behavior

- locks level-1 candidates in deterministic ID order with `FOR UPDATE`
- intentionally does not use `SKIP LOCKED`; application writes wait on the same row lock protocol
- validates legacy settlement type, cost basis, currency, and compatibility fields before modifying data
- sets `schema_level = 2` only after the authoritative representation is complete
- verifies migration postconditions before commit
- keeps the down migration intentionally non-destructive

## Validation

- focused PostgreSQL migration tests
- complete migration up/down/up chain
- Atlas migration lint
- Atlas migration checksum validation
- `make lint-go-fast`

Ticket: OM-436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migration that upgrades credit purchase cost-basis records to schema level 2.
  * Backfills cost-basis information for promotional, fiat invoice, and custom-currency purchases.
  * Validates settlement and cost-basis data before applying changes.
  * Safely waits for locked records and reports affected records when checks fail.

* **Bug Fixes**
  * Preserved existing settlement and authoritative state when reversing the migration.

* **Tests**
  * Added coverage for successful migrations, locked records, existing level-2 data, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an atomic migration that validates legacy credit purchases, materializes their schema-level-2 cost-basis representation, and preserves the legacy settlement shadow.
- Locks and validates legacy rows before backfilling authoritative fields.
- Creates resolved manual cost-basis records for custom-currency purchases.
- Adds migration coverage for valid mappings, corrupt records, and row-lock blocking.
- Keeps rollback intentionally non-destructive and updates the Atlas checksum.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql | Adds the transactional validation, locking, cost-basis materialization, schema-level update, and postcondition checks. |
| tools/migrate/migrations/20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.down.sql | Documents an intentionally non-destructive no-op rollback. |
| tools/migrate/credit_purchase_cost_basis_backfill_test.go | Covers representative mappings, invalid legacy states, preservation of native level-2 rows, and lock-wait behavior. |
| tools/migrate/migrations/atlas.sum | Registers the new upward migration and updates the aggregate Atlas checksum. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Begin transaction] --> B[Lock schema-level-1 purchases in ID order]
  B --> C[Validate settlement and compatibility state]
  C --> D{Purchase type and currency}
  D -->|Promotional| E[Set settlement type only]
  D -->|Fiat invoice or external| F[Populate fiat cost basis]
  D -->|Custom currency| G[Create resolved manual cost-basis record]
  G --> H[Attach cost-basis ID]
  E --> I[Set schema level 2]
  F --> I
  H --> I
  I --> J[Verify postconditions]
  J --> K[Commit]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: scope migration lock timeout to co..."](https://github.com/openmeterio/openmeter/commit/89f4ee3335ca897c9bfa7bde9601fbfcba49b71d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51088058)</sub>

<!-- /greptile_comment -->