### PR TITLE
fix: add charge discount correlation IDs

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -88,6 +88,9 @@ when an active override hides it.
   advancement and patching also take charge-scoped locks.
 - `UpdateCharge` persists the concrete base row. Expanded realizations are read
   model state and are written through dedicated adapter operations.
+- Persisted charge discounts have stable correlation IDs allocated at their
+  write boundary. Rerating, invoice projection, and correction reuse those IDs
+  so discount child references preserve lineage across realization runs.
 - Ledger effects and the realization or payment facts that reference them are
   written under the lifecycle transaction. Retry safety comes from persisted
   lifecycle facts checked before handlers run, not from the

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -46,6 +46,9 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 
 		var discounts *billing.Discounts
 		if intent.PercentageDiscounts != nil {
+			// Note: this is just a defensive mechanism to ensure that if the DB has invalid entities (e.g. ones missing the correlation ID),
+			// we backfill the correlation ID.
+			intent.PercentageDiscounts = intent.PercentageDiscounts.UpsertCorrelationID()
 			discounts = &billing.Discounts{Percentage: intent.PercentageDiscounts}
 		}
 
@@ -420,6 +423,7 @@ func (a *adapter) buildCreateFlatFeeCharge(ns string, intentWithStatus flatfee.I
 
 	var discounts *billing.Discounts
 	if intent.PercentageDiscounts != nil {
+		intent.PercentageDiscounts = intent.PercentageDiscounts.UpsertCorrelationID()
 		discounts = &billing.Discounts{Percentage: intent.PercentageDiscounts}
 	}
 

--- a/openmeter/billing/charges/flatfee/adapter/intentoverride.go
+++ b/openmeter/billing/charges/flatfee/adapter/intentoverride.go
@@ -140,6 +140,7 @@ func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.Charge
 	}
 
 	normalized := override.Normalized(currency)
+	normalized.PercentageDiscounts = normalized.PercentageDiscounts.UpsertCorrelationID()
 	if err := normalized.Validate(); err != nil {
 		return nil, fmt.Errorf("validating intent override: %w", err)
 	}
@@ -177,6 +178,7 @@ func (a *adapter) updateIntentOverride(ctx context.Context, chargeID meta.Charge
 	}
 
 	normalized := override.Normalized(currency)
+	normalized.PercentageDiscounts = normalized.PercentageDiscounts.UpsertCorrelationID()
 	if err := normalized.Validate(); err != nil {
 		return nil, fmt.Errorf("validating intent override: %w", err)
 	}

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -35,6 +35,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		// Let's create all the flat fee charges in bulk
 		intentsWithStatus, err := slicesx.MapWithErr(input.Intents, func(intent flatfee.Intent) (flatfee.IntentWithInitialStatus, error) {
 			chargeIntent := intent.Normalized()
+			chargeIntent.PercentageDiscounts = chargeIntent.PercentageDiscounts.UpsertCorrelationID()
 
 			var resolvedCostBasis *costbasis.State
 			if chargeIntent.CostBasis != nil {

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -97,14 +97,19 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 // mutateIntentLayer mutates the requested intent layer, creating a new override
 // layer first when the target is override and the charge has no override yet.
 func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*flatfee.IntentMutableFields)) error {
+	editWithDiscountCorrelationID := func(fields *flatfee.IntentMutableFields) {
+		editFn(fields)
+		fields.PercentageDiscounts = fields.PercentageDiscounts.UpsertCorrelationID()
+	}
+
 	switch target {
 	case meta.ChangeTargetBase:
-		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editFn); err != nil {
+		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editWithDiscountCorrelationID); err != nil {
 			return fmt.Errorf("mutating base intent: %w", err)
 		}
 	case meta.ChangeTargetOverride:
 		if s.Charge.Intent.HasOverrideLayer() {
-			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editFn); err != nil {
+			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editWithDiscountCorrelationID); err != nil {
 				return fmt.Errorf("mutating override intent: %w", err)
 			}
 
@@ -113,7 +118,7 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 
 		effectiveIntent := s.Charge.Intent.GetEffectiveIntent()
 		overrideFields := effectiveIntent.IntentMutableFields
-		editFn(&overrideFields)
+		editWithDiscountCorrelationID(&overrideFields)
 		overrideFields = overrideFields.Normalized(effectiveIntent.Currency)
 		if err := overrideFields.Validate(); err != nil {
 			return fmt.Errorf("validating override intent: %w", err)

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -97,19 +97,18 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 // mutateIntentLayer mutates the requested intent layer, creating a new override
 // layer first when the target is override and the charge has no override yet.
 func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*flatfee.IntentMutableFields)) error {
-	editWithDiscountCorrelationID := func(fields *flatfee.IntentMutableFields) {
-		editFn(fields)
-		fields.PercentageDiscounts = fields.PercentageDiscounts.UpsertCorrelationID()
-	}
-
 	switch target {
 	case meta.ChangeTargetBase:
-		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editWithDiscountCorrelationID); err != nil {
+		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, func(fields *flatfee.IntentMutableFields) {
+			mutateFlatFeeIntentFields(fields, editFn)
+		}); err != nil {
 			return fmt.Errorf("mutating base intent: %w", err)
 		}
 	case meta.ChangeTargetOverride:
 		if s.Charge.Intent.HasOverrideLayer() {
-			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editWithDiscountCorrelationID); err != nil {
+			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, func(fields *flatfee.IntentMutableFields) {
+				mutateFlatFeeIntentFields(fields, editFn)
+			}); err != nil {
 				return fmt.Errorf("mutating override intent: %w", err)
 			}
 
@@ -118,7 +117,7 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 
 		effectiveIntent := s.Charge.Intent.GetEffectiveIntent()
 		overrideFields := effectiveIntent.IntentMutableFields
-		editWithDiscountCorrelationID(&overrideFields)
+		mutateFlatFeeIntentFields(&overrideFields, editFn)
 		overrideFields = overrideFields.Normalized(effectiveIntent.Currency)
 		if err := overrideFields.Validate(); err != nil {
 			return fmt.Errorf("validating override intent: %w", err)
@@ -135,6 +134,11 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 	}
 
 	return nil
+}
+
+func mutateFlatFeeIntentFields(fields *flatfee.IntentMutableFields, editFn func(*flatfee.IntentMutableFields)) {
+	editFn(fields)
+	fields.PercentageDiscounts = fields.PercentageDiscounts.UpsertCorrelationID()
 }
 
 // rejectHiddenIntentTarget prevents lifecycle state machines from processing a

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -35,6 +36,8 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
 		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
 	}
+	clock.FreezeTime(servicePeriod.To)
+	defer clock.UnFreeze()
 
 	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
 	featureKey := apiRequestsTotal.Feature.Key
@@ -68,7 +71,7 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	flatLine := billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 		Namespace:     ns,
 		Period:        servicePeriod,
-		InvoiceAt:     servicePeriod.From,
+		InvoiceAt:     servicePeriod.To.Add(time.Hour),
 		ManagedBy:     billing.ManuallyManagedLine,
 		Name:          "manual flat",
 		Currency:      currencyx.FiatCode(USD),
