### PR TITLE
fix(billing): retain non-zero overage lines settled via credits

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -190,6 +190,11 @@ Within the charges domain, custom-currency `credit_then_invoice`:
 - retains the managed currency as charge identity rather than replacing it
   with the settlement fiat currency or display code
 
+The converted post-allocation overage and the required fiat transaction are
+separate settlement facts. A zero converted overage controls line omission and
+invoice bypass. A zero required transaction controls payment handling and does
+not by itself remove an otherwise billable line from the invoice.
+
 This is a charge-domain contract, not end-to-end support: current ledger-backed
 charge adapters reject custom currencies. Enabling them spans ledger route
 identity and persistence, charge realization, settlement rounding, corrections,

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -583,7 +583,14 @@ func (s *CreditThenInvoiceStateMachine) IsCurrentRunZeroFiatAmountOverage() bool
 		return false
 	}
 
-	return isZeroFiatAmountOverageRun(s.Charge, *currentRun)
+	fiatOverage, err := calculateFiatOverageForRun(s.Charge, *currentRun)
+	if err != nil {
+		// Stateless guards cannot return errors. Conversion failures are exposed
+		// by line mapping before this transition becomes reachable.
+		return false
+	}
+
+	return fiatOverage.ShouldOmitInvoiceLine
 }
 
 // FinalizeZeroFiatAmountOverageRun seals the persisted current run while the
@@ -594,7 +601,12 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx con
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
 	}
 
-	if !isZeroFiatAmountOverageRun(s.Charge, *currentRun) {
+	fiatOverage, err := calculateFiatOverageForRun(s.Charge, *currentRun)
+	if err != nil {
+		return fmt.Errorf("calculate fiat overage for current realization run %s: %w", currentRun.ID.ID, err)
+	}
+
+	if !fiatOverage.ShouldOmitInvoiceLine {
 		return fmt.Errorf("current realization run %s is not a zero fiat amount overage", currentRun.ID.ID)
 	}
 
@@ -613,25 +625,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx con
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil
-}
-
-// isZeroFiatAmountOverageRun identifies custom-currency overage runs whose
-// converted fiat amount is zero before any fiat settlement is applied. If the
-// conversion cannot be evaluated, the run must keep its line so the normal
-// invoice path can surface the underlying error instead of deleting billable
-// history.
-func isZeroFiatAmountOverageRun(charge flatfee.Charge, run flatfee.RealizationRun) bool {
-	if !charge.Intent.GetCurrency().IsCustom() ||
-		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		return false
-	}
-
-	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
-	if err != nil {
-		return false
-	}
-
-	return fiatOverage.Amount.IsZero()
 }
 
 type reconcileInvoicingStateInput struct {

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -616,11 +616,22 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx con
 }
 
 // isZeroFiatAmountOverageRun identifies custom-currency overage runs whose
-// converted fiat Amount is zero.
+// converted fiat amount is zero before any fiat settlement is applied. If the
+// conversion cannot be evaluated, the run must keep its line so the normal
+// invoice path can surface the underlying error instead of deleting billable
+// history.
 func isZeroFiatAmountOverageRun(charge flatfee.Charge, run flatfee.RealizationRun) bool {
-	return charge.Intent.GetCurrency().IsCustom() &&
-		charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode &&
-		run.NoFiatTransactionRequired
+	if !charge.Intent.GetCurrency().IsCustom() ||
+		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return false
+	}
+
+	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	if err != nil {
+		return false
+	}
+
+	return fiatOverage.Amount.IsZero()
 }
 
 type reconcileInvoicingStateInput struct {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -772,7 +772,11 @@ func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input bill
 		// Collection deletes only the presentation line for a zero-fiat-amount
 		// overage. Its run, credits, and details remain durable billing history
 		// and must not enter mutable-line cleanup.
-		if isZeroFiatAmountOverageRun(charge, run) {
+		fiatOverage, err := calculateFiatOverageForRun(charge, run)
+		if err != nil {
+			return fmt.Errorf("calculating fiat overage for flat fee realization run[%s]: %w", run.ID.ID, err)
+		}
+		if fiatOverage.ShouldOmitInvoiceLine {
 			continue
 		}
 

--- a/openmeter/billing/charges/flatfee/service/linemapper.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -45,6 +46,32 @@ type populateFlatFeeStandardLineFromRunInput struct {
 	Charge flatfee.Charge
 	Run    flatfee.RealizationRun
 	Stage  standardLinePopulationStage
+}
+
+type calculateFiatOverageForRunResult struct {
+	FiatCurrency          *currencyx.FiatCurrency
+	FiatOverage           alpacadecimal.Decimal
+	ShouldOmitInvoiceLine bool
+}
+
+// calculateFiatOverageForRun resolves the post-allocation custom-currency
+// overage and the invoice-line omission decision from the same conversion.
+func calculateFiatOverageForRun(charge flatfee.Charge, run flatfee.RealizationRun) (calculateFiatOverageForRunResult, error) {
+	if !charge.Intent.GetCurrency().IsCustom() ||
+		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return calculateFiatOverageForRunResult{}, nil
+	}
+
+	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatOverage.Currency,
+		FiatOverage:           fiatOverage.Amount,
+		ShouldOmitInvoiceLine: fiatOverage.Amount.IsZero(),
+	}, nil
 }
 
 func (i populateFlatFeeStandardLineFromRunInput) Validate() error {
@@ -139,17 +166,20 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	fiatOverage, err := calculateFiatOverageForRun(charge, run)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}
+	if fiatOverage.FiatCurrency == nil {
+		return fmt.Errorf("custom currency charge[%s] does not have an invoiceable fiat overage", charge.ID)
+	}
 
