### PR TITLE
feat(charges): add backend customer charge override set

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -76,6 +76,19 @@ Effective deletion and base-intent deletion are therefore different query
 concepts. Subscription reconciliation must be able to find a base intent even
 when an active override hides it.
 
+### Customer charge override updates
+
+Setting a customer charge override replaces the complete mutable override
+snapshot while preserving the immutable base intent. Repeated sets update the
+same layer; overrides never stack. Deletion state is not part of this operation
+and remains owned by customer charge deletion.
+
+Flat-fee override updates reuse normal rerating and invoice reconciliation.
+Credit-only usage-based updates void and rebuild mutable realization history.
+Invoice-backed usage-based updates are supported before realization starts;
+after that point they are rejected until historical usage rerating and invoice
+correction semantics are defined.
+
 ### Customer charge deletion payment adjustment
 
 The customer charge API facade requires a payment adjustment when deleting a

--- a/openmeter/billing/charges/api.go
+++ b/openmeter/billing/charges/api.go
@@ -19,6 +19,7 @@ import (
 type CustomerChargeAPIService interface {
 	CreateCustomerCharge(ctx context.Context, input CreateCustomerChargeInput) (Charge, error)
 	DeleteCustomerCharge(ctx context.Context, input DeleteCustomerChargeInput) error
+	SetCustomerChargeOverride(ctx context.Context, input SetCustomerChargeOverrideInput) (Charge, error)
 }
 
 type CreditPurchaseFacadeService interface {
@@ -113,6 +114,59 @@ func (i DeleteCustomerChargeInput) Validate() error {
 
 	if err := i.PaymentAdjustment.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("payment adjustment: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// SetCustomerChargeOverrideInput replaces the complete mutable override layer
+// of a flat-fee or usage-based charge. The immutable base intent is preserved.
+type SetCustomerChargeOverrideInput struct {
+	Namespace  string
+	CustomerID string
+	ChargeID   string
+
+	FlatFee    *flatfee.IntentMutableFields
+	UsageBased *usagebased.IntentMutableFields
+}
+
+func (i SetCustomerChargeOverrideInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, errors.New("namespace is required"))
+	}
+
+	if i.CustomerID == "" {
+		errs = append(errs, errors.New("customer ID is required"))
+	}
+
+	if i.ChargeID == "" {
+		errs = append(errs, errors.New("charge ID is required"))
+	}
+
+	if (i.FlatFee == nil) == (i.UsageBased == nil) {
+		errs = append(errs, errors.New("exactly one charge type is required"))
+	}
+
+	if i.FlatFee != nil {
+		if i.FlatFee.IntentDeletedAt != nil {
+			errs = append(errs, errors.New("flat fee intent deleted at cannot be set by an override update"))
+		}
+
+		if err := i.FlatFee.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("flat fee intent mutable fields: %w", err))
+		}
+	}
+
+	if i.UsageBased != nil {
+		if i.UsageBased.IntentDeletedAt != nil {
+			errs = append(errs, errors.New("usage based intent deleted at cannot be set by an override update"))
+		}
+
+		if err := i.UsageBased.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("usage based intent mutable fields: %w", err))
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/api_test.go
+++ b/openmeter/billing/charges/api_test.go
@@ -2,8 +2,16 @@ package charges
 
 import (
 	"testing"
+	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestDeleteCustomerChargeInputValidate(t *testing.T) {
@@ -62,6 +70,125 @@ func TestDeleteCustomerChargeInputValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			input := validInput
+			if test.mutate != nil {
+				test.mutate(&input)
+			}
+
+			err := input.Validate()
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSetCustomerChargeOverrideInputValidate(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	validInput := SetCustomerChargeOverrideInput{
+		Namespace:  "namespace",
+		CustomerID: "customer-id",
+		ChargeID:   "charge-id",
+		FlatFee: &flatfee.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              "override",
+				ServicePeriod:     period,
+				FullServicePeriod: period,
+				BillingPeriod:     period,
+			},
+			InvoiceAt:             period.From,
+			PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+			AmountBeforeProration: alpacadecimal.NewFromInt(10),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*SetCustomerChargeOverrideInput)
+		wantErr bool
+	}{
+		{
+			name: "valid flat fee override",
+		},
+		{
+			name: "valid usage based override",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.FlatFee = nil
+				input.UsageBased = &usagebased.IntentMutableFields{
+					IntentMutableFields: meta.IntentMutableFields{
+						Name:              "override",
+						ServicePeriod:     period,
+						FullServicePeriod: period,
+						BillingPeriod:     period,
+					},
+					InvoiceAt: period.To,
+					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(10),
+					}),
+				}
+			},
+		},
+		{
+			name: "missing namespace",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.Namespace = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing customer ID",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.CustomerID = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing charge ID",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.ChargeID = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing charge type",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.FlatFee = nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple charge types",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.UsageBased = &usagebased.IntentMutableFields{}
+			},
+			wantErr: true,
+		},
+		{
+			name: "deleted override intent",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.FlatFee.IntentDeletedAt = &period.From
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid mutable fields",
+			mutate: func(input *SetCustomerChargeOverrideInput) {
+				input.FlatFee.Name = ""
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput
+			flatFee := validInput.FlatFee.Clone()
+			input.FlatFee = &flatFee
 			if test.mutate != nil {
 				test.mutate(&input)
 			}

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -613,6 +613,10 @@ func (f IntentMutableFields) Clone() IntentMutableFields {
 	return out
 }
 
+func (f IntentMutableFields) GetIntentDeletedAt() *time.Time {
+	return f.IntentDeletedAt
+}
+
 func (f IntentMutableFields) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/flatfee/patch.go
+++ b/openmeter/billing/charges/flatfee/patch.go
@@ -2,5 +2,7 @@ package flatfee
 
 import "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 
-type PatchSetOverride = meta.PatchSetOverride[IntentMutableFields]
-type NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]
+type (
+	PatchSetOverride         = meta.PatchSetOverride[IntentMutableFields]
+	NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]
+)

--- a/openmeter/billing/charges/flatfee/patch.go
+++ b/openmeter/billing/charges/flatfee/patch.go
@@ -1,0 +1,6 @@
+package flatfee
+
+import "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+
+type PatchSetOverride = meta.PatchSetOverride[IntentMutableFields]
+type NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -87,6 +87,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		Permit(meta.TriggerAttachInvoiceLine, flatfee.StatusActiveRealizationProcessing).
 		OnActive(s.AdvanceAfterInvoiceAt)
 
@@ -100,6 +101,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		OnActive(statelessx.AllOf(
 			s.ResolveDynamicCostBasis,
 			s.AdvanceAfterServicePeriodTo,
@@ -111,6 +113,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		OnEntryFrom(meta.TriggerInvoiceCreated, statelessx.WithParameters(s.StartRealization))
 
 	s.Configure(flatfee.StatusActiveRealizationWaitingForCollection).
@@ -118,7 +121,8 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
-		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit))
+		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride))
 
 	s.Configure(flatfee.StatusActiveRealizationProcessing).
 		Permit(
@@ -131,6 +135,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		OnEntryFrom(meta.TriggerAttachInvoiceLine, statelessx.WithParameters(s.AttachInvoiceLine))
 
 	s.Configure(flatfee.StatusActiveRealizationIssuing).
@@ -139,6 +144,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.AccrueInvoiceUsage))
 
 	// Zero-fiat-amount overages bypass invoice issuance. This state seals the
@@ -150,6 +156,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		OnActive(s.FinalizeZeroFiatAmountOverageRun)
 
 	s.Configure(flatfee.StatusActiveRealizationCompleted).
@@ -157,26 +164,50 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation))
+		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation))
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
-		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit))
+		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride))
 
 	s.Configure(flatfee.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		OnActive(s.ClearAdvanceAfter)
 
 	s.Configure(flatfee.StatusDeleted).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation))
