### PR TITLE
fix: fix late review comments for costbasis change

### DIFF
--- a/api/v3/handlers/customers/credits/convert.go
+++ b/api/v3/handlers/customers/credits/convert.go
@@ -103,7 +103,7 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 		}
 
 		costBasis := resolvedCostBasis.Rate.String()
-		purchaseAmount := resolvedCostBasis.FiatCurrency.RoundToPrecision(charge.Intent.CreditAmount.Mul(resolvedCostBasis.Rate))
+		purchaseAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
 		settlementStatus := api.BillingCreditPurchasePaymentSettlementStatusPending
 
 		if charge.Realizations.InvoiceSettlement != nil {
@@ -129,7 +129,7 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 		}
 
 		costBasis := resolvedCostBasis.Rate.String()
-		purchaseAmount := resolvedCostBasis.FiatCurrency.RoundToPrecision(charge.Intent.CreditAmount.Mul(resolvedCostBasis.Rate))
+		purchaseAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
 		availPolicy, err := toAPIBillingCreditAvailabilityPolicy(ext.InitialStatus)
 		if err != nil {
 			return nil, fmt.Errorf("converting availability policy: %w", err)

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -61,9 +61,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge creditpurchase.Charge
 		if err != nil {
 			return creditpurchase.ChargeBase{}, err
 		}
-		if err := tx.loadCostBasisEdge(ctx, dbCreditPurchase); err != nil {
-			return creditpurchase.ChargeBase{}, err
-		}
+		dbCreditPurchase.Edges.CostBasis = lockedCharge.Edges.CostBasis
 
 		return fromDBBaseWithCurrency(dbCreditPurchase, charge.Intent.Currency)
 	})
@@ -267,7 +265,8 @@ func (a *adapter) MarkVoided(ctx context.Context, input creditpurchase.MarkVoide
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (creditpurchase.ChargeBase, error) {
-		if _, err := tx.upgradeCostBasisSchemaForWrite(ctx, input.Charge.GetChargeID()); err != nil {
+		lockedCharge, err := tx.upgradeCostBasisSchemaForWrite(ctx, input.Charge.GetChargeID())
+		if err != nil {
 			return creditpurchase.ChargeBase{}, err
 		}
 
@@ -278,9 +277,7 @@ func (a *adapter) MarkVoided(ctx context.Context, input creditpurchase.MarkVoide
 		if err != nil {
 			return creditpurchase.ChargeBase{}, fmt.Errorf("marking credit purchase charge voided [id=%s]: %w", input.Charge.ID, err)
 		}
-		if err := tx.loadCostBasisEdge(ctx, dbCreditPurchase); err != nil {
-			return creditpurchase.ChargeBase{}, err
-		}
+		dbCreditPurchase.Edges.CostBasis = lockedCharge.Edges.CostBasis
 
 		return fromDBBaseWithCurrency(dbCreditPurchase, input.Charge.Intent.Currency)
 	})

--- a/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
@@ -4,18 +4,104 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargecreditpurchase "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchase"
-	dbchargecreditpurchasecostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchasecostbasis"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+type mapLegacyCostBasisInput struct {
+	Settlement             creditpurchase.PersistedSettlement
+	CustomCurrency         bool
+	FiatCreditCurrencyCode *currencyx.Code
+	CreatedAt              time.Time
+}
+
+var _ models.Validator = (*mapLegacyCostBasisInput)(nil)
+
+func (i mapLegacyCostBasisInput) Validate() error {
+	var errs []error
+
+	if err := i.Settlement.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("settlement: %w", err))
+	}
+
+	if i.CustomCurrency {
+		if i.FiatCreditCurrencyCode != nil {
+			errs = append(errs, errors.New("custom-currency charge cannot have a fiat credit currency code"))
+		}
+	} else if i.FiatCreditCurrencyCode == nil {
+		errs = append(errs, errors.New("fiat credit currency code is required"))
+	} else if !i.FiatCreditCurrencyCode.IsFiat() {
+		errs = append(errs, fmt.Errorf("credit currency %q is not fiat", *i.FiatCreditCurrencyCode))
+	}
+
+	if i.CustomCurrency && i.Settlement.Type != creditpurchase.SettlementTypePromotional && i.CreatedAt.IsZero() {
+		errs = append(errs, errors.New("created at is required for custom-currency cost basis"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func mapLegacyCostBasis(in mapLegacyCostBasisInput) (mappedCostBasis, error) {
+	if err := in.Validate(); err != nil {
+		return mappedCostBasis{}, err
+	}
+
+	if in.Settlement.Type == creditpurchase.SettlementTypePromotional {
+		return mappedCostBasis{}, nil
+	}
+
+	rate, err := in.Settlement.GetCostBasis()
+	if err != nil {
+		return mappedCostBasis{}, fmt.Errorf("getting legacy settlement cost basis: %w", err)
+	}
+
+	fiatCode, err := in.Settlement.GetCurrency()
+	if err != nil {
+		return mappedCostBasis{}, fmt.Errorf("getting legacy settlement currency: %w", err)
+	}
+	if fiatCode == nil {
+		return mappedCostBasis{}, errors.New("legacy cost basis requires a settlement currency")
+	}
+
+	if !in.CustomCurrency {
+		if currencyx.Code(*fiatCode) != *in.FiatCreditCurrencyCode {
+			return mappedCostBasis{}, fmt.Errorf("settlement currency %q must match credit currency %q", *fiatCode, *in.FiatCreditCurrencyCode)
+		}
+
+		return mappedCostBasis{
+			CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: rate})),
+		}, nil
+	}
+
+	fiatCurrency, err := currencyx.NewFiatCurrency(*fiatCode)
+	if err != nil {
+		return mappedCostBasis{}, fmt.Errorf("mapping legacy settlement currency: %w", err)
+	}
+
+	intent := costbasis.NewIntent(costbasis.ManualIntent{
+		FiatCurrency: fiatCurrency,
+		Rate:         rate,
+	})
+	state := costbasis.State{
+		CostBasis:  rate,
+		ResolvedAt: in.CreatedAt.UTC(),
+	}
+
+	return mappedCostBasis{
+		CostBasis:         lo.ToPtr(creditpurchase.NewCostBasis(intent)),
+		ResolvedCostBasis: &state,
+	}, nil
+}
 
 // upgradeCostBasisSchemaForWrite materializes the legacy settlement cost basis
 // while holding a row lock. Callers must run it inside the transaction that
