### PR TITLE
refactor(charges): make state machine invoice effects explicit

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -89,6 +89,15 @@ when an active override hides it.
 - Charge creation resolves every supplied feature reference before persistence.
   Usage-based features require a meter; flat-fee features are optional and may
   be meterless.
+- Charge state machines do not expose invoice patches through a separate peek
+  or drain operation. A caller must choose an invoice-aware
+  `*UntilInvoicePatchesOrStable` operation, which stops at the first invoice
+  effect boundary and transfers ownership of the returned patches, or a
+  no-invoice-patches `*UntilStable` operation.
+- The no-invoice-patches operations fail if a transition produces invoice
+  patches. This makes forgetting to retrieve and apply invoice effects an
+  explicit error instead of silently losing them while advancing lifecycle
+  state.
 - `UpdateCharge` persists the concrete base row. Expanded realizations are read
   model state and are written through dedicated adapter operations.
 - Persisted charge discounts have stable correlation IDs allocated at their

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -40,14 +40,11 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 				return creditpurchase.ChargeWithGatheringLine{}, fmt.Errorf("new promotional state machine: %w", err)
 			}
 
-			advancedCharge, err := stateMachine.AdvanceUntilStateStable(ctx)
-			if err != nil {
+			if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 				return creditpurchase.ChargeWithGatheringLine{}, fmt.Errorf("advance promotional state machine: %w", err)
 			}
 
-			if advancedCharge != nil {
-				charge = *advancedCharge
-			}
+			charge = stateMachine.GetCharge()
 		case creditpurchase.SettlementTypeInvoice:
 			// noop, as we will transition to active state when the invoice is created, as
 			// - invocing based charges are driven by the invoice state machine

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -28,12 +26,11 @@ func (s *service) onExternalCreditPurchase(ctx context.Context, charge creditpur
 		return creditpurchase.Charge{}, fmt.Errorf("new external state machine: %w", err)
 	}
 
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(ctx)
-	if err != nil {
+	if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 		return creditpurchase.Charge{}, fmt.Errorf("advance external state machine: %w", err)
 	}
 
-	charge = lo.FromPtrOr(advancedCharge, charge)
+	charge = stateMachine.GetCharge()
 
 	if trigger == "" {
 		return charge, nil
@@ -156,11 +153,15 @@ func (s *service) newExternalCreditPurchaseStateMachine(charge creditpurchase.Ch
 }
 
 func (s *ExternalCreditPurchaseStateMachine) handleExternalPaymentLifecycleTrigger(ctx context.Context, trigger meta.Trigger) (creditpurchase.Charge, error) {
-	if _, err := s.AdvanceUntilStateStable(ctx); err != nil {
+	if err := s.AdvanceUntilStable(ctx); err != nil {
 		return creditpurchase.Charge{}, fmt.Errorf("advance external state machine: %w", err)
 	}
 
-	return s.FireAndAdvanceUntilStateStable(ctx, trigger)
+	if err := s.FireAndAdvanceUntilStable(ctx, trigger); err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	return s.GetCharge(), nil
 }
 
 func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -114,7 +114,7 @@ func TestExternalCreditPurchaseStateMachineAuthorizationUsesRealizationDuplicate
 	})
 	require.NoError(t, err)
 
-	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
+	err = stateMachine.FireAndAdvanceUntilStable(t.Context(), billing.TriggerAuthorized)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, payment.ErrPaymentAlreadyAuthorized)

--- a/openmeter/billing/charges/creditpurchase/service/invoice.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice.go
@@ -188,21 +188,12 @@ func (s *service) handleInvoiceLifecycleTrigger(ctx context.Context, input Handl
 		return creditpurchase.Charge{}, err
 	}
 
-	if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+	if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 		return creditpurchase.Charge{}, fmt.Errorf("reconcile invoice credit purchase state: %w", err)
 	}
 
-	if err := stateMachine.FireAndActivate(ctx, input.Trigger, input.LineWithHeader); err != nil {
+	if err := stateMachine.FireAndAdvanceUntilStable(ctx, input.Trigger, input.LineWithHeader); err != nil {
 		return creditpurchase.Charge{}, fmt.Errorf("fire invoice lifecycle trigger %s: %w", input.Trigger, err)
-	}
-
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(ctx)
-	if err != nil {
-		return creditpurchase.Charge{}, fmt.Errorf("advance invoice credit purchase after %s: %w", input.Trigger, err)
-	}
-
-	if advancedCharge != nil {
-		return *advancedCharge, nil
 	}
 
 	return stateMachine.GetCharge(), nil

--- a/openmeter/billing/charges/creditpurchase/service/promotional_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/promotional_test.go
@@ -35,7 +35,7 @@ func TestPromotionalCreditPurchaseStateMachineAdvancesCreatedChargeToFinal(t *te
 		creditpurchase.StatusCreated,
 	)
 
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
+	advancedCharge, err := advancePromotionalChargeUntilStable(t, stateMachine)
 
 	require.NoError(t, err)
 	require.NotNil(t, advancedCharge)
@@ -63,7 +63,7 @@ func TestPromotionalCreditPurchaseStateMachineAdvancesActiveChargeToFinal(t *tes
 		creditpurchase.StatusActive,
 	)
 
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
+	advancedCharge, err := advancePromotionalChargeUntilStable(t, stateMachine)
 
 	require.NoError(t, err)
 	require.NotNil(t, advancedCharge)
@@ -103,7 +103,7 @@ func TestPromotionalCreditPurchaseStateMachineRejectsExistingCreditGrant(t *test
 	})
 	require.NoError(t, err)
 
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
+	advancedCharge, err := advancePromotionalChargeUntilStable(t, stateMachine)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "promotional credit grant already realized")
@@ -134,7 +134,7 @@ func TestPromotionalCreditPurchaseStateMachineReturnsNilForFinalCharge(t *testin
 	})
 	require.NoError(t, err)
 
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
+	advancedCharge, err := advancePromotionalChargeUntilStable(t, stateMachine)
 
 	require.NoError(t, err)
 	require.Nil(t, advancedCharge)
@@ -192,6 +192,20 @@ func TestPromotionalCreditPurchaseStateMachineRejectsMissingService(t *testing.T
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "service is required")
+}
+
+func advancePromotionalChargeUntilStable(t *testing.T, stateMachine *PromotionalCreditpurchaseStateMachine) (*creditpurchase.Charge, error) {
+	canAdvance, err := stateMachine.CanFire(t.Context(), meta.TriggerNext)
+	if err != nil || !canAdvance {
+		return nil, err
+	}
+
+	if err := stateMachine.AdvanceUntilStable(t.Context()); err != nil {
+		return nil, err
+	}
+
+	charge := stateMachine.GetCharge()
+	return &charge, nil
 }
 
 func newPromotionalStateMachineTestMachine(

--- a/openmeter/billing/charges/creditpurchase/service/statemachine.go
+++ b/openmeter/billing/charges/creditpurchase/service/statemachine.go
@@ -82,20 +82,3 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 
 	return out, nil
 }
-
-func (s *stateMachine) FireAndAdvanceUntilStateStable(ctx context.Context, trigger meta.Trigger) (creditpurchase.Charge, error) {
-	if err := s.FireAndActivate(ctx, trigger); err != nil {
-		return creditpurchase.Charge{}, err
-	}
-
-	advancedCharge, err := s.AdvanceUntilStateStable(ctx)
-	if err != nil {
-		return creditpurchase.Charge{}, err
-	}
-
-	if advancedCharge != nil {
-		return *advancedCharge, nil
-	}
-
-	return s.GetCharge(), nil
-}

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -30,11 +30,13 @@ type FlatFeeService interface {
 	// UpdateSubscriptionItemID repairs subscription ownership metadata on the
 	// base intent; it must not rewrite an active customer-facing override layer.
 	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
-	// AdvanceCharge drives one charge through its lifecycle. Invoice-backed
-	// changes are emitted as invoice patches for the billing boundary to consume.
-	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (*Charge, error)
-	// TriggerPatch applies an explicit base/override target patch and then
-	// reconciles invoice artifacts from the effective flat-fee intent.
+	// AdvanceCharge drives one charge until invoice patches are emitted or its
+	// lifecycle becomes stable. Callers must apply returned invoice patches
+	// before resuming when CanAdvance is true.
+	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (meta.TriggerPatchResult[Charge], error)
+	// TriggerPatch applies an explicit base/override target patch and advances
+	// until invoice patches are emitted or the lifecycle becomes stable. Callers
+	// that apply returned invoice patches must resume with AdvanceCharge.
 	TriggerPatch(ctx context.Context, charge meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[Charge], error)
 }
 

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -643,7 +643,10 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 	// history can be adjusted safely; while that is false, we update the
 	// charge intent/state but avoid creating replacement billable work for
 	// the already-invoiced period.
-	if !s.CreditNotesSupported {
+	// A finalized zero-fiat run has immutable billing history, but deleting its
+	// presentation line cannot require a credit note. Let the normal immutable
+	// path detach that run and create replacement billable work.
+	if !s.CreditNotesSupported && !s.IsCurrentRunZeroFiatAmountOverage() {
 		// Case 1: We are trying to shrink an immutable invoice, but credit notes are not supported yet.
 
 		// the immutable invoice cannot be corrected safely. Emit only the delete patch so the invoice

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -153,19 +153,15 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			return nil, err
 		}
 
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 			return nil, fmt.Errorf("advancing flat fee charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceCreated, billing.StandardLineWithInvoiceHeader{
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerInvoiceCreated, billing.StandardLineWithInvoiceHeader{
 			Line:    stdLine,
 			Invoice: input.Invoice,
 		}); err != nil {
 			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing flat fee charge[%s] after %s: %w", stateMachine.GetCharge().ID, meta.TriggerInvoiceCreated, err)
 		}
 
 		charge := stateMachine.GetCharge()
@@ -214,12 +210,8 @@ func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.On
 			continue
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerCollectionCompleted); err != nil {
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerCollectionCompleted); err != nil {
 			return nil, fmt.Errorf("triggering collection_completed for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing flat fee charge[%s] after collection_completed: %w", stateMachine.GetCharge().ID, err)
 		}
 
 		charge := stateMachine.GetCharge()
@@ -305,11 +297,11 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 			return nil, fmt.Errorf("creating flat-fee line manual edit patch for line[%s]: %w", override.ExistingLine.GetID(), err)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerLineManualEdit, lineManualEditPatch); err != nil {
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerLineManualEdit, lineManualEditPatch)
+		if err != nil {
 			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerLineManualEdit, charge.ID, err)
 		}
 
-		patches := stateMachine.DrainInvoicePatches()
 		var targetLine billing.GenericInvoiceLine
 		switch override.ExistingLine.AsInvoiceLine().Type() {
 		case billing.InvoiceLineTypeStandard:
@@ -408,11 +400,12 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerDelete, deletePatch); err != nil {
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
+		if err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
 		}
 
-		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, stateMachine.DrainInvoicePatches()); err != nil {
+		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, patches); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -640,14 +633,14 @@ func (e *LineEngine) attachManualStandardLine(ctx context.Context, invoice billi
 	// TODO: reject cost-basis-backed charges in manual line attachment. This
 	// path bypasses StatusActive, which owns cost-basis resolution, so accepting
 	// it would create an invoice-backed charge without the required resolved value.
-	if err := stateMachine.FireAndActivate(ctx, meta.TriggerAttachInvoiceLine, billing.StandardLineWithInvoiceHeader{
+	patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerAttachInvoiceLine, billing.StandardLineWithInvoiceHeader{
 		Line:    &standardLine,
 		Invoice: standardInvoice,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerAttachInvoiceLine, charge.ID, err)
 	}
 
-	patches := stateMachine.DrainInvoicePatches()
 	updatePatch, err := patches.RequireSingularLineUpdatePatchForTarget(sourceLine)
 	if err != nil {
 		return nil, fmt.Errorf("line[%s]: validating attach update patch target: %w", sourceLine.GetID(), err)
@@ -961,15 +954,11 @@ func (e *LineEngine) OnInvoiceIssued(ctx context.Context, input billing.OnInvoic
 			return err
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceIssued, billing.StandardLineWithInvoiceHeader{
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerInvoiceIssued, billing.StandardLineWithInvoiceHeader{
 			Line:    stdLine,
 			Invoice: input.Invoice,
 		}); err != nil {
 			return fmt.Errorf("triggering invoice_issued for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return fmt.Errorf("advancing flat fee charge[%s] after invoice_issued: %w", stateMachine.GetCharge().ID, err)
 		}
 	}
 
@@ -1020,7 +1009,7 @@ func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPayme
 			return fmt.Errorf("refetching flat fee charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 			return fmt.Errorf("advancing flat fee charge[%s] after payment settlement: %w", stateMachine.GetCharge().ID, err)
 		}
 	}

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -96,7 +96,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 
 		invoicePatches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, patch.Trigger(), patch)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to advance charge: %w", err)
 		}
 		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
 		if err != nil {

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -13,12 +13,13 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceChargeInput) (*flatfee.Charge, error) {
+func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceChargeInput) (meta.TriggerPatchResult[flatfee.Charge], error) {
 	if err := input.Validate(); err != nil {
-		return nil, fmt.Errorf("validate: %w", err)
+		return meta.TriggerPatchResult[flatfee.Charge]{}, fmt.Errorf("validate: %w", err)
 	}
 
-	return s.withLockedCharge(ctx, input.ChargeID, func(ctx context.Context, charge flatfee.Charge) (*flatfee.Charge, error) {
+	var result meta.TriggerPatchResult[flatfee.Charge]
+	charge, err := s.withLockedCharge(ctx, input.ChargeID, func(ctx context.Context, charge flatfee.Charge) (*flatfee.Charge, error) {
 		stateMachine, err := s.newStateMachineForCharge(charge)
 		if err != nil {
 			return nil, fmt.Errorf("new state machine: %w", err)
@@ -32,13 +33,28 @@ func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceCharge
 			return nil, nil
 		}
 
-		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
+		invoicePatches, err := stateMachine.AdvanceUntilInvoicePatchesOrStable(ctx)
+		if err != nil {
 			return nil, err
 		}
+		canAdvance, err = stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, fmt.Errorf("check next transition: %w", err)
+		}
 
-		updatedCharge := stateMachine.GetCharge()
-		return &updatedCharge, nil
+		charge = stateMachine.GetCharge()
+		result.InvoicePatches = invoicePatches
+		result.CanAdvance = canAdvance
+
+		return &charge, nil
 	})
+	if err != nil {
+		return meta.TriggerPatchResult[flatfee.Charge]{}, err
+	}
+
+	result.Charge = charge
+
+	return result, nil
 }
 
 func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[flatfee.Charge], error) {
@@ -82,9 +98,14 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 		if err != nil {
 			return nil, err
 		}
+		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, fmt.Errorf("check next transition: %w", err)
+		}
 
 		charge = stateMachine.GetCharge()
 		result.InvoicePatches = invoicePatches
+		result.CanAdvance = canAdvance
 
 		return &charge, nil
 	})

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -24,7 +24,20 @@ func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceCharge
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		return stateMachine.AdvanceUntilStateStable(ctx)
+		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, err
+		}
+		if !canAdvance {
+			return nil, nil
+		}
+
+		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
+			return nil, err
+		}
+
+		updatedCharge := stateMachine.GetCharge()
+		return &updatedCharge, nil
 	})
 }
 

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -78,13 +78,13 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		err = stateMachine.FireAndActivate(ctx, patch.Trigger(), patch)
+		invoicePatches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, patch.Trigger(), patch)
 		if err != nil {
 			return nil, err
 		}
 
 		charge = stateMachine.GetCharge()
