### PR TITLE
feat(kafka): add rackId for kafka consumers

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -241,6 +241,7 @@ func TestComplete(t *testing.T) {
 					SaslUsername:                 "user",
 					SaslPassword:                 "pass",
 					ClientID:                     "kafka-client-1",
+					ClientRack:                   "use1-az1",
 					StatsInterval:                pkgkafka.TimeDurationMilliSeconds(5 * time.Second),
 					BrokerAddressFamily:          pkgkafka.BrokerAddressFamilyAny,
 					TopicMetadataRefreshInterval: pkgkafka.TimeDurationMilliSeconds(time.Minute),

--- a/app/config/kafka.go
+++ b/app/config/kafka.go
@@ -69,6 +69,7 @@ func ConfigureKafkaConfiguration(v *viper.Viper, prefix string) {
 	v.SetDefault(AddPrefix(prefix, "kafka.socketKeepAliveEnabled"), false)
 	v.SetDefault(AddPrefix(prefix, "kafka.debugContexts"), nil)
 	v.SetDefault(AddPrefix(prefix, "kafka.clientID"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.clientRack"), "")
 	v.SetDefault(AddPrefix(prefix, "kafka.consumerGroupID"), "")
 	v.SetDefault(AddPrefix(prefix, "kafka.consumerGroupInstanceID"), "")
 	v.SetDefault(AddPrefix(prefix, "kafka.sessionTimeout"), "9s")

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -99,6 +99,7 @@ sink:
       - topic
       - consumer
     clientID: kafka-client-1
+    clientRack: use1-az1
     consumerGroupID: consumer-group
     consumerGroupInstanceID: consumer-group-1
     sessionTimeout: 5m

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -210,6 +210,9 @@ notification:
 #      - topic
 #    # Consumer/Producer identifier
 #    clientID: kafka-client-1
+#    # Rack identifier (e.g. availability zone) the client is running in.
+#    # Enables rack-aware consumer group assignment and fetching from the closest replica.
+#    clientRack: use1-az1
 #    # Consumer group identifier
 #    consumerGroupID: consumer-group
 #    # Static membership identifier in consumer group

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -57,6 +57,11 @@ type CommonConfigParams struct {
 
 	// ClientID sets the Consumer/Producer identifier
 	ClientID string
+
+	// ClientRack sets the rack identifier (e.g. availability zone) the client is running in.
+	// It enables rack-aware partition assignment for consumer groups and lets consumers fetch
+	// from the replica in the same rack, reducing cross-AZ network traffic.
+	ClientRack string
 }
 
 func (c CommonConfigParams) AsConfigMap() (kafka.ConfigMap, error) {
@@ -137,6 +142,12 @@ func (c CommonConfigParams) AsConfigMap() (kafka.ConfigMap, error) {
 
 	if c.ClientID != "" {
 		if err := m.SetKey("client.id", c.ClientID); err != nil {
+			return nil, err
+		}
+	}
+
+	if c.ClientRack != "" {
+		if err := m.SetKey("client.rack", c.ClientRack); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -20,6 +20,7 @@ func TestConsumerConfig(t *testing.T) {
 		ExpectedError           error
 		ExpectedValidationError error
 		ExpectedConfigMap       kafka.ConfigMap
+		ExpectedAbsentKeys      []string
 	}{
 		{
 			Name: "Valid",
@@ -38,7 +39,8 @@ func TestConsumerConfig(t *testing.T) {
 						DebugContextAdmin,
 						DebugContextBroker,
 					},
-					ClientID: "client-id-1",
+					ClientID:   "client-id-1",
+					ClientRack: "use1-az1",
 				},
 				ConsumerConfigParams{
 					ConsumerGroupID:             "consumer-group",
@@ -66,6 +68,7 @@ func TestConsumerConfig(t *testing.T) {
 				"metadata.max.age.ms":                3 * TimeDurationMilliSeconds(30*time.Second),
 				"debug":                              "admin,broker",
 				"client.id":                          "client-id-1",
+				"client.rack":                        "use1-az1",
 				"group.id":                           "consumer-group",
 				"group.instance.id":                  "consumer-group-1",
 				"session.timeout.ms":                 TimeDurationMilliSeconds(5 * time.Minute),
@@ -75,6 +78,44 @@ func TestConsumerConfig(t *testing.T) {
 				"auto.offset.reset":                  AutoOffsetResetLatest,
 				"partition.assignment.strategy":      PartitionAssignmentStrategies{PartitionAssignmentStrategyCooperativeSticky},
 			},
+		},
+		{
+			Name: "EmptyClientRack",
+			Params: ConsumerConfig{
+				CommonConfigParams{
+					Brokers:                      "broker-1:9092,broker-2:9092",
+					SecurityProtocol:             "SASL_SSL",
+					SaslMechanisms:               "PLAIN",
+					SaslUsername:                 "user",
+					SaslPassword:                 "pass",
+					StatsInterval:                TimeDurationMilliSeconds(5 * time.Second),
+					BrokerAddressFamily:          BrokerAddressFamilyAny,
+					SocketKeepAliveEnabled:       true,
+					TopicMetadataRefreshInterval: TimeDurationMilliSeconds(30 * time.Second),
+					DebugContexts: DebugContexts{
+						DebugContextAdmin,
+						DebugContextBroker,
+					},
+					ClientID:   "client-id-1",
+					ClientRack: "",
+				},
+				ConsumerConfigParams{
+					ConsumerGroupID:             "consumer-group",
+					ConsumerGroupInstanceID:     "consumer-group-1",
+					SessionTimeout:              TimeDurationMilliSeconds(5 * time.Minute),
+					HeartbeatInterval:           TimeDurationMilliSeconds(5 * time.Second),
+					EnableAutoCommit:            true,
+					EnableAutoOffsetStore:       true,
+					AutoOffsetReset:             AutoOffsetResetLatest,
+					PartitionAssignmentStrategy: PartitionAssignmentStrategies{PartitionAssignmentStrategyCooperativeSticky},
+				},
+			},
+			ExpectedError:           nil,
+			ExpectedValidationError: nil,
+			ExpectedConfigMap: kafka.ConfigMap{
+				"client.id": "client-id-1",
+			},
+			ExpectedAbsentKeys: []string{"client.rack"},
 		},
 	}
 
@@ -88,6 +129,11 @@ func TestConsumerConfig(t *testing.T) {
 
 			for k, v := range test.ExpectedConfigMap {
 				assert.Equal(t, v, m[k], fmt.Sprintf("expected %s got %s", v, m[k]))
+			}
+
+			for _, k := range test.ExpectedAbsentKeys {
+				_, ok := m[k]
+				assert.False(t, ok, fmt.Sprintf("expected key %s to be absent", k))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds clientRack config option, mapped to librdkafka's client.rack setting.

## Why

Enables rack-aware consumer group assignment and lets consumers fetch from replicas in the same rack/AZ, reducing cross-AZ network traffic and cost.

## Changes

- pkg/kafka/config.go: new ClientRack field on CommonConfigParams; sets client.rack in the config map when non-empty.
- app/config/kafka.go: registers kafka.clientRack viper default (empty string, opt-in).
- config.example.yaml: documents the new option.
- Test coverage updated across pkg/kafka/config_test.go, app/config/config_test.go, and app/config/testdata/complete.yaml.

## Compatibility

Backward compatible. Field defaults to empty, so client.rack is only set when explicitly configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Kafka client rack configuration for rack-aware behavior.
  * Kafka clients now include the configured rack identifier when provided.
  * Added example configuration and documentation for setting the client rack.

* **Bug Fixes**
  * Improved handling and reporting of Kafka configuration errors.
  * Configurations without a rack identifier continue to work without adding an empty setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional Kafka client rack setting and maps it to librdkafka’s `client.rack` property.
- Registers the `kafka.clientRack` configuration default.
- Propagates non-empty rack identifiers into the shared Kafka configuration map.
- Updates example configuration, fixtures, and tests for configured and empty values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pkg/kafka/config.go | Adds the optional `ClientRack` field and conditionally maps it to librdkafka’s `client.rack` property. |
| app/config/kafka.go | Registers an empty, opt-in default for the new Kafka client rack setting. |
| pkg/kafka/config_test.go | Covers both configured rack propagation and omission of the property when the value is empty. |
| app/config/config_test.go | Extends complete configuration decoding coverage to include `ClientRack`. |
| config.example.yaml | Documents the optional rack identifier and its rack-aware consumer behavior. |

<sub>Reviews (2): Last reviewed commit: ["feat(kafka): add rackId for kafka consum..."](https://github.com/openmeterio/openmeter/commit/a83d5e447e5c1f6dbc1d78d414b360467a61ee42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51092595)</sub>

<!-- /greptile_comment -->