@@ -59,61 +145,65 @@ func (a *adapter) upgradeCostBasisSchemaForWrite(ctx context.Context, chargeID m
 		update.SetInitialPaymentSettlementStatus(*entity.Settlement.InitialStatus)
 	}
 
-	switch entity.Settlement.Type {
-	case creditpurchase.SettlementTypePromotional:
-		// Promotional purchases have no cost basis to materialize.
-	case creditpurchase.SettlementTypeInvoice, creditpurchase.SettlementTypeExternal:
-		rate, err := entity.Settlement.GetCostBasis()
-		if err != nil {
-			return nil, fmt.Errorf("getting legacy settlement cost basis: %w", err)
-		}
+	if entity.CustomCurrencyID != nil && entity.FiatCurrencyCode != nil {
+		return nil, errors.New("legacy credit purchase contains both fiat and custom currency state")
+	}
 
-		if entity.CustomCurrencyID == nil {
-			update.SetFiatCostBasis(rate)
-			break
-		}
+	mappedLegacyCostBasis, err := mapLegacyCostBasis(mapLegacyCostBasisInput{
+		Settlement:             entity.Settlement,
+		CustomCurrency:         entity.CustomCurrencyID != nil,
+		FiatCreditCurrencyCode: entity.FiatCurrencyCode,
+		CreatedAt:              entity.CreatedAt,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mapping legacy cost basis: %w", err)
+	}
 
-		fiatCode, err := entity.Settlement.GetCurrency()
-		if err != nil {
-			return nil, fmt.Errorf("getting legacy settlement currency: %w", err)
-		}
-		if fiatCode == nil {
-			return nil, errors.New("legacy custom-currency cost basis requires a settlement currency")
-		}
+	if mappedLegacyCostBasis.CostBasis != nil {
+		switch mappedLegacyCostBasis.CostBasis.Type() {
+		case creditpurchase.CostBasisTypeFiat:
+			fiatCostBasis, err := mappedLegacyCostBasis.CostBasis.AsFiat()
+			if err != nil {
+				return nil, fmt.Errorf("getting mapped legacy fiat cost basis: %w", err)
+			}
 
-		fiatCurrency, err := currencyx.NewFiatCurrency(*fiatCode)
-		if err != nil {
-			return nil, fmt.Errorf("mapping legacy settlement currency: %w", err)
-		}
+			update.SetFiatCostBasis(fiatCostBasis.Rate)
+		case creditpurchase.CostBasisTypeCustomCurrency:
+			if entity.CustomCurrencyID == nil {
+				return nil, errors.New("legacy custom-currency cost basis requires a custom currency ID")
+			}
+			if mappedLegacyCostBasis.ResolvedCostBasis == nil {
+				return nil, errors.New("mapped legacy custom-currency cost basis is unresolved")
+			}
 
-		costBasisEntity, err := costbasis.Create(a.db.ChargeCreditPurchaseCostBasis.Create(), costbasis.CreateInput{
-			NamespacedID: models.NamespacedID{
-				Namespace: entity.Namespace,
-				ID:        ulid.Make().String(),
-			},
-			CurrencyID: *entity.CustomCurrencyID,
-			Intent: costbasis.NewIntent(costbasis.ManualIntent{
-				FiatCurrency: fiatCurrency,
-				Rate:         rate,
-			}),
-			State: &costbasis.State{
-				CostBasis:  rate,
-				ResolvedAt: entity.CreatedAt.UTC(),
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("building legacy custom-currency cost basis: %w", err)
-		}
+			intent, err := mappedLegacyCostBasis.CostBasis.AsCustomCurrency()
+			if err != nil {
+				return nil, fmt.Errorf("getting mapped legacy custom-currency cost basis: %w", err)
+			}
 
-		createdCostBasis, err := costBasisEntity.Save(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("creating legacy custom-currency cost basis: %w", err)
-		}
+			costBasisEntity, err := costbasis.Create(a.db.ChargeCreditPurchaseCostBasis.Create(), costbasis.CreateInput{
+				NamespacedID: models.NamespacedID{
+					Namespace: entity.Namespace,
+					ID:        ulid.Make().String(),
+				},
+				CurrencyID: *entity.CustomCurrencyID,
+				Intent:     intent,
+				State:      mappedLegacyCostBasis.ResolvedCostBasis,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("building legacy custom-currency cost basis: %w", err)
+			}
 
-		update.SetCostBasisID(createdCostBasis.ID)
-		entity.Edges.CostBasis = createdCostBasis
-	default:
-		return nil, fmt.Errorf("unsupported credit purchase settlement type: %s", entity.Settlement.Type)
+			createdCostBasis, err := costBasisEntity.Save(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("creating legacy custom-currency cost basis: %w", err)
+			}
+
+			update.SetCostBasisID(createdCostBasis.ID)
+			entity.Edges.CostBasis = createdCostBasis
+		default:
+			return nil, fmt.Errorf("unsupported mapped legacy cost basis type: %s", mappedLegacyCostBasis.CostBasis.Type())
+		}
 	}
 
 	upgraded, err := update.
@@ -126,28 +216,4 @@ func (a *adapter) upgradeCostBasisSchemaForWrite(ctx context.Context, chargeID m
 	upgraded.Edges.CostBasis = entity.Edges.CostBasis
 
 	return upgraded, nil
-}
-
-func (a *adapter) loadCostBasisEdge(ctx context.Context, entity *entdb.ChargeCreditPurchase) error {
-	if entity.Edges.CostBasis != nil {
-		return fmt.Errorf("credit purchase cost basis edge is already loaded [charge_id=%s,edge_id=%s]", entity.ID, entity.Edges.CostBasis.ID)
-	}
-
-	if entity.CostBasisID == nil {
-		return nil
-	}
-
-	costBasisEntity, err := a.db.ChargeCreditPurchaseCostBasis.Query().
-		Where(
-			dbchargecreditpurchasecostbasis.ID(*entity.CostBasisID),
-			dbchargecreditpurchasecostbasis.Namespace(entity.Namespace),
-		).
-		Only(ctx)
-	if err != nil {
-		return fmt.Errorf("loading credit purchase cost basis edge [charge_id=%s,cost_basis_id=%s]: %w", entity.ID, *entity.CostBasisID, err)
-	}
-
-	entity.Edges.CostBasis = costBasisEntity
-
-	return nil
 }

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper.go
@@ -136,65 +136,22 @@ func fromDBCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.C
 			return mappedCostBasis{}, errors.New("legacy schema row contains dedicated cost-basis state")
 		}
 
-		return fromDBLegacyCostBasis(dbEntity, currency)
+		var fiatCreditCurrencyCode *currencyx.Code
+		if !currency.IsCustom() {
+			fiatCreditCurrencyCode = lo.ToPtr(currency.GetCode())
+		}
+
+		return mapLegacyCostBasis(mapLegacyCostBasisInput{
+			Settlement:             dbEntity.Settlement,
+			CustomCurrency:         currency.IsCustom(),
+			FiatCreditCurrencyCode: fiatCreditCurrencyCode,
+			CreatedAt:              dbEntity.CreatedAt,
+		})
 	case creditpurchase.SchemaLevelCostBasis:
 		return fromDBDedicatedCostBasis(dbEntity, currency)
 	default:
 		return mappedCostBasis{}, fmt.Errorf("unsupported credit purchase schema level: %d", schemaLevel)
 	}
-}
-
-func fromDBLegacyCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.Currency) (mappedCostBasis, error) {
-	if dbEntity.Settlement.Type == creditpurchase.SettlementTypePromotional {
-		return mappedCostBasis{}, nil
-	}
-
-	rate, err := dbEntity.Settlement.GetCostBasis()
-	if err != nil {
-		return mappedCostBasis{}, fmt.Errorf("getting legacy settlement cost basis: %w", err)
-	}
-
-	if !currency.IsCustom() {
-		fiatCode, err := dbEntity.Settlement.GetCurrency()
-		if err != nil {
-			return mappedCostBasis{}, fmt.Errorf("getting legacy settlement currency: %w", err)
-		}
-		if fiatCode == nil {
-			return mappedCostBasis{}, errors.New("legacy fiat cost basis requires a settlement currency")
-		}
-		if currencyx.Code(*fiatCode) != currency.GetCode() {
-			return mappedCostBasis{}, fmt.Errorf("settlement currency %q must match credit currency %q", *fiatCode, currency.GetCode())
-		}
-
-		return mappedCostBasis{CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: rate}))}, nil
-	}
-
-	fiatCode, err := dbEntity.Settlement.GetCurrency()
-	if err != nil {
-		return mappedCostBasis{}, fmt.Errorf("getting legacy settlement currency: %w", err)
-	}
-	if fiatCode == nil {
-		return mappedCostBasis{}, errors.New("legacy custom-currency cost basis requires a settlement currency")
-	}
-
-	fiatCurrency, err := currencyx.NewFiatCurrency(*fiatCode)
-	if err != nil {
-		return mappedCostBasis{}, fmt.Errorf("mapping legacy settlement currency: %w", err)
-	}
-
-	intent := costbasis.NewIntent(costbasis.ManualIntent{
-		FiatCurrency: fiatCurrency,
-		Rate:         rate,
-	})
-	state := costbasis.State{
-		CostBasis:  rate,
-		ResolvedAt: dbEntity.CreatedAt.UTC(),
-	}
-
-	return mappedCostBasis{
-		CostBasis:         lo.ToPtr(creditpurchase.NewCostBasis(intent)),
-		ResolvedCostBasis: &state,
-	}, nil
 }
 
 func fromDBDedicatedCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.Currency) (mappedCostBasis, error) {

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -219,15 +219,7 @@ func (f IntentMutableFields) Normalized(currency currencies.Currency) IntentMuta
 }
 
 func (f IntentMutableFields) CalculateEffectiveAt() time.Time {
-	if f.EffectiveAt != nil {
-		return *f.EffectiveAt
-	}
-
-	if !f.ServicePeriod.From.IsZero() {
-		return f.ServicePeriod.From
-	}
-
-	return clock.Now().UTC()
+	return lo.FromPtrOr(f.EffectiveAt, clock.Now().UTC())
 }
 
 func (f IntentMutableFields) Validate() error {

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -248,7 +248,7 @@ func (f IntentMutableFields) Validate() error {
 		}
 	}
 