@@ -119,6 +122,9 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	s.Equal(featureKey, usageBasedIntent.FeatureKey)
 	s.Require().NotNil(usageBasedIntent.Discounts.Usage)
 	s.Equal(float64(3), usageBasedIntent.Discounts.Usage.Quantity.InexactFloat64())
+	s.NotEmpty(usageBasedIntent.Discounts.Usage.CorrelationID)
+	s.Require().NotNil(result.Lines[0].RateCardDiscounts.Usage)
+	s.Equal(usageBasedIntent.Discounts.Usage.CorrelationID, result.Lines[0].RateCardDiscounts.Usage.CorrelationID)
 
 	flatCharge := s.mustGetChargeByID(meta.ChargeID{
 		Namespace: ns,
@@ -134,6 +140,23 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	s.Equal(float64(10), flatFeeIntent.AmountBeforeProration.InexactFloat64())
 	s.Require().NotNil(flatFeeIntent.PercentageDiscounts)
 	s.Equal(float64(10), flatFeeIntent.PercentageDiscounts.Percentage.InexactFloat64())
+	s.NotEmpty(flatFeeIntent.PercentageDiscounts.CorrelationID)
+	s.Require().NotNil(result.Lines[1].RateCardDiscounts.Percentage)
+	s.Equal(flatFeeIntent.PercentageDiscounts.CorrelationID, result.Lines[1].RateCardDiscounts.Percentage.CorrelationID)
+
+	// Given the pending usage line was created without an internal discount correlation ID.
+	// When billing collects the charge-backed usage line into a standard invoice.
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+	// Then charge rating can reuse the persisted discount identity while generating detailed lines.
+	s.NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+	invoicedUsageLine := invoices[0].Lines.OrEmpty()[0]
+	s.Require().NotNil(invoicedUsageLine.RateCardDiscounts.Usage)
+	s.Equal(usageBasedIntent.Discounts.Usage.CorrelationID, invoicedUsageLine.RateCardDiscounts.Usage.CorrelationID)
 }
 
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreatedChargesOnFailure() {

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -37,6 +37,9 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 		}
 
 		baseIntent := charge.Intent.GetBaseIntent()
+		// Note: this is just a defensive mechanism to ensure that if the DB has invalid entities (e.g. ones missing the correlation ID),
+		// we backfill the correlation ID.
+		baseIntent.Discounts = baseIntent.Discounts.UpsertCorrelationIDs()
 
 		update := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
@@ -402,6 +405,7 @@ func expandRealizations(query *db.ChargeUsageBasedQuery, expands meta.Expands) *
 
 func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, intent usagebased.CreateIntent) (*db.ChargeUsageBasedCreate, error) {
 	baseIntent := intent.Intent.GetBaseIntent()
+	baseIntent.Discounts = baseIntent.Discounts.UpsertCorrelationIDs()
 
 	create := a.db.ChargeUsageBased.Create().
 		SetNillableDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride.go
@@ -130,6 +130,7 @@ func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.Charge
 	}
 
 	normalized := override.Normalized()
+	normalized.Discounts = normalized.Discounts.UpsertCorrelationIDs()
 	if err := normalized.Validate(); err != nil {
 		return nil, fmt.Errorf("validating intent override: %w", err)
 	}
@@ -166,6 +167,7 @@ func (a *adapter) updateIntentOverride(ctx context.Context, chargeID meta.Charge
 	}
 
 	normalized := override.Normalized()