+		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation))
+}
+
+func (s *CreditThenInvoiceStateMachine) SetOverride(ctx context.Context, patch flatfee.PatchSetOverride) error {
+	oldAmountAfterProration := s.Charge.State.AmountAfterProration
+
+	if err := s.setOverrideIntent(ctx, patch); err != nil {
+		return err
+	}
+
+	amountAfterProration, err := s.Charge.Intent.CalculateAmountAfterProration()
+	if err != nil {
+		return fmt.Errorf("calculating amount after proration: %w", err)
+	}
+
+	return s.reconcileInvoicingState(ctx, reconcileInvoicingStateInput{
+		Op:                      meta.PatchTypeSetOverride,
+		Intent:                  s.Charge.Intent,
+		OldAmountAfterProration: oldAmountAfterProration,
+		NewAmountAfterProration: amountAfterProration,
+	})
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -45,6 +45,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
 		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsAfterInvoiceAt)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -54,6 +55,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusActive).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterBookedAt)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -62,6 +64,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 
 	s.Configure(flatfee.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -70,6 +73,9 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 				s.ClearAdvanceAfter,
 			),
 		)
+
+	s.Configure(flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation))
 }
 
 func (s *CreditsOnlyStateMachine) IsAfterBookedAt() bool {
@@ -85,6 +91,24 @@ func (s *CreditsOnlyStateMachine) AdvanceAfterBookedAt(ctx context.Context) erro
 		s.Charge.Intent.GetEffectiveServicePeriod(),
 	)))
 	return nil
+}
+
+func (s *CreditsOnlyStateMachine) SetOverride(ctx context.Context, patch flatfee.PatchSetOverride) error {
+	if err := s.setOverrideIntent(ctx, patch); err != nil {
+		return err
+	}
+
+	ratingResult, err := s.rateEffectiveIntent()
+	if err != nil {
+		return err
+	}
+	s.Charge.State.AmountAfterProration = ratingResult.Intent.AmountAfterProration
+
+	if s.Charge.Realizations.CurrentRun == nil {
+		return nil
+	}
+
+	return s.reconcileCurrentRunCredits(ctx, ratingResult)
 }
 
 func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -141,6 +141,30 @@ func mutateFlatFeeIntentFields(fields *flatfee.IntentMutableFields, editFn func(
 	fields.PercentageDiscounts = fields.PercentageDiscounts.UpsertCorrelationID()
 }
 
+// setOverrideIntent replaces the complete mutable override snapshot while
+// preserving the charge's base intent.
+func (s *stateMachine) setOverrideIntent(ctx context.Context, patch flatfee.PatchSetOverride) error {
+	target, err := patch.GetTargetLayer(s.Charge.Intent)
+	if err != nil {
+		return fmt.Errorf("getting patch target layer: %w", err)
+	}
+
+	fields := patch.GetIntentMutableFields()
+	if err := s.mutateIntentLayer(ctx, target, func(current *flatfee.IntentMutableFields) {
+		*current = fields
+	}); err != nil {
+		return fmt.Errorf("setting flat-fee override intent: %w", err)
+	}
+
+	return nil
+}
+
+func (s *stateMachine) UnsupportedSetOverrideOperation(_ context.Context, _ flatfee.PatchSetOverride) error {
+	return models.NewGenericPreConditionFailedError(
+		fmt.Errorf("cannot set override for flat-fee charge in status %s; retry after billing advances", s.Charge.Status),
+	)
+}
+
 // rejectHiddenIntentTarget prevents lifecycle state machines from processing a
 // hidden source intent. When an override layer exists, the override is the
 // active customer-facing charge: it owns status transitions, realization runs,

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -19,6 +19,7 @@ const (
 	PatchTypeExtend                 PatchType = "extend"
 	PatchTypeShrink                 PatchType = "shrink"
 	PatchTypeDelete                 PatchType = "delete"
+	PatchTypeSetOverride            PatchType = "set_override"
 	PatchTypeLineManualEdit         PatchType = "line_manual_edit"
 	PatchTypeShrinkToRealizedPeriod PatchType = "shrink_to_realized_period"
 )

--- a/openmeter/billing/charges/meta/patchsetoverride.go
+++ b/openmeter/billing/charges/meta/patchsetoverride.go
@@ -1,0 +1,93 @@
+package meta
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/qmuntal/stateless"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// SetOverrideMutableFields captures the behavior needed to validate and
+// snapshot a concrete charge's mutable override intent.
+type SetOverrideMutableFields[T any] interface {
+	models.Validator
+
+	Clone() T
+	GetIntentDeletedAt() *time.Time
+}
+
+// PatchSetOverride replaces the complete mutable override intent for a charge.
+type PatchSetOverride[T SetOverrideMutableFields[T]] struct {
+	changeSource        billing.ChangeSource
+	intentMutableFields T
+}
+
+// NewPatchSetOverrideInput configures a typed override patch.
+type NewPatchSetOverrideInput[T SetOverrideMutableFields[T]] struct {
+	ChangeSource        billing.ChangeSource
+	IntentMutableFields T
+}
+
+func (i NewPatchSetOverrideInput[T]) Validate() error {
+	var errs []error
+
+	if err := i.ChangeSource.Require(billing.ChangeSourceAPIRequest); err != nil {
+		errs = append(errs, fmt.Errorf("change source: %w", err))
+	}
+
+	if i.IntentMutableFields.GetIntentDeletedAt() != nil {
+		errs = append(errs, errors.New("intent deleted at cannot be set by an override update"))
+	}
+
+	if err := i.IntentMutableFields.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("intent mutable fields: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func NewPatchSetOverride[T SetOverrideMutableFields[T]](input NewPatchSetOverrideInput[T]) (PatchSetOverride[T], error) {
+	if err := input.Validate(); err != nil {
+		return PatchSetOverride[T]{}, err
+	}
+
+	return PatchSetOverride[T]{
+		changeSource:        input.ChangeSource,
+		intentMutableFields: input.IntentMutableFields.Clone(),
+	}, nil
+}
+
+func (p PatchSetOverride[T]) GetIntentMutableFields() T {
+	return p.intentMutableFields.Clone()
+}
+
+func (p PatchSetOverride[T]) GetTargetLayer(intent LayeredIntentReader) (ChangeTarget, error) {
+	if err := p.changeSource.Require(billing.ChangeSourceAPIRequest); err != nil {
+		return "", fmt.Errorf("change source: %w", err)
+	}
+
+	if intent == nil {
+		return "", errors.New("intent is required")
+	}
+
+	return ChangeTargetOverride, nil
+}
+
+func (p PatchSetOverride[T]) Op() PatchType {
+	return PatchTypeSetOverride
+}
+
+func (p PatchSetOverride[T]) Trigger() stateless.Trigger {
+	return TriggerSetOverride
+}
+
+func (p PatchSetOverride[T]) Validate() error {
+	return NewPatchSetOverrideInput[T]{
+		ChangeSource:        p.changeSource,
+		IntentMutableFields: p.intentMutableFields,
+	}.Validate()
+}

--- a/openmeter/billing/charges/meta/patchsetoverride_test.go
+++ b/openmeter/billing/charges/meta/patchsetoverride_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -19,7 +20,16 @@ type setOverrideMutableFieldsForTest struct {
 }
 
 func (f setOverrideMutableFieldsForTest) Clone() setOverrideMutableFieldsForTest {
-	return f
+	var deletedAt *time.Time
+	if f.DeletedAt != nil {
+		deletedAt = lo.ToPtr(*f.DeletedAt)
+	}
+
+	return setOverrideMutableFieldsForTest{
+		Name:      f.Name,
+		DeletedAt: deletedAt,
+		Invalid:   f.Invalid,
+	}
 }
 
 func (f setOverrideMutableFieldsForTest) GetIntentDeletedAt() *time.Time {

--- a/openmeter/billing/charges/meta/patchsetoverride_test.go
+++ b/openmeter/billing/charges/meta/patchsetoverride_test.go
@@ -1,0 +1,113 @@
+package meta
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+var _ Patch = PatchSetOverride[setOverrideMutableFieldsForTest]{}
+
+type setOverrideMutableFieldsForTest struct {
+	Name      string
+	DeletedAt *time.Time
+	Invalid   bool
+}
+
+func (f setOverrideMutableFieldsForTest) Clone() setOverrideMutableFieldsForTest {
+	return f
+}
+
+func (f setOverrideMutableFieldsForTest) GetIntentDeletedAt() *time.Time {
+	return f.DeletedAt
+}
+
+func (f setOverrideMutableFieldsForTest) Validate() error {
+	if f.Invalid {
+		return errors.New("invalid mutable fields")
+	}
+
+	return nil
+}
+
+func TestPatchSetOverride(t *testing.T) {
+	fields := setOverrideMutableFieldsForTest{Name: "override"}
+
+	t.Run("snapshots mutable fields", func(t *testing.T) {
+		inputFields := fields.Clone()
+		patch, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: inputFields,
+		})
+		require.NoError(t, err)
+
+		inputFields.Name = "mutated input"
+		returnedFields := patch.GetIntentMutableFields()
+		returnedFields.Name = "mutated getter result"
+
+		require.Equal(t, "override", patch.GetIntentMutableFields().Name)
+	})
+
+	t.Run("always targets the override layer", func(t *testing.T) {
+		patch, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: fields,
+		})
+		require.NoError(t, err)
+
+		target, err := patch.GetTargetLayer(layeredIntentReaderForTest{
+			baseManagedBy: billing.ManuallyManagedLine,
+		})
+		require.NoError(t, err)
+		require.Equal(t, ChangeTargetOverride, target)
+	})
+
+	t.Run("rejects missing intent when selecting target", func(t *testing.T) {
+		patch, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: fields,
+		})
+		require.NoError(t, err)
+
+		_, err = patch.GetTargetLayer(nil)
+		require.ErrorContains(t, err, "intent is required")
+	})
+
+	t.Run("rejects non API source", func(t *testing.T) {
+		_, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceSystem,
+			IntentMutableFields: fields,
+		})
+
+		require.ErrorContains(t, err, "must be api_request")
+	})
+
+	t.Run("rejects deleted override intent", func(t *testing.T) {
+		deletedAt := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+		deletedFields := fields.Clone()
+		deletedFields.DeletedAt = &deletedAt
+
+		_, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: deletedFields,
+		})
+
+		require.ErrorContains(t, err, "intent deleted at")
+	})
+
+	t.Run("rejects invalid mutable fields", func(t *testing.T) {
+		invalidFields := fields.Clone()
+		invalidFields.Invalid = true
+
+		_, err := NewPatchSetOverride(NewPatchSetOverrideInput[setOverrideMutableFieldsForTest]{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: invalidFields,
+		})
+
+		require.ErrorContains(t, err, "invalid mutable fields")
+	})
+}

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -10,6 +10,7 @@ var (
 	TriggerCollectionCompleted    Trigger = "collection_completed"
 	TriggerInvoiceIssued          Trigger = "invoice_issued"
 	TriggerLineManualEdit         Trigger = "line_manual_edit"
+	TriggerSetOverride            Trigger = "set_override"
 	TriggerShrinkToRealizedPeriod Trigger = "shrink_to_realized_period"
 	TriggerAttachInvoiceLine      Trigger = "attach_invoice_line"
 )

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -141,7 +142,7 @@ func (s *service) SetCustomerChargeOverride(ctx context.Context, input charges.S
 	}
 
 	if customerID.ID != input.CustomerID {
-		return charges.Charge{}, fmt.Errorf("charge %s is not owned by customer %s", input.ChargeID, input.CustomerID)
+		return charges.Charge{}, models.NewGenericNotFoundError(errors.New("charge not found"))
 	}
 
 	var patch charges.Patch

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -115,3 +115,72 @@ func resolveDeletePolicy(adjustment charges.PaymentAdjustment) (meta.PatchDelete
 		return meta.PatchDeletePolicy{}, fmt.Errorf("unsupported payment adjustment: %s", adjustment)
 	}
 }