-	if f.ExpiresAt != nil && !f.ExpiresAt.After(f.CalculateEffectiveAt()) {
+	if f.EffectiveAt != nil && f.ExpiresAt != nil && !f.ExpiresAt.After(*f.EffectiveAt) {
 		errs = append(errs, fmt.Errorf("expires at must be after effective at"))
 	}
 

--- a/openmeter/billing/charges/creditpurchase/charge_test.go
+++ b/openmeter/billing/charges/creditpurchase/charge_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -56,6 +60,92 @@ func TestIntentMutableFieldsCalculateEffectiveAtDoesNotBackdateToServicePeriod(t
 	}
 
 	require.Equal(t, now, fields.CalculateEffectiveAt())
+}
+
+func TestIntentMutableFieldsValidateAllowsHistoricalExpiryWithoutEffectiveAt(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	period := timeutil.ClosedPeriod{
+		From: now.Add(-2 * time.Hour),
+		To:   now.Add(-time.Hour),
+	}
+
+	require.NoError(t, (IntentMutableFields{
+		IntentMutableFields: meta.IntentMutableFields{
+			Name:              "historical credit purchase",
+			ServicePeriod:     period,
+			FullServicePeriod: period,
+			BillingPeriod:     period,
+		},
+		CreditAmount: alpacadecimal.NewFromInt(1),
+		ExpiresAt:    lo.ToPtr(period.To),
+		Settlement:   NewInvoiceSettlement(),
+	}).Validate())
+}
+
+func TestCreateInputValidateRejectsExpiryWithoutEffectiveAt(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	period := timeutil.ClosedPeriod{
+		From: now.Add(-2 * time.Hour),
+		To:   now.Add(-time.Hour),
+	}
+
+	for _, tc := range []struct {
+		name      string
+		expiresAt time.Time
+	}{
+		{
+			name:      "before now",
+			expiresAt: period.To,
+		},
+		{
+			name:      "equal to now",
+			expiresAt: now,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given: a credit purchase without an explicit effective time that
+			// expires no later than its creation time
+			input := CreateInput{
+				Namespace: "test",
+				Intent: Intent{
+					Intent: meta.Intent{
+						ManagedBy:  billing.ManuallyManagedLine,
+						CustomerID: "customer-1",
+						Currency:   currenciestestutils.NewFiatCurrency(t, "USD"),
+						TaxConfig: productcatalog.TaxCodeConfig{
+							TaxCodeID: "tax-code-1",
+						},
+					},
+					IntentMutableFields: IntentMutableFields{
+						IntentMutableFields: meta.IntentMutableFields{
+							Name:              "historical credit purchase",
+							ServicePeriod:     period,
+							FullServicePeriod: period,
+							BillingPeriod:     period,
+						},
+						CreditAmount: alpacadecimal.NewFromInt(1),
+						ExpiresAt:    lo.ToPtr(tc.expiresAt),
+						Settlement:   NewInvoiceSettlement(),
+					},
+					CostBasis: lo.ToPtr(NewCostBasis(FiatCostBasis{
+						Rate: alpacadecimal.NewFromInt(1),
+					})),
+				},
+			}
+
+			// when: the create input is validated
+			err := input.Validate()
+
+			// then: expiration at or before creation is rejected
+			require.ErrorContains(t, err, "expires at must be after effective at")
+		})
+	}
 }
 
 func TestFeatureFiltersNormalize(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/charge_test.go
+++ b/openmeter/billing/charges/creditpurchase/charge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -38,6 +39,23 @@ func TestIntentNormalizedPinsServicePeriodsToEffectiveAt(t *testing.T) {
 	require.Equal(t, expectedPeriod, got.ServicePeriod)
 	require.Equal(t, expectedPeriod, got.FullServicePeriod)
 	require.Equal(t, expectedPeriod, got.BillingPeriod)
+}
+
+func TestIntentMutableFieldsCalculateEffectiveAtDoesNotBackdateToServicePeriod(t *testing.T) {
+	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	fields := IntentMutableFields{
+		IntentMutableFields: meta.IntentMutableFields{
+			ServicePeriod: timeutil.ClosedPeriod{
+				From: now.Add(-24 * time.Hour),
+				To:   now,
+			},
+		},
+	}
+
+	require.Equal(t, now, fields.CalculateEffectiveAt())
 }
 
 func TestFeatureFiltersNormalize(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis.go
@@ -1,11 +1,13 @@
 package creditpurchase
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -84,6 +86,14 @@ type CostBasis struct {
 
 var _ models.Validator = (*CostBasis)(nil)
 
+type costBasisJSON struct {
+	Type                CostBasisType          `json:"type"`
+	Mode                chargecostbasis.Mode   `json:"mode,omitempty"`
+	FiatCurrency        *currencyx.FiatCode    `json:"fiatCurrency,omitempty"`
+	CurrencyCostBasisID *string                `json:"currencyCostBasisID,omitempty"`
+	Rate                *alpacadecimal.Decimal `json:"rate,omitempty"`
+}
+
 func NewCostBasis[T FiatCostBasis | chargecostbasis.Intent](in T) CostBasis {
 	switch value := any(in).(type) {
 	case FiatCostBasis:
@@ -103,6 +113,123 @@ func NewCostBasis[T FiatCostBasis | chargecostbasis.Intent](in T) CostBasis {
 
 func (c CostBasis) Type() CostBasisType {
 	return c.kind
+}
+
+func (c CostBasis) MarshalJSON() ([]byte, error) {
+	if err := c.Validate(); err != nil {
+		return nil, fmt.Errorf("validating credit purchase cost basis: %w", err)
+	}
+
+	serde := costBasisJSON{Type: c.kind}
+
+	switch c.kind {
+	case CostBasisTypeFiat:
+		serde.Rate = &c.fiat.Rate
+	case CostBasisTypeCustomCurrency:
+		serde.Mode = c.customCurrency.Kind()
+
+		fiatCurrency, err := c.customCurrency.GetFiatCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting custom-currency fiat currency: %w", err)
+		}
+		serde.FiatCurrency = lo.ToPtr(fiatCurrency.GetFiatCode())
+
+		switch serde.Mode {
+		case chargecostbasis.ModeDynamic:
+		case chargecostbasis.ModePinned:
+			intent, err := c.customCurrency.AsPinned()
+			if err != nil {
+				return nil, err
+			}
+			serde.CurrencyCostBasisID = &intent.CurrencyCostBasisID
+		case chargecostbasis.ModeManual:
+			intent, err := c.customCurrency.AsManual()
+			if err != nil {
+				return nil, err
+			}
+			serde.Rate = &intent.Rate
+		default:
+			return nil, fmt.Errorf("unsupported custom-currency cost basis mode: %s", serde.Mode)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", c.kind)
+	}
+
+	return json.Marshal(serde)
+}
+
+func (c *CostBasis) UnmarshalJSON(data []byte) error {
+	var serde costBasisJSON
+	if err := json.Unmarshal(data, &serde); err != nil {
+		return fmt.Errorf("deserializing credit purchase cost basis: %w", err)
+	}
+
+	var decoded CostBasis
+
+	switch serde.Type {
+	case CostBasisTypeFiat:
+		if serde.Rate == nil {
+			return errors.New("fiat cost basis rate is required")
+		}
+		if serde.Mode != "" || serde.FiatCurrency != nil || serde.CurrencyCostBasisID != nil {
+			return errors.New("fiat cost basis contains custom-currency fields")
+		}
+
+		decoded = NewCostBasis(FiatCostBasis{Rate: *serde.Rate})
+	case CostBasisTypeCustomCurrency:
+		if serde.FiatCurrency == nil {
+			return errors.New("custom-currency fiat currency is required")
+		}
+
+		fiatCurrency, err := currencyx.NewFiatCurrency(*serde.FiatCurrency)
+		if err != nil {
+			return fmt.Errorf("mapping custom-currency fiat currency: %w", err)
+		}
+
+		switch serde.Mode {
+		case chargecostbasis.ModeDynamic:
+			if serde.Rate != nil || serde.CurrencyCostBasisID != nil {
+				return errors.New("dynamic cost basis contains resolved fields")
+			}
+			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
+				FiatCurrency: fiatCurrency,
+			}))
+		case chargecostbasis.ModePinned:
+			if serde.CurrencyCostBasisID == nil {
+				return errors.New("pinned currency cost basis ID is required")
+			}
+			if serde.Rate != nil {
+				return errors.New("pinned cost basis contains a manual rate")
+			}
+			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.PinnedIntent{
+				FiatCurrency:        fiatCurrency,
+				CurrencyCostBasisID: *serde.CurrencyCostBasisID,
+			}))
+		case chargecostbasis.ModeManual:
+			if serde.Rate == nil {
+				return errors.New("manual cost basis rate is required")
+			}
+			if serde.CurrencyCostBasisID != nil {
+				return errors.New("manual cost basis contains a pinned cost basis ID")
+			}
+			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				FiatCurrency: fiatCurrency,
+				Rate:         *serde.Rate,
+			}))
+		default:
+			return fmt.Errorf("unsupported custom-currency cost basis mode: %s", serde.Mode)
+		}
+	default:
+		return fmt.Errorf("unsupported credit purchase cost basis type: %s", serde.Type)
+	}
+
+	if err := decoded.Validate(); err != nil {
+		return fmt.Errorf("validating credit purchase cost basis: %w", err)
+	}
+
+	*c = decoded
+
+	return nil
 }
 
 func (c *CostBasis) Validate() error {
@@ -167,6 +294,12 @@ func (c CostBasis) AsCustomCurrency() (chargecostbasis.Intent, error) {
 type ResolvedCostBasis struct {
 	FiatCurrency *currencyx.FiatCurrency
 	Rate         alpacadecimal.Decimal
+}
+
+// FiatAmount converts a credit amount to fiat and rounds it at the settlement
+// currency's precision.
+func (c ResolvedCostBasis) FiatAmount(creditAmount alpacadecimal.Decimal) alpacadecimal.Decimal {
+	return c.FiatCurrency.RoundToPrecision(creditAmount.Mul(c.Rate))
 }
 
 func (c ResolvedCostBasis) Validate() error {

--- a/openmeter/billing/charges/creditpurchase/costbasis_test.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis_test.go
@@ -1,6 +1,7 @@
 package creditpurchase
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -58,6 +59,45 @@ func TestCostBasisVariants(t *testing.T) {
 	})
 }
 
+func TestCostBasisJSONRoundTrip(t *testing.T) {
+	usd, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	testCases := map[string]CostBasis{
+		"fiat": NewCostBasis(FiatCostBasis{
+			Rate: alpacadecimal.NewFromFloat(1.25),
+		}),
+		"custom currency dynamic": NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
+			FiatCurrency: usd,
+		})),
+		"custom currency pinned": NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.PinnedIntent{
+			FiatCurrency:        usd,
+			CurrencyCostBasisID: "01J00000000000000000000000",
+		})),
+		"custom currency manual": NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+			FiatCurrency: usd,
+			Rate:         alpacadecimal.NewFromFloat(0.5),
+		})),
+	}
+
+	for name, costBasis := range testCases {
+		t.Run(name, func(t *testing.T) {
+			encoded, err := json.Marshal(costBasis)
+			require.NoError(t, err)
+			require.NotEqual(t, "{}", string(encoded))
+
+			var decoded CostBasis
+			require.NoError(t, json.Unmarshal(encoded, &decoded))
+			require.NoError(t, decoded.Validate())
+			require.Equal(t, costBasis.Type(), decoded.Type())
+
+			reencoded, err := json.Marshal(decoded)
+			require.NoError(t, err)
+			require.JSONEq(t, string(encoded), string(reencoded))
+		})
+	}
+}
+
 func TestResolvedCostBasisValidate(t *testing.T) {
 	require.ErrorContains(t, (ResolvedCostBasis{
 		Rate: alpacadecimal.NewFromInt(1),
@@ -69,6 +109,18 @@ func TestResolvedCostBasisValidate(t *testing.T) {
 		FiatCurrency: usd,
 		Rate:         alpacadecimal.Zero,
 	}).Validate(), "rate must be positive")
+}
+
+func TestResolvedCostBasisFiatAmount(t *testing.T) {
+	usd, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	amount := (ResolvedCostBasis{
+		FiatCurrency: usd,
+		Rate:         alpacadecimal.NewFromFloat(0.5),
+	}).FiatAmount(alpacadecimal.NewFromFloat(100.1234))
+
+	require.Equal(t, 50.06, amount.InexactFloat64())
 }
 
 func TestChargeBaseValidateCostBasis(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/service.go
+++ b/openmeter/billing/charges/creditpurchase/service.go
@@ -66,5 +66,9 @@ func (i CreateInput) Validate() error {
 		errs = append(errs, fmt.Errorf("intent: %w", err))
 	}
 
+	if i.Intent.EffectiveAt == nil && i.Intent.ExpiresAt != nil && !i.Intent.ExpiresAt.After(i.Intent.CalculateEffectiveAt()) {
+		errs = append(errs, errors.New("intent: expires at must be after effective at"))
+	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -92,7 +92,7 @@ func (s *service) buildInvoiceCreditPurchaseGatheringLine(charge creditpurchase.
 	}
 
 	// Total cost = credit amount * cost basis (e.g., 100 credits * $0.5 = $50)
-	totalCost := resolvedCostBasis.FiatCurrency.RoundToPrecision(intent.CreditAmount.Mul(resolvedCostBasis.Rate))
+	totalCost := resolvedCostBasis.FiatAmount(intent.CreditAmount)
 	invoiceCurrency := resolvedCostBasis.FiatCurrency.GetFiatCode()
 
 	// Clone metadata and add credit-purchase specific annotations

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -82,7 +82,7 @@ func (e *LineEngine) buildInvoiceCreditPurchaseStandardLines(ctx context.Context
 			return nil, fmt.Errorf("getting resolved cost basis for credit purchase charge[%s]: %w", charge.ID, err)
 		}
 
-		fiatAmount := resolvedCostBasis.FiatCurrency.RoundToPrecision(charge.Intent.CreditAmount.Mul(resolvedCostBasis.Rate))
+		fiatAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
 		stdLineWithDetails, err := creditpurchasemodels.WithDetailedLines(creditpurchasemodels.WithDetailedLinesInput{
 			Line:              stdLine,
 			Name:              stdLine.Name,

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -244,9 +244,7 @@ func (s *Service) AuthorizeExternalPayment(ctx context.Context, charge creditpur
 		return creditpurchase.Charge{}, err
 	}
 
-	fiatAmount := resolvedCostBasis.FiatCurrency.RoundToPrecision(
-		charge.Intent.CreditAmount.Mul(resolvedCostBasis.Rate),
-	)
+	fiatAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
 
 	eventAt := clock.Now()
 	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -316,6 +316,26 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() 
 		s.Equal(currencyx.FiatCode(currency.USD), resolvedCostBasis.FiatCurrency.GetFiatCode())
 	})
 
+	s.Run("referenced cost basis cannot be deleted", func() {
+		// given:
+		// - a persisted custom-currency purchase referencing its cost basis
+		s.Require().NotNil(createdCharge.State.CostBasisID, "create subtest must have persisted a cost basis")
+
+		// when:
+		// - the referenced cost-basis row is deleted directly
+		err := s.DBClient.ChargeCreditPurchaseCostBasis.DeleteOneID(*createdCharge.State.CostBasisID).Exec(ctx)
+
+		// then:
+		// - the foreign key rejects the delete and preserves the financial charge
+		s.Require().Error(err)
+		persisted, err := creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+			Namespace: ns,
+			IDs:       []string{createdCharge.ID},
+		})
+		s.Require().NoError(err)
+		s.Require().Len(persisted, 1)
+	})
+
 	s.Run("legacy row upgrades on write", func() {
 		// given:
 		// - the persisted custom-currency purchase is reverted to the level-1
@@ -328,8 +348,6 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() 
 			ClearInitialPaymentSettlementStatus().
 			SetSchemaLevel(int(creditpurchase.SchemaLevelLegacy)).
 			Save(ctx)
-		s.Require().NoError(err)
-		err = s.DBClient.ChargeCreditPurchaseCostBasis.DeleteOneID(originalCostBasisID).Exec(ctx)
 		s.Require().NoError(err)
 
 		legacy, err := s.CreditPurchaseAdapter.GetByID(ctx, creditpurchase.GetByIDInput{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1847,7 +1847,7 @@ var (
 				Symbol:     "charge_credit_purchase_cost_basis_charge_fk",
 				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[34]},
 				RefColumns: []*schema.Column{ChargeCreditPurchaseCostBasesColumns[0]},
-				OnDelete:   schema.Cascade,
+				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_credit_purchases_custom_currencies_charges_credit_purchase",
@@ -1924,6 +1924,11 @@ var (
 				Name:    "chargecreditpurchases_tax_code_id",
 				Unique:  false,
 				Columns: []*schema.Column{ChargeCreditPurchasesColumns[40]},
+			},
+			{
+				Name:    "chargecreditpurchases_cost_basis_id",
+				Unique:  true,
+				Columns: []*schema.Column{ChargeCreditPurchasesColumns[34]},
 			},
 			{
 				Name:    "chargecreditpurchase_namespace_customer_id_key",
@@ -2309,6 +2314,11 @@ var (
 				Name:    "chargeflatfees_tax_code_id",
 				Unique:  false,
 				Columns: []*schema.Column{ChargeFlatFeesColumns[39]},
+			},
+			{
+				Name:    "chargeflatfees_cost_basis_id",
+				Unique:  true,
+				Columns: []*schema.Column{ChargeFlatFeesColumns[32]},
 			},
 		},
 	}
@@ -3002,6 +3012,11 @@ var (
 				Name:    "chargeusagebased_tax_code_id",
 				Unique:  false,
 				Columns: []*schema.Column{ChargeUsageBasedColumns[38]},
+			},
+			{
+				Name:    "chargeusagebased_cost_basis_id",
+				Unique:  true,
+				Columns: []*schema.Column{ChargeUsageBasedColumns[31]},
 			},
 		},
 	}

--- a/openmeter/ent/schema/chargescreditpurchase.go
+++ b/openmeter/ent/schema/chargescreditpurchase.go
@@ -129,7 +129,9 @@ func (ChargeCreditPurchase) Edges() []ent.Edge {
 			Field("cost_basis_id").
 			StorageKey(edge.Symbol("charge_credit_purchase_cost_basis_charge_fk")).
 			Unique().
-			Annotations(entsql.OnDelete(entsql.Cascade)),
+			// The charge stores the foreign key, so cascading a cost-basis delete
+			// would delete the financial charge record instead of its child state.
+			Annotations(entsql.OnDelete(entsql.Restrict)),
 		edge.To("charge", Charge.Type).
 			Unique().
 			Immutable().
@@ -175,6 +177,9 @@ func (ChargeCreditPurchase) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tax_code_id").
 			StorageKey("chargecreditpurchases_tax_code_id"),
+		index.Fields("cost_basis_id").
+			StorageKey("chargecreditpurchases_cost_basis_id").
+			Unique(),
 		// Idempotency key, unique per customer within a namespace. Partial so it is enforced
 		// only while live: NULL means no idempotency requested, and a soft-deleted grant must
 		// not permanently reserve a key the caller may reuse.

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -168,6 +168,9 @@ func (ChargeFlatFee) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tax_code_id").
 			StorageKey("chargeflatfees_tax_code_id"),
+		index.Fields("cost_basis_id").
+			StorageKey("chargeflatfees_cost_basis_id").
+			Unique(),
 	}
 }
 

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -174,6 +174,9 @@ func (ChargeUsageBased) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tax_code_id").
 			StorageKey("chargeusagebased_tax_code_id"),
+		index.Fields("cost_basis_id").
+			StorageKey("chargeusagebased_cost_basis_id").
+			Unique(),
 	}
 }
 