-		result.InvoicePatches = stateMachine.DrainInvoicePatches()
+		result.InvoicePatches = invoicePatches
 
 		return &charge, nil
 	})

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -73,6 +73,10 @@ type Patch interface {
 type TriggerPatchResult[T any] struct {
 	Charge         *T
 	InvoicePatches invoiceupdater.Patches
+	// CanAdvance reports whether TriggerNext is available at the returned
+	// invoice-effect boundary. Returned invoice patches must be applied before
+	// lifecycle advancement resumes.
+	CanAdvance bool
 }
 
 // PatchAction adapts a generic Patch action to a concrete patch action when

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -60,6 +60,9 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 			}
 
 			mappedResult := mapTriggerPatchResult(result)
+			if err := mappedResult.requireInvoicePatchesIfAdvanceable(); err != nil {
+				return nil, fmt.Errorf("flat fee charge %s: %w", charge.ID, err)
+			}
 			if mappedResult.Charge != nil {
 				advancedChargesByID[charge.ID] = *mappedResult.Charge
 				advancedChargeIDs = append(advancedChargeIDs, charge.ID)
@@ -67,9 +70,6 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 			invoicePatches = append(invoicePatches, mappedResult.InvoicePatches...)
 
 			if mappedResult.CanAdvance {
-				if len(mappedResult.InvoicePatches) == 0 {
-					return nil, fmt.Errorf("flat fee charge %s can advance without an invoice-effect boundary", charge.ID)
-				}
 				pendingAdvancement[charge.ID] = &flatFeeInvocableCharge{
 					chargeID:       charge.GetChargeID(),
 					flatFeeService: s.flatFeeService,
@@ -105,6 +105,9 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 				}
 
 				mappedResult := mapTriggerPatchResult(result)
+				if err := mappedResult.requireInvoicePatchesIfAdvanceable(); err != nil {
+					return nil, fmt.Errorf("usage based charge %s: %w", charge.ID, err)
+				}
 				if mappedResult.Charge != nil {
 					advancedChargesByID[charge.ID] = *mappedResult.Charge
 					advancedChargeIDs = append(advancedChargeIDs, charge.ID)
@@ -112,12 +115,11 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 				invoicePatches = append(invoicePatches, mappedResult.InvoicePatches...)
 
 				if mappedResult.CanAdvance {
-					if len(mappedResult.InvoicePatches) == 0 {
-						return nil, fmt.Errorf("usage based charge %s can advance without an invoice-effect boundary", charge.ID)
-					}
 					pendingAdvancement[charge.ID] = &usageBasedInvocableCharge{
 						chargeID:          charge.GetChargeID(),
 						usageBasedService: s.usageBasedService,
+						customerOverride:  mo.Some(customerOverride),
+						featureMeters:     mo.Some(featureMeters),
 					}
 				}
 			}

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
@@ -44,21 +46,35 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 			return charges.Charges{}, nil
 		}
 
-		advancedCharges := make(charges.Charges, 0, len(chargesByType.usageBased)+len(chargesByType.flatFees))
+		advancedChargesByID := make(map[string]charges.Charge, len(chargesByType.usageBased)+len(chargesByType.flatFees))
+		advancedChargeIDs := make([]string, 0, len(chargesByType.usageBased)+len(chargesByType.flatFees))
+		var invoicePatches invoiceupdater.Patches
+		pendingAdvancement := make(map[string]InvocableCharge, len(chargesByType.usageBased)+len(chargesByType.flatFees))
 
 		for _, charge := range chargesByType.flatFees {
-			advancedCharge, err := s.flatFeeService.AdvanceCharge(ctx, flatfee.AdvanceChargeInput{
+			result, err := s.flatFeeService.AdvanceCharge(ctx, flatfee.AdvanceChargeInput{
 				ChargeID: charge.GetChargeID(),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("advance flat fee charge %s: %w", charge.ID, err)
 			}
 
-			if advancedCharge == nil {
-				continue
+			mappedResult := mapTriggerPatchResult(result)
+			if mappedResult.Charge != nil {
+				advancedChargesByID[charge.ID] = *mappedResult.Charge
+				advancedChargeIDs = append(advancedChargeIDs, charge.ID)
 			}
+			invoicePatches = append(invoicePatches, mappedResult.InvoicePatches...)
 
-			advancedCharges = append(advancedCharges, charges.NewCharge(*advancedCharge))
+			if mappedResult.CanAdvance {
+				if len(mappedResult.InvoicePatches) == 0 {
+					return nil, fmt.Errorf("flat fee charge %s can advance without an invoice-effect boundary", charge.ID)
+				}
+				pendingAdvancement[charge.ID] = &flatFeeInvocableCharge{
+					chargeID:       charge.GetChargeID(),
+					flatFeeService: s.flatFeeService,
+				}
+			}
 		}
 
 		// Advance usage-based charges
@@ -79,21 +95,47 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 			}
 
 			for _, charge := range chargesByType.usageBased {
-				advancedCharge, err := s.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{
+				result, err := s.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{
 					ChargeID:         charge.GetChargeID(),
-					CustomerOverride: customerOverride,
-					FeatureMeters:    featureMeters,
+					CustomerOverride: mo.Some(customerOverride),
+					FeatureMeters:    mo.Some(featureMeters),
 				})
 				if err != nil {
 					return nil, fmt.Errorf("advance usage based charge %s: %w", charge.ID, err)
 				}
 
-				if advancedCharge == nil {
-					continue
+				mappedResult := mapTriggerPatchResult(result)
+				if mappedResult.Charge != nil {
+					advancedChargesByID[charge.ID] = *mappedResult.Charge
+					advancedChargeIDs = append(advancedChargeIDs, charge.ID)
 				}
+				invoicePatches = append(invoicePatches, mappedResult.InvoicePatches...)
 
-				advancedCharges = append(advancedCharges, charges.NewCharge(*advancedCharge))
+				if mappedResult.CanAdvance {
+					if len(mappedResult.InvoicePatches) == 0 {
+						return nil, fmt.Errorf("usage based charge %s can advance without an invoice-effect boundary", charge.ID)
+					}
+					pendingAdvancement[charge.ID] = &usageBasedInvocableCharge{
+						chargeID:          charge.GetChargeID(),
+						usageBasedService: s.usageBasedService,
+					}
+				}
 			}
+		}
+
+		continuedResults, err := s.advanceChargesAndApplyInvoicePatches(ctx, input.Customer, pendingAdvancement, invoicePatches)
+		if err != nil {
+			return nil, err
+		}
+		for chargeID, result := range continuedResults {
+			if result.Charge != nil {
+				advancedChargesByID[chargeID] = *result.Charge
+			}
+		}
+
+		advancedCharges := make(charges.Charges, 0, len(advancedChargeIDs))
+		for _, chargeID := range advancedChargeIDs {
+			advancedCharges = append(advancedCharges, advancedChargesByID[chargeID])
 		}
 
 		currencies, err := collectCurrencies(advancedCharges)

--- a/openmeter/billing/charges/service/flatfee_costbasis_test.go
+++ b/openmeter/billing/charges/service/flatfee_costbasis_test.go
@@ -301,18 +301,18 @@ func (s *FlatFeeCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeBeco
 		ChargeID: created[0].Charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Require().NotNil(advanced)
-	s.Require().Equal(flatfee.StatusActive, advanced.Status)
-	s.Require().Equal(created[0].Charge.State.CostBasisID, advanced.State.CostBasisID)
-	s.Require().NotNil(advanced.State.ResolvedCostBasis)
-	s.Require().Equal(first.ID, *advanced.State.ResolvedCostBasis.CostBasisID)
-	s.Require().Equal(first.Rate.InexactFloat64(), advanced.State.ResolvedCostBasis.CostBasis.InexactFloat64())
-	s.Require().Equal(servicePeriodFrom, advanced.State.ResolvedCostBasis.ResolvedAt)
+	s.Require().NotNil(advanced.Charge)
+	s.Require().Equal(flatfee.StatusActive, advanced.Charge.Status)
+	s.Require().Equal(created[0].Charge.State.CostBasisID, advanced.Charge.State.CostBasisID)
+	s.Require().NotNil(advanced.Charge.State.ResolvedCostBasis)
+	s.Require().Equal(first.ID, *advanced.Charge.State.ResolvedCostBasis.CostBasisID)
+	s.Require().Equal(first.Rate.InexactFloat64(), advanced.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
+	s.Require().Equal(servicePeriodFrom, advanced.Charge.State.ResolvedCostBasis.ResolvedAt)
 
 	reloaded, err := s.mustGetChargeByID(created[0].Charge.GetChargeID()).AsFlatFeeCharge()
 	s.Require().NoError(err)
-	s.Require().Equal(advanced.State.CostBasisID, reloaded.State.CostBasisID)
-	s.Require().Equal(advanced.State.ResolvedCostBasis, reloaded.State.ResolvedCostBasis)
+	s.Require().Equal(advanced.Charge.State.CostBasisID, reloaded.State.CostBasisID)
+	s.Require().Equal(advanced.Charge.State.ResolvedCostBasis, reloaded.State.ResolvedCostBasis)
 }
 
 func (s *FlatFeeCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAndFiatCurrency() {

--- a/openmeter/billing/charges/service/helpers.go
+++ b/openmeter/billing/charges/service/helpers.go
@@ -60,9 +60,25 @@ func chargesByType(in charges.Charges) (chargesByTypeResult, error) {
 type InvocableCharge interface {
 	GetChargeID() meta.ChargeID
 	TriggerPatch(ctx context.Context, patch meta.Patch) (TriggerPatchResult, error)
+	// AdvanceCharge reloads the concrete charge after its
+	// preceding invoice batch and resumes lifecycle continuation.
+	AdvanceCharge(ctx context.Context) (TriggerPatchResult, error)
 }
 
 type TriggerPatchResult = meta.TriggerPatchResult[charges.Charge]
+
+func mapTriggerPatchResult[T flatfee.Charge | usagebased.Charge](res meta.TriggerPatchResult[T]) TriggerPatchResult {
+	result := TriggerPatchResult{
+		InvoicePatches: res.InvoicePatches,
+		CanAdvance:     res.CanAdvance,
+	}
+
+	if res.Charge != nil {
+		result.Charge = lo.ToPtr(charges.NewCharge(*res.Charge))
+	}
+
+	return result
+}
 
 func (s *service) newInvocableCharges(si charges.ChargeSearchItems) (map[string]InvocableCharge, error) {
 	result := make(map[string]InvocableCharge, len(si))
@@ -102,14 +118,16 @@ func (c *flatFeeInvocableCharge) TriggerPatch(ctx context.Context, patch meta.Pa
 		return TriggerPatchResult{}, err
 	}
 
-	if res.Charge == nil {
-		return TriggerPatchResult{}, nil
+	return mapTriggerPatchResult(res), nil
+}
+
+func (c *flatFeeInvocableCharge) AdvanceCharge(ctx context.Context) (TriggerPatchResult, error) {
+	res, err := c.flatFeeService.AdvanceCharge(ctx, flatfee.AdvanceChargeInput{ChargeID: c.chargeID})
+	if err != nil {
+		return TriggerPatchResult{}, err
 	}
 
-	return TriggerPatchResult{
-		InvoicePatches: res.InvoicePatches,
-		Charge:         lo.ToPtr(charges.NewCharge(*res.Charge)),
-	}, nil
+	return mapTriggerPatchResult(res), nil
 }
 
 func (c *flatFeeInvocableCharge) GetChargeID() meta.ChargeID {
@@ -129,14 +147,16 @@ func (c *usageBasedInvocableCharge) TriggerPatch(ctx context.Context, patch meta
 		return TriggerPatchResult{}, err
 	}
 
-	if res.Charge == nil {
-		return TriggerPatchResult{}, nil
+	return mapTriggerPatchResult(res), nil
+}
+
+func (c *usageBasedInvocableCharge) AdvanceCharge(ctx context.Context) (TriggerPatchResult, error) {
+	res, err := c.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{ChargeID: c.chargeID})
+	if err != nil {
+		return TriggerPatchResult{}, err
 	}
 
-	return TriggerPatchResult{
-		InvoicePatches: res.InvoicePatches,
-		Charge:         lo.ToPtr(charges.NewCharge(*res.Charge)),
-	}, nil
+	return mapTriggerPatchResult(res), nil
 }
 
 func (c *usageBasedInvocableCharge) GetChargeID() meta.ChargeID {

--- a/openmeter/billing/charges/service/helpers.go
+++ b/openmeter/billing/charges/service/helpers.go
@@ -2,15 +2,19 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
 type chargesByTypeResult struct {
@@ -65,7 +69,15 @@ type InvocableCharge interface {
 	AdvanceCharge(ctx context.Context) (TriggerPatchResult, error)
 }
 
-type TriggerPatchResult = meta.TriggerPatchResult[charges.Charge]
+type TriggerPatchResult meta.TriggerPatchResult[charges.Charge]
+
+func (r TriggerPatchResult) requireInvoicePatchesIfAdvanceable() error {
+	if r.CanAdvance && len(r.InvoicePatches) == 0 {
+		return errors.New("can advance without an invoice-effect boundary")
+	}
+
+	return nil
+}
 
 func mapTriggerPatchResult[T flatfee.Charge | usagebased.Charge](res meta.TriggerPatchResult[T]) TriggerPatchResult {
 	result := TriggerPatchResult{
@@ -139,6 +151,8 @@ var _ InvocableCharge = (*usageBasedInvocableCharge)(nil)
 type usageBasedInvocableCharge struct {
 	chargeID          meta.ChargeID
 	usageBasedService usagebased.Service
+	customerOverride  mo.Option[billing.CustomerOverrideWithDetails]
+	featureMeters     mo.Option[feature.FeatureMeters]
 }
 
 func (c *usageBasedInvocableCharge) TriggerPatch(ctx context.Context, patch meta.Patch) (TriggerPatchResult, error) {
@@ -151,7 +165,11 @@ func (c *usageBasedInvocableCharge) TriggerPatch(ctx context.Context, patch meta
 }
 
 func (c *usageBasedInvocableCharge) AdvanceCharge(ctx context.Context) (TriggerPatchResult, error) {
-	res, err := c.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{ChargeID: c.chargeID})
+	res, err := c.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{
+		ChargeID:         c.chargeID,
+		CustomerOverride: c.customerOverride,
+		FeatureMeters:    c.featureMeters,
+	})
 	if err != nil {
 		return TriggerPatchResult{}, err
 	}

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1316,7 +1316,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		// when:
 		// - the charge is shrunk to a positive TOKENS amount that rounds to zero USD
 		// then:
-		// - the same run and line remain, and the run records that no fiat transaction is required
+		// - the same run and line remain, and the zero-fiat run is finalized without payment
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
 			ChangeSource:           billing.ChangeSourceSystem,
 			NewServicePeriodTo:     zeroFiatServicePeriodTo,
@@ -1352,7 +1352,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		})
 
 		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
-		s.Equal(flatfee.StatusActiveRealizationProcessing, charge.Status)
+		s.Equal(flatfee.StatusFinal, charge.Status)
 		s.Equal(float64(0.001), charge.State.AmountAfterProration.InexactFloat64())
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		s.Equal(runID, charge.Realizations.CurrentRun.ID)
@@ -1361,7 +1361,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Equal(zeroFiatServicePeriodTo, charge.Realizations.CurrentRun.ServicePeriod.To)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 0.001, Total: 0.001}, charge.Realizations.CurrentRun.Totals)
 		s.True(charge.Realizations.CurrentRun.NoFiatTransactionRequired)
-		s.False(charge.Realizations.CurrentRun.Immutable)
+		s.True(charge.Realizations.CurrentRun.Immutable)
 		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
 		s.Nil(charge.Realizations.CurrentRun.Payment)
 		s.Empty(activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID))
@@ -1369,13 +1369,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Equal(3, allocationCallback.nrInvocations)
 	})
 
-	s.Run("extend the mutable realization to the full period", func() {
+	s.Run("extend the finalized zero-fiat realization to the full period", func() {
 		// given:
-		// - the mutable run and standard line represent a positive TOKENS overage that rounds to zero USD
+		// - the finalized run and standard line represent a positive TOKENS overage that rounds to zero USD
 		// when:
 		// - the charge is extended back to its full period
 		// then:
-		// - the same run and line return to 31 TOKENS and 15.50 USD
+		// - the zero-fiat line becomes history and replacement gathering work covers the full period
 		patch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
 			ChangeSource:           billing.ChangeSourceSystem,
 			NewServicePeriodTo:     servicePeriod.To,
@@ -1396,38 +1396,23 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 			Expand:  billing.StandardInvoiceExpandAll,
 		})
 		s.Require().NoError(err)
-		s.RequireTotals(billingtest.ExpectedTotals{Amount: 15.5, Total: 15.5}, reloadedInvoice.Totals)
-		s.Require().Len(reloadedInvoice.Lines.OrEmpty(), 1)
-		line := reloadedInvoice.Lines.GetByID(lineID.ID)
-		s.Require().NotNil(line)
-		s.Nil(line.DeletedAt)
-		s.Equal(servicePeriod, line.Period)
-		s.requireCustomCurrencyOverageLine(requireCustomCurrencyOverageLineInput{
-			line:               line,
-			expectTokenOverage: 31,
-			expectCostBasis:    0.5,
-			expectFiatTotals: billingtest.ExpectedTotals{
-				Amount: 15.5,
-				Total:  15.5,
-			},
-		})
+		s.RequireTotals(billingtest.ExpectedTotals{}, reloadedInvoice.Totals)
+		s.Empty(reloadedInvoice.Lines.OrEmpty())
 
 		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
-		s.Equal(flatfee.StatusActiveRealizationProcessing, charge.Status)
+		s.Equal(flatfee.StatusActive, charge.Status)
 		s.Equal(float64(31), charge.State.AmountAfterProration.InexactFloat64())
-		s.Require().NotNil(charge.Realizations.CurrentRun)
-		s.Equal(runID, charge.Realizations.CurrentRun.ID)
-		s.Require().NotNil(charge.Realizations.CurrentRun.LineID)
-		s.Equal(lineID.ID, *charge.Realizations.CurrentRun.LineID)
-		s.Equal(servicePeriod, charge.Realizations.CurrentRun.ServicePeriod)
-		s.RequireTotals(billingtest.ExpectedTotals{Amount: 31, Total: 31}, charge.Realizations.CurrentRun.Totals)
-		s.False(charge.Realizations.CurrentRun.NoFiatTransactionRequired)
-		s.False(charge.Realizations.CurrentRun.Immutable)
-		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
-		s.Nil(charge.Realizations.CurrentRun.Payment)
-		s.Empty(activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID))
-		s.Equal([]float64{31, 15, 0.001, 31}, allocationTargets)
-		s.Equal(4, allocationCallback.nrInvocations)
+		s.Nil(charge.Realizations.CurrentRun)
+		s.Require().Len(charge.Realizations.PriorRuns, 1)
+		s.Equal(runID, charge.Realizations.PriorRuns[0].ID)
+		s.True(charge.Realizations.PriorRuns[0].NoFiatTransactionRequired)
+		s.True(charge.Realizations.PriorRuns[0].Immutable)
+
+		gatheringLines := activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID)
+		s.Require().Len(gatheringLines, 1)
+		s.Equal(servicePeriod, gatheringLines[0].ServicePeriod)
+		s.Equal([]float64{31, 15, 0.001}, allocationTargets)
+		s.Equal(3, allocationCallback.nrInvocations)
 	})
 }
 
@@ -1673,7 +1658,7 @@ func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectR
 
 		if expectReplacementGatheringLine {
 			charge := mustGetFlatFeeChargeWithExpands(s, flatFeeChargeID, meta.Expands{meta.ExpandRealizations})
-			s.Equal(flatfee.StatusCreated, charge.Status)
+			s.Equal(flatfee.StatusActive, charge.Status)
 			s.Nil(charge.Realizations.CurrentRun)
 			s.Require().Len(activeGatheringLines, 1)
 			s.Equal(servicePeriod.From, activeGatheringLines[0].ServicePeriod.From)

--- a/openmeter/billing/charges/service/patch.go
+++ b/openmeter/billing/charges/service/patch.go
@@ -71,7 +71,21 @@ func (s *service) applyPatches(ctx context.Context, customerID customer.Customer
 		return err
 	}
 
+	return s.applyInvocableChargePatches(ctx, customerID, invocableChargesByID, patchesByChargeID)
+}
+
+// applyInvocableChargePatches advances all affected charges in rounds so invoice
+// effects produced at the same lifecycle boundary remain one customer batch.
+// Charges that emit effects are reloaded and resumed only after that batch is
+// applied; charges that reach stability leave the next round.
+func (s *service) applyInvocableChargePatches(
+	ctx context.Context,
+	customerID customer.CustomerID,
+	invocableChargesByID map[string]InvocableCharge,
+	patchesByChargeID map[string]charges.Patch,
+) error {
 	var invoicePatches invoiceupdater.Patches
+	pendingAdvancement := make(map[string]InvocableCharge, len(patchesByChargeID))
 
 	for chargeID, patch := range patchesByChargeID {
 		invocableCharge, ok := invocableChargesByID[chargeID]
@@ -85,13 +99,57 @@ func (s *service) applyPatches(ctx context.Context, customerID customer.Customer
 		}
 
 		invoicePatches = append(invoicePatches, result.InvoicePatches...)
-	}
-
-	if len(invoicePatches) > 0 {
-		if err := s.invoiceUpdater.ApplyPatches(ctx, customerID, invoicePatches); err != nil {
-			return fmt.Errorf("applying invoice patches: %w", err)
+		if result.CanAdvance {
+			if len(result.InvoicePatches) == 0 {
+				return fmt.Errorf("charge %s can advance without an invoice-effect boundary", chargeID)
+			}
+			pendingAdvancement[chargeID] = invocableCharge
 		}
 	}
 
-	return nil
+	_, err := s.advanceChargesAndApplyInvoicePatches(ctx, customerID, pendingAdvancement, invoicePatches)
+	return err
+}
+
+// advanceChargesAndApplyInvoicePatches preserves customer-level invoice batches
+// while resuming only charges whose preceding effect boundary still permits
+// Next. The returned map contains the latest result for each resumed charge.
+func (s *service) advanceChargesAndApplyInvoicePatches(
+	ctx context.Context,
+	customerID customer.CustomerID,
+	pendingAdvancement map[string]InvocableCharge,
+	invoicePatches invoiceupdater.Patches,
+) (map[string]TriggerPatchResult, error) {
+	latestResults := make(map[string]TriggerPatchResult, len(pendingAdvancement))
+
+	for len(invoicePatches) > 0 {
+		if err := s.invoiceUpdater.ApplyPatches(ctx, customerID, invoicePatches); err != nil {
+			return nil, fmt.Errorf("applying invoice patches: %w", err)
+		}
+		if len(pendingAdvancement) == 0 {
+			return latestResults, nil
+		}
+
+		invoicePatches = nil
+		nextPendingAdvancement := make(map[string]InvocableCharge, len(pendingAdvancement))
+		for chargeID, invocableCharge := range pendingAdvancement {
+			result, err := invocableCharge.AdvanceCharge(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("advancing charge %s after invoice patches: %w", chargeID, err)
+			}
+			latestResults[chargeID] = result
+
+			invoicePatches = append(invoicePatches, result.InvoicePatches...)
+			if result.CanAdvance {
+				if len(result.InvoicePatches) == 0 {
+					return nil, fmt.Errorf("charge %s can advance without an invoice-effect boundary", chargeID)
+				}
+				nextPendingAdvancement[chargeID] = invocableCharge
+			}
+		}
+
+		pendingAdvancement = nextPendingAdvancement
+	}
+
+	return latestResults, nil
 }

--- a/openmeter/billing/charges/service/patch.go
+++ b/openmeter/billing/charges/service/patch.go
@@ -12,6 +12,11 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
+// maxInvoiceEffectRounds is a theoretical safety guard against a future
+// lifecycle loop that continually emits invoice effects while holding the
+// customer transaction open.
+const maxInvoiceEffectRounds = 100
+
 func (s *service) ApplyPatches(ctx context.Context, input charges.ApplyPatchesInput) error {
 	if input.CustomerID.Namespace != "" && len(input.Creates) > 0 {
 		intentsWithDefaults, err := s.applyDefaultTaxCodes(ctx, input.CustomerID.Namespace, input.Creates)
@@ -97,12 +102,12 @@ func (s *service) applyInvocableChargePatches(
 		if err != nil {
 			return err
 		}
+		if err := result.requireInvoicePatchesIfAdvanceable(); err != nil {
+			return fmt.Errorf("charge %s: %w", chargeID, err)
+		}
 
 		invoicePatches = append(invoicePatches, result.InvoicePatches...)
 		if result.CanAdvance {
-			if len(result.InvoicePatches) == 0 {
-				return fmt.Errorf("charge %s can advance without an invoice-effect boundary", chargeID)
-			}
 			pendingAdvancement[chargeID] = invocableCharge
 		}
 	}
@@ -122,7 +127,13 @@ func (s *service) advanceChargesAndApplyInvoicePatches(
 ) (map[string]TriggerPatchResult, error) {
 	latestResults := make(map[string]TriggerPatchResult, len(pendingAdvancement))
 
+	rounds := 0
 	for len(invoicePatches) > 0 {
+		rounds++
+		if rounds > maxInvoiceEffectRounds {
+			return nil, fmt.Errorf("charge advancement exceeded %d invoice-effect rounds for customer %s", maxInvoiceEffectRounds, customerID.ID)
+		}
+
 		if err := s.invoiceUpdater.ApplyPatches(ctx, customerID, invoicePatches); err != nil {
 			return nil, fmt.Errorf("applying invoice patches: %w", err)
 		}
@@ -137,13 +148,13 @@ func (s *service) advanceChargesAndApplyInvoicePatches(
 			if err != nil {
 				return nil, fmt.Errorf("advancing charge %s after invoice patches: %w", chargeID, err)
 			}
+			if err := result.requireInvoicePatchesIfAdvanceable(); err != nil {
+				return nil, fmt.Errorf("charge %s: %w", chargeID, err)
+			}
 			latestResults[chargeID] = result
 
 			invoicePatches = append(invoicePatches, result.InvoicePatches...)
 			if result.CanAdvance {
-				if len(result.InvoicePatches) == 0 {
-					return nil, fmt.Errorf("charge %s can advance without an invoice-effect boundary", chargeID)
-				}
 				nextPendingAdvancement[chargeID] = invocableCharge
 			}
 		}

--- a/openmeter/billing/charges/service/patch_test.go
+++ b/openmeter/billing/charges/service/patch_test.go
@@ -93,12 +93,81 @@ func TestApplyInvocableChargePatchesBatchesEachInvoiceEffectRound(t *testing.T) 
 	require.Zero(t, secondCharge.advanceCalls)
 }
 
+func TestApplyInvocableChargePatchesRejectsContinuationWithoutInvoiceEffectBoundary(t *testing.T) {
+	// given
+	// - A patched charge reports that it can continue without producing invoice effects.
+	// when:
+	// - The root charge service applies the patch.
+	// then:
+	// - The impossible continuation is rejected before charge advancement resumes.
+	charge := &scriptedInvocableCharge{
+		chargeID: meta.ChargeID{Namespace: "ns", ID: "charge"},
+		triggerResult: TriggerPatchResult{
+			CanAdvance: true,
+		},
+	}
+
+	svc := service{}
+	err := svc.applyInvocableChargePatches(
+		t.Context(),
+		customer.CustomerID{Namespace: "ns", ID: "customer"},
+		map[string]InvocableCharge{
+			charge.chargeID.ID: charge,
+		},
+		map[string]charges.Patch{
+			charge.chargeID.ID: meta.PatchDelete{},
+		},
+	)
+
+	require.ErrorContains(t, err, "can advance without an invoice-effect boundary")
+	require.Equal(t, 1, charge.triggerCalls)
+	require.Zero(t, charge.advanceCalls)
+}
+
+func TestAdvanceChargesAndApplyInvoicePatchesRejectsTheoreticalInvoiceEffectLoop(t *testing.T) {
+	// given
+	// - A charge keeps emitting an invoice effect and requesting another continuation.
+	// when:
+	// - The root charge service resumes it after each invoice-effect batch.
+	// then:
+	// - The theoretical loop is bounded before it can hold the transaction indefinitely.
+	invoicePatch := invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge")
+	repeatedAdvanceResult := TriggerPatchResult{
+		InvoicePatches: invoiceupdater.Patches{invoicePatch},
+		CanAdvance:     true,
+	}
+	charge := &scriptedInvocableCharge{
+		chargeID:              meta.ChargeID{Namespace: "ns", ID: "charge"},
+		repeatedAdvanceResult: &repeatedAdvanceResult,
+	}
+	svc := service{
+		invoiceUpdater: recordingInvoiceUpdater{
+			apply: func(context.Context, customer.CustomerID, invoiceupdater.Patches) error {
+				return nil
+			},
+		},
+	}
+
+	_, err := svc.advanceChargesAndApplyInvoicePatches(
+		t.Context(),
+		customer.CustomerID{Namespace: "ns", ID: "customer"},
+		map[string]InvocableCharge{
+			charge.chargeID.ID: charge,
+		},
+		invoiceupdater.Patches{invoicePatch},
+	)
+
+	require.ErrorContains(t, err, "exceeded 100 invoice-effect rounds")
+	require.Equal(t, maxInvoiceEffectRounds, charge.advanceCalls)
+}
+
 type scriptedInvocableCharge struct {
-	chargeID       meta.ChargeID
-	triggerResult  TriggerPatchResult
-	advanceResults []TriggerPatchResult
-	triggerCalls   int
-	advanceCalls   int
+	chargeID              meta.ChargeID
+	triggerResult         TriggerPatchResult
+	advanceResults        []TriggerPatchResult
+	repeatedAdvanceResult *TriggerPatchResult
+	triggerCalls          int
+	advanceCalls          int
 }
 
 func (c *scriptedInvocableCharge) GetChargeID() meta.ChargeID {
@@ -111,6 +180,11 @@ func (c *scriptedInvocableCharge) TriggerPatch(context.Context, meta.Patch) (Tri
 }
 
 func (c *scriptedInvocableCharge) AdvanceCharge(context.Context) (TriggerPatchResult, error) {
+	if c.repeatedAdvanceResult != nil {
+		c.advanceCalls++
+		return *c.repeatedAdvanceResult, nil
+	}
+
 	result := c.advanceResults[c.advanceCalls]
 	c.advanceCalls++
 	return result, nil

--- a/openmeter/billing/charges/service/patch_test.go
+++ b/openmeter/billing/charges/service/patch_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+)
+
+func TestApplyInvocableChargePatchesBatchesEachInvoiceEffectRound(t *testing.T) {
+	// given
+	// - Two patched charges emit invoice effects in the first lifecycle round.
+	// - Only one charge emits another invoice effect after the first batch is applied.
+	// when:
+	// - The root charge service applies and advances the patches.
+	// then:
+	// - Effects are batched by round and each charge resumes only after its preceding batch.
+	patch := meta.PatchDelete{}
+
+	firstCharge := &scriptedInvocableCharge{
+		chargeID: meta.ChargeID{Namespace: "ns", ID: "first"},
+		triggerResult: TriggerPatchResult{
+			InvoicePatches: invoiceupdater.Patches{
+				invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("first-round-1"),
+			},
+			CanAdvance: true,
+		},
+		advanceResults: []TriggerPatchResult{
+			{
+				InvoicePatches: invoiceupdater.Patches{
+					invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("first-round-2"),
+				},
+				CanAdvance: true,
+			},
+			{},
+		},
+	}
+	secondCharge := &scriptedInvocableCharge{
+		chargeID: meta.ChargeID{Namespace: "ns", ID: "second"},
+		triggerResult: TriggerPatchResult{InvoicePatches: invoiceupdater.Patches{
+			invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("second-round-1"),
+		}},
+		advanceResults: []TriggerPatchResult{{}},
+	}
+
+	var appliedBatches [][]string
+	updater := recordingInvoiceUpdater{apply: func(_ context.Context, _ customer.CustomerID, patches invoiceupdater.Patches) error {
+		if len(appliedBatches) == 0 {
+			require.Zero(t, firstCharge.advanceCalls)
+			require.Zero(t, secondCharge.advanceCalls)
+		} else {
+			require.Equal(t, 1, firstCharge.advanceCalls)
+			require.Zero(t, secondCharge.advanceCalls)
+		}
+
+		chargeIDs := make([]string, 0, len(patches))
+		for _, patch := range patches {
+			deletePatch, err := patch.AsDeleteGatheringLineByChargeIDPatch()
+			require.NoError(t, err)
+			chargeIDs = append(chargeIDs, deletePatch.ChargeID)
+		}
+		appliedBatches = append(appliedBatches, chargeIDs)
+
+		return nil
+	}}
+
+	svc := service{invoiceUpdater: updater}
+	err := svc.applyInvocableChargePatches(
+		t.Context(),
+		customer.CustomerID{Namespace: "ns", ID: "customer"},
+		map[string]InvocableCharge{
+			"first":  firstCharge,
+			"second": secondCharge,
+		},
+		map[string]charges.Patch{
+			"first":  patch,
+			"second": patch,
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, appliedBatches, 2)
+	require.ElementsMatch(t, []string{"first-round-1", "second-round-1"}, appliedBatches[0])
+	require.Equal(t, []string{"first-round-2"}, appliedBatches[1])
+	require.Equal(t, 1, firstCharge.triggerCalls)
+	require.Equal(t, 2, firstCharge.advanceCalls)
+	require.Equal(t, 1, secondCharge.triggerCalls)
+	require.Zero(t, secondCharge.advanceCalls)
+}
+
+type scriptedInvocableCharge struct {
+	chargeID       meta.ChargeID
+	triggerResult  TriggerPatchResult
+	advanceResults []TriggerPatchResult
+	triggerCalls   int
+	advanceCalls   int
+}
+
+func (c *scriptedInvocableCharge) GetChargeID() meta.ChargeID {
+	return c.chargeID
+}
+
+func (c *scriptedInvocableCharge) TriggerPatch(context.Context, meta.Patch) (TriggerPatchResult, error) {
+	c.triggerCalls++
+	return c.triggerResult, nil
+}
+
+func (c *scriptedInvocableCharge) AdvanceCharge(context.Context) (TriggerPatchResult, error) {
+	result := c.advanceResults[c.advanceCalls]
+	c.advanceCalls++
+	return result, nil
+}
+
+type recordingInvoiceUpdater struct {
+	apply func(context.Context, customer.CustomerID, invoiceupdater.Patches) error
+}
+
+func (u recordingInvoiceUpdater) ApplyPatches(ctx context.Context, customerID customer.CustomerID, patches invoiceupdater.Patches) error {
+	return u.apply(ctx, customerID, patches)
+}

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	ErrUnsupportedOperation    = models.NewGenericPreConditionFailedError(fmt.Errorf("unsupported operation"))
+	ErrUnsupportedOperation    = models.NewGenericPreConditionFailedError(errors.New("unsupported operation"))
 	ErrUnhandledInvoicePatches = errors.New("unhandled invoice patches")
 )
 

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/qmuntal/stateless"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var (
+	ErrUnsupportedOperation    = models.NewGenericPreConditionFailedError(fmt.Errorf("unsupported operation"))
+	ErrUnhandledInvoicePatches = errors.New("unhandled invoice patches")
 )
 
 type Status interface {
@@ -37,12 +42,33 @@ type Config[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] st
 }
 
 type StateMachine[CHARGE any] interface {
-	AdvanceUntilStateStable(ctx context.Context) (*CHARGE, error)
+	// AdvanceUntilInvoicePatchesOrStable fires lifecycle continuation
+	// transitions until the machine emits invoice patches or has no next
+	// transition. Returned patches are removed from the machine; the caller must
+	// settle them before advancing a freshly loaded charge again.
+	AdvanceUntilInvoicePatchesOrStable(ctx context.Context) (invoiceupdater.Patches, error)
+	// AdvanceUntilStable fires lifecycle continuation transitions until the
+	// machine has no next transition. It fails with ErrUnhandledInvoicePatches
+	// when a transition emits invoice patches instead of advancing past them.
+	AdvanceUntilStable(ctx context.Context) error
+	// CanFire reports whether the trigger is permitted from the current charge
+	// state without mutating or persisting the charge.
 	CanFire(ctx context.Context, trigger meta.Trigger) (bool, error)
-	FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error
+	// FireAndAdvanceUntilInvoicePatchesOrStable validates and fires the explicit
+	// trigger, persists the resulting charge state, then fires continuation
+	// transitions until invoice patches are emitted or the machine has no next
+	// transition. Returned patches are removed from the machine; the caller must
+	// settle them before advancing a freshly loaded charge again.
+	FireAndAdvanceUntilInvoicePatchesOrStable(ctx context.Context, trigger meta.Trigger, args ...models.Validator) (invoiceupdater.Patches, error)
+	// FireAndAdvanceUntilStable validates and fires the explicit trigger, then
+	// advances until the machine has no next transition. It fails with
+	// ErrUnhandledInvoicePatches rather than advancing past emitted patches.
+	FireAndAdvanceUntilStable(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error
+	// GetCharge returns the machine's current in-memory charge, including state
+	// and base values returned by persistence during completed transitions.
 	GetCharge() CHARGE
-	InvoicePatches() invoiceupdater.Patches
-	DrainInvoicePatches() invoiceupdater.Patches
+	// RefetchCharge replaces the current in-memory charge with its latest
+	// persisted representation.
 	RefetchCharge(ctx context.Context) error
 }
 
@@ -109,11 +135,7 @@ func (m *Machine[CHARGE, BASE, STATUS]) GetCharge() CHARGE {
 	return m.Charge
 }
 
-func (m *Machine[CHARGE, BASE, STATUS]) InvoicePatches() invoiceupdater.Patches {
-	return slices.Clone(m.invoicePatches)
-}
-
-func (m *Machine[CHARGE, BASE, STATUS]) DrainInvoicePatches() invoiceupdater.Patches {
+func (m *Machine[CHARGE, BASE, STATUS]) drainInvoicePatches() invoiceupdater.Patches {
 	patches := m.invoicePatches
 	m.invoicePatches = nil
 	return patches
@@ -123,21 +145,35 @@ func (m *Machine[CHARGE, BASE, STATUS]) AddInvoicePatch(patches ...invoiceupdate
 	m.invoicePatches = append(m.invoicePatches, patches...)
 }
 
-var ErrUnsupportedOperation = models.NewGenericPreConditionFailedError(fmt.Errorf("unsupported operation"))
-
-func (m *Machine[CHARGE, BASE, STATUS]) FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error {
-	fireArgs := make([]any, 0, len(args))
-	for _, arg := range args {
-		if arg == nil {
-			return fmt.Errorf("trigger %s argument: argument is required", trigger)
-		}
-
-		if err := arg.Validate(); err != nil {
-			return fmt.Errorf("trigger %s argument: %w", trigger, err)
-		}
-
-		fireArgs = append(fireArgs, arg)
+func (m *Machine[CHARGE, BASE, STATUS]) fireAndActivate(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error {
+	if len(m.invoicePatches) > 0 {
+		return fmt.Errorf("%w: cannot fire trigger %v with %d pending invoice patches", ErrUnhandledInvoicePatches, trigger, len(m.invoicePatches))
 	}
+
+	var validationErrors []error
+	if trigger == nil {
+		validationErrors = append(validationErrors, errors.New("trigger is required"))
+	}
+
+	validationErrors = append(validationErrors, lo.Map(args, func(argument models.Validator, index int) error {
+		if argument == nil {
+			return fmt.Errorf("arguments[%d]: argument is required", index)
+		}
+
+		if err := argument.Validate(); err != nil {
+			return fmt.Errorf("arguments[%d]: %w", index, err)
+		}
+
+		return nil
+	})...)
+
+	if err := models.NewNillableGenericValidationError(errors.Join(validationErrors...)); err != nil {
+		return fmt.Errorf("trigger %v input: %w", trigger, err)
+	}
+
+	fireArgs := lo.Map(args, func(argument models.Validator, _ int) any {
+		return argument
+	})
 
 	canFire, err := m.CanFire(ctx, trigger)
 	if err != nil {
@@ -172,32 +208,80 @@ func (m *Machine[CHARGE, BASE, STATUS]) FireAndActivate(ctx context.Context, tri
 	return nil
 }
 
-func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStateStable(ctx context.Context) (*CHARGE, error) {
-	var advanced bool
+// FireAndAdvanceUntilInvoicePatchesOrStable applies an explicit lifecycle
+// trigger and continues through next transitions until invoice patches are
+// emitted or the machine becomes stable. Returned patches are removed from the
+// machine and must be settled before the charge is advanced again.
+func (m *Machine[CHARGE, BASE, STATUS]) FireAndAdvanceUntilInvoicePatchesOrStable(ctx context.Context, trigger meta.Trigger, args ...models.Validator) (invoiceupdater.Patches, error) {
+	if err := m.fireAndActivate(ctx, trigger, args...); err != nil {
+		return nil, fmt.Errorf("fire trigger %v: %w", trigger, err)
+	}
 
+	patches, err := m.advanceUntilInvoicePatchesOrStable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("advance after trigger %v: %w", trigger, err)
+	}
+
+	return patches, nil
+}
+
+// AdvanceUntilInvoicePatchesOrStable continues through next transitions until
+// invoice patches are emitted or the machine becomes stable. Returned patches
+// are removed from the machine and must be settled before the charge is
+// advanced again.
+func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilInvoicePatchesOrStable(ctx context.Context) (invoiceupdater.Patches, error) {
+	return m.advanceUntilInvoicePatchesOrStable(ctx)
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) advanceUntilInvoicePatchesOrStable(ctx context.Context) (invoiceupdater.Patches, error) {
 	for {
+		if len(m.invoicePatches) > 0 {
+			return m.drainInvoicePatches(), nil
+		}
+
 		canFire, err := m.CanFire(ctx, meta.TriggerNext)
 		if err != nil {
 			return nil, err
 		}
-
 		if !canFire {
-			if !advanced {
-				return nil, nil
-			}
-
-			charge := m.Charge
-			return &charge, nil
+			return nil, nil
 		}
 
 		currentStatus := m.Charge.GetStatus()
-
-		if err := m.FireAndActivate(ctx, meta.TriggerNext); err != nil {
+		if err := m.fireAndActivate(ctx, meta.TriggerNext); err != nil {
 			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", currentStatus, err)
 		}
-
-		advanced = true
 	}
+}
+
+// FireAndAdvanceUntilStable applies an explicit lifecycle trigger and advances
+// until the machine is stable. Invoice patches are rejected because callers
+// that own them must use FireAndAdvanceUntilInvoicePatchesOrStable.
+func (m *Machine[CHARGE, BASE, STATUS]) FireAndAdvanceUntilStable(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error {
+	patches, err := m.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, trigger, args...)
+	if err != nil {
+		return err
+	}
+	if len(patches) > 0 {
+		return fmt.Errorf("%w: trigger %v produced %d invoice patches", ErrUnhandledInvoicePatches, trigger, len(patches))
+	}
+
+	return nil
+}
+
+// AdvanceUntilStable advances until the machine is stable. Invoice patches are
+// rejected because callers that own them must use
+// AdvanceUntilInvoicePatchesOrStable.
+func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStable(ctx context.Context) error {
+	patches, err := m.advanceUntilInvoicePatchesOrStable(ctx)
+	if err != nil {
+		return err
+	}
+	if len(patches) > 0 {
+		return fmt.Errorf("%w: transition produced %d invoice patches", ErrUnhandledInvoicePatches, len(patches))
+	}
+
+	return nil
 }
 
 func (m *Machine[CHARGE, BASE, STATUS]) RefetchCharge(ctx context.Context) error {

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -217,7 +217,7 @@ func (m *Machine[CHARGE, BASE, STATUS]) FireAndAdvanceUntilInvoicePatchesOrStabl
 		return nil, fmt.Errorf("fire trigger %v: %w", trigger, err)
 	}
 
-	patches, err := m.advanceUntilInvoicePatchesOrStable(ctx)
+	patches, err := m.AdvanceUntilInvoicePatchesOrStable(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("advance after trigger %v: %w", trigger, err)
 	}
@@ -230,10 +230,6 @@ func (m *Machine[CHARGE, BASE, STATUS]) FireAndAdvanceUntilInvoicePatchesOrStabl
 // are removed from the machine and must be settled before the charge is
 // advanced again.
 func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilInvoicePatchesOrStable(ctx context.Context) (invoiceupdater.Patches, error) {
-	return m.advanceUntilInvoicePatchesOrStable(ctx)
-}
-
-func (m *Machine[CHARGE, BASE, STATUS]) advanceUntilInvoicePatchesOrStable(ctx context.Context) (invoiceupdater.Patches, error) {
 	for {
 		if len(m.invoicePatches) > 0 {
 			return m.drainInvoicePatches(), nil
@@ -273,7 +269,7 @@ func (m *Machine[CHARGE, BASE, STATUS]) FireAndAdvanceUntilStable(ctx context.Co
 // rejected because callers that own them must use
 // AdvanceUntilInvoicePatchesOrStable.
 func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStable(ctx context.Context) error {
-	patches, err := m.advanceUntilInvoicePatchesOrStable(ctx)
+	patches, err := m.AdvanceUntilInvoicePatchesOrStable(ctx)
 	if err != nil {
 		return err
 	}

--- a/openmeter/billing/charges/statemachine/machine_test.go
+++ b/openmeter/billing/charges/statemachine/machine_test.go
@@ -341,6 +341,36 @@ func TestMachine_FireAndAdvanceUntilInvoicePatchesOrStable(t *testing.T) {
 		require.Empty(t, patches)
 		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
 	})
+
+	t.Run("rejects a trigger while invoice patches are pending", func(t *testing.T) {
+		// Given:
+		// - a machine in created state has a pending invoice patch
+		// - invoice-created would otherwise transition it to active
+		// When:
+		// - an invoice-aware trigger is fired
+		// Then:
+		// - the trigger is rejected before the transition can mutate the charge
+		var updateCalls int
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) {
+				updateCalls++
+				return base, nil
+			},
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+		machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+
+		_, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.ErrorIs(t, err, ErrUnhandledInvoicePatches)
+		require.Equal(t, fakeStatusCreated, machine.GetCharge().GetStatus())
+		require.Equal(t, 1, len(machine.invoicePatches))
+		require.Zero(t, updateCalls)
+	})
 }
 
 func TestMachine_AdvanceUntilInvoicePatchesOrStable(t *testing.T) {
@@ -367,6 +397,63 @@ func TestMachine_AdvanceUntilInvoicePatchesOrStable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, patches, 1)
 	require.Equal(t, fakeStatusFinal, machine.GetCharge().GetStatus())
+
+	t.Run("returns pending invoice patches before advancing", func(t *testing.T) {
+		// Given:
+		// - a machine already has a pending invoice patch and can advance
+		// When:
+		// - AdvanceUntilInvoicePatchesOrStable is called
+		// Then:
+		// - it returns the pending patch without firing a transition
+		var updateCalls int
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) {
+				updateCalls++
+				return base, nil
+			},
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+		machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+
+		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Equal(t, fakeStatusCreated, machine.GetCharge().GetStatus())
+		require.Zero(t, updateCalls)
+	})
+
+	t.Run("returns invoice patches before evaluating next", func(t *testing.T) {
+		// Given:
+		// - the charge can advance from created to active to final
+		// - entering active emits an invoice patch
+		// When:
+		// - AdvanceUntilInvoicePatchesOrStable is called
+		// Then:
+		// - it returns the patch without evaluating the transition to final
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+		machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
 }
 
 func TestMachine_AdvanceUntilStable(t *testing.T) {
@@ -388,35 +475,6 @@ func TestMachine_AdvanceUntilStable(t *testing.T) {
 		err := machine.AdvanceUntilStable(t.Context())
 
 		require.NoError(t, err)
-		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
-	})
-
-	t.Run("returns invoice patches before evaluating next", func(t *testing.T) {
-		// Given:
-		// - the charge can advance from created to active to final
-		// - entering active emits an invoice patch
-		// When:
-		// - AdvanceUntilInvoicePatchesOrStable is called
-		// Then:
-		// - it returns the patch without evaluating the transition to final
-
-		machine := newTestMachine(
-			t,
-			newFakeCharge(fakeStatusCreated),
-			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
-			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
-		)
-		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
-		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
-		machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
-			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
-			return nil
-		})
-
-		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
-
-		require.NoError(t, err)
-		require.Len(t, patches, 1)
 		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
 	})
 
@@ -449,35 +507,6 @@ func TestMachine_AdvanceUntilStable(t *testing.T) {
 		require.ErrorIs(t, err, ErrUnhandledInvoicePatches)
 		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
 		require.Equal(t, 1, updateCalls)
-	})
-
-	t.Run("returns pending invoice patches before advancing", func(t *testing.T) {
-		// Given:
-		// - a machine already has a pending invoice patch and can advance
-		// When:
-		// - AdvanceUntilInvoicePatchesOrStable is called
-		// Then:
-		// - it returns the pending patch without firing a transition
-		var updateCalls int
-
-		machine := newTestMachine(
-			t,
-			newFakeCharge(fakeStatusCreated),
-			func(ctx context.Context, base fakeBase) (fakeBase, error) {
-				updateCalls++
-				return base, nil
-			},
-			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
-		)
-		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
-		machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
-
-		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
-
-		require.NoError(t, err)
-		require.Len(t, patches, 1)
-		require.Equal(t, fakeStatusCreated, machine.GetCharge().GetStatus())
-		require.Zero(t, updateCalls)
 	})
 
 	t.Run("advances through an empty lifecycle boundary", func(t *testing.T) {

--- a/openmeter/billing/charges/statemachine/machine_test.go
+++ b/openmeter/billing/charges/statemachine/machine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 )
 
@@ -103,11 +104,11 @@ func newTestMachine(
 	return machine
 }
 
-func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStableUpdatesStatus(t *testing.T) {
 	// Given:
 	// a machine in created state with a next transition to active.
 	// When:
-	// FireAndActivate is called with the next trigger.
+	// FireAndAdvanceUntilStable is called with the next trigger.
 	// Then:
 	// the machine updates the in-memory charge status to active and persists the updated base.
 	var updateCalls int
@@ -125,7 +126,7 @@ func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
 
 	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext)
 
 	require.NoError(t, err)
 	require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
@@ -133,11 +134,11 @@ func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
 	require.Equal(t, 1, updateCalls)
 }
 
-func TestMachine_FireAndActivateReturnsUnsupportedOperationWhenTriggerCannotFire(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStableReturnsUnsupportedOperationWhenTriggerCannotFire(t *testing.T) {
 	// Given:
 	// a machine in created state without a next transition.
 	// When:
-	// FireAndActivate is called with the next trigger.
+	// FireAndAdvanceUntilStable is called with the next trigger.
 	// Then:
 	// the machine returns an unsupported-operation error that includes the trigger, status, and charge id.
 	machine := newTestMachine(
@@ -147,7 +148,7 @@ func TestMachine_FireAndActivateReturnsUnsupportedOperationWhenTriggerCannotFire
 		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
 	)
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext)
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrUnsupportedOperation)
@@ -156,11 +157,11 @@ func TestMachine_FireAndActivateReturnsUnsupportedOperationWhenTriggerCannotFire
 	require.ErrorContains(t, err, "charge-1")
 }
 
-func TestMachine_FireAndActivateValidatesTriggerArguments(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStableValidatesTriggerArguments(t *testing.T) {
 	// Given:
 	// a machine with a transition and an invalid trigger argument.
 	// When:
-	// FireAndActivate is called.
+	// FireAndAdvanceUntilStable is called.
 	// Then:
 	// it returns the argument validation error before firing or persisting.
 	validationErr := errors.New("invalid trigger argument")
@@ -178,7 +179,7 @@ func TestMachine_FireAndActivateValidatesTriggerArguments(t *testing.T) {
 
 	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext, fakeTriggerArg{err: validationErr})
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext, fakeTriggerArg{err: validationErr})
 
 	require.ErrorIs(t, err, validationErr)
 	require.ErrorContains(t, err, fmt.Sprint(meta.TriggerNext))
@@ -186,13 +187,13 @@ func TestMachine_FireAndActivateValidatesTriggerArguments(t *testing.T) {
 	require.Zero(t, updateCalls)
 }
 
-func TestMachine_AdvanceUntilStateStableReturnsNilWhenAlreadyStable(t *testing.T) {
+func TestMachine_AdvanceUntilStableDoesNothingWhenAlreadyStable(t *testing.T) {
 	// Given:
 	// a machine already in a stable state with no next transition.
 	// When:
-	// AdvanceUntilStateStable is called.
+	// AdvanceUntilStable is called.
 	// Then:
-	// it returns nil and does not persist the base.
+	// it succeeds without persisting the base.
 	var updateCalls int
 
 	machine := newTestMachine(
@@ -205,20 +206,315 @@ func TestMachine_AdvanceUntilStateStableReturnsNilWhenAlreadyStable(t *testing.T
 		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
 	)
 
-	charge, err := machine.AdvanceUntilStateStable(t.Context())
+	err := machine.AdvanceUntilStable(t.Context())
 
 	require.NoError(t, err)
-	require.Nil(t, charge)
 	require.Zero(t, updateCalls)
 }
 
-func TestMachine_AdvanceUntilStateStableWalksTransitionsAndPersistsReturnedBase(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStable(t *testing.T) {
+	t.Run("advances when no invoice patches are emitted", func(t *testing.T) {
+		// Given:
+		// - an explicit invoice-created trigger enters active
+		// - active can advance to final without emitting invoice effects
+		// When:
+		// - FireAndAdvanceUntilStable is called
+		// Then:
+		// - the machine reaches final
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+
+		err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.NoError(t, err)
+		require.Equal(t, fakeStatusFinal, machine.GetCharge().GetStatus())
+	})
+
+	t.Run("rejects unhandled invoice effects", func(t *testing.T) {
+		// Given:
+		// - an explicit invoice-created trigger enters active and emits an invoice effect
+		// - active can otherwise advance to final
+		// When:
+		// - FireAndAdvanceUntilStable is called
+		// Then:
+		// - it reports the unhandled patch and does not fire next
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.ErrorIs(t, err, ErrUnhandledInvoicePatches)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
+}
+
+func TestMachine_FireAndAdvanceUntilInvoicePatchesOrStable(t *testing.T) {
+	t.Run("stops after the explicit trigger emits invoice patches", func(t *testing.T) {
+		// Given:
+		// - invoice-created enters active and emits an invoice patch
+		// - active could otherwise continue to final
+		// When:
+		// - the explicit trigger is fired and advanced toward an invoice boundary
+		// Then:
+		// - the patch is returned before the next transition fires
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		patches, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Empty(t, machine.invoicePatches)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
+
+	t.Run("advances through transitions without invoice patches", func(t *testing.T) {
+		// Given:
+		// - invoice-created enters active without invoice effects
+		// - the following transition to final emits an invoice patch
+		// When:
+		// - the explicit trigger is fired and advanced toward an invoice boundary
+		// Then:
+		// - the machine reaches final and returns its patch
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+		machine.Configure(fakeStatusFinal).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		patches, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Equal(t, fakeStatusFinal, machine.GetCharge().GetStatus())
+	})
+
+	t.Run("returns empty when the machine becomes stable", func(t *testing.T) {
+		// Given:
+		// - invoice-created enters an active state without invoice effects or a next transition
+		// When:
+		// - the explicit trigger is fired and advanced toward an invoice boundary
+		// Then:
+		// - the machine becomes stable and returns no patches
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerInvoiceCreated, fakeStatusActive)
+
+		patches, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), meta.TriggerInvoiceCreated)
+
+		require.NoError(t, err)
+		require.Empty(t, patches)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
+}
+
+func TestMachine_AdvanceUntilInvoicePatchesOrStable(t *testing.T) {
+	// Given:
+	// - active can continue to final and emits an invoice patch there
+	// When:
+	// - advancement resumes toward the next invoice boundary
+	// Then:
+	// - it returns the final-state patch
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusActive),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+	machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+	machine.Configure(fakeStatusFinal).OnActive(func(ctx context.Context) error {
+		machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+		return nil
+	})
+
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+
+	require.NoError(t, err)
+	require.Len(t, patches, 1)
+	require.Equal(t, fakeStatusFinal, machine.GetCharge().GetStatus())
+}
+
+func TestMachine_AdvanceUntilStable(t *testing.T) {
+	t.Run("advances when no invoice patches are emitted", func(t *testing.T) {
+		// Given:
+		// - a charge can advance from created to active without emitting invoice effects
+		// When:
+		// - AdvanceUntilStable is called
+		// Then:
+		// - the transition completes successfully
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+
+		err := machine.AdvanceUntilStable(t.Context())
+
+		require.NoError(t, err)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
+
+	t.Run("returns invoice patches before evaluating next", func(t *testing.T) {
+		// Given:
+		// - the charge can advance from created to active to final
+		// - entering active emits an invoice patch
+		// When:
+		// - AdvanceUntilInvoicePatchesOrStable is called
+		// Then:
+		// - it returns the patch without evaluating the transition to final
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+		machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+		machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	})
+
+	t.Run("rejects invoice patches", func(t *testing.T) {
+		// Given:
+		// - a continuation transition emits an invoice patch
+		// When:
+		// - AdvanceUntilStable is called
+		// Then:
+		// - it reports the unhandled patch and leaves the following transition unevaluated
+		var updateCalls int
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) {
+				updateCalls++
+				return base, nil
+			},
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+		machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+			machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+			return nil
+		})
+
+		err := machine.AdvanceUntilStable(t.Context())
+
+		require.ErrorIs(t, err, ErrUnhandledInvoicePatches)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+		require.Equal(t, 1, updateCalls)
+	})
+
+	t.Run("returns pending invoice patches before advancing", func(t *testing.T) {
+		// Given:
+		// - a machine already has a pending invoice patch and can advance
+		// When:
+		// - AdvanceUntilInvoicePatchesOrStable is called
+		// Then:
+		// - it returns the pending patch without firing a transition
+		var updateCalls int
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) {
+				updateCalls++
+				return base, nil
+			},
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+		machine.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch("charge-1"))
+
+		patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+
+		require.NoError(t, err)
+		require.Len(t, patches, 1)
+		require.Equal(t, fakeStatusCreated, machine.GetCharge().GetStatus())
+		require.Zero(t, updateCalls)
+	})
+
+	t.Run("advances through an empty lifecycle boundary", func(t *testing.T) {
+		// Given:
+		// - a charge that can advance without emitting invoice effects
+		// When:
+		// - AdvanceUntilStable is called
+		// Then:
+		// - the machine advances normally
+		var updateCalls int
+
+		machine := newTestMachine(
+			t,
+			newFakeCharge(fakeStatusCreated),
+			func(ctx context.Context, base fakeBase) (fakeBase, error) {
+				updateCalls++
+				return base, nil
+			},
+			func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+		)
+		machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+
+		err := machine.AdvanceUntilStable(t.Context())
+
+		require.NoError(t, err)
+		require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+		require.Equal(t, 1, updateCalls)
+	})
+}
+
+func TestMachine_AdvanceUntilStableWalksTransitionsAndPersistsReturnedBase(t *testing.T) {
 	// Given:
 	// a machine that can advance from created to active to final.
 	// When:
-	// AdvanceUntilStateStable is called.
+	// AdvanceUntilStable is called.
 	// Then:
-	// it walks all next transitions and the returned charge contains the persisted base returned by UpdateBase.
+	// it walks all next transitions and the machine contains the persisted base returned by UpdateBase.
 	var updateCalls int
 
 	machine := newTestMachine(
@@ -235,22 +531,22 @@ func TestMachine_AdvanceUntilStateStableWalksTransitionsAndPersistsReturnedBase(
 	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
 	machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
 
-	charge, err := machine.AdvanceUntilStateStable(t.Context())
+	err := machine.AdvanceUntilStable(t.Context())
+	charge := machine.GetCharge()
 
 	require.NoError(t, err)
-	require.NotNil(t, charge)
 	require.Equal(t, fakeStatusFinal, charge.GetStatus())
 	require.Equal(t, 2, charge.GetBase().Revision)
 	require.Equal(t, 2, updateCalls)
 }
 
-func TestMachine_AdvanceUntilStateStablePersistsPostActivationBase(t *testing.T) {
+func TestMachine_AdvanceUntilStablePersistsPostActivationBase(t *testing.T) {
 	// Given:
 	// a machine whose activation logic mutates the in-memory base before persistence.
 	// When:
-	// AdvanceUntilStateStable is called.
+	// AdvanceUntilStable is called.
 	// Then:
-	// UpdateBase receives the post-activation base and the returned charge contains the persisted result.
+	// UpdateBase receives the post-activation base and the machine contains the persisted result.
 	var observedBase fakeBase
 
 	machine := newTestMachine(
@@ -271,19 +567,19 @@ func TestMachine_AdvanceUntilStateStablePersistsPostActivationBase(t *testing.T)
 		return nil
 	})
 
-	charge, err := machine.AdvanceUntilStateStable(t.Context())
+	err := machine.AdvanceUntilStable(t.Context())
+	charge := machine.GetCharge()
 
 	require.NoError(t, err)
-	require.NotNil(t, charge)
 	require.Equal(t, 7, observedBase.Revision)
 	require.Equal(t, 8, charge.GetBase().Revision)
 }
 
-func TestMachine_FireAndActivatePropagatesActivationErrors(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStablePropagatesActivationErrors(t *testing.T) {
 	// Given:
 	// a machine whose activation callback fails after a valid transition fires.
 	// When:
-	// FireAndActivate is called.
+	// FireAndAdvanceUntilStable is called.
 	// Then:
 	// the activation error is returned to the caller.
 	activationErr := errors.New("activation failed")
@@ -301,16 +597,16 @@ func TestMachine_FireAndActivatePropagatesActivationErrors(t *testing.T) {
 		return activationErr
 	})
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext)
 
 	require.ErrorIs(t, err, activationErr)
 }
 
-func TestMachine_FireAndActivateDoesNotPersistWhenActivationFails(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStableDoesNotPersistWhenActivationFails(t *testing.T) {
 	// Given:
 	// a machine whose activation callback fails.
 	// When:
-	// FireAndActivate is called.
+	// FireAndAdvanceUntilStable is called.
 	// Then:
 	// it returns the activation error without persisting the base.
 	activationErr := errors.New("activation failed")
@@ -332,17 +628,17 @@ func TestMachine_FireAndActivateDoesNotPersistWhenActivationFails(t *testing.T) 
 		return activationErr
 	})
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext)
 
 	require.ErrorIs(t, err, activationErr)
 	require.Zero(t, updateCalls)
 }
 
-func TestMachine_FireAndActivateFailsFastOnInvalidTargetStatus(t *testing.T) {
+func TestMachine_FireAndAdvanceUntilStableFailsFastOnInvalidTargetStatus(t *testing.T) {
 	// Given:
 	// a machine with a transition targeting an invalid status value.
 	// When:
-	// FireAndActivate is called.
+	// FireAndAdvanceUntilStable is called.
 	// Then:
 	// it fails before any persistence logic is involved.
 	machine := newTestMachine(
@@ -357,7 +653,7 @@ func TestMachine_FireAndActivateFailsFastOnInvalidTargetStatus(t *testing.T) {
 
 	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatus("broken"))
 
-	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), meta.TriggerNext)
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid status")
@@ -390,11 +686,11 @@ func TestMachine_RefetchChargeReplacesTheInMemoryCharge(t *testing.T) {
 	require.Equal(t, "refetched", machine.GetCharge().Marker)
 }
 
-func TestMachine_AdvanceUntilStateStablePropagatesPersistenceErrors(t *testing.T) {
+func TestMachine_AdvanceUntilStablePropagatesPersistenceErrors(t *testing.T) {
 	// Given:
 	// a machine that can advance but fails while persisting the updated base.
 	// When:
-	// AdvanceUntilStateStable is called.
+	// AdvanceUntilStable is called.
 	// Then:
 	// it returns the wrapped persistence error and stops advancing.
 	persistErr := errors.New("persist failed")
@@ -410,9 +706,8 @@ func TestMachine_AdvanceUntilStateStablePropagatesPersistenceErrors(t *testing.T
 
 	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
 
-	charge, err := machine.AdvanceUntilStateStable(t.Context())
+	err := machine.AdvanceUntilStable(t.Context())
 
-	require.Nil(t, charge)
 	require.ErrorIs(t, err, persistErr)
 	require.ErrorContains(t, err, "persist charge")
 }

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/mo"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
@@ -29,11 +31,13 @@ type UsageBasedService interface {
 	// UpdateSubscriptionItemID repairs subscription ownership metadata on the
 	// base intent; it must not rewrite an active customer-facing override layer.
 	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
-	// AdvanceCharge drives one usage-based charge. Realization runs store
-	// cumulative usage snapshots; billing-line quantities are mapped separately.
-	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (*Charge, error)
-	// TriggerPatch applies an explicit base/override target patch and then
-	// reconciles invoice artifacts from the effective usage-based intent.
+	// AdvanceCharge drives one charge until invoice patches are emitted or its
+	// lifecycle becomes stable. Callers must apply returned invoice patches
+	// before resuming when CanAdvance is true.
+	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (meta.TriggerPatchResult[Charge], error)
+	// TriggerPatch applies an explicit base/override target patch and advances
+	// until invoice patches are emitted or the lifecycle becomes stable. Callers
+	// that apply returned invoice patches must resume with AdvanceCharge.
 	TriggerPatch(ctx context.Context, charge meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[Charge], error)
 	// GetCurrentTotals calculates the current customer-facing totals from the
 	// effective intent and non-voided realization history.
@@ -139,9 +143,15 @@ func (i GetByIDsInput) Validate() error {
 }
 
 type AdvanceChargeInput struct {
-	ChargeID         meta.ChargeID
-	CustomerOverride billing.CustomerOverrideWithDetails
-	FeatureMeters    feature.FeatureMeters
+	ChargeID meta.ChargeID
+	// CustomerOverride is an authoritative optional resolution hint. None lets
+	// the service resolve the current customer override; Some uses only the
+	// supplied snapshot.
+	CustomerOverride mo.Option[billing.CustomerOverrideWithDetails]
+	// FeatureMeters is an authoritative optional resolution hint. None lets the
+	// service resolve the required feature meter; Some resolves exclusively from
+	// the supplied collection and returns an error when the feature is absent.
+	FeatureMeters mo.Option[feature.FeatureMeters]
 }
 
 func (i AdvanceChargeInput) Validate() error {
@@ -150,16 +160,18 @@ func (i AdvanceChargeInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge ID: %w", err))
 	}
 
-	if i.CustomerOverride.Customer == nil {
-		errs = append(errs, errors.New("expanded customer is required"))
+	if customerOverride, ok := i.CustomerOverride.Get(); ok {
+		if customerOverride.Customer == nil {
+			errs = append(errs, errors.New("expanded customer is required"))
+		}
+
+		if err := customerOverride.MergedProfile.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("merged profile is required: %w", err))
+		}
 	}
 
-	if err := i.CustomerOverride.MergedProfile.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("merged profile is required: %w", err))
-	}
-
-	if i.FeatureMeters == nil {
-		errs = append(errs, errors.New("feature meters are required"))
+	if featureMeters, ok := i.FeatureMeters.Get(); ok && featureMeters == nil {
+		errs = append(errs, errors.New("feature meters cannot be nil when provided"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -165,7 +165,6 @@ func TestUnsupportedExtendOperation(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot extend usage-based charge in status "+string(status))
-			require.Empty(t, machine.InvoicePatches())
 		})
 	}
 }
@@ -191,11 +190,11 @@ func TestUnsupportedExtendOperationIsConfiguredForFinalRealizationBoundary(t *te
 			require.NoError(t, err)
 			require.True(t, canFire)
 
-			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			patches, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), patch.Trigger(), patch)
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot extend usage-based charge in status "+string(status))
-			require.Empty(t, machine.InvoicePatches())
+			require.Empty(t, patches)
 			require.Equal(t, status, machine.GetCharge().Status)
 		})
 	}
@@ -225,7 +224,6 @@ func TestUnsupportedShrinkOperation(t *testing.T) {
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot shrink usage-based charge in status "+string(status))
-			require.Empty(t, machine.InvoicePatches())
 		})
 	}
 }
@@ -252,11 +250,11 @@ func TestUnsupportedShrinkOperationIsConfiguredForImmutableBoundaries(t *testing
 			require.NoError(t, err)
 			require.True(t, canFire)
 
-			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			patches, err := machine.FireAndAdvanceUntilInvoicePatchesOrStable(t.Context(), patch.Trigger(), patch)
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot shrink usage-based charge in status "+string(status))
-			require.Empty(t, machine.InvoicePatches())
+			require.Empty(t, patches)
 			require.Equal(t, status, machine.GetCharge().Status)
 		})
 	}
@@ -292,13 +290,14 @@ func TestShrinkChargeKeepsCurrentRunStateWhenCurrentRunSurvivesShrink(t *testing
 
 	err := machine.ShrinkCharge(t.Context(), mustNewPatchShrink(t, newServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
 	charge := machine.GetCharge()
 	require.Equal(t, usagebased.StatusActiveRealizationProcessing, charge.Status)
 	require.Equal(t, currentRunID, *charge.State.CurrentRealizationRunID)
 	require.Equal(t, currentAdvanceAfter, *charge.State.AdvanceAfter)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpUpsertGatheringLineByChargeID, patches[0].Op())
 
@@ -333,8 +332,9 @@ func TestExtendChargeDeletesPendingGatheringLineWhenRunsCoverExtendedPeriod(t *t
 
 	err := machine.ExtendCharge(t.Context(), mustNewPatchExtend(t, extendedServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 
@@ -371,13 +371,14 @@ func TestShrinkChargeMovesToAwaitingPaymentWhenKeptRunCoversNewEnd(t *testing.T)
 
 	err := machine.ShrinkCharge(t.Context(), mustNewPatchShrink(t, newServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
 	charge := machine.GetCharge()
 	require.Equal(t, usagebased.StatusActiveAwaitingPaymentSettlement, charge.Status)
 	require.Nil(t, charge.State.CurrentRealizationRunID)
 	require.Nil(t, charge.State.AdvanceAfter)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }
@@ -416,13 +417,14 @@ func TestShrinkChargeMovesToFinalWhenKeptRunCoversNewEndAndSettlementIsComplete(
 
 	err := machine.ShrinkCharge(t.Context(), mustNewPatchShrink(t, newServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
 	charge := machine.GetCharge()
 	require.Equal(t, usagebased.StatusFinal, charge.Status)
 	require.Nil(t, charge.State.CurrentRealizationRunID)
 	require.Nil(t, charge.State.AdvanceAfter)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }
@@ -457,6 +459,8 @@ func TestShrinkToRealizedPeriodFinalizesKeptPartialRunAndPreservesChargeState(t 
 
 	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, newServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
 	charge = machine.GetCharge()
 	require.Equal(t, usagebased.StatusActive, charge.Status)
@@ -474,7 +478,6 @@ func TestShrinkToRealizedPeriodFinalizesKeptPartialRunAndPreservesChargeState(t 
 	require.Equal(t, usagebased.RealizationRunTypeFinalRealization, run.Type)
 	require.Equal(t, usagebased.RealizationRunTypePartialInvoice, run.InitialType)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }
@@ -538,6 +541,8 @@ func TestShrinkToRealizedPeriodFinalizesCurrentPartialRunAndPreservesChargeState
 
 	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, newServicePeriodTo))
 	require.NoError(t, err)
+	patches, err := machine.AdvanceUntilInvoicePatchesOrStable(t.Context())
+	require.NoError(t, err)
 
 	charge = machine.GetCharge()
 	require.Equal(t, usagebased.StatusActiveRealizationProcessing, charge.Status)
@@ -554,7 +559,6 @@ func TestShrinkToRealizedPeriodFinalizesCurrentPartialRunAndPreservesChargeState
 	require.Equal(t, usagebased.RealizationRunTypeFinalRealization, run.Type)
 	require.Equal(t, usagebased.RealizationRunTypePartialInvoice, run.InitialType)
 
-	patches := machine.InvoicePatches()
 	require.Len(t, patches, 1)
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -18,6 +18,7 @@ import (
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -79,6 +80,9 @@ func TestCreditsOnlyPeriodPatchWhileCreatedUpdatesIntentAndKeepsCreatedSchedule(
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			clock.FreezeTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+			defer clock.UnFreeze()
+
 			// given:
 			// - a created credit-only usage-based charge before realization
 			// when:
@@ -98,7 +102,7 @@ func TestCreditsOnlyPeriodPatchWhileCreatedUpdatesIntentAndKeepsCreatedSchedule(
 			})
 
 			patch := tc.new(t, tc.to)
-			err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			err := machine.FireAndAdvanceUntilStable(t.Context(), patch.Trigger(), patch)
 			require.NoError(t, err)
 
 			charge := machine.GetCharge()
@@ -117,6 +121,9 @@ func TestCreditsOnlyExtendWhileFinalRealizationInProgressVoidsCurrentRunAndMoves
 		usagebased.StatusActiveRealizationWaitingForCollection,
 	} {
 		t.Run(string(status), func(t *testing.T) {
+			clock.FreezeTime(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+			defer clock.UnFreeze()
+
 			// given:
 			// - a credit-only usage-based charge with final realization in progress
 			// when:
@@ -147,7 +154,7 @@ func TestCreditsOnlyExtendWhileFinalRealizationInProgressVoidsCurrentRunAndMoves
 			})
 
 			patch := mustNewPatchExtend(t, extendedServicePeriodTo)
-			err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			err := machine.FireAndAdvanceUntilStable(t.Context(), patch.Trigger(), patch)
 			require.NoError(t, err)
 
 			charge := machine.GetCharge()
@@ -165,6 +172,9 @@ func TestCreditsOnlyExtendWhileFinalRealizationInProgressVoidsCurrentRunAndMoves
 }
 
 func TestCreditsOnlyShrinkWhileCompletedVoidsRunBeyondNewEndAndMovesActive(t *testing.T) {
+	clock.FreezeTime(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -187,7 +197,7 @@ func TestCreditsOnlyShrinkWhileCompletedVoidsRunBeyondNewEndAndMovesActive(t *te
 	})
 
 	patch := mustNewPatchShrink(t, newServicePeriodTo)
-	err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), patch.Trigger(), patch)
 	require.NoError(t, err)
 
 	charge := machine.GetCharge()
@@ -203,6 +213,9 @@ func TestCreditsOnlyShrinkWhileCompletedVoidsRunBeyondNewEndAndMovesActive(t *te
 }
 
 func TestCreditsOnlyExtendWhileCompletedVoidsRunAndMovesActive(t *testing.T) {
+	clock.FreezeTime(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -225,7 +238,7 @@ func TestCreditsOnlyExtendWhileCompletedVoidsRunAndMovesActive(t *testing.T) {
 	})
 
 	patch := mustNewPatchExtend(t, extendedServicePeriodTo)
-	err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+	err := machine.FireAndAdvanceUntilStable(t.Context(), patch.Trigger(), patch)
 	require.NoError(t, err)
 
 	charge := machine.GetCharge()

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -246,9 +246,9 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		}
 
 		// Becoming active after the service period starts is not an invoice lifecycle event, so we
-		// still rely on the generic TriggerNext/AdvanceUntilStateStable flow before invoice-created
+		// still rely on the generic TriggerNext/AdvanceUntilStable flow before invoice-created
 		// lifecycle transitions take over.
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 			return nil, fmt.Errorf("advancing usage based charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
@@ -258,16 +258,12 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			}
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceCreated, invoiceCreatedInput{
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerInvoiceCreated, invoiceCreatedInput{
 			LineID:        stdLine.ID,
 			InvoiceID:     input.Invoice.ID,
 			ServicePeriod: stdLine.Period,
 		}); err != nil {
 			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing usage based charge[%s] after %s: %w", stateMachine.GetCharge().ID, meta.TriggerInvoiceCreated, err)
 		}
 
 		charge := stateMachine.GetCharge()
@@ -317,12 +313,8 @@ func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.On
 			continue
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerCollectionCompleted); err != nil {
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerCollectionCompleted); err != nil {
 			return nil, fmt.Errorf("triggering collection_completed for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing usage based charge[%s] after collection_completed: %w", stateMachine.GetCharge().ID, err)
 		}
 
 		charge := stateMachine.GetCharge()
@@ -513,7 +505,7 @@ func (e *LineEngine) attachManualStandardLine(ctx context.Context, standardInvoi
 		return nil, fmt.Errorf("new state machine for usage-based charge[%s]: %w", charge.ID, err)
 	}
 
-	if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+	if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
 		return nil, fmt.Errorf("advancing usage-based charge[%s]: %w", charge.ID, err)
 	}
 
@@ -523,16 +515,12 @@ func (e *LineEngine) attachManualStandardLine(ctx context.Context, standardInvoi
 		}
 	}
 
-	if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceCreated, invoiceCreatedInput{
+	if err := stateMachine.FireAndAdvanceUntilStable(ctx, meta.TriggerInvoiceCreated, invoiceCreatedInput{
 		LineID:        standardLine.ID,
 		InvoiceID:     standardInvoice.ID,
 		ServicePeriod: standardLine.Period,
 	}); err != nil {
 		return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, charge.ID, err)
-	}
-
-	if patches := stateMachine.DrainInvoicePatches(); len(patches) > 0 {
-		return nil, fmt.Errorf("line[%s]: expected no invoice patches while attaching manually created usage-based charge[%s], got %v", sourceLine.GetID(), charge.ID, patches)
 	}
 
 	charge = stateMachine.GetCharge()
@@ -752,11 +740,12 @@ func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Contex
 		return usagebased.Charge{}, nil, fmt.Errorf("new state machine for usage based charge[%s]: %w", charge.ID, err)
 	}
 
-	if err := stateMachine.FireAndActivate(ctx, patch.Trigger(), patch); err != nil {
+	invoicePatches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, patch.Trigger(), patch)
+	if err != nil {
 		return usagebased.Charge{}, nil, fmt.Errorf("triggering %s for charge[%s]: %w", patch.Trigger(), charge.ID, err)
 	}
 
-	return stateMachine.GetCharge(), stateMachine.DrainInvoicePatches(), nil
+	return stateMachine.GetCharge(), invoicePatches, nil
 }
 
 func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
@@ -1002,7 +991,6 @@ func (e *LineEngine) OnInvoiceIssued(ctx context.Context, input billing.OnInvoic
 				Invoice: input.Invoice,
 			}
 		},
-		AdvanceUntilStateStable: true,
 	})
 }
 
@@ -1031,10 +1019,9 @@ func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPayme
 }
 
 type fireLineTriggerInput struct {
-	Lines                   billing.StandardLines
-	Trigger                 meta.Trigger
-	InputFn                 func(*billing.StandardLine) models.Validator
-	AdvanceUntilStateStable bool
+	Lines   billing.StandardLines
+	Trigger meta.Trigger
+	InputFn func(*billing.StandardLine) models.Validator
 }
 
 func (i fireLineTriggerInput) Validate() error {
@@ -1079,14 +1066,8 @@ func (e *LineEngine) fireLineTrigger(ctx context.Context, input fireLineTriggerI
 			)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, input.Trigger, input.InputFn(stdLine)); err != nil {
+		if err := stateMachine.FireAndAdvanceUntilStable(ctx, input.Trigger, input.InputFn(stdLine)); err != nil {
 			return fmt.Errorf("triggering %s for charge[%s]: %w", input.Trigger, stateMachine.GetCharge().ID, err)
-		}
-
-		if input.AdvanceUntilStateStable {
-			if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-				return fmt.Errorf("advancing usage based charge[%s] after %s: %w", stateMachine.GetCharge().ID, input.Trigger, err)
-			}
 		}
 	}
 

--- a/openmeter/billing/charges/usagebased/service/payments.go
+++ b/openmeter/billing/charges/usagebased/service/payments.go
@@ -100,7 +100,7 @@ func (e *LineEngine) recordPaymentSettled(ctx context.Context, stateMachine Stat
 		return fmt.Errorf("new state machine: %w", err)
 	}
 
-	if _, err := advancementStateMachine.AdvanceUntilStateStable(ctx); err != nil {
+	if err := advancementStateMachine.AdvanceUntilStable(ctx); err != nil {
 		return fmt.Errorf("advancing charge[%s] after payment settlement: %w", charge.ID, err)
 	}
 

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -95,12 +95,13 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, patch.Trigger(), patch); err != nil {
+		invoicePatches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, patch.Trigger(), patch)
+		if err != nil {
 			return nil, err
 		}
 
 		charge = stateMachine.GetCharge()
-		result.InvoicePatches = stateMachine.DrainInvoicePatches()
+		result.InvoicePatches = invoicePatches
 
 		return &charge, nil
 	})

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -38,7 +38,7 @@ func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceCha
 
 		invoicePatches, err := stateMachine.AdvanceUntilInvoicePatchesOrStable(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error advance the invoice patches: %w", err)
 		}
 		canAdvance, err = stateMachine.CanFire(ctx, meta.TriggerNext)
 		if err != nil {

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -16,27 +16,14 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceChargeInput) (*usagebased.Charge, error) {
+func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceChargeInput) (meta.TriggerPatchResult[usagebased.Charge], error) {
 	if err := input.Validate(); err != nil {
-		return nil, fmt.Errorf("validate: %w", err)
+		return meta.TriggerPatchResult[usagebased.Charge]{}, fmt.Errorf("validate: %w", err)
 	}
 
-	return s.withLockedCharge(ctx, input.ChargeID, func(ctx context.Context, charge usagebased.Charge) (*usagebased.Charge, error) {
-		featureMeter, err := charge.ResolveFeatureMeter(input.FeatureMeters)
-		if err != nil {
-			return nil, fmt.Errorf("get feature meter: %w", err)
-		}
-
-		stateMachine, err := s.newStateMachine(StateMachineConfig{
-			Charge:             charge,
-			Adapter:            s.adapter,
-			Rater:              s.rater,
-			Runs:               s.runs,
-			CustomerOverride:   input.CustomerOverride,
-			FeatureMeter:       featureMeter,
-			CurrencyCalculator: charge.Intent.GetCurrency(),
-			CostBasisResolver:  s.costbasisResolver,
-		})
+	var result meta.TriggerPatchResult[usagebased.Charge]
+	charge, err := s.withLockedCharge(ctx, input.ChargeID, func(ctx context.Context, charge usagebased.Charge) (*usagebased.Charge, error) {
+		stateMachine, err := s.newStateMachineForChargeWithHints(ctx, charge, input)
 		if err != nil {
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
@@ -49,13 +36,28 @@ func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceCha
 			return nil, nil
 		}
 
-		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
+		invoicePatches, err := stateMachine.AdvanceUntilInvoicePatchesOrStable(ctx)
+		if err != nil {
 			return nil, err
 		}
+		canAdvance, err = stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, fmt.Errorf("check next transition: %w", err)
+		}
 
-		updatedCharge := stateMachine.GetCharge()
-		return &updatedCharge, nil
+		charge = stateMachine.GetCharge()
+		result.InvoicePatches = invoicePatches
+		result.CanAdvance = canAdvance
+
+		return &charge, nil
 	})
+	if err != nil {
+		return meta.TriggerPatchResult[usagebased.Charge]{}, err
+	}
+
+	result.Charge = charge
+
+	return result, nil
 }
 
 func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[usagebased.Charge], error) {
@@ -99,9 +101,14 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 		if err != nil {
 			return nil, err
 		}
+		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, fmt.Errorf("check next transition: %w", err)
+		}
 
 		charge = stateMachine.GetCharge()
 		result.InvoicePatches = invoicePatches
+		result.CanAdvance = canAdvance
 
 		return &charge, nil
 	})
@@ -195,7 +202,11 @@ func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, erro
 }
 
 func (s *service) newStateMachineForCharge(ctx context.Context, charge usagebased.Charge) (StateMachine, error) {
-	stateMachineConfig, err := s.getStateMachineConfigForCharge(ctx, charge)
+	return s.newStateMachineForChargeWithHints(ctx, charge, usagebased.AdvanceChargeInput{})
+}
+
+func (s *service) newStateMachineForChargeWithHints(ctx context.Context, charge usagebased.Charge, hints usagebased.AdvanceChargeInput) (StateMachine, error) {
+	stateMachineConfig, err := s.getStateMachineConfigForChargeWithHints(ctx, charge, hints)
 	if err != nil {
 		return nil, fmt.Errorf("get state machine config: %w", err)
 	}
@@ -208,30 +219,43 @@ func (s *service) newStateMachineForCharge(ctx context.Context, charge usagebase
 	return stateMachine, nil
 }
 
-// getStateMachineConfigForCharge gets the state machine config for a charge.
-//
-// TODO[later]: This is something we can get from the callsite as we are doing a lot of unnecessary fetching here.
+// getStateMachineConfigForCharge resolves omitted state-machine dependencies
+// from their owning services.
 func (s *service) getStateMachineConfigForCharge(ctx context.Context, charge usagebased.Charge) (StateMachineConfig, error) {
-	customerOverride, err := s.customerOverrideService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
-		Customer: customer.CustomerID{
-			Namespace: charge.Namespace,
-			ID:        charge.Intent.GetCustomerID(),
-		},
-		Expand: billing.CustomerOverrideExpand{
-			Customer: true,
-		},
-	})
-	if err != nil {
-		return StateMachineConfig{}, fmt.Errorf("get customer override: %w", err)
+	return s.getStateMachineConfigForChargeWithHints(ctx, charge, usagebased.AdvanceChargeInput{})
+}
+
+// getStateMachineConfigForChargeWithHints resolves omitted state-machine dependencies
+// while treating supplied advancement hints as authoritative snapshots.
+func (s *service) getStateMachineConfigForChargeWithHints(ctx context.Context, charge usagebased.Charge, hints usagebased.AdvanceChargeInput) (StateMachineConfig, error) {
+	customerOverride, hasCustomerOverrideHint := hints.CustomerOverride.Get()
+	if !hasCustomerOverrideHint {
+		var err error
+		customerOverride, err = s.customerOverrideService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+			Customer: customer.CustomerID{
+				Namespace: charge.Namespace,
+				ID:        charge.Intent.GetCustomerID(),
+			},
+			Expand: billing.CustomerOverrideExpand{
+				Customer: true,
+			},
+		})
+		if err != nil {
+			return StateMachineConfig{}, fmt.Errorf("get customer override: %w", err)
+		}
 	}
 