+
+func (s *service) SetCustomerChargeOverride(ctx context.Context, input charges.SetCustomerChargeOverrideInput) (charges.Charge, error) {
+	if err := input.Validate(); err != nil {
+		return charges.Charge{}, err
+	}
+
+	if err := s.validateNamespaceLockdown(input.Namespace); err != nil {
+		return charges.Charge{}, err
+	}
+
+	chargeID := meta.ChargeID{
+		Namespace: input.Namespace,
+		ID:        input.ChargeID,
+	}
+
+	existing, err := s.GetByID(ctx, charges.GetByIDInput{ChargeID: chargeID})
+	if err != nil {
+		return charges.Charge{}, err
+	}
+
+	customerID, err := existing.GetCustomerID()
+	if err != nil {
+		return charges.Charge{}, fmt.Errorf("getting charge customer: %w", err)
+	}
+
+	if customerID.ID != input.CustomerID {
+		return charges.Charge{}, fmt.Errorf("charge %s is not owned by customer %s", input.ChargeID, input.CustomerID)
+	}
+
+	var patch charges.Patch
+	switch existing.Type() {
+	case meta.ChargeTypeFlatFee:
+		if input.FlatFee == nil {
+			return charges.Charge{}, models.NewGenericValidationError(fmt.Errorf("flat fee override fields are required for flat fee charge %s", input.ChargeID))
+		}
+
+		patch, err = meta.NewPatchSetOverride(flatfee.NewPatchSetOverrideInput{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: *input.FlatFee,
+		})
+	case meta.ChargeTypeUsageBased:
+		if input.UsageBased == nil {
+			return charges.Charge{}, models.NewGenericValidationError(fmt.Errorf("usage based override fields are required for usage based charge %s", input.ChargeID))
+		}
+
+		patch, err = meta.NewPatchSetOverride(usagebased.NewPatchSetOverrideInput{
+			ChangeSource:        billing.ChangeSourceAPIRequest,
+			IntentMutableFields: *input.UsageBased,
+		})
+	case meta.ChargeTypeCreditPurchase:
+		return charges.Charge{}, models.NewGenericValidationError(fmt.Errorf("setting overrides for credit purchase charges is not supported"))
+	default:
+		return charges.Charge{}, fmt.Errorf("unsupported charge type: %s", existing.Type())
+	}
+	if err != nil {
+		return charges.Charge{}, fmt.Errorf("creating charge override patch: %w", err)
+	}
+
+	if err := s.ApplyPatches(ctx, charges.ApplyPatchesInput{
+		CustomerID: customerID,
+		PatchesByChargeID: map[string]charges.Patch{
+			input.ChargeID: patch,
+		},
+	}); err != nil {
+		return charges.Charge{}, err
+	}
+
+	return s.GetByID(ctx, charges.GetByIDInput{ChargeID: chargeID})
+}

--- a/openmeter/billing/charges/service/api_test.go
+++ b/openmeter/billing/charges/service/api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
@@ -1136,7 +1137,8 @@ func (s *CustomerChargeAPISetOverrideTestSuite) TestSetValidatesOwnershipPayload
 			ChargeID:   flatFeeChargeID.ID,
 			FlatFee:    &fields,
 		})
-		require.ErrorContains(s.T(), err, "is not owned by customer")
+		require.True(s.T(), models.IsGenericNotFoundError(err))
+		require.ErrorContains(s.T(), err, "charge not found")
 	})
 
 	s.Run("when the payload type does not match the charge", func() {

--- a/openmeter/billing/charges/service/api_test.go
+++ b/openmeter/billing/charges/service/api_test.go
@@ -677,3 +677,961 @@ func (s *CustomerChargeAPIDeleteTestSuite) TestDeleteWithNoPaymentAdjustmentPres
 		require.Equal(s.T(), billing.ComponentName("charges.invoiceupdater"), invoice.ValidationIssues[0].Component)
 	})
 }