--- a/tools/migrate/migrations/20260807145338_enforce_charge_cost_basis_relationships.down.sql
+++ b/tools/migrate/migrations/20260807145338_enforce_charge_cost_basis_relationships.down.sql
@@ -1,0 +1,8 @@
+-- reverse: create index "chargecreditpurchases_cost_basis_id" to table: "charge_credit_purchases"
+DROP INDEX "chargecreditpurchases_cost_basis_id";
+-- reverse: modify "charge_credit_purchases" table
+ALTER TABLE "charge_credit_purchases" DROP CONSTRAINT "charge_credit_purchase_cost_basis_charge_fk", ADD CONSTRAINT "charge_credit_purchase_cost_basis_charge_fk" FOREIGN KEY ("cost_basis_id") REFERENCES "charge_credit_purchase_cost_bases" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- reverse: create index "chargeusagebased_cost_basis_id" to table: "charge_usage_based"
+DROP INDEX "chargeusagebased_cost_basis_id";
+-- reverse: create index "chargeflatfees_cost_basis_id" to table: "charge_flat_fees"
+DROP INDEX "chargeflatfees_cost_basis_id";

--- a/tools/migrate/migrations/20260807145338_enforce_charge_cost_basis_relationships.up.sql
+++ b/tools/migrate/migrations/20260807145338_enforce_charge_cost_basis_relationships.up.sql
@@ -1,0 +1,11 @@
+-- create index "chargeflatfees_cost_basis_id" to table: "charge_flat_fees"
+-- atlas:nolint MF101
+CREATE UNIQUE INDEX "chargeflatfees_cost_basis_id" ON "charge_flat_fees" ("cost_basis_id");
+-- create index "chargeusagebased_cost_basis_id" to table: "charge_usage_based"
+-- atlas:nolint MF101
+CREATE UNIQUE INDEX "chargeusagebased_cost_basis_id" ON "charge_usage_based" ("cost_basis_id");
+-- modify "charge_credit_purchases" table
+ALTER TABLE "charge_credit_purchases" DROP CONSTRAINT "charge_credit_purchase_cost_basis_charge_fk", ADD CONSTRAINT "charge_credit_purchase_cost_basis_charge_fk" FOREIGN KEY ("cost_basis_id") REFERENCES "charge_credit_purchase_cost_bases" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT;
+-- create index "chargecreditpurchases_cost_basis_id" to table: "charge_credit_purchases"
+-- atlas:nolint MF101
+CREATE UNIQUE INDEX "chargecreditpurchases_cost_basis_id" ON "charge_credit_purchases" ("cost_basis_id");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8gxLlLOMzBrWA6o3y0GrqlrpAqmba9YCCwW9dVC0fEU=
+h1:knTp4LnCav59r5ke+cRxNcBBuyVaTl/mFrYz1j394ac=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -257,3 +257,4 @@ h1:8gxLlLOMzBrWA6o3y0GrqlrpAqmba9YCCwW9dVC0fEU=
 20260806141309_add_charge_run_detailed_line_amount_discounts.up.sql h1:tgLzJPz7ntYq5dmkuVINnkT8yvqmgIIV8m+8ppb+c9A=
 20260806163516_credit_purchase_cost_basis_bridge.up.sql h1:kRNpFRMflhq66wJbSnXkTlMDtcRNaxG1Pr56BNBW7Mw=
 20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql h1:k/byyaoUMzatU0fEugM3xNMyy607xkxlXEC1lAUMeDs=