-	if stdLine.Currency != fiatOverage.Currency.GetFiatCode() {
+	if stdLine.Currency != fiatOverage.FiatCurrency.GetFiatCode() {
 		return fmt.Errorf(
 			"custom currency charge[%s] invoice currency mismatch: %s != %s",
 			charge.ID,
 			stdLine.Currency,
-			fiatOverage.Currency.Details().Code,
+			fiatOverage.FiatCurrency.Details().Code,
 		)
 	}
 
@@ -166,7 +196,7 @@ func populateCustomCurrencyOverageFromRun(
 		ConfigID:   stdLine.UsageBased.ConfigID,
 		FeatureKey: stdLine.UsageBased.FeatureKey,
 		Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-			Amount:      fiatOverage.Amount,
+			Amount:      fiatOverage.FiatOverage,
 			PaymentTerm: productcatalog.InArrearsPaymentTerm,
 		}),
 		MeteredQuantity:              lo.ToPtr(alpacadecimal.NewFromInt(1)),
@@ -187,8 +217,8 @@ func populateCustomCurrencyOverageFromRun(
 		CreditCurrency:    charge.Intent.GetCurrency(),
 		CreditAmount:      run.Totals.Total,
 		ResolvedCostBasis: charge.State.ResolvedCostBasis.CostBasis,
-		FiatCurrency:      fiatOverage.Currency,
-		FiatAmount:        fiatOverage.Amount,
+		FiatCurrency:      fiatOverage.FiatCurrency,
+		FiatAmount:        fiatOverage.FiatOverage,
 	})
 	if err != nil {
 		return fmt.Errorf("populating custom currency overage line: %w", err)
@@ -197,7 +227,7 @@ func populateCustomCurrencyOverageFromRun(
 
 	if (input.Stage == standardLinePopulationStageGatheringPreview ||
 		input.Stage == standardLinePopulationStageCollectionCompleted) &&
-		isZeroFiatAmountOverageRun(charge, run) {
+		fiatOverage.ShouldOmitInvoiceLine {
 		stdLine.DeletedAt = lo.ToPtr(clock.Now())
 	}
 

--- a/openmeter/billing/charges/flatfee/service/linemapper_test.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
+func TestCalculateFiatOverageForRun(t *testing.T) {
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -30,7 +30,9 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 		name                      string
 		runTotals                 totals.Totals
 		noFiatTransactionRequired bool
-		expectZeroOverage         bool
+		conversionFails           bool
+		expectFiatOverage         float64
+		expectOmitInvoiceLine     bool
 	}{
 		{
 			name: "zero converted overage does not depend on transaction requirement",
@@ -39,7 +41,7 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 				CreditsTotal: alpacadecimal.NewFromInt(3),
 			},
 			noFiatTransactionRequired: false,
-			expectZeroOverage:         true,
+			expectOmitInvoiceLine:     true,
 		},
 		{
 			name: "positive converted overage is retained when no transaction is required",
@@ -48,24 +50,43 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 				Total:  alpacadecimal.NewFromInt(3),
 			},
 			noFiatTransactionRequired: true,
-			expectZeroOverage:         false,
+			expectFiatOverage:         6,
+		},
+		{
+			name: "conversion failure is returned",
+			runTotals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(3),
+				Total:  alpacadecimal.NewFromInt(3),
+			},
+			conversionFails: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// given: a custom-currency run where converted overage and transaction requirement intentionally differ
+			charge := charge
+			if test.conversionFails {
+				charge.State.ResolvedCostBasis = nil
+			}
 			run := newFlatFeeCustomCurrencyRunForTest(
 				servicePeriod,
 				test.runTotals,
 				test.noFiatTransactionRequired,
 			)
 
-			// when: zero-overage invoice handling is evaluated
-			isZeroOverage := isZeroFiatAmountOverageRun(charge, run)
+			// when: the run's fiat overage and invoice-line omission decision are calculated
+			fiatOverage, err := calculateFiatOverageForRun(charge, run)
 
-			// then: only the converted overage controls the result
-			require.Equal(t, test.expectZeroOverage, isZeroOverage)
+			// then: conversion errors are returned and successful conversion alone controls omission
+			if test.conversionFails {
+				require.ErrorContains(t, err, "resolved cost basis is required")
+				require.False(t, fiatOverage.ShouldOmitInvoiceLine)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expectFiatOverage, fiatOverage.FiatOverage.InexactFloat64())
+			require.Equal(t, test.expectOmitInvoiceLine, fiatOverage.ShouldOmitInvoiceLine)
 		})
 	}
 }
@@ -127,6 +148,32 @@ func TestPopulateFlatFeeCustomCurrencyOverageLineDeletionUsesConvertedOverage(t 
 
 				// then: the positive billable line is retained independently of payment handling
 				require.NoError(t, err)
+				require.Nil(t, line.DeletedAt)
+			})
+
+			t.Run("conversion failure returns an error without deleting the line", func(t *testing.T) {
+				// given: a custom-currency run whose resolved cost basis is unavailable
+				charge := charge
+				charge.State.ResolvedCostBasis = nil
+				run := newFlatFeeCustomCurrencyRunForTest(
+					servicePeriod,
+					totals.Totals{
+						Amount: alpacadecimal.NewFromInt(3),
+						Total:  alpacadecimal.NewFromInt(3),
+					},
+					true,
+				)
+				line := newFlatFeeStandardLineForTest(servicePeriod)
+
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+					Charge: charge,
+					Run:    run,
+					Stage:  stage,
+				})
+
+				// then: conversion failure is exposed before the line can be deleted
+				require.ErrorContains(t, err, "resolved cost basis is required")
 				require.Nil(t, line.DeletedAt)
 			})
 		})