+	normalized.Discounts = normalized.Discounts.UpsertCorrelationIDs()
 	if err := normalized.Validate(); err != nil {
 		return nil, fmt.Errorf("validating intent override: %w", err)
 	}

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -32,6 +32,7 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 		now := clock.Now().UTC()
 		createIntents, err := slicesx.MapWithErr(input.Intents, func(intent usagebased.Intent) (usagebased.CreateIntent, error) {
 			chargeIntent := intent.Normalized()
+			chargeIntent.Discounts = chargeIntent.Discounts.UpsertCorrelationIDs()
 
 			var resolvedCostBasis *costbasis.State
 			if chargeIntent.CostBasis != nil {

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -141,14 +141,24 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 // mutateIntentLayer mutates the requested intent layer, creating a new override
 // layer first when the target is override and the charge has no override yet.
 func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*usagebased.IntentMutableFields) error) error {
+	editWithDiscountCorrelationIDs := func(fields *usagebased.IntentMutableFields) error {
+		if err := editFn(fields); err != nil {
+			return err
+		}
+
+		fields.Discounts = fields.Discounts.UpsertCorrelationIDs()
+
+		return nil
+	}
+
 	switch target {
 	case meta.ChangeTargetBase:
-		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editFn); err != nil {
+		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editWithDiscountCorrelationIDs); err != nil {
 			return fmt.Errorf("mutating base intent: %w", err)
 		}
 	case meta.ChangeTargetOverride:
 		if s.Charge.Intent.HasOverrideLayer() {
-			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editFn); err != nil {
+			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editWithDiscountCorrelationIDs); err != nil {
 				return fmt.Errorf("mutating override intent: %w", err)
 			}
 
@@ -156,7 +166,7 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 		}
 
 		overrideFields := s.Charge.Intent.GetEffectiveIntent().IntentMutableFields
-		if err := editFn(&overrideFields); err != nil {
+		if err := editWithDiscountCorrelationIDs(&overrideFields); err != nil {
 			return err
 		}
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -141,24 +141,18 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 // mutateIntentLayer mutates the requested intent layer, creating a new override
 // layer first when the target is override and the charge has no override yet.
 func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.ChangeTarget, editFn func(*usagebased.IntentMutableFields) error) error {
-	editWithDiscountCorrelationIDs := func(fields *usagebased.IntentMutableFields) error {
-		if err := editFn(fields); err != nil {
-			return err
-		}
-
-		fields.Discounts = fields.Discounts.UpsertCorrelationIDs()
-
-		return nil
-	}
-
 	switch target {
 	case meta.ChangeTargetBase:
-		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, editWithDiscountCorrelationIDs); err != nil {
+		if err := s.Charge.Intent.Mutate(meta.ChangeTargetBase, func(fields *usagebased.IntentMutableFields) error {
+			return mutateUsageBasedIntentFields(fields, editFn)
+		}); err != nil {
 			return fmt.Errorf("mutating base intent: %w", err)
 		}
 	case meta.ChangeTargetOverride:
 		if s.Charge.Intent.HasOverrideLayer() {
-			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, editWithDiscountCorrelationIDs); err != nil {
+			if err := s.Charge.Intent.Mutate(meta.ChangeTargetOverride, func(fields *usagebased.IntentMutableFields) error {
+				return mutateUsageBasedIntentFields(fields, editFn)
+			}); err != nil {
 				return fmt.Errorf("mutating override intent: %w", err)
 			}
 
@@ -166,7 +160,7 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 		}
 
 		overrideFields := s.Charge.Intent.GetEffectiveIntent().IntentMutableFields
-		if err := editWithDiscountCorrelationIDs(&overrideFields); err != nil {
+		if err := mutateUsageBasedIntentFields(&overrideFields, editFn); err != nil {
 			return err
 		}
 
@@ -184,6 +178,16 @@ func (s *stateMachine) mutateIntentLayer(ctx context.Context, target meta.Change
 	default:
 		return fmt.Errorf("invalid change target: %s", target)
 	}
+
+	return nil
+}
+
+func mutateUsageBasedIntentFields(fields *usagebased.IntentMutableFields, editFn func(*usagebased.IntentMutableFields) error) error {
+	if err := editFn(fields); err != nil {
+		return err
+	}
+
+	fields.Discounts = fields.Discounts.UpsertCorrelationIDs()
 
 	return nil
 }

--- a/openmeter/billing/discount.go
+++ b/openmeter/billing/discount.go
@@ -44,6 +44,9 @@ func (d *PercentageDiscount) CloneOrNil() *PercentageDiscount {
 	return lo.ToPtr(d.Clone())
 }
 
+// UpsertCorrelationID returns a copy with a correlation ID allocated when it is missing.
+// Persisted charge discounts use the ID to preserve detailed-line lineage across realizations.
+// Existing IDs are preserved, and a nil discount remains nil.
 func (d *PercentageDiscount) UpsertCorrelationID() *PercentageDiscount {
 	if d == nil {
 		return nil
@@ -96,6 +99,9 @@ func (d UsageDiscount) Equal(other UsageDiscount) bool {
 	return true
 }
 
+// UpsertCorrelationID returns a copy with a correlation ID allocated when it is missing.
+// Persisted charge discounts use the ID to preserve detailed-line lineage across realizations.
+// Existing IDs are preserved, and a nil discount remains nil.
 func (d *UsageDiscount) UpsertCorrelationID() *UsageDiscount {
 	if d == nil {
 		return nil
@@ -200,6 +206,8 @@ func DiscountsFromProductCatalog(discounts productcatalog.Discounts) Discounts {
 	return out
 }
 
+// UpsertCorrelationIDs returns a copy with correlation IDs allocated for all present discounts.
+// It preserves existing IDs and leaves the receiver unchanged.
 func (d Discounts) UpsertCorrelationIDs() Discounts {
 	d.Percentage = d.Percentage.UpsertCorrelationID()
 	d.Usage = d.Usage.UpsertCorrelationID()

--- a/openmeter/billing/discount.go
+++ b/openmeter/billing/discount.go
@@ -44,6 +44,19 @@ func (d *PercentageDiscount) CloneOrNil() *PercentageDiscount {
 	return lo.ToPtr(d.Clone())
 }
 
+func (d *PercentageDiscount) UpsertCorrelationID() *PercentageDiscount {
+	if d == nil {
+		return nil
+	}
+
+	out := d.Clone()
+	if out.CorrelationID == "" {
+		out.CorrelationID = ulid.Make().String()
+	}
+
+	return &out
+}
+
 func (d PercentageDiscount) Equal(other PercentageDiscount) bool {
 	if d.PercentageDiscount.Hash() != other.PercentageDiscount.Hash() {
 		return false
@@ -81,6 +94,19 @@ func (d UsageDiscount) Equal(other UsageDiscount) bool {
 	}
 
 	return true
+}
+
+func (d *UsageDiscount) UpsertCorrelationID() *UsageDiscount {
+	if d == nil {
+		return nil
+	}
+
+	out := d.Clone()
+	if out.CorrelationID == "" {
+		out.CorrelationID = ulid.Make().String()
+	}
+
+	return &out
 }
 
 var _ models.Clonable[Discounts] = (*Discounts)(nil)
@@ -175,21 +201,10 @@ func DiscountsFromProductCatalog(discounts productcatalog.Discounts) Discounts {
 }
 
 func (d Discounts) UpsertCorrelationIDs() Discounts {
-	out := d.Clone()
+	d.Percentage = d.Percentage.UpsertCorrelationID()
+	d.Usage = d.Usage.UpsertCorrelationID()
 
-	if out.Percentage != nil {
-		if out.Percentage.CorrelationID == "" {
-			out.Percentage.CorrelationID = ulid.Make().String()
-		}
-	}
-
-	if out.Usage != nil {
-		if out.Usage.CorrelationID == "" {
-			out.Usage.CorrelationID = ulid.Make().String()
-		}
-	}
-
-	return out
+	return d
 }
 
 // DiscountReason type

--- a/openmeter/billing/discount_test.go
+++ b/openmeter/billing/discount_test.go
@@ -95,3 +95,23 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 		})
 	}
 }
+
+func TestDiscountsUpsertCorrelationIDs(t *testing.T) {
+	discounts := Discounts{
+		Percentage: &PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+			CorrelationID:      "existing-percentage-discount",
+		},
+		Usage: &UsageDiscount{
+			UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)},
+		},
+	}
+
+	first := discounts.UpsertCorrelationIDs()
+	retried := first.UpsertCorrelationIDs()
+
+	require.Equal(t, "existing-percentage-discount", first.Percentage.CorrelationID)
+	require.NotEmpty(t, first.Usage.CorrelationID)
+	require.Equal(t, first, retried)
+	require.Empty(t, discounts.Usage.CorrelationID)
+}

--- a/tools/migrate/charge_discount_correlation_ids_test.go
+++ b/tools/migrate/charge_discount_correlation_ids_test.go
@@ -23,32 +23,23 @@ func TestBackfillChargeDiscountCorrelationIDs(t *testing.T) {
 
 	createChargeDiscountCorrelationIDMigrationFixtures(t, conn)
 
+	untouchedBefore := readUntouchedDiscounts(t, conn)
+
 	_, err = conn.ExecContext(t.Context(), up)
 	require.NoError(t, err)
 
-	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-line", "percentage", "gathering-percentage")
-	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-line", "usage", "gathering-usage")
-	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-existing", "percentage", "existing-percentage")
-	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-existing", "usage", "existing-usage")
-	assertGeneratedDiscountCorrelationID(t, conn, "charge_usage_based", "usage-generated", "usage")
+	percentageID := assertGeneratedGatheringLineDiscountCorrelationID(t, conn, "charge-both", "percentage")
+	usageID := assertGeneratedGatheringLineDiscountCorrelationID(t, conn, "charge-both", "usage")
+	require.NotEqual(t, percentageID, usageID)
 
-	assertDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-override", "percentage", "gathering-percentage")
-	assertDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-override", "usage", "override-existing-usage")
-	assertGeneratedDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-generated-override", "usage")
+	assertGatheringLineDiscountCorrelationID(t, conn, "charge-existing", "percentage", "existing-percentage")
+	assertGeneratedGatheringLineDiscountCorrelationID(t, conn, "charge-existing", "usage")
+	require.Equal(t, untouchedBefore, readUntouchedDiscounts(t, conn))
 
-	assertDiscountCorrelationID(t, conn, "charge_flat_fees", "flat-line", "percentage", "standard-percentage")
-	assertDiscountCorrelationID(t, conn, "charge_flat_fees", "flat-existing", "percentage", "existing-flat-percentage")
-	assertGeneratedDiscountCorrelationID(t, conn, "charge_flat_fee_overrides", "flat-generated-override", "percentage")
-
-	var nullDiscounts bool
-	err = conn.QueryRowContext(t.Context(), `SELECT discounts IS NULL FROM charge_flat_fees WHERE id = 'flat-without-discount'`).Scan(&nullDiscounts)
-	require.NoError(t, err)
-	require.True(t, nullDiscounts)
-
-	beforeRetry := readChargeDiscounts(t, conn)
+	afterFirstRun := readGatheringLineDiscounts(t, conn)
 	_, err = conn.ExecContext(t.Context(), up)
 	require.NoError(t, err)
-	require.Equal(t, beforeRetry, readChargeDiscounts(t, conn))
+	require.Equal(t, afterFirstRun, readGatheringLineDiscounts(t, conn))
 }
 
 func createChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.Conn) {
@@ -68,94 +59,59 @@ func createChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.
 			id text PRIMARY KEY,
 			charge_id text NULL,
 			ratecard_discounts jsonb NULL,
-			updated_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL DEFAULT '2026-08-01T00:00:00Z',
 			deleted_at timestamptz NULL
 		);
 		CREATE TEMP TABLE billing_invoice_lines (
 			id text PRIMARY KEY,
 			charge_id text NULL,
 			ratecard_discounts jsonb NULL,
-			updated_at timestamptz NOT NULL,
 			deleted_at timestamptz NULL
 		);
 		CREATE TEMP TABLE charge_usage_based (
 			id text PRIMARY KEY,
-			discounts jsonb NULL,
-			updated_at timestamptz NOT NULL
-		);
-		CREATE TEMP TABLE charge_usage_based_overrides (
-			id text PRIMARY KEY,
-			charge_id text NOT NULL,
-			discounts jsonb NULL
-		);
-		CREATE TEMP TABLE charge_flat_fees (
-			id text PRIMARY KEY,
-			discounts jsonb NULL,
-			updated_at timestamptz NOT NULL
-		);
-		CREATE TEMP TABLE charge_flat_fee_overrides (
-			id text PRIMARY KEY,
-			charge_id text NOT NULL,
 			discounts jsonb NULL
 		);
 
-		INSERT INTO billing_gathering_invoice_lines (id, charge_id, ratecard_discounts, updated_at, deleted_at) VALUES
-			('usage-gathering', 'usage-line', '{
-				"percentage":{"percentage":10,"correlationID":"gathering-percentage"},
-				"usage":{"quantity":"5","correlationID":"gathering-usage"}
-			}', '2026-08-01T00:00:00Z', NULL),
-			('flat-deleted-gathering', 'flat-line', '{
-				"percentage":{"percentage":20,"correlationID":"deleted-gathering-percentage"}
-			}', '2026-08-03T00:00:00Z', '2026-08-03T01:00:00Z');
-
-		INSERT INTO billing_invoice_lines (id, charge_id, ratecard_discounts, updated_at, deleted_at) VALUES
-			('usage-standard', 'usage-line', '{
-				"percentage":{"percentage":10,"correlationID":"standard-percentage"},
-				"usage":{"quantity":"5","correlationID":"standard-usage"}
-			}', '2026-08-02T00:00:00Z', NULL),
-			('flat-standard', 'flat-line', '{
-				"percentage":{"percentage":20,"correlationID":"standard-percentage"}
-			}', '2026-08-02T00:00:00Z', NULL);
-
-		INSERT INTO charge_usage_based (id, discounts, updated_at) VALUES
-			('usage-line', '{
+		INSERT INTO billing_gathering_invoice_lines (id, charge_id, ratecard_discounts, deleted_at) VALUES
+			('charge-both', 'charge-1', '{
 				"percentage":{"percentage":10},
 				"usage":{"quantity":"5","correlationID":""}
-			}', '2026-08-01T00:00:00Z'),
-			('usage-existing', '{
+			}', NULL),
+			('charge-existing', 'charge-2', '{
 				"percentage":{"percentage":15,"correlationID":"existing-percentage"},
-				"usage":{"quantity":"3","correlationID":"existing-usage"}
-			}', '2026-08-01T00:00:00Z'),
-			('usage-generated', '{
-				"usage":{"quantity":"8"}
-			}', '2026-08-01T00:00:00Z');
+				"usage":{"quantity":"3"}
+			}', NULL),
+			('not-charge-backed', NULL, '{
+				"percentage":{"percentage":20},
+				"usage":{"quantity":"7"}
+			}', NULL),
+			('deleted-charge-backed', 'charge-3', '{
+				"percentage":{"percentage":25}
+			}', '2026-08-03T01:00:00Z'),
+			('without-discounts', 'charge-4', NULL, NULL);
 
-		INSERT INTO charge_usage_based_overrides (id, charge_id, discounts) VALUES
-			('usage-override', 'usage-line', '{
-				"percentage":{"percentage":25},
-				"usage":{"quantity":"7","correlationID":"override-existing-usage"}
-			}'),
-			('usage-generated-override', 'usage-generated', '{
-				"usage":{"quantity":"9","correlationID":""}
+		INSERT INTO billing_invoice_lines (id, charge_id, ratecard_discounts, deleted_at) VALUES
+			('standard-charge-backed', 'charge-1', '{
+				"percentage":{"percentage":10},
+				"usage":{"quantity":"5"}
+			}', NULL);
+
+		INSERT INTO charge_usage_based (id, discounts) VALUES
+			('charge-1', '{
+				"percentage":{"percentage":10},
+				"usage":{"quantity":"5"}
 			}');
-
-		INSERT INTO charge_flat_fees (id, discounts, updated_at) VALUES
-			('flat-line', '{"percentage":{"percentage":20}}', '2026-08-01T00:00:00Z'),
-			('flat-existing', '{"percentage":{"percentage":30,"correlationID":"existing-flat-percentage"}}', '2026-08-01T00:00:00Z'),
-			('flat-without-discount', NULL, '2026-08-01T00:00:00Z');
-
-		INSERT INTO charge_flat_fee_overrides (id, charge_id, discounts) VALUES
-			('flat-generated-override', 'flat-without-discount', '{"percentage":{"percentage":40,"correlationID":""}}');
 	`)
 	require.NoError(t, err)
 }
 
-func assertDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType, expected string) {
+func assertGatheringLineDiscountCorrelationID(t *testing.T, conn *sql.Conn, id, discountType, expected string) {
 	t.Helper()
 
 	var actual string
 	err := conn.QueryRowContext(t.Context(),
-		`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM `+table+` WHERE id = $2`,
+		`SELECT ratecard_discounts #>> ARRAY[$1, 'correlationID'] FROM billing_gathering_invoice_lines WHERE id = $2`,
 		discountType,
 		id,
 	).Scan(&actual)
@@ -163,34 +119,56 @@ func assertDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discou
 	require.Equal(t, expected, actual)
 }
 