+
+func TestCustomerChargeAPISetOverride(t *testing.T) {
+	suite.Run(t, new(CustomerChargeAPISetOverrideTestSuite))
+}
+
+type CustomerChargeAPISetOverrideTestSuite struct {
+	BaseSuite
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TearDownTest() {
+	s.BaseSuite.TearDownTest()
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetCreatesAndReplacesOverrideForSupportedChargeTypes() {
+	// given
+	// - Future subscription-managed flat-fee and usage-based charges expose their base mutable snapshots.
+	// when:
+	// - The customer sets and then replaces a complete override snapshot for each charge.
+	// then:
+	// - The latest override is effective while each immutable subscription-owned base remains unchanged.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var flatFeeChargeID meta.ChargeID
+	var usageBasedChargeID meta.ChargeID
+	var flatFeeBase flatfee.IntentMutableFields
+	var usageBasedBase usagebased.IntentMutableFields
+	var flatFeeOverride flatfee.IntentMutableFields
+	var usageBasedOverride usagebased.IntentMutableFields
+
+	s.Run("given subscription-managed supported charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set")
+		customerID = customer.ID
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditOnlySettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditOnlySettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			switch charge.Type() {
+			case meta.ChargeTypeFlatFee:
+				flatFee, err := charge.AsFlatFeeCharge()
+				require.NoError(s.T(), err)
+				flatFeeChargeID = flatFee.GetChargeID()
+				flatFeeBase = flatFee.Intent.GetBaseIntent().IntentMutableFields.Clone()
+			case meta.ChargeTypeUsageBased:
+				usageBased, err := charge.AsUsageBasedCharge()
+				require.NoError(s.T(), err)
+				usageBasedChargeID = usageBased.GetChargeID()
+				usageBasedBase = usageBased.Intent.GetBaseIntent().IntentMutableFields.Clone()
+			}
+		}
+	})
+
+	s.Run("when setting complete override snapshots", func() {
+		flatFeeOverride = flatFeeBase.Clone()
+		flatFeeOverride.Name = "flat-fee-override"
+		flatFeeOverride.AmountBeforeProration = alpacadecimal.NewFromInt(20)
+		flatFeeOverride.InvoiceAt = servicePeriod.From.Add(24 * time.Hour)
+
+		returned, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &flatFeeOverride,
+		})
+		require.NoError(s.T(), err)
+		returnedFlatFee, err := returned.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatFeeOverride, returnedFlatFee.Intent.GetEffectiveIntent().IntentMutableFields)
+
+		usageBasedOverride = usageBasedBase.Clone()
+		usageBasedOverride.Name = "usage-based-override"
+		usageBasedOverride.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(2)})
+		usageBasedOverride.InvoiceAt = servicePeriod.To.Add(24 * time.Hour)
+
+		returned, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   usageBasedChargeID.ID,
+			UsageBased: &usageBasedOverride,
+		})
+		require.NoError(s.T(), err)
+		returnedUsageBased, err := returned.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usageBasedOverride, returnedUsageBased.Intent.GetEffectiveIntent().IntentMutableFields)
+	})
+
+	s.Run("when replacing the existing override snapshots", func() {
+		flatFeeOverride.Name = "flat-fee-override-replaced"
+		flatFeeOverride.AmountBeforeProration = alpacadecimal.NewFromInt(30)
+		_, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &flatFeeOverride,
+		})
+		require.NoError(s.T(), err)
+
+		usageBasedOverride.Name = "usage-based-override-replaced"
+		usageBasedOverride.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(3)})
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   usageBasedChargeID.ID,
+			UsageBased: &usageBasedOverride,
+		})
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("then only the latest overrides are effective", func() {
+		flatFeeCharge := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeCharge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatFeeBase, flatFee.Intent.GetBaseIntent().IntentMutableFields)
+		require.Equal(s.T(), flatFeeOverride, *flatFee.Intent.GetOverrideLayerMutableFields())
+		require.Equal(s.T(), flatFeeOverride, flatFee.Intent.GetEffectiveIntent().IntentMutableFields)
+
+		usageBasedCharge := s.mustGetChargeByID(usageBasedChargeID)
+		usageBased, err := usageBasedCharge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usageBasedBase, usageBased.Intent.GetBaseIntent().IntentMutableFields)
+		require.Equal(s.T(), usageBasedOverride, *usageBased.Intent.GetOverrideLayerMutableFields())
+		require.Equal(s.T(), usageBasedOverride, usageBased.Intent.GetEffectiveIntent().IntentMutableFields)
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetDeleteOrdering() {
+	// given
+	// - Subscription-managed flat-fee and usage-based charges have customer overrides.
+	// when:
+	// - The customer deletes the charges and then attempts to set another override.
+	// then:
+	// - Delete marks the existing override as deleted, and Set cannot implicitly restore it.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var flatFeeChargeID meta.ChargeID
+	var usageBasedChargeID meta.ChargeID
+	var flatFeeBase flatfee.IntentMutableFields
+	var usageBasedBase usagebased.IntentMutableFields
+	var flatFeeOverride flatfee.IntentMutableFields
+	var usageBasedOverride usagebased.IntentMutableFields
+	var flatFeeDeletedAt time.Time
+	var usageBasedDeletedAt time.Time
+
+	s.Run("given representative supported charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-delete-ordering")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-delete-ordering")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), billingtest.WithManualApproval())
+		s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			return nil, nil
+		}
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-delete-ordering-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditOnlySettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-delete-ordering-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			switch charge.Type() {
+			case meta.ChargeTypeFlatFee:
+				flatFee, err := charge.AsFlatFeeCharge()
+				require.NoError(s.T(), err)
+				flatFeeChargeID = flatFee.GetChargeID()
+				flatFeeBase = flatFee.Intent.GetBaseIntent().IntentMutableFields.Clone()
+			case meta.ChargeTypeUsageBased:
+				usageBased, err := charge.AsUsageBasedCharge()
+				require.NoError(s.T(), err)
+				usageBasedChargeID = usageBased.GetChargeID()
+				usageBasedBase = usageBased.Intent.GetBaseIntent().IntentMutableFields.Clone()
+			default:
+				s.T().Fatalf("unexpected charge type: %s", charge.Type())
+			}
+		}
+	})
+
+	s.Run("when setting customer overrides", func() {
+		flatFeeOverride = flatFeeBase.Clone()
+		flatFeeOverride.Name = "flat-fee-override"
+		flatFeeOverride.AmountBeforeProration = alpacadecimal.NewFromInt(20)
+		_, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &flatFeeOverride,
+		})
+		require.NoError(s.T(), err)
+
+		usageBasedOverride = usageBasedBase.Clone()
+		usageBasedOverride.Name = "usage-based-override"
+		usageBasedOverride.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(2)})
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   usageBasedChargeID.ID,
+			UsageBased: &usageBasedOverride,
+		})
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("when deleting charges with existing overrides", func() {
+		for _, chargeID := range []meta.ChargeID{flatFeeChargeID, usageBasedChargeID} {
+			require.NoError(s.T(), s.Charges.DeleteCustomerCharge(ctx, charges.DeleteCustomerChargeInput{
+				Namespace:         namespace,
+				CustomerID:        customerID,
+				ChargeID:          chargeID.ID,
+				PaymentAdjustment: charges.PaymentAdjustmentNone,
+			}))
+		}
+	})
+
+	s.Run("then deletion reuses the existing overrides", func() {
+		flatFeeResult := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeResult.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatfee.StatusDeleted, flatFee.Status)
+		require.Equal(s.T(), flatFeeBase, flatFee.Intent.GetBaseIntent().IntentMutableFields)
+		actualFlatFeeOverride := flatFee.Intent.GetOverrideLayerMutableFields().Clone()
+		require.NotNil(s.T(), actualFlatFeeOverride.IntentDeletedAt)
+		flatFeeDeletedAt = *actualFlatFeeOverride.IntentDeletedAt
+		actualFlatFeeOverride.IntentDeletedAt = nil
+		require.Equal(s.T(), flatFeeOverride, actualFlatFeeOverride)
+
+		usageBasedResult := s.mustGetChargeByID(usageBasedChargeID)
+		usageBased, err := usageBasedResult.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usagebased.StatusDeleted, usageBased.Status)
+		require.Equal(s.T(), usageBasedBase, usageBased.Intent.GetBaseIntent().IntentMutableFields)
+		actualUsageBasedOverride := usageBased.Intent.GetOverrideLayerMutableFields().Clone()
+		require.NotNil(s.T(), actualUsageBasedOverride.IntentDeletedAt)
+		usageBasedDeletedAt = *actualUsageBasedOverride.IntentDeletedAt
+		actualUsageBasedOverride.IntentDeletedAt = nil
+		require.Equal(s.T(), usageBasedOverride, actualUsageBasedOverride)
+	})
+
+	s.Run("when setting another override on deleted charges", func() {
+		flatFeeRejectedOverride := flatFeeOverride.Clone()
+		flatFeeRejectedOverride.Name = "flat-fee-should-not-apply"
+		_, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &flatFeeRejectedOverride,
+		})
+		require.ErrorContains(s.T(), err, "cannot set override for flat-fee charge")
+
+		usageBasedRejectedOverride := usageBasedOverride.Clone()
+		usageBasedRejectedOverride.Name = "usage-based-should-not-apply"
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   usageBasedChargeID.ID,
+			UsageBased: &usageBasedRejectedOverride,
+		})
+		require.ErrorContains(s.T(), err, "cannot set override for usage-based charge")
+	})
+
+	s.Run("then the deleted overrides remain unchanged", func() {
+		flatFeeResult := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeResult.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), flatfee.StatusDeleted, flatFee.Status)
+		require.Equal(s.T(), flatFeeBase, flatFee.Intent.GetBaseIntent().IntentMutableFields)
+		actualFlatFeeOverride := flatFee.Intent.GetOverrideLayerMutableFields().Clone()
+		require.NotNil(s.T(), actualFlatFeeOverride.IntentDeletedAt)
+		require.True(s.T(), flatFeeDeletedAt.Equal(*actualFlatFeeOverride.IntentDeletedAt))
+		actualFlatFeeOverride.IntentDeletedAt = nil
+		require.Equal(s.T(), flatFeeOverride, actualFlatFeeOverride)
+
+		usageBasedResult := s.mustGetChargeByID(usageBasedChargeID)
+		usageBased, err := usageBasedResult.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usagebased.StatusDeleted, usageBased.Status)
+		require.Equal(s.T(), usageBasedBase, usageBased.Intent.GetBaseIntent().IntentMutableFields)
+		actualUsageBasedOverride := usageBased.Intent.GetOverrideLayerMutableFields().Clone()
+		require.NotNil(s.T(), actualUsageBasedOverride.IntentDeletedAt)
+		require.True(s.T(), usageBasedDeletedAt.Equal(*actualUsageBasedOverride.IntentDeletedAt))
+		actualUsageBasedOverride.IntentDeletedAt = nil
+		require.Equal(s.T(), usageBasedOverride, actualUsageBasedOverride)
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetValidatesOwnershipPayloadAndChargeType() {
+	// given
+	// - Supported customer charges and an out-of-scope credit purchase exist without overrides.
+	// when:
+	// - A non-owner, mismatched payload, or credit-purchase override request is submitted.
+	// then:
+	// - The facade rejects each request before mutating any charge intent.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var otherCustomerID string
+	var flatFeeChargeID meta.ChargeID
+	var usageBasedFields usagebased.IntentMutableFields
+	var creditPurchaseChargeID meta.ChargeID
+
+	s.Run("given supported and unsupported customer charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-validation")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-validation")
+		customerID = customer.ID
+		otherCustomerID = s.CreateTestCustomer(namespace, "api-set-validation-other").ID
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditOnlySettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-validation-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditOnlySettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-validation-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			switch charge.Type() {
+			case meta.ChargeTypeFlatFee:
+				flatFeeChargeID = lo.Must(charge.GetChargeID())
+			case meta.ChargeTypeUsageBased:
+				usageBased, err := charge.AsUsageBasedCharge()
+				require.NoError(s.T(), err)
+				usageBasedFields = usageBased.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+			}
+		}
+
+		s.CreditPurchaseTestHandler.onPromotionalCreditPurchase = func(_ context.Context, _ creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+			return ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()}, nil
+		}
+		creditPurchaseChargeID = lo.Must(s.grantPromotionalCredits(ctx, customer.GetID(), 10)[0].GetChargeID())
+	})
+
+	s.Run("when a different customer sets an override", func() {
+		flatFeeCharge := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeCharge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		fields := flatFee.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		fields.Name = "should-not-apply"
+
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: otherCustomerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &fields,
+		})
+		require.ErrorContains(s.T(), err, "is not owned by customer")
+	})
+
+	s.Run("when the payload type does not match the charge", func() {
+		_, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			UsageBased: &usageBasedFields,
+		})
+		require.ErrorContains(s.T(), err, "flat fee override fields are required")
+	})
+
+	s.Run("when setting an override on a credit purchase", func() {
+		flatFeeCharge := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeCharge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		fields := flatFee.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   creditPurchaseChargeID.ID,
+			FlatFee:    &fields,
+		})
+		require.ErrorContains(s.T(), err, "credit purchase charges is not supported")
+	})
+
+	s.Run("then no rejected request created an override", func() {
+		flatFeeCharge := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeCharge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Nil(s.T(), flatFee.Intent.GetOverrideLayerMutableFields())
+
+		creditPurchaseCharge := s.mustGetChargeByID(creditPurchaseChargeID)
+		creditPurchase, err := creditPurchaseCharge.AsCreditPurchaseCharge()
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), creditPurchase.Realizations.CreditGrantRealization)
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetReconcilesRealizedFlatFeeCredits() {
+	// given
+	// - A subscription-managed credit-only flat fee has allocated its original amount.
+	// when:
+	// - The customer sets an override with a larger amount.
+	// then:
+	// - The base remains unchanged and the current run receives only the additional allocation.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var allocationAmounts []float64
+
+	s.Run("given a realized credit-only flat-fee charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-flat-fee-credit")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-flat-fee-credit")
+		customerID = customer.ID
+
+		s.FlatFeeTestHandler.onAllocateCredits = func(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			allocationAmounts = append(allocationAmounts, input.PreTaxAmountToAllocate.InexactFloat64())
+			return creditrealization.CreateAllocationInputs{{
+				ServicePeriod: input.ServicePeriod,
+				Amount:        input.PreTaxAmountToAllocate,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+			}}, nil
+		}
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       customer.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-base",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-set-flat-fee-credit",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+		require.Equal(s.T(), []float64{10}, allocationAmounts)
+	})
+
+	s.Run("when increasing the effective amount through an override", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		flatFee, err := charge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		fields := flatFee.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		fields.Name = "flat-fee-override"
+		fields.AmountBeforeProration = alpacadecimal.NewFromInt(20)
+
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   chargeID.ID,
+			FlatFee:    &fields,
+		})
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("then only the additional credits are allocated", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		flatFee, err := charge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), float64(10), flatFee.Intent.GetBaseIntent().AmountBeforeProration.InexactFloat64())
+		require.Equal(s.T(), float64(20), flatFee.Intent.GetEffectiveIntent().AmountBeforeProration.InexactFloat64())
+		require.Equal(s.T(), float64(20), flatFee.State.AmountAfterProration.InexactFloat64())
+		require.Equal(s.T(), []float64{10, 10}, allocationAmounts)
+		require.NotNil(s.T(), flatFee.Realizations.CurrentRun)
+		require.Len(s.T(), flatFee.Realizations.CurrentRun.CreditRealizations, 2)
+		require.Equal(s.T(), float64(20), flatFee.Realizations.CurrentRun.CreditRealizations.Sum().InexactFloat64())
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetUpdatesInvoiceBackedGatheringLines() {
+	// given
+	// - Active invoice-backed flat-fee and usage-based charges have mutable gathering lines.
+	// when:
+	// - The customer changes each charge's complete mutable snapshot before realization.
+	// then:
+	// - Billing keeps one gathering line per charge and updates it from the effective override.
+	ctx := s.T().Context()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var flatFeeChargeID meta.ChargeID
+	var usageBasedChargeID meta.ChargeID
+
+	s.Run("given active invoice-backed supported charges", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-gathering")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-gathering")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), billingtest.WithManualApproval())
+		s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+			return nil, nil
+		}
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       customer.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(10),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					name:              "flat-fee-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-gathering-flat-fee",
+				}),
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:          customer.GetID(),
+					currency:          USD,
+					servicePeriod:     servicePeriod,
+					settlementMode:    productcatalog.CreditThenInvoiceSettlementMode,
+					price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+					featureKey:        feature.Feature.Key,
+					name:              "usage-based-base",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "api-set-gathering-usage-based",
+				}),
+			},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 2)
+
+		for _, charge := range created {
+			chargeID := lo.Must(charge.GetChargeID())
+			require.Len(s.T(), activeGatheringLinesForCharge(&s.BaseSuite, namespace, customerID, chargeID.ID), 1)
+			switch charge.Type() {
+			case meta.ChargeTypeFlatFee:
+				flatFeeChargeID = chargeID
+			case meta.ChargeTypeUsageBased:
+				usageBasedChargeID = chargeID
+			}
+		}
+	})
+
+	s.Run("when setting invoice-backed overrides", func() {
+		flatFeeCharge := s.mustGetChargeByID(flatFeeChargeID)
+		flatFee, err := flatFeeCharge.AsFlatFeeCharge()
+		require.NoError(s.T(), err)
+		flatFeeFields := flatFee.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		flatFeeFields.Name = "flat-fee-override"
+		flatFeeFields.AmountBeforeProration = alpacadecimal.NewFromInt(20)
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   flatFeeChargeID.ID,
+			FlatFee:    &flatFeeFields,
+		})
+		require.NoError(s.T(), err)
+
+		usageBasedCharge := s.mustGetChargeByID(usageBasedChargeID)
+		usageBased, err := usageBasedCharge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		usageBasedFields := usageBased.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		usageBasedFields.Name = "usage-based-override"
+		usageBasedFields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(2)})
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   usageBasedChargeID.ID,
+			UsageBased: &usageBasedFields,
+		})
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("then gathering lines reflect the effective overrides", func() {
+		flatFeeLines := activeGatheringLinesForCharge(&s.BaseSuite, namespace, customerID, flatFeeChargeID.ID)
+		require.Len(s.T(), flatFeeLines, 1)
+		require.Equal(s.T(), "flat-fee-override", flatFeeLines[0].Name)
+		flatPrice, err := flatFeeLines[0].Price.AsFlat()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), float64(20), flatPrice.Amount.InexactFloat64())
+
+		usageBasedLines := activeGatheringLinesForCharge(&s.BaseSuite, namespace, customerID, usageBasedChargeID.ID)
+		require.Len(s.T(), usageBasedLines, 1)
+		require.Equal(s.T(), "usage-based-override", usageBasedLines[0].Name)
+		unitPrice, err := usageBasedLines[0].Price.AsUnit()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), float64(2), unitPrice.Amount.InexactFloat64())
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetVoidsUsageBasedCreditRealizationHistory() {
+	// given
+	// - A subscription-managed credit-only usage charge has mutable realization history.
+	// when:
+	// - The customer replaces its effective period and price with an override.
+	// then:
+	// - The old run is voided and the active charge is rescheduled from the override without changing its base.
+	ctx := s.T().Context()
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2026-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var runID usagebased.RealizationRunID
+	var overrideFields usagebased.IntentMutableFields
+	var correctionCalls int
+
+	s.Run("given a realized credit-only usage-based charge", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-usage-credit")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-usage-credit")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		customInvoicing := s.SetupCustomInvoicing(namespace)
+		_ = s.ProvisionBillingProfile(
+			ctx,
+			namespace,
+			customInvoicing.App.GetID(),
+			billingtest.WithProgressiveBilling(),
+			billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+			billingtest.WithManualApproval(),
+		)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          customer.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.CreditOnlySettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				featureKey:        feature.Feature.Key,
+				name:              "usage-based-base",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-set-usage-credit",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+
+		clock.FreezeTime(servicePeriod.From)
+		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: customer.GetID()})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), advanced, 1)
+
+		s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(_ context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+			return creditrealization.CreateAllocationInputs{{
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
+				Amount:        input.AmountToAllocate,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+			}}, nil
+		}
+		s.UsageBasedTestHandler.onCreditsOnlyUsageAccruedCorrection = func(_ context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
+			correctionCalls++
+			return lo.Map(input.Corrections, func(item creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
+				return creditrealization.CreateCorrectionInput{
+					Amount:                item.Amount,
+					CorrectsRealizationID: item.Allocation.ID,
+					LedgerTransaction: ledgertransaction.GroupReference{
+						TransactionGroupID: ulid.Make().String(),
+					},
+				}
+			}), nil
+		}
+		s.MockStreamingConnector.AddSimpleEvent(
+			feature.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(s.T(), "2027-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		clock.FreezeTime(servicePeriod.To.Add(12 * time.Hour))
+		advanced, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: customer.GetID()})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), advanced, 1)
+
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Len(s.T(), usageBased.Realizations, 1)
+		runID = usageBased.Realizations[0].ID
+	})
+
+	s.Run("when setting a new period and price override", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		overrideFields = usageBased.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		overrideFields.Name = "usage-based-override"
+		overrideFields.ServicePeriod.To = servicePeriod.To.AddDate(0, 1, 0)
+		overrideFields.FullServicePeriod.To = overrideFields.ServicePeriod.To
+		overrideFields.BillingPeriod.To = overrideFields.ServicePeriod.To
+		overrideFields.InvoiceAt = overrideFields.ServicePeriod.To
+		overrideFields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(2)})
+
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   chargeID.ID,
+			UsageBased: &overrideFields,
+		})
+		require.NoError(s.T(), err)
+	})
+
+	s.Run("then old realization history is voided", func() {
+		charge, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
+			ChargeID: chargeID,
+			Expands:  meta.Expands{meta.ExpandRealizations, meta.ExpandDeletedRealizations},
+		})
+		require.NoError(s.T(), err)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usagebased.StatusActive, usageBased.Status)
+		require.Nil(s.T(), usageBased.State.CurrentRealizationRunID)
+		require.Equal(s.T(), servicePeriod.To, usageBased.Intent.GetBaseIntent().ServicePeriod.To)
+		require.Equal(s.T(), overrideFields, *usageBased.Intent.GetOverrideLayerMutableFields())
+		require.True(s.T(), overrideFields.ServicePeriod.To.Equal(*usageBased.State.AdvanceAfter))
+		require.Equal(s.T(), 1, correctionCalls)
+
+		run, err := usageBased.Realizations.GetByID(runID.ID)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), run.DeletedAt)
+	})
+}
+
+func (s *CustomerChargeAPISetOverrideTestSuite) TestSetRejectsUsageBasedInvoiceOverrideAfterRealizationStarts() {
+	// given
+	// - A credit-then-invoice usage charge has started an invoice realization without an override.
+	// when:
+	// - The customer attempts to replace its mutable snapshot.
+	// then:
+	// - The operation fails atomically because historical usage rerating is unsupported.
+	ctx := s.T().Context()
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2026-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2027-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2027-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	var namespace string
+	var customerID string
+	var chargeID meta.ChargeID
+	var baseFields usagebased.IntentMutableFields
+
+	s.Run("given an invoice realization has started", func() {
+		namespace = s.GetUniqueNamespace("charges-service-api-set-usage-invoice-realized")
+		s.ProvisionDefaultTaxCodes(ctx, namespace)
+		customer := s.CreateTestCustomer(namespace, "api-set-usage-invoice-realized")
+		customerID = customer.ID
+		feature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+		customInvoicing := s.SetupCustomInvoicing(namespace)
+		_ = s.ProvisionBillingProfile(
+			ctx,
+			namespace,
+			customInvoicing.App.GetID(),
+			billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+			billingtest.WithManualApproval(),
+		)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: namespace,
+			Intents: charges.ChargeIntents{s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          customer.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.CreditThenInvoiceSettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				featureKey:        feature.Feature.Key,
+				name:              "usage-based-base",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "api-set-usage-invoice-realized",
+			})},
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), created, 1)
+		chargeID = lo.Must(created[0].GetChargeID())
+
+		s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(context.Context, usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+			return nil, nil
+		}
+		s.MockStreamingConnector.AddSimpleEvent(
+			feature.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(s.T(), "2027-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		clock.FreezeTime(servicePeriod.To)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: customer.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		require.NoError(s.T(), err)
+		require.Len(s.T(), invoices, 1)
+
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), usageBased.State.CurrentRealizationRunID)
+		require.NotEmpty(s.T(), usageBased.Realizations)
+		baseFields = usageBased.Intent.GetBaseIntent().IntentMutableFields.Clone()
+	})
+
+	s.Run("when setting an override after realization starts", func() {
+		fields := baseFields.Clone()
+		fields.Name = "should-not-apply"
+
+		_, err := s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  namespace,
+			CustomerID: customerID,
+			ChargeID:   chargeID.ID,
+			UsageBased: &fields,
+		})
+		// TODO: enable this once we have corrections and credit notes implemented.
+		require.ErrorContains(s.T(), err, "cannot set override for usage-based charge")
+	})
+
+	s.Run("then the charge remains on its base intent", func() {
+		charge := s.mustGetChargeByID(chargeID)
+		usageBased, err := charge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), baseFields, usageBased.Intent.GetBaseIntent().IntentMutableFields)
+		require.Nil(s.T(), usageBased.Intent.GetOverrideLayerMutableFields())
+		require.NotNil(s.T(), usageBased.State.CurrentRealizationRunID)
+	})
+}

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -667,6 +667,10 @@ func (f IntentMutableFields) Clone() IntentMutableFields {
 	return out
 }
 