--- a/openmeter/billing/charges/flatfee/service/linemapper_test.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper_test.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge := newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+
+	tests := []struct {
+		name                      string
+		runTotals                 totals.Totals
+		noFiatTransactionRequired bool
+		expectZeroOverage         bool
+	}{
+		{
+			name: "zero converted overage does not depend on transaction requirement",
+			runTotals: totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(3),
+				CreditsTotal: alpacadecimal.NewFromInt(3),
+			},
+			noFiatTransactionRequired: false,
+			expectZeroOverage:         true,
+		},
+		{
+			name: "positive converted overage is retained when no transaction is required",
+			runTotals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(3),
+				Total:  alpacadecimal.NewFromInt(3),
+			},
+			noFiatTransactionRequired: true,
+			expectZeroOverage:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given: a custom-currency run where converted overage and transaction requirement intentionally differ
+			run := newFlatFeeCustomCurrencyRunForTest(
+				servicePeriod,
+				test.runTotals,
+				test.noFiatTransactionRequired,
+			)
+
+			// when: zero-overage invoice handling is evaluated
+			isZeroOverage := isZeroFiatAmountOverageRun(charge, run)
+
+			// then: only the converted overage controls the result
+			require.Equal(t, test.expectZeroOverage, isZeroOverage)
+		})
+	}
+}
+
+func TestPopulateFlatFeeCustomCurrencyOverageLineDeletionUsesConvertedOverage(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge := newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+
+	for _, stage := range []standardLinePopulationStage{
+		standardLinePopulationStageGatheringPreview,
+		standardLinePopulationStageCollectionCompleted,
+	} {
+		t.Run(string(stage), func(t *testing.T) {
+			t.Run("zero converted overage deletes the line", func(t *testing.T) {
+				// given: a zero converted overage whose transaction flag does not request payment skipping
+				run := newFlatFeeCustomCurrencyRunForTest(
+					servicePeriod,
+					totals.Totals{
+						Amount:       alpacadecimal.NewFromInt(3),
+						CreditsTotal: alpacadecimal.NewFromInt(3),
+					},
+					false,
+				)
+				line := newFlatFeeStandardLineForTest(servicePeriod)
+
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+					Charge: charge,
+					Run:    run,
+					Stage:  stage,
+				})
+
+				// then: line omission follows the converted overage
+				require.NoError(t, err)
+				require.NotNil(t, line.DeletedAt)
+			})
+
+			t.Run("positive converted overage retains the line without a transaction", func(t *testing.T) {
+				// given: a positive converted overage whose settlement does not require a fiat transaction
+				run := newFlatFeeCustomCurrencyRunForTest(
+					servicePeriod,
+					totals.Totals{
+						Amount: alpacadecimal.NewFromInt(3),
+						Total:  alpacadecimal.NewFromInt(3),
+					},
+					true,
+				)
+				line := newFlatFeeStandardLineForTest(servicePeriod)
+
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+					Charge: charge,
+					Run:    run,
+					Stage:  stage,
+				})
+
+				// then: the positive billable line is retained independently of payment handling
+				require.NoError(t, err)
+				require.Nil(t, line.DeletedAt)
+			})
+		})
+	}
+}
+
+func newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t testing.TB, servicePeriod timeutil.ClosedPeriod) flatfee.Charge {
+	t.Helper()
+
+	customCurrency, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
+		WithCode("TOKENS").
+		WithName("Tokens").
+		WithPrecision(4).
+		Build()
+	require.NoError(t, err)
+
+	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: fiatCurrency,
+		Rate:         alpacadecimal.NewFromInt(2),
+	})
+	costBasisID := "cost-basis-id"
+	createdAt := servicePeriod.From
+
+	return flatfee.Charge{
+		ChargeBase: flatfee.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: createdAt,
+					UpdatedAt: createdAt,
+				},
+				ID: "charge-id",
+			},
+			Intent: flatfee.Intent{
+				Intent: meta.Intent{
+					ManagedBy:  billing.SubscriptionManagedLine,
+					CustomerID: "customer-id",
+					Currency: currencies.Currency{
+						NamespacedID: models.NamespacedID{
+							Namespace: "namespace",
+							ID:        "currency-id",
+						},
+						Currency: customCurrency,
+					},
+					TaxConfig: productcatalog.TaxCodeConfig{TaxCodeID: "tax-code-id"},
+				},
+				IntentMutableFields: flatfee.IntentMutableFields{
+					IntentMutableFields: meta.IntentMutableFields{
+						Name:              "flat fee",
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:             servicePeriod.To,
+					PaymentTerm:           productcatalog.InArrearsPaymentTerm,
+					AmountBeforeProration: alpacadecimal.NewFromInt(3),
+				},
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				CostBasis:      &costBasisIntent,
+			}.AsOverridableIntent(),
+			Status: flatfee.StatusActiveRealizationProcessing,
+			State: flatfee.State{
+				AmountAfterProration: alpacadecimal.NewFromInt(3),
+				CostBasisID:          &costBasisID,
+				ResolvedCostBasis: &costbasis.State{
+					CostBasis:  alpacadecimal.NewFromInt(2),
+					ResolvedAt: servicePeriod.From,
+				},
+			},
+		},
+	}
+}
+
+func newFlatFeeCustomCurrencyRunForTest(
+	servicePeriod timeutil.ClosedPeriod,
+	runTotals totals.Totals,
+	noFiatTransactionRequired bool,
+) flatfee.RealizationRun {
+	return flatfee.RealizationRun{
+		RealizationRunBase: flatfee.RealizationRunBase{
+			ID: flatfee.RealizationRunID{
+				Namespace: "namespace",
+				ID:        "run-id",
+			},
+			ManagedModel: models.ManagedModel{
+				CreatedAt: servicePeriod.From,
+				UpdatedAt: servicePeriod.From,
+			},
+			Type:                      flatfee.RealizationRunTypeFinalRealization,
+			InitialType:               flatfee.RealizationRunTypeFinalRealization,
+			ServicePeriod:             servicePeriod,
+			AmountAfterProration:      alpacadecimal.NewFromInt(3),
+			Totals:                    runTotals,
+			NoFiatTransactionRequired: noFiatTransactionRequired,
+		},
+	}
+}
+
+func newFlatFeeStandardLineForTest(servicePeriod timeutil.ClosedPeriod) *billing.StandardLine {
+	chargeID := "charge-id"
+	return &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				ID:        "line-id",
+				Namespace: "namespace",
+				CreatedAt: servicePeriod.From,
+				UpdatedAt: servicePeriod.From,
+				Name:      "flat fee",
+			}),
+			ManagedBy: billing.SystemManagedLine,
+			Engine:    billing.LineEngineTypeChargeFlatFee,
+			InvoiceID: "invoice-id",
+			Currency:  currencyx.FiatCode("USD"),
+			Period:    servicePeriod,
+			InvoiceAt: servicePeriod.To,
+			ChargeID:  &chargeID,
+		},
+		UsageBased: &billing.UsageBasedLine{},
+	}
+}

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -243,8 +243,13 @@ func (s *CreditThenInvoiceStateMachine) HasTerminalCompletedRealizationWithoutCu
 		return false
 	}
 