-func assertGeneratedDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType string) {
+func assertGeneratedGatheringLineDiscountCorrelationID(t *testing.T, conn *sql.Conn, id, discountType string) string {
 	t.Helper()
 
 	var actual string
 	err := conn.QueryRowContext(t.Context(),
-		`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM `+table+` WHERE id = $2`,
+		`SELECT ratecard_discounts #>> ARRAY[$1, 'correlationID'] FROM billing_gathering_invoice_lines WHERE id = $2`,
 		discountType,
 		id,
 	).Scan(&actual)
 	require.NoError(t, err)
-	require.NotEmpty(t, actual)
 	require.Contains(t, actual, "generated-")
+
+	return actual
 }
 
-func readChargeDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
+func readUntouchedDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
 	t.Helper()
 
 	rows, err := conn.QueryContext(t.Context(), `
-		SELECT 'usage:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based
+		SELECT 'gathering:' || id, COALESCE(ratecard_discounts::text, 'null')
+		FROM billing_gathering_invoice_lines
+		WHERE charge_id IS NULL OR deleted_at IS NOT NULL OR ratecard_discounts IS NULL
 		UNION ALL
-		SELECT 'usage_override:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based_overrides
+		SELECT 'standard:' || id, COALESCE(ratecard_discounts::text, 'null')
+		FROM billing_invoice_lines
 		UNION ALL
-		SELECT 'flat:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fees
-		UNION ALL
-		SELECT 'flat_override:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fee_overrides
+		SELECT 'charge:' || id, COALESCE(discounts::text, 'null')
+		FROM charge_usage_based
 	`)
 	require.NoError(t, err)
 	defer rows.Close()
+
+	return scanDiscounts(t, rows)
+}
+
+func readGatheringLineDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
+	t.Helper()
+
+	rows, err := conn.QueryContext(t.Context(), `
+		SELECT id, COALESCE(ratecard_discounts::text, 'null')
+		FROM billing_gathering_invoice_lines
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	return scanDiscounts(t, rows)
+}
+
+func scanDiscounts(t *testing.T, rows *sql.Rows) map[string]string {
+	t.Helper()
 
 	result := map[string]string{}
 	for rows.Next() {

--- a/tools/migrate/charge_discount_correlation_ids_test.go
+++ b/tools/migrate/charge_discount_correlation_ids_test.go
@@ -1,0 +1,204 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+const chargeDiscountCorrelationIDMigration = "20260809152600_backfill_charge_discount_correlation_ids.up.sql"
+
+func TestBackfillChargeDiscountCorrelationIDs(t *testing.T) {
+	up := readMigration(t, chargeDiscountCorrelationIDMigration)
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	defer testDB.PGDriver.Close()
+
+	conn, err := testDB.PGDriver.DB().Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	createChargeDiscountCorrelationIDMigrationFixtures(t, conn)
+
+	_, err = conn.ExecContext(t.Context(), up)
+	require.NoError(t, err)
+
+	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-line", "percentage", "gathering-percentage")
+	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-line", "usage", "gathering-usage")
+	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-existing", "percentage", "existing-percentage")
+	assertDiscountCorrelationID(t, conn, "charge_usage_based", "usage-existing", "usage", "existing-usage")
+	assertGeneratedDiscountCorrelationID(t, conn, "charge_usage_based", "usage-generated", "usage")
+
+	assertDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-override", "percentage", "gathering-percentage")
+	assertDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-override", "usage", "override-existing-usage")
+	assertGeneratedDiscountCorrelationID(t, conn, "charge_usage_based_overrides", "usage-generated-override", "usage")
+
+	assertDiscountCorrelationID(t, conn, "charge_flat_fees", "flat-line", "percentage", "standard-percentage")
+	assertDiscountCorrelationID(t, conn, "charge_flat_fees", "flat-existing", "percentage", "existing-flat-percentage")
+	assertGeneratedDiscountCorrelationID(t, conn, "charge_flat_fee_overrides", "flat-generated-override", "percentage")
+
+	var nullDiscounts bool
+	err = conn.QueryRowContext(t.Context(), `SELECT discounts IS NULL FROM charge_flat_fees WHERE id = 'flat-without-discount'`).Scan(&nullDiscounts)
+	require.NoError(t, err)
+	require.True(t, nullDiscounts)
+
+	beforeRetry := readChargeDiscounts(t, conn)
+	_, err = conn.ExecContext(t.Context(), up)
+	require.NoError(t, err)
+	require.Equal(t, beforeRetry, readChargeDiscounts(t, conn))
+}
+
+func createChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+
+	_, err := conn.ExecContext(t.Context(), `
+		CREATE SEQUENCE migration_test_ulid_sequence;
+		CREATE FUNCTION om_func_generate_ulid()
+		RETURNS text
+		AS $$
+			SELECT 'generated-' || nextval('migration_test_ulid_sequence')::text
+		$$
+		LANGUAGE sql
+		VOLATILE;
+
+		CREATE TEMP TABLE billing_gathering_invoice_lines (
+			id text PRIMARY KEY,
+			charge_id text NULL,
+			ratecard_discounts jsonb NULL,
+			updated_at timestamptz NOT NULL,
+			deleted_at timestamptz NULL
+		);
+		CREATE TEMP TABLE billing_invoice_lines (
+			id text PRIMARY KEY,
+			charge_id text NULL,
+			ratecard_discounts jsonb NULL,
+			updated_at timestamptz NOT NULL,
+			deleted_at timestamptz NULL
+		);
+		CREATE TEMP TABLE charge_usage_based (
+			id text PRIMARY KEY,
+			discounts jsonb NULL,
+			updated_at timestamptz NOT NULL
+		);
+		CREATE TEMP TABLE charge_usage_based_overrides (
+			id text PRIMARY KEY,
+			charge_id text NOT NULL,
+			discounts jsonb NULL
+		);
+		CREATE TEMP TABLE charge_flat_fees (
+			id text PRIMARY KEY,
+			discounts jsonb NULL,
+			updated_at timestamptz NOT NULL
+		);
+		CREATE TEMP TABLE charge_flat_fee_overrides (
+			id text PRIMARY KEY,
+			charge_id text NOT NULL,
+			discounts jsonb NULL
+		);
+
+		INSERT INTO billing_gathering_invoice_lines (id, charge_id, ratecard_discounts, updated_at, deleted_at) VALUES
+			('usage-gathering', 'usage-line', '{
+				"percentage":{"percentage":10,"correlationID":"gathering-percentage"},
+				"usage":{"quantity":"5","correlationID":"gathering-usage"}
+			}', '2026-08-01T00:00:00Z', NULL),
+			('flat-deleted-gathering', 'flat-line', '{
+				"percentage":{"percentage":20,"correlationID":"deleted-gathering-percentage"}
+			}', '2026-08-03T00:00:00Z', '2026-08-03T01:00:00Z');
+
+		INSERT INTO billing_invoice_lines (id, charge_id, ratecard_discounts, updated_at, deleted_at) VALUES
+			('usage-standard', 'usage-line', '{
+				"percentage":{"percentage":10,"correlationID":"standard-percentage"},
+				"usage":{"quantity":"5","correlationID":"standard-usage"}
+			}', '2026-08-02T00:00:00Z', NULL),
+			('flat-standard', 'flat-line', '{
+				"percentage":{"percentage":20,"correlationID":"standard-percentage"}
+			}', '2026-08-02T00:00:00Z', NULL);
+
+		INSERT INTO charge_usage_based (id, discounts, updated_at) VALUES
+			('usage-line', '{
+				"percentage":{"percentage":10},
+				"usage":{"quantity":"5","correlationID":""}
+			}', '2026-08-01T00:00:00Z'),
+			('usage-existing', '{
+				"percentage":{"percentage":15,"correlationID":"existing-percentage"},
+				"usage":{"quantity":"3","correlationID":"existing-usage"}
+			}', '2026-08-01T00:00:00Z'),
+			('usage-generated', '{
+				"usage":{"quantity":"8"}
+			}', '2026-08-01T00:00:00Z');
+
+		INSERT INTO charge_usage_based_overrides (id, charge_id, discounts) VALUES
+			('usage-override', 'usage-line', '{
+				"percentage":{"percentage":25},
+				"usage":{"quantity":"7","correlationID":"override-existing-usage"}
+			}'),
+			('usage-generated-override', 'usage-generated', '{
+				"usage":{"quantity":"9","correlationID":""}
+			}');
+
+		INSERT INTO charge_flat_fees (id, discounts, updated_at) VALUES
+			('flat-line', '{"percentage":{"percentage":20}}', '2026-08-01T00:00:00Z'),
+			('flat-existing', '{"percentage":{"percentage":30,"correlationID":"existing-flat-percentage"}}', '2026-08-01T00:00:00Z'),
+			('flat-without-discount', NULL, '2026-08-01T00:00:00Z');
+
+		INSERT INTO charge_flat_fee_overrides (id, charge_id, discounts) VALUES
+			('flat-generated-override', 'flat-without-discount', '{"percentage":{"percentage":40,"correlationID":""}}');
+	`)
+	require.NoError(t, err)
+}
+
+func assertDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType, expected string) {
+	t.Helper()
+
+	var actual string
+	err := conn.QueryRowContext(t.Context(),
+		`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM `+table+` WHERE id = $2`,
+		discountType,
+		id,
+	).Scan(&actual)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func assertGeneratedDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType string) {
+	t.Helper()
+
+	var actual string
+	err := conn.QueryRowContext(t.Context(),
+		`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM `+table+` WHERE id = $2`,
+		discountType,
+		id,
+	).Scan(&actual)
+	require.NoError(t, err)
+	require.NotEmpty(t, actual)
+	require.Contains(t, actual, "generated-")
+}
+
+func readChargeDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
+	t.Helper()
+
+	rows, err := conn.QueryContext(t.Context(), `
+		SELECT 'usage:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based
+		UNION ALL
+		SELECT 'usage_override:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based_overrides
+		UNION ALL
+		SELECT 'flat:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fees
+		UNION ALL
+		SELECT 'flat_override:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fee_overrides
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	result := map[string]string{}
+	for rows.Next() {
+		var key, discounts string
+		require.NoError(t, rows.Scan(&key, &discounts))
+		result[key] = discounts
+	}
+	require.NoError(t, rows.Err())
+
+	return result
+}

