### PR TITLE
feat(charges): add backend customer charge deletion

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -76,6 +76,24 @@ Effective deletion and base-intent deletion are therefore different query
 concepts. Subscription reconciliation must be able to find a base intent even
 when an active override hides it.
 
+### Customer charge deletion payment adjustment
+
+The customer charge API facade requires a payment adjustment when deleting a
+flat-fee or usage-based charge. The facade owns this customer-facing choice and
+maps it to the more detailed internal deletion policies used by charge state
+machines.
+
+`none` requests no compensating adjustment for economic effects already
+realized by the charge. It maps to ignoring both credit and invoice refunds:
+credit-only realizations are not corrected, and payment authorization,
+settlement, payment intents, and external collection state are not refunded or
+otherwise adjusted.
+
+Payment adjustment is separate from invoice lifecycle reconciliation. Deleting
+a charge still removes its gathering or mutable invoice lines. Immutable
+invoice and payment history is preserved; unsupported drift is recorded as an
+invoice validation issue.
+
 ## Lifecycle and persistence invariants
 
 - Each concrete state machine is the authority for reachable detailed states.

--- a/openmeter/billing/charges/api.go
+++ b/openmeter/billing/charges/api.go
@@ -15,10 +15,10 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-// CustomerChargeAPIService resolves API-facing references before constructing
-// complete charge intents for the core charge creation flow.
+// CustomerChargeAPIService is the API-facing facade for customer-scoped charge operations.
 type CustomerChargeAPIService interface {
 	CreateCustomerCharge(ctx context.Context, input CreateCustomerChargeInput) (Charge, error)
+	DeleteCustomerCharge(ctx context.Context, input DeleteCustomerChargeInput) error
 }
 
 type CreditPurchaseFacadeService interface {
@@ -65,6 +65,54 @@ func (i CreateCustomerChargeInput) Validate() error {
 
 	if (i.FlatFee == nil) == (i.UsageBased == nil) {
 		errs = append(errs, errors.New("exactly one charge type is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type DeleteCustomerChargeInput struct {
+	Namespace  string
+	CustomerID string
+	ChargeID   string
+
+	// PaymentAdjustment is required so callers explicitly select how deletion
+	// compensates already-realized economic effects.
+	PaymentAdjustment PaymentAdjustment
+}
+
+type PaymentAdjustment string
+
+const (
+	// PaymentAdjustmentNone requests no compensating payment adjustment. Charge
+	// deletion still performs its normal invoice lifecycle reconciliation.
+	PaymentAdjustmentNone PaymentAdjustment = "none"
+)
+
+func (a PaymentAdjustment) Validate() error {
+	if a != PaymentAdjustmentNone {
+		return models.NewGenericValidationError(fmt.Errorf("invalid payment adjustment: %s", a))
+	}
+
+	return nil
+}
+
+func (i DeleteCustomerChargeInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, errors.New("namespace is required"))
+	}
+
+	if i.CustomerID == "" {
+		errs = append(errs, errors.New("customer ID is required"))
+	}
+
+	if i.ChargeID == "" {
+		errs = append(errs, errors.New("charge ID is required"))
+	}
+
+	if err := i.PaymentAdjustment.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("payment adjustment: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/api_test.go
+++ b/openmeter/billing/charges/api_test.go
@@ -1,0 +1,78 @@
+package charges
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCustomerChargeInputValidate(t *testing.T) {
+	validInput := DeleteCustomerChargeInput{
+		Namespace:         "namespace",
+		CustomerID:        "customer-id",
+		ChargeID:          "charge-id",
+		PaymentAdjustment: PaymentAdjustmentNone,
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*DeleteCustomerChargeInput)
+		wantErr bool
+	}{
+		{
+			name: "valid",
+		},
+		{
+			name: "missing namespace",
+			mutate: func(input *DeleteCustomerChargeInput) {
+				input.Namespace = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing customer ID",
+			mutate: func(input *DeleteCustomerChargeInput) {
+				input.CustomerID = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing charge ID",
+			mutate: func(input *DeleteCustomerChargeInput) {
+				input.ChargeID = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing payment adjustment",
+			mutate: func(input *DeleteCustomerChargeInput) {
+				input.PaymentAdjustment = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid payment adjustment",
+			mutate: func(input *DeleteCustomerChargeInput) {
+				input.PaymentAdjustment = PaymentAdjustment("invalid")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput
+			if test.mutate != nil {
+				test.mutate(&input)
+			}
+
+			err := input.Validate()
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -68,4 +69,49 @@ func (s *service) CreateCustomerCharge(ctx context.Context, input charges.Create
 	}
 
 	return created[0], nil
+}
+
+func (s *service) DeleteCustomerCharge(ctx context.Context, input charges.DeleteCustomerChargeInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if err := s.validateNamespaceLockdown(input.Namespace); err != nil {
+		return err
+	}
+
+	policy, err := resolveDeletePolicy(input.PaymentAdjustment)
+	if err != nil {
+		return err
+	}
+
+	patch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		Policy:       policy,
+	})
+	if err != nil {
+		return fmt.Errorf("creating charge delete patch: %w", err)
+	}
+
+	return s.ApplyPatches(ctx, charges.ApplyPatchesInput{
+		CustomerID: customer.CustomerID{
+			Namespace: input.Namespace,
+			ID:        input.CustomerID,
+		},
+		PatchesByChargeID: map[string]charges.Patch{
+			input.ChargeID: patch,
+		},
+	})
+}
+
+func resolveDeletePolicy(adjustment charges.PaymentAdjustment) (meta.PatchDeletePolicy, error) {
+	switch adjustment {
+	case charges.PaymentAdjustmentNone:
+		return meta.PatchDeletePolicy{
+			CreditRefundPolicy:  meta.CreditRefundPolicyIgnore,
+			InvoiceRefundPolicy: meta.InvoiceRefundPolicyIgnore,
+		}, nil
+	default:
+		return meta.PatchDeletePolicy{}, fmt.Errorf("unsupported payment adjustment: %s", adjustment)
+	}
 }

--- a/openmeter/billing/charges/service/api_test.go
+++ b/openmeter/billing/charges/service/api_test.go
@@ -1,0 +1,687 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+func TestResolveDeletePolicy(t *testing.T) {
+	t.Run("none ignores credit and invoice refunds", func(t *testing.T) {
+		policy, err := resolveDeletePolicy(charges.PaymentAdjustmentNone)
+
+		require.NoError(t, err)
+		require.Equal(t, meta.CreditRefundPolicyIgnore, policy.CreditRefundPolicy)
+		require.Equal(t, meta.InvoiceRefundPolicyIgnore, policy.InvoiceRefundPolicy)
+	})
+
+	t.Run("unsupported adjustment is rejected", func(t *testing.T) {
+		_, err := resolveDeletePolicy(charges.PaymentAdjustment("unsupported"))
+
+		require.ErrorContains(t, err, "unsupported payment adjustment")
+	})
+}
+
+func TestCustomerChargeAPIDelete(t *testing.T) {
+	suite.Run(t, new(CustomerChargeAPIDeleteTestSuite))
+}
+
+type CustomerChargeAPIDeleteTestSuite struct {
+	BaseSuite
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TearDownTest() {
+	s.BaseSuite.TearDownTest()
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteCreatesOverrideForSupportedChargeTypes() {
+	// given
+	// - Future flat-fee and usage-based charges have subscription-owned base intents without API overrides.
+	// when:
+	// - The customer-facing facade deletes both charges with PaymentAdjustmentNone.
+	// then:
+	// - Each effective charge is deleted through an override while its base intent remains undeleted.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeIDs []meta.ChargeID
+
+	s.Run("given subscription-managed flat-fee and usage-based charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-delete")
+		customerID = customer.ID
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditOnlySettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-delete-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditOnlySettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-delete-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			chargeID, err := charge.GetChargeID()
+			require.NoError(s.T(), err)
+			chargeIDs = append(chargeIDs, chargeID)
+		}
+	})
+
+	s.Run("when deleting both charges without a payment adjustment", func() {
+		for _, chargeID := range chargeIDs {
+			require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+				Namespace:         namespace,
+				CustomerID:        customerID,
+				ChargeID:          chargeID.ID,
+				PaymentAdjustment: charges.PaymentAdjustmentNone,
+			}))
+		}
+	})
+
+	s.Run("then the effective intents are deleted overrides", func() {
+		for _, chargeID := range chargeIDs {
+			deletedCharge, err := s.Charges.GetByID(ctx, charges.GetByIDInput{ChargeID: chargeID})
+			require.NoError(s.T(), err)
+
+			switch deletedCharge.Type() {
+			case meta.ChargeTypeFlatFee:
+				charge, err := deletedCharge.AsFlatFeeCharge()
+				require.NoError(s.T(), err)
+				require.Equal(s.T(), flatfee.StatusDeleted, charge.Status)
+				require.Nil(s.T(), charge.Intent.GetBaseIntent().IntentDeletedAt)
+				require.NotNil(s.T(), charge.Intent.GetOverrideLayerMutableFields())
+				require.NotNil(s.T(), charge.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
+			case meta.ChargeTypeUsageBased:
+				charge, err := deletedCharge.AsUsageBasedCharge()
+				require.NoError(s.T(), err)
+				require.Equal(s.T(), usagebased.StatusDeleted, charge.Status)
+				require.Nil(s.T(), charge.Intent.GetBaseIntent().IntentDeletedAt)
+				require.NotNil(s.T(), charge.Intent.GetOverrideLayerMutableFields())
+				require.NotNil(s.T(), charge.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
+			default:
+				s.T().Fatalf("unexpected deleted charge type: %s", deletedCharge.Type())
+			}
+		}
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteEnforcesCustomerOwnership() {
+	// given
+	// - A future subscription-managed flat-fee charge and another customer exist in the same namespace.
+	// when:
+	// - The non-owner customer requests deletion through the facade.
+	// then:
+	// - The request is rejected and the owner's charge remains unchanged without an override.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	var namespace string
+	var ownerID string
+	var otherCustomerID string
+	var chargeID meta.ChargeID
+
+	s.Run("given a charge owned by another customer", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-owner")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		owner := s.CreateTestCustomer(namespace, "owner")
+		ownerID = owner.ID
+		otherCustomerID = s.CreateTestCustomer(namespace, "other").ID
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       owner.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-delete-owner-flat-fee",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+	})
+
+	s.Run("when another customer deletes the charge", func() {
+		err := s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+			Namespace:         namespace,
+			CustomerID:        otherCustomerID,
+			ChargeID:          chargeID.ID,
+			PaymentAdjustment: charges.PaymentAdjustmentNone,
+		})
+
+		require.ErrorContains(s.T(), err, "is not owned by customer")
+	})
+
+	s.Run("then the owner charge remains unchanged", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		flatFee, err := charge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), ownerID, flatFee.Intent.GetCustomerID())
+		require.Equal(s.T(), flatfee.StatusCreated, flatFee.Status)
+		require.Nil(s.T(), flatFee.Intent.GetOverrideLayerMutableFields())
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteRejectsCreditPurchase() {
+	// given
+	// - A realized promotional credit purchase exists for the customer.
+	// when:
+	// - The customer requests its deletion through the charge facade.
+	// then:
+	// - The unsupported charge type is rejected and its lifecycle and realization remain unchanged.
+	ctx := s.T().Context()
+	clock.FreezeTime(datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime())
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var status creditpurchase.Status
+
+	s.Run("given a realized credit-purchase charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-credit-purchase")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "credit-purchase")
+		customerID = customer.ID
+		s.CreditPurchaseTestHandler.onPromotionalCreditPurchase = func(_ context.Context, _ creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+			return ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()}, nil
+		}
+
+		created := s.grantPromotionalCredits(ctx, customer.GetID(), 10)
+		chargeID = lo.Must(created[0].GetChargeID())
+		charge, err := created[0].AsCreditPurchaseCharge()
+		require.NoError(s.T(), err)
+		status = charge.Status
+	})
+
+	s.Run("when deleting it through the customer charge facade", func() {
+		err := s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+			Namespace:         namespace,
+			CustomerID:        customerID,
+			ChargeID:          chargeID.ID,
+			PaymentAdjustment: charges.PaymentAdjustmentNone,
+		})
+
+		require.ErrorContains(s.T(), err, "unsupported charge type")
+	})
+
+	s.Run("then the credit purchase remains unchanged", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		creditPurchase, err := charge.AsCreditPurchaseCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), status, creditPurchase.Status)
+		require.NotNil(s.T(), creditPurchase.Realizations.CreditGrantRealization)
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteWithNoPaymentAdjustmentPreservesFlatFeeCreditRealization() {
+	// given
+	// - A subscription-managed credit-only flat fee has an allocation and no correction callback.
+	// when:
+	// - The customer deletes it without compensating realized credits.
+	// then:
+	// - Deletion succeeds and the existing allocation remains uncorrected on the charge.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var realizationID string
+
+	s.Run("given a realized credit-only flat-fee charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-flat-fee-credit")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "flat-fee-credit")
+		customerID = customer.ID
+
+		s.FlatFeeTestHandler.onAllocateCredits = func(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			return creditrealization.CreateAllocationInputs{{
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
+				Amount:        input.PreTaxAmountToAllocate,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+			}}, nil
+		}
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       customer.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-delete-flat-fee-credit",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+
+		charge, err := created[0].AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), charge.Realizations.CurrentRun)
+		require.Len(s.T(), charge.Realizations.CurrentRun.CreditRealizations, 1)
+		realizationID = charge.Realizations.CurrentRun.CreditRealizations[0].ID
+	})
+
+	s.Run("when deleting with no payment adjustment", func() {
+		require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+			Namespace:         namespace,
+			CustomerID:        customerID,
+			ChargeID:          chargeID.ID,
+			PaymentAdjustment: charges.PaymentAdjustmentNone,
+		}))
+	})
+
+	s.Run("then the allocation remains uncorrected", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		flatFee, err := charge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatfee.StatusDeleted, flatFee.Status)
+		require.NotNil(s.T(), flatFee.Realizations.CurrentRun)
+		require.Len(s.T(), flatFee.Realizations.CurrentRun.CreditRealizations, 1)
+		require.Equal(s.T(), realizationID, flatFee.Realizations.CurrentRun.CreditRealizations[0].ID)
+		require.Equal(s.T(), creditrealization.TypeAllocation, flatFee.Realizations.CurrentRun.CreditRealizations[0].Type)
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteWithNoPaymentAdjustmentPreservesUsageBasedCreditRealization() {
+	// given
+	// - A subscription-managed credit-only usage charge has an allocation and no correction callback.
+	// when:
+	// - The customer deletes it without compensating realized credits.
+	// then:
+	// - Deletion succeeds and the existing allocation remains uncorrected on the charge realization.
+	ctx := s.T().Context()
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2026-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var realizationID string
+
+	s.Run("given a realized credit-only usage-based charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-usage-credit")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "usage-credit")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		customInvoicing := s.SetupCustomInvoicing(namespace)
+		_ = s.ProvisionBillingProfile(
+			ctx,
+			namespace,
+			customInvoicing.App.GetID(),
+			billingtest.WithProgressiveBilling(),
+			billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+			billingtest.WithManualApproval(),
+		)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          customer.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.CreditOnlySettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				featureKey:        feature.Feature.Key,
+				name:              "usage-based",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-delete-usage-credit",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+
+		clock.FreezeTime(servicePeriod.From)
+		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: customer.GetID()})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), advanced, 1)
+
+		s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(_ context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+			return creditrealization.CreateAllocationInputs{{
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
+				Amount:        input.AmountToAllocate,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+			}}, nil
+		}
+		s.MockStreamingConnector.AddSimpleEvent(
+			feature.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(s.T(), "2027-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		clock.FreezeTime(servicePeriod.To.Add(12 * time.Hour))
+		advanced, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: customer.GetID()})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), advanced, 1)
+
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Len(s.T(), usageBased.Realizations, 1)
+		require.Len(s.T(), usageBased.Realizations[0].CreditsAllocated, 1)
+		realizationID = usageBased.Realizations[0].CreditsAllocated[0].ID
+	})
+
+	s.Run("when deleting with no payment adjustment", func() {
+		require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+			Namespace:         namespace,
+			CustomerID:        customerID,
+			ChargeID:          chargeID.ID,
+			PaymentAdjustment: charges.PaymentAdjustmentNone,
+		}))
+	})
+
+	s.Run("then the allocation remains uncorrected", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usagebased.StatusDeleted, usageBased.Status)
+		require.Len(s.T(), usageBased.Realizations, 1)
+		require.Len(s.T(), usageBased.Realizations[0].CreditsAllocated, 1)
+		require.Equal(s.T(), realizationID, usageBased.Realizations[0].CreditsAllocated[0].ID)
+		require.Equal(s.T(), creditrealization.TypeAllocation, usageBased.Realizations[0].CreditsAllocated[0].Type)
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteWithNoPaymentAdjustmentRemovesGatheringLines() {
+	// given
+	// - Active invoice-backed flat-fee and usage-based charges have mutable gathering lines.
+	// when:
+	// - The customer deletes both charges without compensating economic effects.
+	// then:
+	// - Normal invoice lifecycle cleanup removes both gathering lines despite PaymentAdjustmentNone.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeIDs []meta.ChargeID
+
+	s.Run("given active invoice-backed flat-fee and usage-based charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-gathering")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "gathering")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), billingtest.WithManualApproval())
+		s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			return nil, nil
+		}
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-delete-gathering-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditThenInvoiceSettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-delete-gathering-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			chargeID := lo.Must(charge.GetChargeID())
+			chargeIDs = append(chargeIDs, chargeID)
+			require.Len(s.T(), activeGatheringLinesForCharge(&s.BaseSuite, namespace, customerID, chargeID.ID), 1)
+		}
+	})
+
+	s.Run("when deleting both charges with no payment adjustment", func() {
+		for _, chargeID := range chargeIDs {
+			require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+				Namespace:         namespace,
+				CustomerID:        customerID,
+				ChargeID:          chargeID.ID,
+				PaymentAdjustment: charges.PaymentAdjustmentNone,
+			}))
+		}
+	})
+
+	s.Run("then normal invoice lifecycle cleanup removes both gathering lines", func() {
+		for _, chargeID := range chargeIDs {
+			require.Empty(s.T(), activeGatheringLinesForCharge(&s.BaseSuite, namespace, customerID, chargeID.ID))
+		}
+	})
+}
+
+func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteWithNoPaymentAdjustmentPreservesPaidInvoice() {
+	// given
+	// - A subscription-managed flat fee has immutable paid invoice and payment history.
+	// when:
+	// - The customer deletes it without compensating the settled payment.
+	// then:
+	// - The override deletes the charge, preserves paid history, and records unsupported immutable drift.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var invoiceID billing.InvoiceID
+	var lineID billing.LineID
+	var paymentAuthorizedTransactionID string
+	var paymentSettledTransactionID string
+
+	s.Run("given a paid invoice for a subscription-managed flat-fee charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-delete-paid")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "paid")
+		customerID = customer.ID
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), billingtest.WithManualApproval())
+
+		s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			return nil, nil
+		}
+		s.FlatFeeTestHandler.onInvoiceUsageAccrued = newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]().Handler(s.T())
+		authorizedCallback := newCountedLedgerTransactionCallback[flatfee.OnPaymentAuthorizedInput]()
+		paymentAuthorizedTransactionID = authorizedCallback.id
+		s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T())
+		settledCallback := newCountedLedgerTransactionCallback[flatfee.OnPaymentSettledInput]()
+		paymentSettledTransactionID = settledCallback.id
+		s.FlatFeeTestHandler.onPaymentSettled = settledCallback.Handler(s.T())
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       customer.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-delete-paid-flat-fee",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: customer.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), invoices, 1)
+		require.Len(s.T(), invoices[0].Lines.OrEmpty(), 1)
+
+		invoice, err := s.BillingService.ApproveInvoice(ctx, invoices[0].GetInvoiceID())
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), billing.StandardInvoiceStatusPaid, invoice.Status)
+		require.Len(s.T(), invoice.Lines.OrEmpty(), 1)
+		invoiceID = invoice.GetInvoiceID()
+		lineID = invoice.Lines.OrEmpty()[0].GetLineID()
+	})
+
+	s.Run("when deleting with no payment adjustment", func() {
+		require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+			Namespace:         namespace,
+			CustomerID:        customerID,
+			ChargeID:          chargeID.ID,
+			PaymentAdjustment: charges.PaymentAdjustmentNone,
+		}))
+	})
+
+	s.Run("then paid billing history is retained", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		flatFee, err := charge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatfee.StatusDeleted, flatFee.Status)
+		require.Nil(s.T(), flatFee.Intent.GetBaseIntent().IntentDeletedAt)
+		require.NotNil(s.T(), flatFee.Intent.GetOverrideLayerMutableFields())
+		require.NotNil(s.T(), flatFee.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
+		require.Nil(s.T(), flatFee.Realizations.CurrentRun)
+		require.Len(s.T(), flatFee.Realizations.PriorRuns, 1)
+
+		payment := flatFee.Realizations.PriorRuns[0].Payment
+		require.NotNil(s.T(), payment)
+		require.NotNil(s.T(), payment.Authorized)
+		require.Equal(s.T(), paymentAuthorizedTransactionID, payment.Authorized.TransactionGroupID)
+		require.NotNil(s.T(), payment.Settled)
+		require.Equal(s.T(), paymentSettledTransactionID, payment.Settled.TransactionGroupID)
+
+		invoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoiceID,
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), billing.StandardInvoiceStatusPaid, invoice.Status)
+		require.Nil(s.T(), invoice.DeletedAt)
+		require.Len(s.T(), invoice.Lines.OrEmpty(), 1)
+		require.Equal(s.T(), lineID, invoice.Lines.OrEmpty()[0].GetLineID())
+		require.Nil(s.T(), invoice.Lines.OrEmpty()[0].DeletedAt)
+		require.Len(s.T(), invoice.ValidationIssues, 1)
+		require.Equal(s.T(), billing.ImmutableInvoiceHandlingNotSupportedErrorCode, invoice.ValidationIssues[0].Code)
+		require.Equal(s.T(), billing.ComponentName("charges.invoiceupdater"), invoice.ValidationIssues[0].Component)
+	})
+}