-	if latestRun.InvoiceUsage == nil && !isZeroFiatAmountOverageRun(s.Charge, latestRun) {
-		return false
+	if latestRun.InvoiceUsage == nil {
+		fiatOverage, err := calculateFiatOverageForRun(s.Charge, latestRun)
+		if err != nil || !fiatOverage.ShouldOmitInvoiceLine {
+			// Stateless guards cannot return errors. Conversion failures are
+			// exposed by line mapping or snapshotting before this state is durable.
+			return false
+		}
 	}
 
 	return isFinalRunInPeriod(s.Charge, timeutil.ClosedPeriod{
@@ -635,7 +640,9 @@ func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 		}
 	}
 
-	s.updateStateAfterShrink(runsToKeep, gatheringLinePeriod, newServicePeriodTo)
+	if err := s.updateStateAfterShrink(runsToKeep, gatheringLinePeriod, newServicePeriodTo); err != nil {
+		return fmt.Errorf("updating state after shrink: %w", err)
+	}
 
 	return nil
 }
@@ -644,9 +651,9 @@ func (s *CreditThenInvoiceStateMachine) updateStateAfterShrink(
 	runsToKeep usagebased.RealizationRuns,
 	replacementGatheringLinePeriod timeutil.ClosedPeriod,
 	newServicePeriodTo time.Time,
-) {
+) error {
 	if s.Charge.Status == usagebased.StatusCreated {
-		return
+		return nil
 	}
 
 	if s.Charge.State.CurrentRealizationRunID != nil {
@@ -655,7 +662,7 @@ func (s *CreditThenInvoiceStateMachine) updateStateAfterShrink(
 			// Billing still owns the current invoice lifecycle. Shrink may shorten
 			// future gathering, but it must not make the charge forget an in-flight
 			// invoice-backed run that still fits inside the new service period.
-			return
+			return nil
 		}
 	}
 
@@ -669,18 +676,24 @@ func (s *CreditThenInvoiceStateMachine) updateStateAfterShrink(
 		// arrive.
 		chargeWithKeptRuns := s.Charge
 		chargeWithKeptRuns.Realizations = runsToKeep
-		if areAllRealizationRunsSettled(chargeWithKeptRuns) {
+		allSettled, err := areAllRealizationRunsSettled(chargeWithKeptRuns)
+		if err != nil {
+			return err
+		}
+		if allSettled {
 			s.Charge.Status = usagebased.StatusFinal
 		} else if s.Charge.Status != usagebased.StatusFinal {
 			s.Charge.Status = usagebased.StatusActiveAwaitingPaymentSettlement
 		}
 		s.Charge.State.AdvanceAfter = nil
 
-		return
+		return nil
 	}
 
 	s.Charge.Status = usagebased.StatusActive
 	s.Charge.State.AdvanceAfter = lo.ToPtr(newServicePeriodTo)
+
+	return nil
 }
 
 // Extending a charge after a final invoice run moves the customer's contractual
@@ -842,7 +855,14 @@ func isFinalRunInPeriod(charge usagebased.Charge, servicePeriod timeutil.ClosedP
 }
 
 func (s *CreditThenInvoiceStateMachine) AreAllRealizationRunsSettled() bool {
-	return areAllRealizationRunsSettled(s.Charge)
+	allSettled, err := areAllRealizationRunsSettled(s.Charge)
+	if err != nil {
+		// Stateless guards cannot return errors. Conversion failures are exposed
+		// by line mapping or snapshotting before this transition becomes reachable.
+		return false
+	}
+
+	return allSettled
 }
 
 func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context) error {
@@ -949,7 +969,14 @@ func (s *CreditThenInvoiceStateMachine) IsCurrentRunZeroFiatAmountOverage() bool
 		return false
 	}
 
-	return isZeroFiatAmountOverageRun(s.Charge, currentRun)
+	fiatOverage, err := calculateFiatOverageForRun(s.Charge, currentRun)
+	if err != nil {
+		// Stateless guards cannot return errors. Conversion failures are exposed
+		// by line mapping or snapshotting before this transition becomes reachable.
+		return false
+	}
+
+	return fiatOverage.ShouldOmitInvoiceLine
 }
 
 // FinalizeZeroFiatAmountOverageRun releases the persisted current run while the
@@ -964,7 +991,12 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(_ conte
 		return fmt.Errorf("get current realization run: %w", err)
 	}
 