-	featureRef := charge.GetFeatureKeyOrID()
-	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, feature.FeatureMeterRef{
-		IDOrKey:      featureRef,
-		RequireMeter: true,
-	})
-	if err != nil {
-		return StateMachineConfig{}, fmt.Errorf("resolve feature meters: %w", err)
+	featureMeters, hasFeatureMetersHint := hints.FeatureMeters.Get()
+	if !hasFeatureMetersHint {
+		featureRef := charge.GetFeatureKeyOrID()
+		var err error
+		featureMeters, err = s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, feature.FeatureMeterRef{
+			IDOrKey:      featureRef,
+			RequireMeter: true,
+		})
+		if err != nil {
+			return StateMachineConfig{}, fmt.Errorf("resolve feature meters: %w", err)
+		}
 	}
 
 	featureMeter, err := charge.ResolveFeatureMeter(featureMeters)

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -41,7 +41,20 @@ func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceCha
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		return stateMachine.AdvanceUntilStateStable(ctx)
+		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, err
+		}
+		if !canAdvance {
+			return nil, nil
+		}
+
+		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
+			return nil, err
+		}
+
+		updatedCharge := stateMachine.GetCharge()
+		return &updatedCharge, nil
 	})
 }
 

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -30,7 +30,7 @@ func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceCha
 
 		canAdvance, err := stateMachine.CanFire(ctx, meta.TriggerNext)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("charge state trigger failed with: %w", err)
 		}
 		if !canAdvance {
 			return nil, nil

--- a/openmeter/billing/charges/usagebased/service/triggers_test.go
+++ b/openmeter/billing/charges/usagebased/service/triggers_test.go
@@ -4,14 +4,75 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestGetStateMachineConfigUsesAuthoritativeFeatureMeters(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 7, 8, 8, 45, 3, 0, time.UTC),
+		To:   time.Date(2026, 8, 8, 8, 45, 3, 0, time.UTC),
+	}
+	charge := usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+			Intent:          newUsageBasedIntentForCreditThenInvoiceTest(t, servicePeriod),
+			Status:          usagebased.StatusCreated,
+		},
+	}
+
+	t.Run("when the supplied collection contains the charge feature", func(t *testing.T) {
+		// given:
+		// - Advancement receives an authoritative feature-meter collection containing the charge feature.
+		// when:
+		// - The state-machine configuration resolves the charge feature.
+		// then:
+		// - It uses the supplied snapshot without consulting the feature service.
+		featureMeter := feature.FeatureMeter{
+			Feature: feature.Feature{
+				ID:  "feature-id",
+				Key: "feature-key",
+			},
+			Meter: &meter.Meter{},
+		}
+		featureMeters := feature.FeatureMeterCollection{
+			ByKey: map[string]feature.FeatureMeter{
+				featureMeter.Feature.Key: featureMeter,
+			},
+		}
+
+		config, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
+			CustomerOverride: mo.Some(billing.CustomerOverrideWithDetails{}),
+			FeatureMeters:    mo.Some[feature.FeatureMeters](featureMeters),
+		})
+		require.NoError(t, err)
+		require.Equal(t, featureMeter, config.FeatureMeter)
+	})
+
+	t.Run("when the supplied collection omits the charge feature", func(t *testing.T) {
+		// given:
+		// - Advancement receives an authoritative feature-meter collection without the charge feature.
+		// when:
+		// - The state-machine configuration resolves the charge feature.
+		// then:
+		// - It returns the snapshot lookup error instead of falling back to the feature service.
+		_, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
+			CustomerOverride: mo.Some(billing.CustomerOverrideWithDetails{}),
+			FeatureMeters: mo.Some[feature.FeatureMeters](feature.FeatureMeterCollection{
+				ByKey: map[string]feature.FeatureMeter{},
+			}),
+		})
+		require.ErrorContains(t, err, "feature[feature-key] not found")
+	})
+}
 
 func TestApplyBaseIntentPatchForOverriddenChargeShrinksDeletedEffectiveCharge(t *testing.T) {
 	baseServicePeriod := timeutil.ClosedPeriod{

--- a/openmeter/billing/charges/usagebased/service_test.go
+++ b/openmeter/billing/charges/usagebased/service_test.go
@@ -3,10 +3,40 @@ package usagebased
 import (
 	"testing"
 
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
+
+func TestAdvanceChargeInputValidateFeatureMeterHint(t *testing.T) {
+	chargeID := meta.ChargeID{Namespace: "namespace", ID: "charge-id"}
+
+	t.Run("when feature meters are omitted", func(t *testing.T) {
+		// given:
+		// - Advancement does not supply a feature-meter hint.
+		// when:
+		// - The input is validated.
+		// then:
+		// - Validation allows the service to resolve the feature meter itself.
+		require.NoError(t, (AdvanceChargeInput{ChargeID: chargeID}).Validate())
+	})
+
+	t.Run("when an explicit nil feature-meter hint is supplied", func(t *testing.T) {
+		// given:
+		// - Advancement explicitly supplies a nil authoritative feature-meter hint.
+		// when:
+		// - The input is validated.
+		// then:
+		// - Validation rejects the unusable authoritative snapshot.
+		err := (AdvanceChargeInput{
+			ChargeID:      chargeID,
+			FeatureMeters: mo.Some[feature.FeatureMeters](nil),
+		}).Validate()
+		require.ErrorContains(t, err, "feature meters cannot be nil when provided")
+	})
+}
 
 func TestValidateExpands(t *testing.T) {
 	t.Parallel()

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
@@ -971,8 +972,8 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 		s.Equal(usagebased.RealizationRunTypeFinalRealization, finalRun.Type)
 		s.Equal(cancelAt, finalRun.StoredAtLT)
 		s.Equal(cancelAt, finalRun.ServicePeriodTo)
-		s.Equal(alpacadecimal.NewFromInt(8), finalRun.MeteredQuantity)
-		s.Equal(alpacadecimal.NewFromInt(8), finalRun.CreditsAllocated.Sum())
+		require.Equal(s.T(), float64(8), finalRun.MeteredQuantity.InexactFloat64())
+		require.Equal(s.T(), float64(8), finalRun.CreditsAllocated.Sum().InexactFloat64())
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
 			ChargeID: chargesmeta.ChargeID{

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -790,8 +790,8 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 	//
 	// Then:
 	// - the current usage based charge is shrunk in place to the cancellation boundary
-	// - the remaining charge stays created and scheduled from the service-period start
-	// - no realization is created before the next advancement
+	// - synchronization advances the remaining charge through its final realization
+	// - usage before the cancellation boundary is allocated and collection is scheduled
 	// - the future usage based charge is deleted
 	ctx := s.testContext()
 	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -963,10 +963,16 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 
 		afterShrinkCharge, err := afterShrinkChargeRes.AsUsageBasedCharge()
 		s.NoError(err)
-		s.Equal(usagebased.StatusCreated, afterShrinkCharge.Status)
+		s.Equal(usagebased.StatusActiveRealizationWaitingForCollection, afterShrinkCharge.Status)
 		s.Require().NotNil(afterShrinkCharge.State.AdvanceAfter)
-		s.True(afterShrinkCharge.State.AdvanceAfter.Equal(s.mustParseTime("2024-02-01T00:00:00Z")))
-		s.Empty(afterShrinkCharge.Realizations)
+		s.True(afterShrinkCharge.State.AdvanceAfter.Equal(cancelAt.Add(usagebased.InternalCollectionPeriod)))
+		s.Require().Len(afterShrinkCharge.Realizations, 1)
+		finalRun := afterShrinkCharge.Realizations[0]
+		s.Equal(usagebased.RealizationRunTypeFinalRealization, finalRun.Type)
+		s.Equal(cancelAt, finalRun.StoredAtLT)
+		s.Equal(cancelAt, finalRun.ServicePeriodTo)
+		s.Equal(alpacadecimal.NewFromInt(8), finalRun.MeteredQuantity)
+		s.Equal(alpacadecimal.NewFromInt(8), finalRun.CreditsAllocated.Sum())
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
 			ChargeID: chargesmeta.ChargeID{

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -1155,7 +1155,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 				PeriodMax: 0,
 			},
 			Type:   chargesmeta.ChargeTypeFlatFee,
-			Status: string(flatfee.StatusCreated),
+			Status: string(flatfee.StatusActive),
 			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
@@ -1519,7 +1519,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncBillableAmountPro
 				PeriodMax: 0,
 			},
 			Type:   chargesmeta.ChargeTypeFlatFee,
-			Status: string(flatfee.StatusCreated),
+			Status: string(flatfee.StatusActive),
 			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
@@ -5285,7 +5285,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedStandardInvoiceManualCreateSy
 		}, chargesmeta.Expands{chargesmeta.ExpandRealizations, chargesmeta.ExpandDetailedLines})
 
 		s.Equal(*createdLine.ChargeID, manualCharge.ID)
-		s.Equal(usagebased.StatusActiveRealizationStarted, manualCharge.Status)
+		s.Equal(usagebased.StatusActiveRealizationWaitingForCollection, manualCharge.Status)
 		s.Equal(billing.ManuallyManagedLine, manualCharge.Intent.GetBaseIntent().ManagedBy)
 		s.False(manualCharge.Intent.HasOverrideLayer(), "manual charge override layer")
 		s.Nil(manualCharge.Intent.GetSubscription())
@@ -6231,7 +6231,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 				PeriodMax: 0,
 			},
 			Type:   chargesmeta.ChargeTypeUsageBased,
-			Status: string(usagebased.StatusCreated),
+			Status: string(usagebased.StatusActive),
 			Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			}),