--- a/openmeter/billing/charges/service/api_test.go
+++ b/openmeter/billing/charges/service/api_test.go
@@ -50,14 +50,6 @@ type CustomerChargeAPIDeleteTestSuite struct {
 	BaseSuite
 }
 
-func (s *CustomerChargeAPIDeleteTestSuite) SetupSuite() {
-	s.BaseSuite.SetupSuite()
-}
-
-func (s *CustomerChargeAPIDeleteTestSuite) TearDownTest() {
-	s.BaseSuite.TearDownTest()
-}
-
 func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteCreatesOverrideForSupportedChargeTypes() {
 	// given
 	// - Future flat-fee and usage-based charges have subscription-owned base intents without API overrides.

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -886,6 +886,10 @@ func (n NoopChargeService) CreateCustomerCharge(_ context.Context, _ billingchar
 	return billingcharges.Charge{}, nil
 }
 
+func (n NoopChargeService) DeleteCustomerCharge(_ context.Context, _ billingcharges.DeleteCustomerChargeInput) error {
+	return nil
+}
+
 func (n NoopChargeService) GetCurrentTotals(_ context.Context, _ usagebased.GetCurrentTotalsInput) (usagebased.GetCurrentTotalsResult, error) {
 	return usagebased.GetCurrentTotalsResult{}, nil
 }


### PR DESCRIPTION
## Summary

- add the backend customer charge deletion facade
- require the facade-owned payment adjustment selection
- map `none` to ignoring both credit and invoice refunds
- support flat-fee and usage-based charges; reject credit purchases

## Stack

- base: #4886

## Verification

- focused existing charge and server suites pass
- no new behavioral test cases are included in this split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for deleting customer charges.
- Added a “no payment adjustment” option for charge deletion.
- Charge deletion preserves immutable invoice and payment history while removing eligible invoice lines.
- Unsupported discrepancies are recorded as invoice validation issues.

## Bug Fixes
- Added validation for required deletion details and payment adjustment values.
- Prevented deletion of charges belonging to another customer or credit purchases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a backend customer-scoped facade for deleting flat-fee and usage-based charges while rejecting credit purchases and preserving immutable billing history.
- Requires callers to explicitly select a payment adjustment policy.
- Maps `none` to ignoring credit and invoice refunds while retaining normal invoice lifecycle reconciliation.
- Adds service-level coverage for ownership checks, supported charge types, credit realizations, mutable invoice-line cleanup, and paid invoice preservation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/api.go | Adds the customer charge deletion contract, validated input, and explicit payment-adjustment enum. |
| openmeter/billing/charges/service/api.go | Implements customer-scoped deletion by mapping the facade policy into an internal delete patch and applying it through the existing charge workflow. |
| openmeter/billing/charges/service/api_test.go | Exercises supported charge types, ownership enforcement, credit-purchase rejection, realization preservation, and mutable versus immutable invoice behavior. |
| openmeter/billing/charges/README.md | Documents the semantics of deleting charges without compensating prior credit or payment effects. |
| openmeter/server/server_test.go | Updates the test no-op charge service to satisfy the expanded facade interface. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Facade as CustomerChargeAPIService
  participant Patches as ApplyPatches
  participant Charge as Charge state machine
  participant Invoice as Invoice updater
  Caller->>Facade: DeleteCustomerCharge(customer, charge, none)
  Facade->>Facade: Validate input and namespace
  Facade->>Patches: "PatchDelete(refunds = ignore)"
  Patches->>Charge: Validate ownership and apply deletion
  Charge->>Invoice: Reconcile associated invoice lines
  Invoice-->>Charge: Delete mutable lines or record immutable drift
  Charge-->>Caller: Deletion result
```
</details>

<sub>Reviews (5): Last reviewed commit: ["test(charges): remove redundant suite ho..."](https://github.com/openmeterio/openmeter/commit/ee110b8503d4866333b3fe339598008fb8fcac3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464199)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->