-	if !isZeroFiatAmountOverageRun(s.Charge, currentRun) {
+	fiatOverage, err := calculateFiatOverageForRun(s.Charge, currentRun)
+	if err != nil {
+		return fmt.Errorf("calculate fiat overage for current realization run %s: %w", currentRun.ID.ID, err)
+	}
+
+	if !fiatOverage.ShouldOmitInvoiceLine {
 		return fmt.Errorf("current realization run %s is not a zero fiat amount overage", currentRun.ID.ID)
 	}
 
@@ -1013,25 +1045,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	s.Charge.ChargeBase = updatedChargeBase
 
 	return nil
-}
-
-// isZeroFiatAmountOverageRun identifies custom-currency overage runs whose
-// converted fiat amount is zero before any fiat settlement is applied. If the
-// conversion cannot be evaluated, the run must keep its line so the normal
-// invoice path can surface the underlying error instead of deleting billable
-// history.
-func isZeroFiatAmountOverageRun(charge usagebased.Charge, run usagebased.RealizationRun) bool {
-	if !charge.Intent.GetCurrency().IsCustom() ||
-		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		return false
-	}
-
-	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
-	if err != nil {
-		return false
-	}
-
-	return fiatOverage.Amount.IsZero()
 }
 
 func getRunForLine(charge usagebased.Charge, lineID string) (usagebased.RealizationRun, error) {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -1016,11 +1016,22 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 }
 
 // isZeroFiatAmountOverageRun identifies custom-currency overage runs whose