+func (f IntentMutableFields) GetIntentDeletedAt() *time.Time {
+	return f.IntentDeletedAt
+}
+
 func (f IntentMutableFields) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/usagebased/patch.go
+++ b/openmeter/billing/charges/usagebased/patch.go
@@ -2,5 +2,7 @@ package usagebased
 
 import "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 
-type PatchSetOverride = meta.PatchSetOverride[IntentMutableFields]
-type NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]
+type (
+	PatchSetOverride         = meta.PatchSetOverride[IntentMutableFields]
+	NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]
+)

--- a/openmeter/billing/charges/usagebased/patch.go
+++ b/openmeter/billing/charges/usagebased/patch.go
@@ -1,0 +1,6 @@
+package usagebased
+
+import "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+
+type PatchSetOverride = meta.PatchSetOverride[IntentMutableFields]
+type NewPatchSetOverrideInput = meta.NewPatchSetOverrideInput[IntentMutableFields]

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -271,6 +271,7 @@ func (s *CreditThenInvoiceStateMachine) HasTerminalCompletedRealizationWithoutCu
 
 func (s *CreditThenInvoiceStateMachine) SetOverride(ctx context.Context, patch usagebased.PatchSetOverride) error {
 	if s.Charge.State.CurrentRealizationRunID != nil || len(s.Charge.Realizations.WithoutVoidedBillingHistory()) > 0 {
+		// TODO: enable this once we have corrections and credit notes implemented.
 		return models.NewGenericPreConditionFailedError(
 			fmt.Errorf("cannot set override for usage-based charge %s after realization has started", s.Charge.ID),
 		)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -74,6 +74,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -94,6 +95,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationStarted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -113,6 +115,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationWaitingForCollection,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -124,6 +127,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationProcessing,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -140,6 +144,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationIssuing,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -151,6 +156,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationCompleted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		// Extend is rejected while invoice-issued callbacks own this state.
 		// Subscription sync can retry after billing advances the charge.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
@@ -167,6 +173,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			s.resolveStateAfterRealizationCompleted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
@@ -178,6 +185,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			s.resolveStateAfterRealizationCompleted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		// Extend is rejected because this branch still has its own next
 		// transition to payment settlement. Subscription sync can retry.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
@@ -193,17 +201,20 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 	s.Configure(usagebased.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllRealizationRunsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
 
 	s.Configure(usagebased.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
 
 	s.Configure(usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.UnsupportedShrinkToRealizedPeriodOperation))
 }
@@ -256,6 +267,49 @@ func (s *CreditThenInvoiceStateMachine) HasTerminalCompletedRealizationWithoutCu
 		From: s.Charge.Intent.GetEffectiveServicePeriod().From,
 		To:   latestRun.ServicePeriodTo,
 	})