--- a/openmeter/billing/worker/subscriptionsync/service/sync_regression_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_regression_test.go
@@ -128,6 +128,11 @@ func (s *CreditThenInvoiceTestSuite) TestCancellationReconcilesPeriodsByServiceD
 					},
 				})
 
+				if tc.chargeType == chargesmeta.ChargeTypeUsageBased {
+					s.Require().NotNil(s.APIRequestsTotalFeature.MeterSlug)
+					s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, start)
+				}
+
 				s.Require().NoError(s.Service.SyncByView(ctx, subsView, start.Add(time.Minute)))
 				chargePage, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 					Namespace:       subsView.Subscription.Namespace,

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -402,11 +402,11 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 		ChargeID: charge.GetChargeID(),
 	})
 	require.NoError(t, err)
-	require.NotNil(t, advancedCharge)
-	require.Equal(t, flatfee.StatusActive, advancedCharge.Status)
-	require.NotNil(t, advancedCharge.State.AdvanceAfter)
-	require.True(t, servicePeriod.From.Equal(*advancedCharge.State.AdvanceAfter))
-	require.Nil(t, advancedCharge.Realizations.CurrentRun)
+	require.NotNil(t, advancedCharge.Charge)
+	require.Equal(t, flatfee.StatusActive, advancedCharge.Charge.Status)
+	require.NotNil(t, advancedCharge.Charge.State.AdvanceAfter)
+	require.True(t, servicePeriod.From.Equal(*advancedCharge.Charge.State.AdvanceAfter))
+	require.Nil(t, advancedCharge.Charge.Realizations.CurrentRun)
 
 	// then:
 	// - after advancement, the active charge still impacts live balance