--- a/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.down.sql
+++ b/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.down.sql
@@ -1,0 +1,1 @@
+-- Data repair migration; intentionally irreversible.

--- a/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.up.sql
+++ b/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.up.sql
@@ -1,0 +1,188 @@
+-- Charge-owned discounts require stable correlation IDs for detailed-line lineage. Reuse the
+-- newest charge-backed invoice-line ID when possible so pending and already materialized lines
+-- keep their existing identity; generate a new ID only when no line can provide one.
+BEGIN;
+
+CREATE TEMPORARY TABLE charge_discount_correlation_ids ON COMMIT DROP AS
+WITH candidates AS (
+  SELECT
+    l.charge_id,
+    discount_type.name AS discount_type,
+    l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'] AS correlation_id,
+    0 AS source_priority,
+    l.updated_at,
+    l.id
+  FROM billing_gathering_invoice_lines l
+  CROSS JOIN (VALUES ('percentage'), ('usage')) AS discount_type(name)
+  WHERE l.charge_id IS NOT NULL
+    AND l.deleted_at IS NULL
+    AND NULLIF(l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'], '') IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    l.charge_id,
+    discount_type.name AS discount_type,
+    l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'] AS correlation_id,
+    1 AS source_priority,
+    l.updated_at,
+    l.id
+  FROM billing_invoice_lines l
+  CROSS JOIN (VALUES ('percentage'), ('usage')) AS discount_type(name)
+  WHERE l.charge_id IS NOT NULL
+    AND l.deleted_at IS NULL
+    AND NULLIF(l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'], '') IS NOT NULL
+), ranked AS (
+  SELECT
+    candidates.*,
+    row_number() OVER (
+      PARTITION BY charge_id, discount_type
+      ORDER BY source_priority, updated_at DESC, id DESC
+    ) AS row_number
+  FROM candidates
+)
+SELECT
+  charge_id,
+  max(correlation_id) FILTER (WHERE discount_type = 'percentage') AS percentage_correlation_id,
+  max(correlation_id) FILTER (WHERE discount_type = 'usage') AS usage_correlation_id
+FROM ranked
+WHERE row_number = 1
+GROUP BY charge_id;
+
+CREATE OR REPLACE FUNCTION pg_temp.upsert_discount_correlation_id(
+  discounts jsonb,
+  discount_type text,
+  correlation_id text
+)
+RETURNS jsonb
+AS $$
+  SELECT CASE
+    WHEN jsonb_typeof(discounts -> discount_type) = 'object'
+      AND COALESCE(discounts #>> ARRAY[discount_type, 'correlationID'], '') = ''
+    THEN jsonb_set(
+      discounts,
+      ARRAY[discount_type, 'correlationID'],
+      to_jsonb(correlation_id),
+      true
+    )
+    ELSE discounts
+  END
+$$
+LANGUAGE sql
+IMMUTABLE;
+
+UPDATE charge_usage_based charge
+SET
+  discounts = pg_temp.upsert_discount_correlation_id(
+    pg_temp.upsert_discount_correlation_id(
+      charge.discounts,
+      'percentage',
+      COALESCE(
+        (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
+        om_func_generate_ulid()
+      )
+    ),
+    'usage',
+    COALESCE(
+      (SELECT ids.usage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
+      om_func_generate_ulid()
+    )
+  ),
+  updated_at = now()
+WHERE (
+    jsonb_typeof(charge.discounts -> 'percentage') = 'object'
+    AND COALESCE(charge.discounts #>> '{percentage,correlationID}', '') = ''
+  ) OR (
+    jsonb_typeof(charge.discounts -> 'usage') = 'object'
+    AND COALESCE(charge.discounts #>> '{usage,correlationID}', '') = ''
+  );
+
+UPDATE charge_usage_based_overrides override
+SET discounts = pg_temp.upsert_discount_correlation_id(
+  pg_temp.upsert_discount_correlation_id(
+    override.discounts,
+    'percentage',
+    COALESCE(
+      (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
+      om_func_generate_ulid()
+    )
+  ),
+  'usage',
+  COALESCE(
+    (SELECT ids.usage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
+    om_func_generate_ulid()
+  )
+)
+WHERE (
+    jsonb_typeof(override.discounts -> 'percentage') = 'object'
+    AND COALESCE(override.discounts #>> '{percentage,correlationID}', '') = ''
+  ) OR (
+    jsonb_typeof(override.discounts -> 'usage') = 'object'
+    AND COALESCE(override.discounts #>> '{usage,correlationID}', '') = ''
+  );
+
+UPDATE charge_flat_fees charge
+SET
+  discounts = pg_temp.upsert_discount_correlation_id(
+    charge.discounts,
+    'percentage',
+    COALESCE(
+      (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
+      om_func_generate_ulid()
+    )
+  ),
+  updated_at = now()
+WHERE jsonb_typeof(charge.discounts -> 'percentage') = 'object'
+  AND COALESCE(charge.discounts #>> '{percentage,correlationID}', '') = '';
+
+UPDATE charge_flat_fee_overrides override
+SET discounts = pg_temp.upsert_discount_correlation_id(
+  override.discounts,
+  'percentage',
+  COALESCE(
+    (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
+    om_func_generate_ulid()
+  )
+)
+WHERE jsonb_typeof(override.discounts -> 'percentage') = 'object'
+  AND COALESCE(override.discounts #>> '{percentage,correlationID}', '') = '';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM charge_usage_based
+    WHERE (
+        jsonb_typeof(discounts -> 'percentage') = 'object'
+        AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+      ) OR (
+        jsonb_typeof(discounts -> 'usage') = 'object'
+        AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+      )
+  ) OR EXISTS (
+    SELECT 1
+    FROM charge_usage_based_overrides
+    WHERE (
+        jsonb_typeof(discounts -> 'percentage') = 'object'
+        AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+      ) OR (
+        jsonb_typeof(discounts -> 'usage') = 'object'
+        AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+      )
+  ) OR EXISTS (
+    SELECT 1
+    FROM charge_flat_fees
+    WHERE jsonb_typeof(discounts -> 'percentage') = 'object'
+      AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+  ) OR EXISTS (
+    SELECT 1
+    FROM charge_flat_fee_overrides
+    WHERE jsonb_typeof(discounts -> 'percentage') = 'object'
+      AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+  ) THEN
+    RAISE EXCEPTION 'charge discounts still have missing correlation IDs after repair';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.up.sql
+++ b/tools/migrate/migrations/20260809152600_backfill_charge_discount_correlation_ids.up.sql
@@ -1,53 +1,6 @@
--- Charge-owned discounts require stable correlation IDs for detailed-line lineage. Reuse the
--- newest charge-backed invoice-line ID when possible so pending and already materialized lines
--- keep their existing identity; generate a new ID only when no line can provide one.
+-- Repair charge-backed gathering-line discount snapshots so detailed-line rating can rely on
+-- correlation IDs. Existing IDs are preserved; the generated value has no charge semantics.
 BEGIN;
-
-CREATE TEMPORARY TABLE charge_discount_correlation_ids ON COMMIT DROP AS
-WITH candidates AS (
-  SELECT
-    l.charge_id,
-    discount_type.name AS discount_type,
-    l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'] AS correlation_id,
-    0 AS source_priority,
-    l.updated_at,
-    l.id
-  FROM billing_gathering_invoice_lines l
-  CROSS JOIN (VALUES ('percentage'), ('usage')) AS discount_type(name)
-  WHERE l.charge_id IS NOT NULL
-    AND l.deleted_at IS NULL
-    AND NULLIF(l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'], '') IS NOT NULL
-
-  UNION ALL
-
-  SELECT
-    l.charge_id,
-    discount_type.name AS discount_type,
-    l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'] AS correlation_id,
-    1 AS source_priority,
-    l.updated_at,
-    l.id
-  FROM billing_invoice_lines l
-  CROSS JOIN (VALUES ('percentage'), ('usage')) AS discount_type(name)
-  WHERE l.charge_id IS NOT NULL
-    AND l.deleted_at IS NULL
-    AND NULLIF(l.ratecard_discounts #>> ARRAY[discount_type.name, 'correlationID'], '') IS NOT NULL
-), ranked AS (
-  SELECT
-    candidates.*,
-    row_number() OVER (
-      PARTITION BY charge_id, discount_type
-      ORDER BY source_priority, updated_at DESC, id DESC
-    ) AS row_number
-  FROM candidates
-)
-SELECT
-  charge_id,
-  max(correlation_id) FILTER (WHERE discount_type = 'percentage') AS percentage_correlation_id,
-  max(correlation_id) FILTER (WHERE discount_type = 'usage') AS usage_correlation_id
-FROM ranked
-WHERE row_number = 1
-GROUP BY charge_id;
 
 CREATE OR REPLACE FUNCTION pg_temp.upsert_discount_correlation_id(
   discounts jsonb,
@@ -71,116 +24,48 @@ $$
 LANGUAGE sql
 IMMUTABLE;
 
-UPDATE charge_usage_based charge
+UPDATE billing_gathering_invoice_lines line
 SET
-  discounts = pg_temp.upsert_discount_correlation_id(
+  ratecard_discounts = pg_temp.upsert_discount_correlation_id(
     pg_temp.upsert_discount_correlation_id(
-      charge.discounts,
+      line.ratecard_discounts,
       'percentage',
-      COALESCE(
-        (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
-        om_func_generate_ulid()
-      )
+      om_func_generate_ulid()
     ),
     'usage',
-    COALESCE(
-      (SELECT ids.usage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
-      om_func_generate_ulid()
-    )
+    om_func_generate_ulid()
   ),
   updated_at = now()
-WHERE (
-    jsonb_typeof(charge.discounts -> 'percentage') = 'object'
-    AND COALESCE(charge.discounts #>> '{percentage,correlationID}', '') = ''
-  ) OR (
-    jsonb_typeof(charge.discounts -> 'usage') = 'object'
-    AND COALESCE(charge.discounts #>> '{usage,correlationID}', '') = ''
-  );
-
-UPDATE charge_usage_based_overrides override
-SET discounts = pg_temp.upsert_discount_correlation_id(
-  pg_temp.upsert_discount_correlation_id(
-    override.discounts,
-    'percentage',
-    COALESCE(
-      (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
-      om_func_generate_ulid()
+WHERE line.charge_id IS NOT NULL
+  AND line.deleted_at IS NULL
+  AND (
+    (
+      jsonb_typeof(line.ratecard_discounts -> 'percentage') = 'object'
+      AND COALESCE(line.ratecard_discounts #>> '{percentage,correlationID}', '') = ''
+    ) OR (
+      jsonb_typeof(line.ratecard_discounts -> 'usage') = 'object'
+      AND COALESCE(line.ratecard_discounts #>> '{usage,correlationID}', '') = ''
     )
-  ),
-  'usage',
-  COALESCE(
-    (SELECT ids.usage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
-    om_func_generate_ulid()
-  )
-)
-WHERE (
-    jsonb_typeof(override.discounts -> 'percentage') = 'object'
-    AND COALESCE(override.discounts #>> '{percentage,correlationID}', '') = ''
-  ) OR (
-    jsonb_typeof(override.discounts -> 'usage') = 'object'
-    AND COALESCE(override.discounts #>> '{usage,correlationID}', '') = ''
   );
-
-UPDATE charge_flat_fees charge
-SET
-  discounts = pg_temp.upsert_discount_correlation_id(
-    charge.discounts,
-    'percentage',
-    COALESCE(
-      (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = charge.id),
-      om_func_generate_ulid()
-    )
-  ),
-  updated_at = now()
-WHERE jsonb_typeof(charge.discounts -> 'percentage') = 'object'
-  AND COALESCE(charge.discounts #>> '{percentage,correlationID}', '') = '';
-
-UPDATE charge_flat_fee_overrides override
-SET discounts = pg_temp.upsert_discount_correlation_id(
-  override.discounts,
-  'percentage',
-  COALESCE(
-    (SELECT ids.percentage_correlation_id FROM charge_discount_correlation_ids ids WHERE ids.charge_id = override.charge_id),
-    om_func_generate_ulid()
-  )
-)
-WHERE jsonb_typeof(override.discounts -> 'percentage') = 'object'
-  AND COALESCE(override.discounts #>> '{percentage,correlationID}', '') = '';
 
 DO $$
 BEGIN
   IF EXISTS (
     SELECT 1
-    FROM charge_usage_based
-    WHERE (
-        jsonb_typeof(discounts -> 'percentage') = 'object'
-        AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
-      ) OR (
-        jsonb_typeof(discounts -> 'usage') = 'object'
-        AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+    FROM billing_gathering_invoice_lines line
+    WHERE line.charge_id IS NOT NULL
+      AND line.deleted_at IS NULL
+      AND (
+        (
+          jsonb_typeof(line.ratecard_discounts -> 'percentage') = 'object'
+          AND COALESCE(line.ratecard_discounts #>> '{percentage,correlationID}', '') = ''
+        ) OR (
+          jsonb_typeof(line.ratecard_discounts -> 'usage') = 'object'
+          AND COALESCE(line.ratecard_discounts #>> '{usage,correlationID}', '') = ''
+        )
       )
-  ) OR EXISTS (
-    SELECT 1
-    FROM charge_usage_based_overrides
-    WHERE (
-        jsonb_typeof(discounts -> 'percentage') = 'object'
-        AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
-      ) OR (
-        jsonb_typeof(discounts -> 'usage') = 'object'
-        AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
-      )
-  ) OR EXISTS (
-    SELECT 1
-    FROM charge_flat_fees
-    WHERE jsonb_typeof(discounts -> 'percentage') = 'object'
-      AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
-  ) OR EXISTS (
-    SELECT 1
-    FROM charge_flat_fee_overrides
-    WHERE jsonb_typeof(discounts -> 'percentage') = 'object'
-      AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
   ) THEN
-    RAISE EXCEPTION 'charge discounts still have missing correlation IDs after repair';
+    RAISE EXCEPTION 'charge-backed gathering-line discounts still have missing correlation IDs after repair';
   END IF;
 END
 $$;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:saQfiQ5k7ABS+Q5qFfmK8JMZ228nA1lmy0U9mxxWykk=
+h1:uoscWZ08JrE3Q0RD0niR/+Howt5QTw7qx2pXUxgBiq4=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -259,3 +259,4 @@ h1:saQfiQ5k7ABS+Q5qFfmK8JMZ228nA1lmy0U9mxxWykk=
 20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql h1:k/byyaoUMzatU0fEugM3xNMyy607xkxlXEC1lAUMeDs=
 20260807145338_enforce_charge_cost_basis_relationships.up.sql h1:+eRqMO8jr7BRn3MW1zJCgjr/+kzx1hSDYrfuTguO/ZI=
 20260807155244_credit_purchase_cost_basis_level_2_only.up.sql h1:rMuXE2Vtccs1zEZrt1Dxr2PmKujrkbY7BzdOU7ebjBw=
+20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:tDUCmEU4t3rtldh97qL+GY/N3kW42dXjOrAvdEHTPhA=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:uoscWZ08JrE3Q0RD0niR/+Howt5QTw7qx2pXUxgBiq4=
+h1:U8Ez0xcas0hz8b5pTtFvY8VNNdnUF70k50KmRjPM8pQ=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -259,4 +259,4 @@ h1:uoscWZ08JrE3Q0RD0niR/+Howt5QTw7qx2pXUxgBiq4=
 20260807061955_migrate_credit_purchase_cost_basis_schema_level_2.up.sql h1:k/byyaoUMzatU0fEugM3xNMyy607xkxlXEC1lAUMeDs=
 20260807145338_enforce_charge_cost_basis_relationships.up.sql h1:+eRqMO8jr7BRn3MW1zJCgjr/+kzx1hSDYrfuTguO/ZI=
 20260807155244_credit_purchase_cost_basis_level_2_only.up.sql h1:rMuXE2Vtccs1zEZrt1Dxr2PmKujrkbY7BzdOU7ebjBw=
-20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:tDUCmEU4t3rtldh97qL+GY/N3kW42dXjOrAvdEHTPhA=
+20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:dkNWwhYido6AriEp87nX077MA19pje+McrNfNshdNYM=


### PR DESCRIPTION
## Summary

- allocate stable correlation IDs when usage-based and flat-fee charge discounts enter or mutate an intent layer
- normalize both base and override layers, with defensive persistence normalization for existing invalid entities
- repair missing IDs only on active charge-backed gathering-line discount snapshots
- cover charge-backed pending-line creation and the scoped SQL repair with regression tests

## Root cause

`billing.PercentageDiscount` and `billing.UsageDiscount` extend product-catalog discounts with a correlation ID, but their promoted validators only validate the embedded commercial fields. Charge creation could therefore persist billing discounts without IDs. After charge-backed rating began consuming the persisted discounts directly, detailed-line generation rejected those entities with `discount has no correlation ID`.

## Repair scope

The migration repairs only active `billing_gathering_invoice_lines` records where `charge_id IS NOT NULL`. For each present percentage or usage discount with a missing ID, it assigns an arbitrary generated ULID while preserving existing IDs. Standard invoice lines, charge rows, and override rows are intentionally not migrated.

New charge writes allocate IDs immediately. Existing base and override intents self-heal on their next persisted state-machine update because the charge and override adapters defensively upsert missing IDs at their write boundaries.

## Impact

Existing affected gathering lines can be rated after migration. New and subsequently updated charge intents persist stable discount identities, and rerating, invoice projection, and corrections reuse those persisted IDs.

## Validation

- `go test ./openmeter/billing -run 'Test.*Correlation' -count=1`
- `go test ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/usagebased/service -count=1`
- `POSTGRES_HOST=127.0.0.1 go test ./tools/migrate -run TestBackfillChargeDiscountCorrelationIDs -count=1`
- `make migrate-check-lint`
- `make migrate-check-validate`