-// converted fiat Amount is zero.
+// converted fiat amount is zero before any fiat settlement is applied. If the
+// conversion cannot be evaluated, the run must keep its line so the normal
+// invoice path can surface the underlying error instead of deleting billable
+// history.
 func isZeroFiatAmountOverageRun(charge usagebased.Charge, run usagebased.RealizationRun) bool {
-	return charge.Intent.GetCurrency().IsCustom() &&
-		charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode &&
-		run.NoFiatTransactionRequired
+	if !charge.Intent.GetCurrency().IsCustom() ||
+		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return false
+	}
+
+	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	if err != nil {
+		return false
+	}
+
+	return fiatOverage.Amount.IsZero()
 }
 
 func getRunForLine(charge usagebased.Charge, lineID string) (usagebased.RealizationRun, error) {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -64,10 +64,12 @@ func TestZeroFiatAmountOverageRunCanResumeCompletionAfterPersistence(t *testing.
 	require.NoError(t, err)
 	require.False(t, canFire)
 	require.True(t, machine.HasTerminalCompletedRealizationWithoutCurrentRun())
-	require.True(t, areAllRealizationRunsSettled(charge))
+	allSettled, err := areAllRealizationRunsSettled(charge)
+	require.NoError(t, err)
+	require.True(t, allSettled)
 }
 
-func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
+func TestCalculateFiatOverageForRun(t *testing.T) {
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -78,7 +80,9 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 		name                      string
 		runTotals                 totals.Totals
 		noFiatTransactionRequired bool
-		expectZeroOverage         bool
+		conversionFails           bool
+		expectFiatOverage         float64
+		expectOmitInvoiceLine     bool
 	}{
 		{
 			name: "zero converted overage does not depend on transaction requirement",
@@ -87,7 +91,7 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 				CreditsTotal: decimal.NewFromInt(3),
 			},
 			noFiatTransactionRequired: false,
-			expectZeroOverage:         true,
+			expectOmitInvoiceLine:     true,
 		},
 		{
 			name: "positive converted overage is retained when no transaction is required",
@@ -96,13 +100,25 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 				Total:  decimal.NewFromInt(3),
 			},
 			noFiatTransactionRequired: true,
-			expectZeroOverage:         false,
+			expectFiatOverage:         6,
+		},
+		{
+			name: "conversion failure is returned",
+			runTotals: totals.Totals{
+				Amount: decimal.NewFromInt(3),
+				Total:  decimal.NewFromInt(3),
+			},
+			conversionFails: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// given: a custom-currency run where converted overage and transaction requirement intentionally differ
+			charge := charge
+			if test.conversionFails {
+				charge.State.ResolvedCostBasis = nil
+			}
 			run := usagebased.RealizationRun{
 				RealizationRunBase: usagebased.RealizationRunBase{
 					Totals:                    test.runTotals,
@@ -110,11 +126,18 @@ func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
 				},
 			}
 
-			// when: zero-overage invoice handling is evaluated
-			isZeroOverage := isZeroFiatAmountOverageRun(charge, run)
+			// when: the run's fiat overage and invoice-line omission decision are calculated
+			fiatOverage, err := calculateFiatOverageForRun(charge, run)
 
-			// then: only the converted overage controls the result
-			require.Equal(t, test.expectZeroOverage, isZeroOverage)
+			// then: conversion errors are returned and successful conversion alone controls omission
+			if test.conversionFails {
+				require.ErrorContains(t, err, "resolved cost basis is required")
+				require.False(t, fiatOverage.ShouldOmitInvoiceLine)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expectFiatOverage, fiatOverage.FiatOverage.InexactFloat64())
+			require.Equal(t, test.expectOmitInvoiceLine, fiatOverage.ShouldOmitInvoiceLine)
 		})
 	}
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -23,30 +25,12 @@ import (
 )
 
 func TestZeroFiatAmountOverageRunCanResumeCompletionAfterPersistence(t *testing.T) {
+	// given: a persisted custom-currency run whose converted fiat overage is zero
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
-	intent := newUsageBasedIntentForCreditThenInvoiceTest(t, servicePeriod).GetBaseIntent()
-	customCurrency, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
-		WithCode("TOKENS").
-		WithName("Tokens").
-		WithPrecision(2).
-		Build()
-	require.NoError(t, err)
-	intent.Intent.Currency = currencies.Currency{
-		NamespacedID: models.NamespacedID{
-			Namespace: "namespace",
-			ID:        "currency-id",
-		},
-		Currency: customCurrency,
-	}
-
-	charge := usagebased.Charge{
-		ChargeBase: usagebased.ChargeBase{
-			Intent: usagebased.NewOverridableIntent(intent, nil),
-		},
-	}
+	charge := newUsageBasedCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
 	run := usagebased.RealizationRun{
 		RealizationRunBase: usagebased.RealizationRunBase{
 			ID: usagebased.RealizationRunID{
@@ -63,18 +47,76 @@ func TestZeroFiatAmountOverageRunCanResumeCompletionAfterPersistence(t *testing.
 	currentRunID := run.ID.ID
 	charge.State.CurrentRealizationRunID = &currentRunID
 
+	// when: the state machine resumes while the run is still current
 	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, charge)
 	canFire, err := machine.CanFire(t.Context(), meta.TriggerNext)
+
+	// then: it can complete the zero-overage transition
 	require.NoError(t, err)
 	require.True(t, canFire)
 
+	// when: the same persisted run is reloaded after the current-run reference was cleared
 	charge.State.CurrentRealizationRunID = nil
 	machine = newCreditThenInvoiceStateMachineWithChargeForTest(t, charge)
 	canFire, err = machine.CanFire(t.Context(), meta.TriggerNext)
+
+	// then: it remains terminal and settled without requiring an invoice line
 	require.NoError(t, err)
 	require.False(t, canFire)
 	require.True(t, machine.HasTerminalCompletedRealizationWithoutCurrentRun())
 	require.True(t, areAllRealizationRunsSettled(charge))
+}
+
+func TestIsZeroFiatAmountOverageRunUsesConvertedOverage(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge := newUsageBasedCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+
+	tests := []struct {
+		name                      string
+		runTotals                 totals.Totals
+		noFiatTransactionRequired bool
+		expectZeroOverage         bool
+	}{
+		{
+			name: "zero converted overage does not depend on transaction requirement",
+			runTotals: totals.Totals{
+				Amount:       decimal.NewFromInt(3),
+				CreditsTotal: decimal.NewFromInt(3),
+			},
+			noFiatTransactionRequired: false,
+			expectZeroOverage:         true,
+		},
+		{
+			name: "positive converted overage is retained when no transaction is required",
+			runTotals: totals.Totals{
+				Amount: decimal.NewFromInt(3),
+				Total:  decimal.NewFromInt(3),
+			},
+			noFiatTransactionRequired: true,
+			expectZeroOverage:         false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// given: a custom-currency run where converted overage and transaction requirement intentionally differ
+			run := usagebased.RealizationRun{
+				RealizationRunBase: usagebased.RealizationRunBase{
+					Totals:                    test.runTotals,
+					NoFiatTransactionRequired: test.noFiatTransactionRequired,
+				},
+			}
+
+			// when: zero-overage invoice handling is evaluated
+			isZeroOverage := isZeroFiatAmountOverageRun(charge, run)
+
+			// then: only the converted overage controls the result
+			require.Equal(t, test.expectZeroOverage, isZeroOverage)
+		})
+	}
 }
 
 func TestUnsupportedExtendOperation(t *testing.T) {
@@ -559,6 +601,50 @@ func newUsageBasedIntentForCreditThenInvoiceTest(t testing.TB, servicePeriod tim
 		SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 		FeatureKey:     "feature-key",
 	}.AsOverridableIntent()
+}
+
+func newUsageBasedCustomCurrencyCreditThenInvoiceChargeForTest(t testing.TB, servicePeriod timeutil.ClosedPeriod) usagebased.Charge {
+	t.Helper()
+
+	customCurrency, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeCustom).
+		WithCode("TOKENS").
+		WithName("Tokens").
+		WithPrecision(4).
+		Build()
+	require.NoError(t, err)
+
+	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: fiatCurrency,
+		Rate:         decimal.NewFromInt(2),
+	})
+
+	intent := newUsageBasedIntentForCreditThenInvoiceTest(t, servicePeriod).GetBaseIntent()
+	intent.Intent.Currency = currencies.Currency{
+		NamespacedID: models.NamespacedID{
+			Namespace: "namespace",
+			ID:        "currency-id",
+		},
+		Currency: customCurrency,
+	}
+	intent.CostBasis = &costBasisIntent
+
+	return usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "charge-id",
+			},
+			Intent: usagebased.NewOverridableIntent(intent, nil),
+			State: usagebased.State{
+				ResolvedCostBasis: &costbasis.State{
+					CostBasis:  decimal.NewFromInt(2),
+					ResolvedAt: servicePeriod.From,
+				},
+			},
+		},
+	}
 }
 
 func newCreditThenInvoiceStateMachineWithChargeForTest(t *testing.T, charge usagebased.Charge) *CreditThenInvoiceStateMachine {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -767,7 +767,11 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		// Collection deletes only the presentation line for a zero-fiat-amount
 		// overage. Its run, credits, and line reference remain durable billing
 		// history and must not enter mutable-line cleanup.
-		if isZeroFiatAmountOverageRun(charge, run) {
+		fiatOverage, err := calculateFiatOverageForRun(charge, run)
+		if err != nil {
+			return fmt.Errorf("calculating fiat overage for usage based realization run[%s]: %w", run.ID.ID, err)
+		}
+		if fiatOverage.ShouldOmitInvoiceLine {
 			continue
 		}
 

--- a/openmeter/billing/charges/usagebased/service/linemapper.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper.go
@@ -155,6 +155,32 @@ type populateStandardLineFromRunInput struct {
 	Stage  standardLinePopulationStage
 }
 
+type calculateFiatOverageForRunResult struct {
+	FiatCurrency          *currencyx.FiatCurrency
+	FiatOverage           alpacadecimal.Decimal
+	ShouldOmitInvoiceLine bool
+}
+
+// calculateFiatOverageForRun resolves the post-allocation custom-currency
+// overage and the invoice-line omission decision from the same conversion.
+func calculateFiatOverageForRun(charge usagebased.Charge, run usagebased.RealizationRun) (calculateFiatOverageForRunResult, error) {
+	if !charge.Intent.GetCurrency().IsCustom() ||
+		charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return calculateFiatOverageForRunResult{}, nil
+	}
+
+	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatOverage.Currency,
+		FiatOverage:           fiatOverage.Amount,
+		ShouldOmitInvoiceLine: fiatOverage.Amount.IsZero(),
+	}, nil
+}
+
 func (i populateStandardLineFromRunInput) Validate() error {
 	var errs []error
 
@@ -251,17 +277,20 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := charge.ConvertCustomCurrencyOverageToFiat(run.Totals)
+	fiatOverage, err := calculateFiatOverageForRun(charge, run)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}
+	if fiatOverage.FiatCurrency == nil {
+		return fmt.Errorf("custom currency charge[%s] does not have an invoiceable fiat overage", charge.ID)
+	}
 