@@ -417,12 +417,12 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 		ChargeID: charge.GetChargeID(),
 	})
 	require.NoError(t, err)
-	require.NotNil(t, advancedCharge)
-	require.Equal(t, flatfee.StatusFinal, advancedCharge.Status)
-	require.Nil(t, advancedCharge.State.AdvanceAfter)
-	require.NotNil(t, advancedCharge.Realizations.CurrentRun)
-	require.Len(t, advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
-	require.Equal(t, float64(30), advancedCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+	require.NotNil(t, advancedCharge.Charge)
+	require.Equal(t, flatfee.StatusFinal, advancedCharge.Charge.Status)
+	require.Nil(t, advancedCharge.Charge.State.AdvanceAfter)
+	require.NotNil(t, advancedCharge.Charge.Realizations.CurrentRun)
+	require.Len(t, advancedCharge.Charge.Realizations.CurrentRun.CreditRealizations, 1)
+	require.Equal(t, float64(30), advancedCharge.Charge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 
 	// then:
 	// - once booked_at is current, the ledger allocation carries the balance

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -590,9 +590,9 @@ func (e *testEnv) advanceFlatFeeCharge(t *testing.T, charge flatfee.Charge) flat
 		ChargeID: charge.GetChargeID(),
 	})
 	require.NoError(t, err)
-	require.NotNil(t, advancedCharge)
+	require.NotNil(t, advancedCharge.Charge)
 
-	return *advancedCharge
+	return *advancedCharge.Charge
 }
 
 func (e *testEnv) createPendingInvoiceCreditGrant(t *testing.T, amount alpacadecimal.Decimal, currency currencyx.Code, features ...string) creditpurchase.Charge {

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -2142,7 +2142,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 		// when:
 		// - the service period is extended back to the full non-zero period
 		// then:
-		// - the charge returns to created with a pending gathering line and a due advance timestamp
+		// - the gathering line is restored and the charge continues to active
 		patch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
 			ChangeSource:           billing.ChangeSourceSystem,
 			NewServicePeriodTo:     servicePeriod.To,
@@ -2158,7 +2158,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 			},
 		}))
 