+}
+
+func (s *CreditThenInvoiceStateMachine) SetOverride(ctx context.Context, patch usagebased.PatchSetOverride) error {
+	if s.Charge.State.CurrentRealizationRunID != nil || len(s.Charge.Realizations.WithoutVoidedBillingHistory()) > 0 {
+		return models.NewGenericPreConditionFailedError(
+			fmt.Errorf("cannot set override for usage-based charge %s after realization has started", s.Charge.ID),
+		)
+	}
+
+	if err := s.setOverrideIntent(ctx, patch); err != nil {
+		return err
+	}
+
+	if err := s.updateGatheringLineForEffectiveIntent(); err != nil {
+		return err
+	}
+
+	if s.Charge.Status == usagebased.StatusCreated {
+		return s.AdvanceAfterServicePeriodFrom(ctx)
+	}
+
+	return s.AdvanceAfterServicePeriodTo(ctx)
+}
+
+// updateGatheringLineForEffectiveIntent keeps the pre-realization invoice
+// placeholder aligned with the charge's currently effective mutable intent.
+func (s *CreditThenInvoiceStateMachine) updateGatheringLineForEffectiveIntent() error {
+	withLine, err := gatheringLineFromUsageBasedChargeForPeriod(
+		s.Charge,
+		s.Charge.Intent.GetEffectiveServicePeriod(),
+		s.Charge.Intent.GetEffectiveInvoiceAt(),
+	)
+	if err != nil {
+		return fmt.Errorf("creating gathering line for override: %w", err)
+	}
+
+	if withLine.GatheringLineToCreate == nil {
+		return fmt.Errorf("creating gathering line for override: gathering line is required")
+	}
+
+	s.AddInvoicePatch(invoiceupdater.NewUpsertGatheringLineByChargeIDPatch(s.Charge.ID, *withLine.GatheringLineToCreate))
+
+	return nil
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -52,6 +52,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(argAsPeriodPatch[meta.PatchExtend](s.patchCreatedChargePeriod))).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(argAsPeriodPatch[meta.PatchShrink](s.patchCreatedChargePeriod))).
 		OnActive(
@@ -65,6 +66,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsAfterServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -80,6 +82,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationWaitingForCollection,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -93,6 +96,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			s.IsAfterCollectionPeriod,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		// TODO: Transition to a failed state if the collection period end is not set
@@ -104,6 +108,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActiveRealizationCompleted,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		OnActive(
 			s.FinalizeRealizationRun,
 		)
@@ -114,19 +119,40 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusFinal,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(usagebased.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.SetOverride)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.ClearAdvanceAfter)
+
+	s.Configure(usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation))
 }
 
 func (s *CreditsOnlyStateMachine) ClearAdvanceAfter(ctx context.Context) error {
 	s.Charge.State.AdvanceAfter = nil
 	return nil
+}
+
+func (s *CreditsOnlyStateMachine) SetOverride(ctx context.Context, patch usagebased.PatchSetOverride) error {
+	if err := s.setOverrideIntent(ctx, patch); err != nil {
+		return err
+	}
+
+	if s.Charge.Status == usagebased.StatusCreated {
+		return s.AdvanceAfterServicePeriodFrom(ctx)
+	}
+
+	if err := s.voidAllRuns(ctx); err != nil {
+		return err
+	}
+
+	return s.persistActivePeriodPatch(ctx)
 }
 
 func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -192,6 +192,31 @@ func mutateUsageBasedIntentFields(fields *usagebased.IntentMutableFields, editFn
 	return nil
 }
 