+20260807145338_enforce_charge_cost_basis_relationships.up.sql h1:+eRqMO8jr7BRn3MW1zJCgjr/+kzx1hSDYrfuTguO/ZI=


### PR DESCRIPTION
## Summary

- correct the credit-purchase cost-basis foreign-key delete behavior and enforce one-to-one cost-basis relationships
- restore the original credit-purchase effective-at behavior
- add JSON round-trip support for credit-purchase cost-basis variants
- consolidate legacy cost-basis projection, fiat amount calculation, and upgraded edge reuse
- add regression coverage for the corrected behavior

## Root cause

Late review identified that the credit-purchase cost-basis foreign key cascaded in the wrong direction once the relationship became active. The original cost-basis change also unintentionally made service-period start affect credit-purchase effective time and left several representation and persistence invariants enforced only by application conventions.

## Impact

Cost-basis records can no longer cascade-delete financial charge records, every charge type enforces the intended one-to-one cost-basis relationship in PostgreSQL, and the follow-up cleanup removes duplicated conversion and loading paths without changing purchase amount behavior.

## Validation

- `go test ./openmeter/billing/charges/creditpurchase ./openmeter/billing/charges/creditpurchase/adapter ./openmeter/billing/charges/creditpurchase/service/... ./api/v3/handlers/customers/credits`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service`
- `make migrate-check-lint`
- `make migrate-check-validate`
- `make lint-go-fast`

Ticket: OM-436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reliably handling promotional, fiat, and custom-currency credit purchase cost bases.
  - Improved cost-basis data exchange and compatibility with existing records.

- **Bug Fixes**
  - Improved fiat amount calculations and rounding across invoices and external payments.
  - Prevented cost-basis records from being deleted while still referenced.
  - Corrected effective and expiration time validation for credit purchases.

- **Data Integrity**
  - Added safeguards to prevent conflicting currency information and duplicate cost-basis associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects credit-purchase cost-basis persistence and effective-time behavior while consolidating conversion logic.
- Changes the credit-purchase cost-basis foreign key from cascading deletion to restricted deletion.
- Adds unique cost-basis reference indexes for credit-purchase, flat-fee, and usage-based charges.
- Adds validated JSON round-trip support for fiat and custom-currency cost-basis variants.
- Reuses upgraded cost-basis edges and centralizes fiat amount calculation.
- Restores creation-time effective-date behavior and adds regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/creditpurchase/adapter/costbasis.go | Consolidates legacy cost-basis projection and preserves the materialized edge through schema upgrades. |
| openmeter/billing/charges/creditpurchase/adapter/charge.go | Reuses the row-locked, eagerly loaded cost-basis edge after charge updates and voiding. |
| openmeter/billing/charges/creditpurchase/charge.go | Restores creation-time effective-date semantics and limits intrinsic expiry comparison to explicit effective times. |
| openmeter/billing/charges/creditpurchase/service.go | Enforces creation-time expiry validation when the effective time is implicit. |
| openmeter/billing/charges/creditpurchase/costbasis.go | Adds validated JSON serialization for all cost-basis variants and centralizes rounded fiat conversion. |
| openmeter/ent/schema/chargescreditpurchase.go | Restricts deletion of referenced cost-basis records and enforces one-to-one references. |
| tools/migrate/migrations/20260807145338_enforce_charge_cost_basis_relationships.up.sql | Applies the corrected foreign-key behavior and unique cost-basis indexes to PostgreSQL. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Input[Credit-purchase input] --> Validate[Validate intent and expiry]
  Validate --> Normalize[Normalize purchase intent]
  Normalize --> Persist[Persist charge]
  Persist --> CostBasis{Cost-basis schema}
  CostBasis -->|Legacy| Upgrade[Materialize dedicated cost basis]
  CostBasis -->|Current| Reuse[Reuse loaded cost-basis edge]
  Upgrade --> Reuse
  Reuse --> Resolve[Resolve fiat rate]
  Resolve --> Amount[Calculate rounded fiat amount]
  Amount --> Invoice[Invoice or external settlement]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: validate credit purchase expiry at ..."](https://github.com/openmeterio/openmeter/commit/10fb5c7d94df79945dbc8b2899ec1dd09344326d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51197795)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)

<!-- /greptile_comment -->