-		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActive)
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(1), charge.State.AmountAfterProration, "extended amount should become non-zero")
 		s.Require().NotNil(charge.State.AdvanceAfter)
 		s.True(servicePeriod.To.Equal(*charge.State.AdvanceAfter))
@@ -2173,19 +2173,19 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	s.Run("when charges advance after the non-zero extension", func() {
+	s.Run("when scheduled advancement runs after the completed extension", func() {
 		// given:
-		// - the non-zero charge is created again and invoice_at has passed
+		// - patch application has already advanced the restored charge to active
 		// when:
-		// - charge advancement runs
+		// - scheduled charge advancement runs at invoice_at
 		// then:
-		// - the charge becomes active and waits for normal invoice-line lifecycle callbacks
+		// - no further lifecycle transition is available until an invoice-line callback
 		clock.FreezeTime(servicePeriod.To)
 		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: cust.GetID(),
 		})
 		s.NoError(err)
-		s.Len(advancedCharges, 1)
+		s.Empty(advancedCharges)
 
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActive)
 		s.Require().NotNil(charge.State.AdvanceAfter)


### PR DESCRIPTION
## Summary

- replace direct charge state-machine firing and invoice-patch draining with explicit invoice-aware and non-invoice advancement APIs
- migrate credit-purchase, flat-fee, and usage-based callers to the new contract
- preserve the historical `AdvanceCharge` no-op behavior when no continuation is available
- remove the redundant credit-purchase fire-and-advance wrapper and document the effects-handling contract

## Why

Charge state-machine callers could previously fire transitions independently from handling their invoice effects. That allowed callers to forget pending invoice patches or to advance through a different execution path.

The new interface makes the choice explicit: invoice-aware calls return the first complete patch batch, while non-invoice calls fail if a transition produces invoice patches. Callers can no longer inspect or drain the internal patch buffer directly.

The coordinator applies each returned invoice patch batch before resuming the charge. This allows lifecycle states to chain correctly when completing an operation requires multiple invoice patch rounds.

## Behavioral impact

Patch and line-engine workflows now continue synchronously until they either produce invoice patches or reach a stable lifecycle state. `AdvanceCharge` retains its previous `nil` result when the charge cannot fire `next`.

## Validation

- `go test ./openmeter/billing/charges/... -count=1`
- focused credit-purchase, flat-fee, usage-based, and generic state-machine tests
- `nix develop --impure .#ci -c make test-nocache` — 6,919 tests passed, 9 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer charge advancement results, including updated charges, invoice patches, and whether further advancement is available.
  * Invoice effects are now applied in batches before related charges continue through their lifecycle.
  * Usage-based charge advancement supports optional customer and feature-meter resolution hints.

* **Bug Fixes**
  * Prevented invoice effects from being discarded during charge advancement.
  * Improved handling of finalized zero-value charges and mid-period cancellations, including more accurate lifecycle statuses and realizations.
  * Added safeguards against unbounded invoice-effect processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes charge advancement explicitly stop at invoice-effect boundaries so callers must apply each patch batch before resuming lifecycle processing.

- Replaces direct state-machine firing and patch draining with invoice-aware and no-invoice advancement APIs.
- Updates flat-fee, usage-based, and credit-purchase callers to the new contract.
- Adds coordinated multi-round invoice-effect processing with progress validation and a bounded loop.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/statemachine/machine.go | Introduces explicit invoice-aware and no-invoice advancement operations while preserving stable-state no-op behavior. |
| openmeter/billing/charges/service/patch.go | Coordinates applying invoice-effect batches and resuming affected charges with progress and round-limit safeguards. |
| openmeter/billing/charges/service/advance.go | Migrates customer-scoped advancement to collect invoice effects and continue charges after those effects are applied. |
| openmeter/billing/charges/usagebased/service/triggers.go | Adopts the advancement result contract and supports optional pre-resolved customer and feature-meter context. |
| openmeter/billing/charges/flatfee/service/triggers.go | Returns explicit charge, invoice-patch, and continuation state from advancement and patch triggers. |
| openmeter/billing/charges/creditpurchase/service/invoice.go | Migrates invoice lifecycle handling to fire and advance synchronously through the stable non-invoice path. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Charge coordinator
  participant S as Charge state machine
  participant I as Invoice updater
  C->>S: Advance until patch boundary or stable
  alt Invoice patches emitted
    S-->>C: Patch batch and CanAdvance
    C->>I: Apply patch batch
    I-->>C: Updated invoice
    C->>S: Resume charge advancement
  else Stable lifecycle state
    S-->>C: No patches and cannot advance
  end
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Update openmeter/billing/charges/usageba..."](https://github.com/openmeterio/openmeter/commit/1c25295d5afb4158940ecef258a00e1795c6d28e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51459129)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->