+// setOverrideIntent replaces the complete mutable override snapshot while
+// preserving the charge's base intent.
+func (s *stateMachine) setOverrideIntent(ctx context.Context, patch usagebased.PatchSetOverride) error {
+	target, err := patch.GetTargetLayer(s.Charge.Intent)
+	if err != nil {
+		return fmt.Errorf("getting patch target layer: %w", err)
+	}
+
+	fields := patch.GetIntentMutableFields()
+	if err := s.mutateIntentLayer(ctx, target, func(current *usagebased.IntentMutableFields) error {
+		*current = fields
+		return nil
+	}); err != nil {
+		return fmt.Errorf("setting usage-based override intent: %w", err)
+	}
+
+	return nil
+}
+
+func (s *stateMachine) UnsupportedSetOverrideOperation(_ context.Context, _ usagebased.PatchSetOverride) error {
+	return models.NewGenericPreConditionFailedError(
+		fmt.Errorf("cannot set override for usage-based charge in status %s; retry after billing advances", s.Charge.Status),
+	)
+}
+
 // rejectHiddenIntentTarget prevents lifecycle state machines from processing a
 // hidden source intent. When an override layer exists, the override is the
 // active customer-facing charge: it owns status transitions, realization runs,

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -778,6 +778,110 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedCance
 	})
 }
 