-	if stdLine.Currency != fiatOverage.Currency.GetFiatCode() {
+	if stdLine.Currency != fiatOverage.FiatCurrency.GetFiatCode() {
 		return fmt.Errorf(
 			"custom currency charge[%s] invoice currency mismatch: %s != %s",
 			charge.ID,
 			stdLine.Currency,
-			fiatOverage.Currency.Details().Code,
+			fiatOverage.FiatCurrency.Details().Code,
 		)
 	}
 
@@ -278,7 +307,7 @@ func populateCustomCurrencyOverageFromRun(
 		ConfigID:   stdLine.UsageBased.ConfigID,
 		FeatureKey: stdLine.UsageBased.FeatureKey,
 		Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-			Amount:      fiatOverage.Amount,
+			Amount:      fiatOverage.FiatOverage,
 			PaymentTerm: productcatalog.InArrearsPaymentTerm,
 		}),
 		MeteredQuantity:              lo.ToPtr(alpacadecimal.NewFromInt(1)),
@@ -298,8 +327,8 @@ func populateCustomCurrencyOverageFromRun(
 		CreditCurrency:    charge.Intent.GetCurrency(),
 		CreditAmount:      run.Totals.Total,
 		ResolvedCostBasis: charge.State.ResolvedCostBasis.CostBasis,
-		FiatCurrency:      fiatOverage.Currency,
-		FiatAmount:        fiatOverage.Amount,
+		FiatCurrency:      fiatOverage.FiatCurrency,
+		FiatAmount:        fiatOverage.FiatOverage,
 	})
 	if err != nil {
 		return fmt.Errorf("populating custom currency overage line: %w", err)
@@ -308,7 +337,7 @@ func populateCustomCurrencyOverageFromRun(
 
 	if (input.Stage == standardLinePopulationStageGatheringPreview ||
 		input.Stage == standardLinePopulationStageCollectionCompleted) &&
-		isZeroFiatAmountOverageRun(charge, run) {
+		fiatOverage.ShouldOmitInvoiceLine {
 		stdLine.DeletedAt = lo.ToPtr(clock.Now())
 	}
 

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -412,6 +412,14 @@ func TestPopulateUsageBasedStandardLineFromCustomCurrencyRunCreatesFiatOverage(t
 				// then: the positive billable line is retained independently of payment handling
 				require.NoError(t, err)
 				require.Nil(t, line.DeletedAt)
+
+				flatPrice, err := line.UsageBased.Price.AsFlat()
+				require.NoError(t, err)
+				require.Equal(t, float64(6), flatPrice.Amount.InexactFloat64())
+
+				require.Len(t, line.DetailedLines, 1)
+				require.Equal(t, creditpurchase.CreditPurchaseChildUniqueReferenceID, line.DetailedLines[0].ChildUniqueReferenceID)
+				require.Equal(t, float64(6), line.DetailedLines[0].Totals.Amount.InexactFloat64())
 			})
 
 			t.Run("conversion failure returns an error without deleting the line", func(t *testing.T) {

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -369,24 +369,52 @@ func TestPopulateUsageBasedStandardLineFromCustomCurrencyRunCreatesFiatOverage(t
 	require.Equal(t, "existing-overage-id", line.DetailedLines[0].ID)
 	require.Nil(t, line.DeletedAt)
 
-	run.NoFiatTransactionRequired = true
-	run.Totals = totals.Totals{}
-	err = populateStandardLineFromRun(line, populateStandardLineFromRunInput{
-		Charge: charge,
-		Run:    run,
-		Stage:  standardLinePopulationStageGatheringPreview,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, line.DeletedAt)
+	for _, stage := range []standardLinePopulationStage{
+		standardLinePopulationStageGatheringPreview,
+		standardLinePopulationStageCollectionCompleted,
+	} {
+		t.Run(string(stage), func(t *testing.T) {
+			t.Run("zero converted overage deletes the line", func(t *testing.T) {
+				// given: a zero converted overage whose transaction flag does not request payment skipping
+				zeroOverageRun := run
+				zeroOverageRun.NoFiatTransactionRequired = false
+				zeroOverageRun.Totals = totals.Totals{
+					Amount:       alpacadecimal.NewFromInt(3),
+					CreditsTotal: alpacadecimal.NewFromInt(3),
+				}
+				line := newUsageBasedStandardLineForTest(period)
 
-	line.DeletedAt = nil
-	err = populateStandardLineFromRun(line, populateStandardLineFromRunInput{
-		Charge: charge,
-		Run:    run,
-		Stage:  standardLinePopulationStageCollectionCompleted,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, line.DeletedAt)
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+					Charge: charge,
+					Run:    zeroOverageRun,
+					Stage:  stage,
+				})
+
+				// then: line omission follows the converted overage
+				require.NoError(t, err)
+				require.NotNil(t, line.DeletedAt)
+			})
+
+			t.Run("positive converted overage retains the line without a transaction", func(t *testing.T) {
+				// given: a positive converted overage whose settlement does not require a fiat transaction
+				noTransactionRun := run
+				noTransactionRun.NoFiatTransactionRequired = true
+				line := newUsageBasedStandardLineForTest(period)
+
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+					Charge: charge,
+					Run:    noTransactionRun,
+					Stage:  stage,
+				})
+
+				// then: the positive billable line is retained independently of payment handling
+				require.NoError(t, err)
+				require.Nil(t, line.DeletedAt)
+			})
+		})
+	}
 }
 
 func newUsageBasedStandardLineForTest(period timeutil.ClosedPeriod) *billing.StandardLine {

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -413,6 +413,24 @@ func TestPopulateUsageBasedStandardLineFromCustomCurrencyRunCreatesFiatOverage(t
 				require.NoError(t, err)
 				require.Nil(t, line.DeletedAt)
 			})
+
+			t.Run("conversion failure returns an error without deleting the line", func(t *testing.T) {
+				// given: a custom-currency run whose resolved cost basis is unavailable
+				charge := charge
+				charge.State.ResolvedCostBasis = nil
+				line := newUsageBasedStandardLineForTest(period)
+
+				// when: the overage line is populated at a deletion-capable stage
+				err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+					Charge: charge,
+					Run:    run,
+					Stage:  stage,
+				})
+
+				// then: conversion failure is exposed before the line can be deleted
+				require.ErrorContains(t, err, "resolved cost basis is required")
+				require.Nil(t, line.DeletedAt)
+			})
 		})
 	}
 }

