### PR TITLE
ci: fix go version for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -48,7 +48,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.4"
+          go-version: "1.26"
+          check-latest: true
           cache: true
           cache-dependency-path: |
             go.sum


### PR DESCRIPTION
## Overview

Fix go version for CodeQL workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go build environment to automatically use the latest available 1.26 release.
  * Retained existing dependency caching settings for consistent automated build performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the CodeQL workflow to resolve the latest available Go 1.26 patch instead of requesting an unavailable exact patch.
- Changes `go-version` from `1.26.4` to `1.26`.
- Enables `check-latest` for Go toolchain resolution.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql-go.yaml | Updates Go toolchain resolution for CodeQL; the previously reported unrelated cache dependencies are not present at current HEAD. |

<sub>Reviews (2): Last reviewed commit: ["ci: fix go version for CodeQL workflow"](https://github.com/openmeterio/openmeter/commit/de8f155709d8c906d667f49f1e5f835417116928) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51116527)</sub>

<!-- /greptile_comment -->