### PR TITLE
ci: add codeql group to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -70,6 +70,11 @@ updates:
       - area/dependencies
       - dependency/github_actions
       - release-note/ignore
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action"
+          - "github/codeql-action/*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Overview

Update CodeQL actions in one go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped CodeQL GitHub Actions dependencies for streamlined update management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Dependabot group so updates to the repository’s CodeQL GitHub Actions are handled together.
- Defines a `codeql` group for the GitHub Actions ecosystem.
- Covers the CodeQL `init`, `analyze`, and `upload-sarif` action paths used by repository workflows.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new wildcard pattern covers the repository’s active CodeQL action references.

The configuration-only change groups existing CodeQL sub-actions without altering workflow execution or leaving an active CodeQL reference outside the intended pattern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yaml | Adds a focused CodeQL action group consistent with the existing Dependabot configuration; no actionable issues identified. |

<sub>Reviews (1): Last reviewed commit: ["ci: add codeql group to dependabot confi..."](https://github.com/openmeterio/openmeter/commit/af6f66b7d251872674a742d9c4bbca5b8fb727ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51117669)</sub>

<!-- /greptile_comment -->