+func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedOverrideSurvivesSubscriptionCancellation() {
+	// given
+	// - Subscription sync owns a future credit-only usage charge whose customer has set a complete override.
+	// when:
+	// - The subscription is canceled mid-period and sync shrinks the hidden source intent.
+	// then:
+	// - The source period follows the subscription while the customer-facing override remains unchanged.
+	ctx := s.testContext()
+	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
+	startAt := s.mustParseTime("2024-02-01T00:00:00Z")
+	periodEnd := s.mustParseTime("2024-03-01T00:00:00Z")
+	cancelAt := s.mustParseTime("2024-02-15T00:00:00Z")
+	clock.SetTime(setupAt)
+	defer clock.ResetTime()
+
+	var subscriptionView subscription.SubscriptionView
+	var chargeID chargesmeta.ChargeID
+	var overrideFields usagebased.IntentMutableFields
+
+	s.Run("given a subscription-owned charge with a customer override", func() {
+		unitPrice := productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromFloat(1),
+		})
+		subscriptionView = s.createSubscriptionFromPlanAt(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{Namespace: s.Namespace},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Credits Only Usage Override",
+					Key:            "credits-only-usage-override",
+					Version:        1,
+					Currency:       currencies.NewCurrencyReference(currencyx.Code(currency.USD)),
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Name:       s.APIRequestsTotalFeature.Key,
+								Key:        s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price:      unitPrice,
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+					},
+				}},
+			},
+		}, startAt)
+
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, periodEnd))
+		result, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+			Namespace:       s.Namespace,
+			SubscriptionIDs: []string{subscriptionView.Subscription.ID},
+			ChargeTypes:     []chargesmeta.ChargeType{chargesmeta.ChargeTypeUsageBased},
+		})
+		s.NoError(err)
+		s.Require().Len(result.Items, 1)
+		charge, err := result.Items[0].AsUsageBasedCharge()
+		s.NoError(err)
+		chargeID = charge.GetChargeID()
+		overrideFields = charge.Intent.GetEffectiveIntent().IntentMutableFields.Clone()
+		overrideFields.Name = "customer usage override"
+		overrideFields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromFloat(2),
+		})
+
+		_, err = s.Charges.SetCustomerChargeOverride(ctx, charges.SetCustomerChargeOverrideInput{
+			Namespace:  s.Namespace,
+			CustomerID: s.Customer.ID,
+			ChargeID:   chargeID.ID,
+			UsageBased: &overrideFields,
+		})
+		s.NoError(err)
+	})
+
+	s.Run("when cancellation sync changes the source period", func() {
+		clock.SetTime(cancelAt)
+		model, err := s.SubscriptionService.Cancel(ctx, subscriptionView.Subscription.NamespacedID, subscription.Timing{
+			Enum: lo.ToPtr(subscription.TimingImmediate),
+		})
+		s.NoError(err)
+		canceledView, err := s.SubscriptionService.GetView(ctx, model.NamespacedID)
+		s.NoError(err)
+		s.NoError(s.Service.SyncByView(ctx, canceledView, cancelAt))
+	})
+
+	s.Run("then the override remains effective over the changed base", func() {
+		result, err := s.Charges.GetByID(ctx, charges.GetByIDInput{ChargeID: chargeID})
+		s.NoError(err)
+		charge, err := result.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(cancelAt, charge.Intent.GetBaseIntent().ServicePeriod.To)
+		s.Equal(overrideFields, *charge.Intent.GetOverrideLayerMutableFields())
+		s.Equal(overrideFields, charge.Intent.GetEffectiveIntent().IntentMutableFields)
+	})
+}
+
 func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPeriodCancellation() {
 	// Given:
 	// - a subscription is created with credits_only settlement

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -890,6 +890,10 @@ func (n NoopChargeService) DeleteCustomerCharge(_ context.Context, _ billingchar
 	return nil
 }
 
+func (n NoopChargeService) SetCustomerChargeOverride(_ context.Context, _ billingcharges.SetCustomerChargeOverrideInput) (billingcharges.Charge, error) {
+	return billingcharges.Charge{}, nil
+}
+
 func (n NoopChargeService) GetCurrentTotals(_ context.Context, _ usagebased.GetCurrentTotalsInput) (usagebased.GetCurrentTotalsResult, error) {
 	return usagebased.GetCurrentTotalsResult{}, nil
 }


### PR DESCRIPTION
## Summary

- add the backend customer charge override Set facade
- introduce the typed generic Set override patch
- replace the complete mutable override snapshot while preserving the base intent
- support flat-fee and usage-based settlement state machines
- reject credit purchases and post-realization invoice-backed usage-based updates

## Stack

- depends on #4887
- base refactor: #4886

## Verification

- production charge packages build
- focused existing charge and server suites pass
- no new behavioral test cases are included in this split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for updating customer charge overrides for flat-fee and usage-based charges.
  - Overrides replace complete mutable charge settings while preserving the original base intent.
  - Updates reconcile credits, invoices, and usage realization history where supported.
  - Override changes persist through subscription cancellation and resynchronization.

- **Bug Fixes**
  - Added validation for ownership, charge type, required fields, deleted charges, and unsupported charge states.
  - Prevented invoice-backed usage-based overrides after realization has begun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a customer-facing facade for replacing complete mutable override snapshots on flat-fee and usage-based charges while preserving base intent.
- Adds a typed generic set-override patch and state-machine trigger.
- Reconciles flat-fee credits and invoice projections after override changes.
- Voids and rebuilds mutable credit-only usage realization history.
- Rejects credit-purchase overrides, deleted charges, and invoice-backed usage updates after realization begins.
- Adds service, validation, subscription-sync, and server integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/api.go | Defines and validates the customer override replacement request without exposing deletion through this operation. |
| openmeter/billing/charges/meta/patchsetoverride.go | Adds an API-only typed patch that snapshots mutable fields and always targets the override layer. |
| openmeter/billing/charges/service/api.go | Implements ownership-aware dispatch for supported charge types and rejects credit purchases. |
| openmeter/billing/charges/flatfee/service/creditsonly.go | Rerates flat-fee overrides and reconciles an existing credit realization run. |
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Reuses invoice-state reconciliation after replacing a flat-fee override. |
| openmeter/billing/charges/usagebased/service/creditsonly.go | Corrects and voids mutable usage runs before rescheduling from the replacement override. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Supports pre-realization override updates and rejects updates once invoice-backed realization history exists. |
| openmeter/billing/charges/service/api_test.go | Covers replacement semantics, ownership and type validation, deletion ordering, settlement reconciliation, and subscription synchronization. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Facade as Customer Charge Facade
  participant ChargeSM as Charge State Machine
  participant Store as Charge Persistence
  participant Billing as Invoice/Credit Reconciliation

  Caller->>Facade: SetCustomerChargeOverride
  Facade->>Facade: Validate ownership, payload, and charge type
  Facade->>ChargeSM: Apply typed SetOverride patch
  ChargeSM->>Store: Create or replace override layer
  alt Flat fee
    ChargeSM->>Billing: Rerate and reconcile credits/invoice state
  else Credit-only usage
    ChargeSM->>Billing: Correct and void mutable runs
    ChargeSM->>Store: Reschedule charge from override
  else Invoice-backed usage after realization
    ChargeSM-->>Facade: Reject with precondition failure
  end
  Facade-->>Caller: Return refreshed charge
```
</details>

<sub>Reviews (7): Last reviewed commit: ["style(charges): format override patch al..."](https://github.com/openmeterio/openmeter/commit/f9c12dceb47a46138b10353692b25495ea908c24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464244)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->