--- a/openmeter/billing/charges/usagebased/service/payments.go
+++ b/openmeter/billing/charges/usagebased/service/payments.go
@@ -107,7 +107,7 @@ func (e *LineEngine) recordPaymentSettled(ctx context.Context, stateMachine Stat
 	return nil
 }
 
-func areAllRealizationRunsSettled(charge usagebased.Charge) bool {
+func areAllRealizationRunsSettled(charge usagebased.Charge) (bool, error) {
 	hasFinalRealization := false
 
 	for _, run := range charge.Realizations {
@@ -117,15 +117,18 @@ func areAllRealizationRunsSettled(charge usagebased.Charge) bool {
 
 		// Zero-fiat-amount overages bypass invoice issuance, they are removed from the
 		// invoice, thus we can consider them settled.
-		isZeroFiatAmountOverage := isZeroFiatAmountOverageRun(charge, run)
+		fiatOverage, err := calculateFiatOverageForRun(charge, run)
+		if err != nil {
+			return false, fmt.Errorf("calculating fiat overage for realization run[%s]: %w", run.ID.ID, err)
+		}
 		if isFinalRunInPeriod(charge, timeutil.ClosedPeriod{
 			From: charge.Intent.GetEffectiveServicePeriod().From,
 			To:   run.ServicePeriodTo,
-		}) && (run.InvoiceUsage != nil || isZeroFiatAmountOverage) {
+		}) && (run.InvoiceUsage != nil || fiatOverage.ShouldOmitInvoiceLine) {
 			hasFinalRealization = true
 		}
 
-		if isZeroFiatAmountOverage {
+		if fiatOverage.ShouldOmitInvoiceLine {
 			continue
 		}
 
@@ -138,9 +141,9 @@ func areAllRealizationRunsSettled(charge usagebased.Charge) bool {
 		}
 
 		if run.Payment == nil || run.Payment.Status != payment.StatusSettled {
-			return false
+			return false, nil
 		}
 	}
 
-	return hasFinalRealization
+	return hasFinalRealization, nil
 }


### PR DESCRIPTION
## Summary

Retain invoice lines for non-zero custom-currency overage even when no fiat transaction is required. This supports overage that is settled via credits: the billable line remains available for invoice settlement while payment handling can still be skipped.

## Root cause

Line omission was based on `NoFiatTransactionRequired`, which describes payment handling rather than whether converted fiat overage is zero. As a result, non-zero overage settled via credits could be deleted from the invoice.

## Changes

- Determine zero-overage line omission from converted post-allocation fiat overage.
- Propagate conversion failures before invoice-line omission or cleanup; stateless guards fail closed.
- Cover flat-fee and usage-based mapping at gathering preview and collection completion.

## Tracking

OM-435

## Validation

- Focused flat-fee and usage-based service unit tests.
- Focused PostgreSQL-backed lifecycle cases for flat fee, usage based, and progressive usage based.
- `make lint-go-fast` (before test-only additions).
- `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-currency overage handling based on converted fiat amounts.
  * Correctly omits invoice lines with zero converted overage while retaining billable lines with positive overage.
  * Separates invoice-line visibility from payment requirements.
  * Propagates conversion errors during invoice processing.

* **Documentation**
  * Clarified the distinction between invoice settlement and payment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates invoice-line omission from payment handling so non-zero custom-currency overage remains invoiceable when credits eliminate the required fiat transaction.
- Calculates omission from converted post-allocation fiat overage for flat-fee and usage-based charges.
- Propagates conversion errors through line mapping, cleanup, and state updates.
- Adds focused coverage for zero overage, credit-settled positive overage, and conversion failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/service/linemapper.go | Centralizes converted fiat-overage calculation and uses the converted amount, rather than the payment flag, to control line omission. |
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Updates zero-overage state transitions to use converted post-allocation fiat overage and propagate conversion errors from transition actions. |
| openmeter/billing/charges/usagebased/service/linemapper.go | Applies the same converted-overage mapping and omission semantics to usage-based invoice lines. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Carries conversion-aware settlement checks through completion, shrink, and zero-overage transitions. |
| openmeter/billing/charges/usagebased/service/payments.go | Makes settlement classification conversion-aware and returns conversion failures to callers. |
| openmeter/billing/charges/flatfee/service/linemapper_test.go | Adds focused flat-fee tests for zero overage, retained credit-settled overage, and conversion failure. |
| openmeter/billing/charges/usagebased/service/linemapper_test.go | Expands usage-based mapping coverage across both line-deletion-capable lifecycle stages. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  R[Realization run totals] --> C[Convert custom-currency overage to fiat]
  C --> Z{Converted fiat overage is zero?}
  Z -->|Yes| O[Omit invoice line and bypass invoice settlement]
  Z -->|No| K[Retain billable invoice line]
  K --> P{Fiat transaction required?}
  P -->|Yes| T[Process fiat payment]
  P -->|No| S[Skip payment handling]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(billing): assert converted overage ..."](https://github.com/openmeterio/openmeter/commit/be83ad3166c392cfaeb6efc43f37a7f32b9af68b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51174449)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->