### PR TITLE
fix: validate billing discount correlation IDs

### DIFF
--- a/api/v3/handlers/billinginvoices/convert.go
+++ b/api/v3/handlers/billinginvoices/convert.go
@@ -702,7 +702,7 @@ func mergeStandardInvoiceLinesFromAPI(inv *billing.StandardInvoice, lines *[]api
 // standardLineFromAPI builds a new top-level standard line from an update request line that
 // has no matching existing line (empty or unrecognized ID).
 func standardLineFromAPI(line api.UpdateInvoiceStandardLine, inv *billing.StandardInvoice) (*billing.StandardLine, error) {
-	price, taxConfig, featureKey, discounts, err := mapRateCardFromAPI(line.RateCard)
+	price, taxConfig, featureKey, desiredDiscounts, err := mapRateCardFromAPI(line.RateCard)
 	if err != nil {
 		return nil, fmt.Errorf("mapping rate card: %w", err)
 	}
@@ -736,7 +736,7 @@ func standardLineFromAPI(line api.UpdateInvoiceStandardLine, inv *billing.Standa
 			InvoiceAt: clock.Now().Truncate(streaming.MinimumWindowSizeDuration),
 
 			TaxConfig:         taxConfig,
-			RateCardDiscounts: discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(desiredDiscounts),
 		},
 		UsageBased: &billing.UsageBasedLine{
 			Price:      price,
@@ -748,7 +748,7 @@ func standardLineFromAPI(line api.UpdateInvoiceStandardLine, inv *billing.Standa
 // mergeStandardLineFromAPI applies the editable fields of an update request line onto an
 // existing top-level standard line, matched by ID.
 func mergeStandardLineFromAPI(existing *billing.StandardLine, line api.UpdateInvoiceStandardLine) (*billing.StandardLine, error) {
-	price, taxConfig, featureKey, discounts, err := mapRateCardFromAPI(line.RateCard)
+	price, taxConfig, featureKey, desiredDiscounts, err := mapRateCardFromAPI(line.RateCard)
 	if err != nil {
 		return nil, fmt.Errorf("mapping rate card: %w", err)
 	}
@@ -766,7 +766,7 @@ func mergeStandardLineFromAPI(existing *billing.StandardLine, line api.UpdateInv
 	existing.Period.To = line.ServicePeriod.To.Truncate(streaming.MinimumWindowSizeDuration)
 
 	existing.TaxConfig = taxConfig
-	existing.RateCardDiscounts = discounts
+	existing.RateCardDiscounts = existing.RateCardDiscounts.ReplaceFromProductCatalog(desiredDiscounts)
 	if existing.UsageBased == nil {
 		return nil, fmt.Errorf("existing line %s has no usage-based pricing", existing.ID)
 	}
@@ -779,20 +779,20 @@ func mergeStandardLineFromAPI(existing *billing.StandardLine, line api.UpdateInv
 // mapRateCardFromAPI maps an update request's rate card onto its domain price, tax config,
 // feature key, and discounts. Feature key requiredness relative to the price type is enforced
 // by billing.UsageBasedLine.Validate downstream, not here.
-func mapRateCardFromAPI(rc api.UpdateInvoiceLineRateCard) (*productcatalog.Price, *billing.TaxConfig, string, billing.Discounts, error) {
+func mapRateCardFromAPI(rc api.UpdateInvoiceLineRateCard) (*productcatalog.Price, *billing.TaxConfig, string, productcatalog.Discounts, error) {
 	price, err := plans.FromAPIBillingPrice(api.BillingPrice(rc.Price), nil)
 	if err != nil {
-		return nil, nil, "", billing.Discounts{}, fmt.Errorf("mapping price: %w", err)
+		return nil, nil, "", productcatalog.Discounts{}, fmt.Errorf("mapping price: %w", err)
 	}
 
-	var discounts billing.Discounts
+	var discounts productcatalog.Discounts
 	if rc.Discounts != nil {
 		pcDiscounts, err := plans.FromAPIBillingRateCardDiscounts(api.BillingRateCardDiscounts(*rc.Discounts))
 		if err != nil {
-			return nil, nil, "", billing.Discounts{}, fmt.Errorf("mapping discounts: %w", err)
+			return nil, nil, "", productcatalog.Discounts{}, fmt.Errorf("mapping discounts: %w", err)
 		}
 
-		discounts = billing.DiscountsFromProductCatalog(pcDiscounts).UpsertCorrelationIDs()
+		discounts = pcDiscounts
 	}
 
 	taxConfig := billing.FromProductCatalog(addons.FromAPIBillingRateCardTaxConfig(fromAPIUpdateRateCardTaxConfig(rc.TaxConfig)))

--- a/api/v3/handlers/billinginvoices/convert_test.go
+++ b/api/v3/handlers/billinginvoices/convert_test.go
@@ -117,6 +117,26 @@ func TestMapRateCardOmitsUnitConfigWhenAbsent(t *testing.T) {
 	require.Nil(t, rc.UnitConfig)
 }
 
+func TestMergeStandardLineFromAPIPreservesDiscountCorrelationID(t *testing.T) {
+	period := mergeTestPeriod()
+	line := standardLineForMergeTest(t, "line-id", period)
+	line.RateCardDiscounts = billing.Discounts{
+		Percentage: &billing.PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(10)},
+			CorrelationID:      "existing-percentage",
+		},
+	}
+
+	apiLine, err := apiLineForMergeTest(t, period, lo.ToPtr(line.ID)).AsUpdateInvoiceStandardLine()
+	require.NoError(t, err)
+	apiLine.RateCard.Discounts = &api.UpdateDiscounts{Percentage: lo.ToPtr(float32(20))}
+
+	mergedLine, err := mergeStandardLineFromAPI(line, apiLine)
+	require.NoError(t, err)
+	require.Equal(t, models.NewPercentage(20), mergedLine.RateCardDiscounts.Percentage.Percentage)
+	require.Equal(t, "existing-percentage", mergedLine.RateCardDiscounts.Percentage.CorrelationID)
+}
+
 func TestMapUsageQuantityDetailSurfacesStoredQuantities(t *testing.T) {
 	period := mergeTestPeriod()
 

--- a/api/v3/handlers/customers/charges/convert.go
+++ b/api/v3/handlers/customers/charges/convert.go
@@ -528,16 +528,13 @@ func fromAPICreateChargeFlatFeeRequest(namespace, customerID string, flatFee api
 		metadata = models.Metadata(*flatFee.Labels)
 	}
 
-	var discount *billing.PercentageDiscount
+	var percentageDiscount *productcatalog.PercentageDiscount
 	if flatFee.Discounts != nil && flatFee.Discounts.Percentage != nil {
-		discount = billing.Discounts{
-			Percentage: &billing.PercentageDiscount{
-				PercentageDiscount: productcatalog.PercentageDiscount{
-					Percentage: models.NewPercentage(float64(lo.FromPtr(flatFee.Discounts.Percentage))),
-				},
-			},
-		}.UpsertCorrelationIDs().Percentage
+		percentageDiscount = &productcatalog.PercentageDiscount{
+			Percentage: models.NewPercentage(float64(lo.FromPtr(flatFee.Discounts.Percentage))),
+		}
 	}
+	billingDiscount := billing.PercentageDiscountFromProductCatalog(percentageDiscount)
 
 	var proRating productcatalog.ProRatingConfig
 	if flatFee.ProrationConfiguration.Mode == api.BillingRateCardProrationModeProratePrices {
@@ -569,7 +566,7 @@ func fromAPICreateChargeFlatFeeRequest(namespace, customerID string, flatFee api
 				},
 				InvoiceAt:             flatFee.InvoiceAt,
 				PaymentTerm:           productcatalog.PaymentTermType(flatFee.PaymentTerm),
-				PercentageDiscounts:   discount,
+				PercentageDiscounts:   billingDiscount,
 				ProRating:             proRating,
 				AmountBeforeProration: amountBeforeProration,
 			},
@@ -592,13 +589,11 @@ func fromAPICreateChargeUsageBasedRequest(namespace, customerID string, usageBas
 		metadata = models.Metadata(*usageBasedFee.Labels)
 	}
 
-	var discounts billing.Discounts
+	var discounts productcatalog.Discounts
 	if usageBasedFee.Discounts != nil {
 		if usageBasedFee.Discounts.Percentage != nil {
-			discounts.Percentage = &billing.PercentageDiscount{
-				PercentageDiscount: productcatalog.PercentageDiscount{
-					Percentage: models.NewPercentage(float64(lo.FromPtr(usageBasedFee.Discounts.Percentage))),
-				},
+			discounts.Percentage = &productcatalog.PercentageDiscount{
+				Percentage: models.NewPercentage(float64(lo.FromPtr(usageBasedFee.Discounts.Percentage))),
 			}
 		}
 		if usageBasedFee.Discounts.Usage != nil {
@@ -606,14 +601,12 @@ func fromAPICreateChargeUsageBasedRequest(namespace, customerID string, usageBas
 			if err != nil {
 				return zero, fmt.Errorf("invalid usage discount quantity: %w", err)
 			}
-			discounts.Usage = &billing.UsageDiscount{
-				UsageDiscount: productcatalog.UsageDiscount{
-					Quantity: quantity,
-				},
+			discounts.Usage = &productcatalog.UsageDiscount{
+				Quantity: quantity,
 			}
 		}
-		discounts = discounts.UpsertCorrelationIDs()
 	}
+	billingDiscounts := billing.DiscountsFromProductCatalog(discounts)
 
 	price, err := plans.FromAPIBillingPrice(usageBasedFee.Price, lo.ToPtr(api.BillingPricePaymentTermInArrears))
 	if err != nil {
@@ -637,7 +630,7 @@ func fromAPICreateChargeUsageBasedRequest(namespace, customerID string, usageBas
 				},
 				InvoiceAt: usageBasedFee.InvoiceAt,
 				Price:     *price,
-				Discounts: discounts,
+				Discounts: billingDiscounts,
 			},
 			FeatureID:      usageBasedFee.FeatureId,
 			SettlementMode: productcatalog.SettlementMode(usageBasedFee.SettlementMode),

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -116,6 +116,9 @@ asynchronously; webhook delivery is not part of the invoice lifecycle.
 
 - invoice manipulation is serialized per customer and runs under the billing
   transaction and customer update lock
+- product-catalog discounts describe commercial configuration without billing
+  identity; once attached to a charge or invoice line, billing owns a stable,
+  non-empty correlation ID for every present discount
 - every invoice contains one fiat currency
 - a customer cannot have two active gathering invoices for the same currency
 - gathering-to-standard conversion preserves line IDs

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -22,6 +23,11 @@ import (
 )
 
 func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flatfee.ChargeWithGatheringLine, error) {
+	input.Intents = slices.Clone(input.Intents)
+	for idx := range input.Intents {
+		input.Intents[idx].PercentageDiscounts = input.Intents[idx].PercentageDiscounts.UpsertCorrelationID()
+	}
+
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -259,26 +259,32 @@ func (s *ChargeFeatureIDTestSuite) TestCreateCustomerChargeResolvesFeatureByID()
 	s.Run("flat fee charge created by feature ID", func() {
 		// given:
 		// - a caller that only knows the feature ID, as the v3 create endpoint does
+		discounts := billing.DiscountsFromProductCatalog(productcatalog.Discounts{
+			Percentage: &productcatalog.PercentageDiscount{Percentage: models.NewPercentage(10)},
+		})
+		flatFeeInput := &charges.CreateCustomerChargeFlatFeeInput{
+			IntentMutableFields: flatfee.IntentMutableFields{
+				IntentMutableFields: meta.IntentMutableFields{
+					Name:              "flat fee by feature id",
+					ServicePeriod:     servicePeriod,
+					FullServicePeriod: servicePeriod,
+					BillingPeriod:     servicePeriod,
+				},
+				InvoiceAt:             servicePeriod.From,
+				PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+				PercentageDiscounts:   discounts.Percentage,
+				AmountBeforeProration: alpacadecimal.NewFromInt(25),
+			},
+			FeatureID:      lo.ToPtr(flatFeeFeature.ID),
+			SettlementMode: productcatalog.CreditOnlySettlementMode,
+		}
+
 		// when:
 		created, err := s.Charges.CreateCustomerCharge(ctx, charges.CreateCustomerChargeInput{
 			Namespace:    ns,
 			CustomerID:   cust.ID,
 			CurrencyCode: USD,
-			FlatFee: &charges.CreateCustomerChargeFlatFeeInput{
-				IntentMutableFields: flatfee.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						Name:              "flat fee by feature id",
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt:             servicePeriod.From,
-					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
-					AmountBeforeProration: alpacadecimal.NewFromInt(25),
-				},
-				FeatureID:      lo.ToPtr(flatFeeFeature.ID),
-				SettlementMode: productcatalog.CreditOnlySettlementMode,
-			},
+			FlatFee:      flatFeeInput,
 		})
 		s.Require().NoError(err)
 
@@ -289,6 +295,8 @@ func (s *ChargeFeatureIDTestSuite) TestCreateCustomerChargeResolvesFeatureByID()
 		s.Require().NotNil(flatFeeCharge.State.FeatureID)
 		s.Equal(flatFeeFeature.ID, *flatFeeCharge.State.FeatureID)
 		s.Equal(flatFeeFeature.Key, flatFeeCharge.Intent.GetFeatureKey())
+		s.Require().NotNil(flatFeeCharge.Intent.GetEffectiveIntent().PercentageDiscounts)
+		s.NotEmpty(flatFeeCharge.Intent.GetEffectiveIntent().PercentageDiscounts.CorrelationID)
 
 		fetched, err := s.mustGetChargeByID(flatFeeCharge.GetChargeID()).AsFlatFeeCharge()
 		s.Require().NoError(err)
@@ -298,27 +306,33 @@ func (s *ChargeFeatureIDTestSuite) TestCreateCustomerChargeResolvesFeatureByID()
 	})
 
 	s.Run("usage based charge created by feature ID", func() {
+		discounts := billing.DiscountsFromProductCatalog(productcatalog.Discounts{
+			Usage: &productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)},
+		})
+		usageBasedInput := &charges.CreateCustomerChargeUsageBasedInput{
+			IntentMutableFields: usagebased.IntentMutableFields{
+				IntentMutableFields: meta.IntentMutableFields{
+					Name:              "usage based by feature id",
+					ServicePeriod:     servicePeriod,
+					FullServicePeriod: servicePeriod,
+					BillingPeriod:     servicePeriod,
+				},
+				InvoiceAt: servicePeriod.From,
+				Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				Discounts: discounts,
+			},
+			FeatureID:      usageFeature.ID,
+			SettlementMode: productcatalog.CreditOnlySettlementMode,
+		}
+
 		// when:
 		created, err := s.Charges.CreateCustomerCharge(ctx, charges.CreateCustomerChargeInput{
 			Namespace:    ns,
 			CustomerID:   cust.ID,
 			CurrencyCode: USD,
-			UsageBased: &charges.CreateCustomerChargeUsageBasedInput{
-				IntentMutableFields: usagebased.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						Name:              "usage based by feature id",
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt: servicePeriod.From,
-					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-						Amount: alpacadecimal.NewFromInt(2),
-					}),
-				},
-				FeatureID:      usageFeature.ID,
-				SettlementMode: productcatalog.CreditOnlySettlementMode,
-			},
+			UsageBased:   usageBasedInput,
 		})
 		s.Require().NoError(err)
 
@@ -327,6 +341,8 @@ func (s *ChargeFeatureIDTestSuite) TestCreateCustomerChargeResolvesFeatureByID()
 		s.Require().NoError(err)
 		s.Equal(usageFeature.ID, usageBasedCharge.State.FeatureID)
 		s.Equal(usageFeature.Key, usageBasedCharge.Intent.GetFeatureKey())
+		s.Require().NotNil(usageBasedCharge.Intent.GetEffectiveIntent().Discounts.Usage)
+		s.NotEmpty(usageBasedCharge.Intent.GetEffectiveIntent().Discounts.Usage.CorrelationID)
 
 		fetched, err := s.mustGetChargeByID(usageBasedCharge.GetChargeID()).AsUsageBasedCharge()
 		s.Require().NoError(err)

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -20,6 +21,11 @@ import (
 )
 
 func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]usagebased.ChargeWithGatheringLine, error) {
+	input.Intents = slices.Clone(input.Intents)
+	for idx := range input.Intents {
+		input.Intents[idx].Discounts = input.Intents[idx].Discounts.UpsertCorrelationIDs()
+	}
+
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/discount.go
+++ b/openmeter/billing/discount.go
@@ -29,6 +29,34 @@ type PercentageDiscount struct {
 	CorrelationID string `json:"correlationID"`
 }
 
+func (d PercentageDiscount) Validate() error {
+	var errs []error
+
+	if err := d.PercentageDiscount.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if d.CorrelationID == "" {
+		errs = append(errs, errors.New("correlation ID is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (d PercentageDiscount) ValidateForPrice(price *productcatalog.Price) error {
+	var errs []error
+
+	if err := d.PercentageDiscount.ValidateForPrice(price); err != nil {
+		errs = append(errs, err)
+	}
+
+	if d.CorrelationID == "" {
+		errs = append(errs, errors.New("correlation ID is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 func (d PercentageDiscount) Clone() PercentageDiscount {
 	return PercentageDiscount{
 		PercentageDiscount: d.PercentageDiscount.Clone(),
@@ -76,6 +104,34 @@ type UsageDiscount struct {
 	productcatalog.UsageDiscount `json:",inline"`
 
 	CorrelationID string `json:"correlationID"`
+}
+
+func (d UsageDiscount) Validate() error {
+	var errs []error
+
+	if err := d.UsageDiscount.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if d.CorrelationID == "" {
+		errs = append(errs, errors.New("correlation ID is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (d UsageDiscount) ValidateForPrice(price *productcatalog.Price) error {
+	var errs []error
+
+	if err := d.UsageDiscount.ValidateForPrice(price); err != nil {
+		errs = append(errs, err)
+	}
+
+	if d.CorrelationID == "" {
+		errs = append(errs, errors.New("correlation ID is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 var _ discountType[UsageDiscount] = (*UsageDiscount)(nil)
@@ -188,12 +244,49 @@ func (d Discounts) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// PercentageDiscountFromProductCatalog turns unowned commercial configuration
+// into a billing-owned discount with a correlation ID.
+func PercentageDiscountFromProductCatalog(discount *productcatalog.PercentageDiscount) *PercentageDiscount {
+	if discount == nil {
+		return nil
+	}
+
+	return (&PercentageDiscount{
+		PercentageDiscount: discount.Clone(),
+	}).UpsertCorrelationID()
+}
+
+// UsageDiscountFromProductCatalog turns unowned commercial configuration into
+// a billing-owned discount with a correlation ID.
+func UsageDiscountFromProductCatalog(discount *productcatalog.UsageDiscount) *UsageDiscount {
+	if discount == nil {
+		return nil
+	}
+
+	return (&UsageDiscount{
+		UsageDiscount: discount.Clone(),
+	}).UpsertCorrelationID()
+}
+
 func DiscountsFromProductCatalog(discounts productcatalog.Discounts) Discounts {
+	return Discounts{
+		Percentage: PercentageDiscountFromProductCatalog(discounts.Percentage),
+		Usage:      UsageDiscountFromProductCatalog(discounts.Usage),
+	}
+}
+
+// ReplaceFromProductCatalog applies unowned commercial discount configuration to
+// an existing billing-owned value. Existing discount kinds preserve their
+// correlation IDs; newly introduced kinds receive new IDs.
+func (d Discounts) ReplaceFromProductCatalog(discounts productcatalog.Discounts) Discounts {
 	out := Discounts{}
 
 	if discounts.Percentage != nil {
 		out.Percentage = &PercentageDiscount{
 			PercentageDiscount: discounts.Percentage.Clone(),
+		}
+		if d.Percentage != nil {
+			out.Percentage.CorrelationID = d.Percentage.CorrelationID
 		}
 	}
 
@@ -201,6 +294,23 @@ func DiscountsFromProductCatalog(discounts productcatalog.Discounts) Discounts {
 		out.Usage = &UsageDiscount{
 			UsageDiscount: discounts.Usage.Clone(),
 		}
+		if d.Usage != nil {
+			out.Usage.CorrelationID = d.Usage.CorrelationID
+		}
+	}
+
+	return out.UpsertCorrelationIDs()
+}
+
+func (d Discounts) ToProductCatalog() productcatalog.Discounts {
+	out := productcatalog.Discounts{}
+
+	if d.Percentage != nil {
+		out.Percentage = lo.ToPtr(d.Percentage.PercentageDiscount.Clone())
+	}
+
+	if d.Usage != nil {
+		out.Usage = lo.ToPtr(d.Usage.UsageDiscount.Clone())
 	}
 
 	return out

--- a/openmeter/billing/discount_test.go
+++ b/openmeter/billing/discount_test.go
@@ -29,8 +29,8 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 		{
 			name: "valid percentage and negative usage validates usage",
 			discounts: Discounts{
-				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}},
-				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(-1)}},
+				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}, CorrelationID: "percentage"},
+				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(-1)}, CorrelationID: "usage"},
 			},
 			price:    unitPrice,
 			wantErrs: []error{productcatalog.ErrUsageDiscountNegativeQuantity},
@@ -38,8 +38,8 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 		{
 			name: "valid percentage and positive usage rejects flat price",
 			discounts: Discounts{
-				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}},
-				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}},
+				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}, CorrelationID: "percentage"},
+				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}, CorrelationID: "usage"},
 			},
 			price:    flatPrice,
 			wantErrs: []error{productcatalog.ErrUsageDiscountWithFlatPrice},
@@ -47,8 +47,8 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 		{
 			name: "negative usage on flat price returns both usage errors",
 			discounts: Discounts{
-				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}},
-				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(-1)}},
+				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}, CorrelationID: "percentage"},
+				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(-1)}, CorrelationID: "usage"},
 			},
 			price: flatPrice,
 			wantErrs: []error{
@@ -59,22 +59,22 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 		{
 			name: "valid percentage and usage for unit price",
 			discounts: Discounts{
-				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}},
-				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}},
+				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}, CorrelationID: "percentage"},
+				Usage:      &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}, CorrelationID: "usage"},
 			},
 			price: unitPrice,
 		},
 		{
 			name: "percentage only",
 			discounts: Discounts{
-				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}},
+				Percentage: &PercentageDiscount{PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}, CorrelationID: "percentage"},
 			},
 			price: flatPrice,
 		},
 		{
 			name: "usage only for unit price",
 			discounts: Discounts{
-				Usage: &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}},
+				Usage: &UsageDiscount{UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}, CorrelationID: "usage"},
 			},
 			price: unitPrice,
 		},
@@ -94,6 +94,111 @@ func TestDiscountsValidateForPrice(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDiscountsRequireCorrelationIDs(t *testing.T) {
+	unitPrice := productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+		Amount: alpacadecimal.NewFromInt(100),
+	})
+
+	tests := []struct {
+		name      string
+		discounts Discounts
+	}{
+		{
+			name: "percentage",
+			discounts: Discounts{
+				Percentage: &PercentageDiscount{
+					PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+				},
+			},
+		},
+		{
+			name: "usage",
+			discounts: Discounts{
+				Usage: &UsageDiscount{
+					UsageDiscount: productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.ErrorContains(t, test.discounts.Validate(), "correlation ID is required")
+			require.ErrorContains(t, test.discounts.ValidateForPrice(unitPrice), "correlation ID is required")
+		})
+	}
+
+	require.NoError(t, (Discounts{}).Validate())
+	require.NoError(t, (Discounts{}).ValidateForPrice(nil))
+	require.NoError(t, (Discounts{
+		Percentage: &PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+			CorrelationID:      "any non-empty string is valid",
+		},
+	}).Validate())
+}
+
+func TestDiscountsFromProductCatalog(t *testing.T) {
+	discounts := productcatalog.Discounts{
+		Percentage: &productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+		Usage:      &productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)},
+	}
+
+	billingDiscounts := DiscountsFromProductCatalog(discounts)
+
+	require.NoError(t, billingDiscounts.Validate())
+	require.NotEmpty(t, billingDiscounts.Percentage.CorrelationID)
+	require.NotEmpty(t, billingDiscounts.Usage.CorrelationID)
+	require.Equal(t, discounts, billingDiscounts.ToProductCatalog())
+}
+
+func TestDiscountFromProductCatalog(t *testing.T) {
+	percentage := &productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)}
+	usage := &productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)}
+
+	billingPercentage := PercentageDiscountFromProductCatalog(percentage)
+	billingUsage := UsageDiscountFromProductCatalog(usage)
+
+	require.NoError(t, billingPercentage.Validate())
+	require.NoError(t, billingUsage.Validate())
+	require.NotEmpty(t, billingPercentage.CorrelationID)
+	require.NotEmpty(t, billingUsage.CorrelationID)
+	require.Equal(t, *percentage, billingPercentage.PercentageDiscount)
+	require.Equal(t, *usage, billingUsage.UsageDiscount)
+	require.Nil(t, PercentageDiscountFromProductCatalog(nil))
+	require.Nil(t, UsageDiscountFromProductCatalog(nil))
+}
+
+func TestDiscountsReplaceFromProductCatalog(t *testing.T) {
+	existing := Discounts{
+		Percentage: &PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(10)},
+			CorrelationID:      "existing-percentage",
+		},
+	}
+
+	replaced := existing.ReplaceFromProductCatalog(productcatalog.Discounts{
+		Percentage: &productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+		Usage:      &productcatalog.UsageDiscount{Quantity: alpacadecimal.NewFromInt(1)},
+	})
+
+	require.NoError(t, replaced.Validate())
+	require.Equal(t, "existing-percentage", replaced.Percentage.CorrelationID)
+	require.Equal(t, models.NewPercentage(50), replaced.Percentage.Percentage)
+	require.NotEmpty(t, replaced.Usage.CorrelationID)
+
+	retried := replaced.ReplaceFromProductCatalog(replaced.ToProductCatalog())
+	require.Equal(t, replaced, retried)
+
+	removed := replaced.ReplaceFromProductCatalog(productcatalog.Discounts{})
+	require.True(t, removed.IsEmpty())
+
+	readded := removed.ReplaceFromProductCatalog(productcatalog.Discounts{
+		Percentage: &productcatalog.PercentageDiscount{Percentage: models.NewPercentage(50)},
+	})
+	require.NotEqual(t, "existing-percentage", readded.Percentage.CorrelationID)
 }
 
 func TestDiscountsUpsertCorrelationIDs(t *testing.T) {

--- a/openmeter/billing/httpdriver/deprecations.go
+++ b/openmeter/billing/httpdriver/deprecations.go
@@ -96,7 +96,7 @@ type invoiceLineRateCardParsed struct {
 	Price      *productcatalog.Price
 	TaxConfig  *productcatalog.TaxConfig
 	FeatureKey string
-	Discounts  billing.Discounts
+	Discounts  productcatalog.Discounts
 }
 
 func mapAndValidateInvoiceLineRateCardDeprecatedFields(in invoiceLineRateCardItems) (*invoiceLineRateCardParsed, error) {
@@ -138,7 +138,7 @@ func mapAndValidateInvoiceLineRateCardDeprecatedFields(in invoiceLineRateCardIte
 		}
 	}
 
-	var discounts billing.Discounts
+	var discounts productcatalog.Discounts
 	if in.RateCard.Discounts != nil {
 		discounts, err = AsDiscounts(in.RateCard.Discounts)
 		if err != nil {
@@ -152,8 +152,6 @@ func mapAndValidateInvoiceLineRateCardDeprecatedFields(in invoiceLineRateCardIte
 				Err: fmt.Errorf("invalid rateCard.discounts: %w", err),
 			}
 		}
-
-		discounts = discounts.UpsertCorrelationIDs()
 	}
 
 	return &invoiceLineRateCardParsed{

--- a/openmeter/billing/httpdriver/discounts.go
+++ b/openmeter/billing/httpdriver/discounts.go
@@ -3,36 +3,28 @@
 package httpdriver
 
 import (
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/api"
-	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	productcataloghttp "github.com/openmeterio/openmeter/openmeter/productcatalog/http"
 )
 
-func AsPercentageDiscount(d api.BillingDiscountPercentage) billing.PercentageDiscount {
-	return billing.PercentageDiscount{
-		PercentageDiscount: productcataloghttp.AsPercentageDiscount(api.FromBillingDiscountPercentageToDiscountPercentage(d)),
-		CorrelationID:      lo.FromPtr(d.CorrelationId),
-	}
+func AsPercentageDiscount(d api.BillingDiscountPercentage) productcatalog.PercentageDiscount {
+	return productcataloghttp.AsPercentageDiscount(api.FromBillingDiscountPercentageToDiscountPercentage(d))
 }
 
-func AsUsageDiscount(d api.BillingDiscountUsage) (billing.UsageDiscount, error) {
+func AsUsageDiscount(d api.BillingDiscountUsage) (productcatalog.UsageDiscount, error) {
 	pcUsageDiscount := api.FromBillingDiscountUsageToDiscountUsage(d)
 
 	usageDiscount, err := productcataloghttp.AsUsageDiscount(pcUsageDiscount)
 	if err != nil {
-		return billing.UsageDiscount{}, err
+		return productcatalog.UsageDiscount{}, err
 	}
 
-	return billing.UsageDiscount{
-		UsageDiscount: usageDiscount,
-		CorrelationID: lo.FromPtr(d.CorrelationId),
-	}, nil
+	return usageDiscount, nil
 }
 
-func AsDiscounts(discounts *api.BillingDiscounts) (billing.Discounts, error) {
-	out := billing.Discounts{}
+func AsDiscounts(discounts *api.BillingDiscounts) (productcatalog.Discounts, error) {
+	out := productcatalog.Discounts{}
 	if discounts == nil {
 		return out, nil
 	}
@@ -40,10 +32,8 @@ func AsDiscounts(discounts *api.BillingDiscounts) (billing.Discounts, error) {
 	if discounts.Percentage != nil {
 		pctDiscount := api.FromBillingDiscountPercentageToDiscountPercentage(*discounts.Percentage)
 
-		out.Percentage = &billing.PercentageDiscount{
-			PercentageDiscount: productcataloghttp.AsPercentageDiscount(pctDiscount),
-			CorrelationID:      lo.FromPtr(discounts.Percentage.CorrelationId),
-		}
+		percentageDiscount := productcataloghttp.AsPercentageDiscount(pctDiscount)
+		out.Percentage = &percentageDiscount
 	}
 
 	if discounts.Usage != nil {
@@ -51,13 +41,10 @@ func AsDiscounts(discounts *api.BillingDiscounts) (billing.Discounts, error) {
 
 		usageDiscount, err := productcataloghttp.AsUsageDiscount(uDiscount)
 		if err != nil {
-			return billing.Discounts{}, err
+			return productcatalog.Discounts{}, err
 		}
 
-		out.Usage = &billing.UsageDiscount{
-			UsageDiscount: usageDiscount,
-			CorrelationID: lo.FromPtr(discounts.Usage.CorrelationId),
-		}
+		out.Usage = &usageDiscount
 	}
 
 	return out, nil

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -193,7 +193,7 @@ func mapCreateLineToEntity(line api.InvoicePendingLineCreate, ns string) (*billi
 
 			InvoiceAt:         line.InvoiceAt,
 			TaxConfig:         billing.FromProductCatalog(rateCardParsed.TaxConfig),
-			RateCardDiscounts: rateCardParsed.Discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(rateCardParsed.Discounts),
 		},
 		UsageBased: &billing.UsageBasedLine{
 			Price:      rateCardParsed.Price,
@@ -236,7 +236,7 @@ func mapCreateGatheringLineToEntity(line api.InvoicePendingLineCreate, ns string
 
 			InvoiceAt:         line.InvoiceAt,
 			TaxConfig:         rateCardParsed.TaxConfig,
-			RateCardDiscounts: rateCardParsed.Discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(rateCardParsed.Discounts),
 			Price:             lo.FromPtr(rateCardParsed.Price),
 			FeatureKey:        rateCardParsed.FeatureKey,
 		},
@@ -667,7 +667,7 @@ func mapSimulationLineToEntity(line api.InvoiceSimulationLine) (*billing.Standar
 
 			InvoiceAt:         line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 			TaxConfig:         billing.FromProductCatalog(rateCardParsed.TaxConfig),
-			RateCardDiscounts: rateCardParsed.Discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(rateCardParsed.Discounts),
 		},
 		UsageBased: &billing.UsageBasedLine{
 			Price:                        rateCardParsed.Price,
@@ -711,7 +711,7 @@ func standardLineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate,
 			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 
 			TaxConfig:         billing.FromProductCatalog(rateCardParsed.TaxConfig),
-			RateCardDiscounts: rateCardParsed.Discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(rateCardParsed.Discounts),
 		},
 		UsageBased: &billing.UsageBasedLine{
 			Price:      rateCardParsed.Price,
@@ -759,7 +759,7 @@ func gatheringLineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate
 			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 
 			TaxConfig:         rateCardParsed.TaxConfig,
-			RateCardDiscounts: rateCardParsed.Discounts,
+			RateCardDiscounts: billing.DiscountsFromProductCatalog(rateCardParsed.Discounts),
 			Price:             lo.FromPtr(rateCardParsed.Price),
 			FeatureKey:        rateCardParsed.FeatureKey,
 		},
@@ -790,7 +790,7 @@ func mergeStandardLineFromInvoiceLineReplaceUpdate(existing *billing.StandardLin
 	existing.TaxConfig = billing.FromProductCatalog(rateCardParsed.TaxConfig)
 	existing.UsageBased.Price = rateCardParsed.Price
 	existing.UsageBased.FeatureKey = rateCardParsed.FeatureKey
-	existing.RateCardDiscounts = rateCardParsed.Discounts
+	existing.RateCardDiscounts = existing.RateCardDiscounts.ReplaceFromProductCatalog(rateCardParsed.Discounts)
 
 	return existing, nil
 }
@@ -825,7 +825,7 @@ func mergeGatheringLineFromInvoiceLineReplaceUpdate(existing billing.GatheringLi
 	existing.TaxConfig = rateCardParsed.TaxConfig
 	existing.Price = lo.FromPtr(rateCardParsed.Price)
 	existing.FeatureKey = rateCardParsed.FeatureKey
-	existing.RateCardDiscounts = rateCardParsed.Discounts
+	existing.RateCardDiscounts = existing.RateCardDiscounts.ReplaceFromProductCatalog(rateCardParsed.Discounts)
 
 	return existing, nil
 }

--- a/openmeter/billing/httpdriver/invoiceline_test.go
+++ b/openmeter/billing/httpdriver/invoiceline_test.go
@@ -189,6 +189,29 @@ func TestMergeStandardLineFromInvoiceLineReplaceUpdateDropsResolvedTaxCodeWhenTa
 	require.Equal(t, newTaxCodeID, *mergedLine.TaxConfig.TaxCodeID)
 }
 
+func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesDiscountCorrelationID(t *testing.T) {
+	period := invoiceLineTestPeriod()
+	line := standardInvoiceLineForMergeTest(t, period)
+	line.RateCardDiscounts = billing.Discounts{
+		Percentage: &billing.PercentageDiscount{
+			PercentageDiscount: productcatalog.PercentageDiscount{Percentage: models.NewPercentage(10)},
+			CorrelationID:      "existing-percentage",
+		},
+	}
+
+	mergedLine, err := mergeStandardLineFromInvoiceLineReplaceUpdate(line, invoiceLineReplaceUpdateForMergeTest(t, period, line.UsageBased.FeatureKey, "1", func(update *api.InvoiceLineReplaceUpdate) {
+		update.RateCard.Discounts = &api.BillingDiscounts{
+			Percentage: &api.BillingDiscountPercentage{
+				Percentage:    models.NewPercentage(20),
+				CorrelationId: lo.ToPtr("client-supplied-correlation-id"),
+			},
+		}
+	}))
+	require.NoError(t, err)
+	require.Equal(t, models.NewPercentage(20), mergedLine.RateCardDiscounts.Percentage.Percentage)
+	require.Equal(t, "existing-percentage", mergedLine.RateCardDiscounts.Percentage.CorrelationID)
+}
+
 func TestMergeGatheringLineFromInvoiceLineReplaceUpdateAcceptsRateCardOnlyPrice(t *testing.T) {
 	period := invoiceLineTestPeriod()
 	line := gatheringInvoiceLineForMergeTest(t, period)


### PR DESCRIPTION
## Summary

- require every present billing percentage or usage discount to have a non-empty correlation ID
- keep API request discounts as product-catalog values until they enter billing ownership, then construct correlated billing discounts
- preserve existing correlation IDs during invoice-line updates while assigning IDs to newly introduced discount kinds
- normalize flat-fee and usage-based charge creates before validation while retaining persistence fallbacks
- provide type-specific product-catalog-to-billing discount constructors and compose the aggregate constructor from them

## Root cause

The original correlation-ID repair allocated IDs at charge lifecycle and persistence boundaries, but the billing discount validators still inherited product-catalog validation and therefore did not enforce billing identity. API conversion paths could also construct billing discount types directly from unowned request data. That made an uncorrelated billing-owned discount valid to the type's validator and left correctness dependent on every caller remembering a later fallback.

## Impact

Billing-owned discounts now reject missing correlation IDs. Product-catalog discounts remain valid without billing identity, and create/update boundaries explicitly materialize or reconcile billing correlation IDs. Existing defensive upserts remain in place for compatibility.

## Validation

- `go test -tags=dynamic ./openmeter/billing/... ./api/v3/handlers/billinginvoices ./api/v3/handlers/customers/charges`
- `golangci-lint run --config .golangci-fast.yaml ./openmeter/billing/... ./api/v3/handlers/billinginvoices/... ./api/v3/handlers/customers/charges/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent handling for percentage, usage-based, and flat-fee discounts across charges and invoices.
  - Discount conversion now automatically assigns stable correlation IDs where needed.
  - Discount updates preserve existing discount identity while applying changed values.

- **Bug Fixes**
  - Fixed discount replacement behavior so client-provided IDs no longer overwrite existing billing identities.
  - Added validation to prevent discounts without required correlation IDs.

- **Documentation**
  - Documented requirements for stable billing discount identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes correlation IDs as required billing-owned identity for percentage and usage discounts.

- Adds correlation-ID validation and product-catalog-to-billing constructors.
- Preserves existing IDs when invoice-line discounts are replaced and allocates IDs for new discount kinds.
- Normalizes charge-create inputs before validation and moves API conversion through product-catalog discount values.
- Leaves a compatibility gap for legacy charge updates because adapter validation runs before the retained backfill.

<h3>Confidence Score: 4/5</h3>

The legacy charge-update compatibility failure should be fixed before merging because affected charges cannot advance or accept patches.

The new validators reject empty correlation IDs at the start of adapter updates, while the adapters' explicit legacy-data backfills execute only after validation and are therefore unreachable for the entities they are intended to repair.

**Files Needing Attention:** openmeter/billing/discount.go and the flat-fee and usage-based charge adapters

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/discount.go | Adds required correlation-ID validation and ownership conversion helpers, but the stricter validator blocks legacy charge updates before adapter repair. |
| openmeter/billing/charges/flatfee/service/create.go | Clones intent slices and safely assigns normalized percentage discounts before validation. |
| openmeter/billing/charges/usagebased/service/create.go | Clones intent slices and safely normalizes usage-based discounts before validation. |
| openmeter/billing/httpdriver/invoiceline.go | Materializes billing-owned discounts on creates and preserves existing correlation IDs during merges. |
| api/v3/handlers/billinginvoices/convert.go | Keeps request discounts as product-catalog values until invoice-line ownership is established. |
| openmeter/billing/httpdriver/discounts.go | Converts API discounts into identity-free product-catalog values in accordance with the new ownership boundary. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as Charge worker/sync
  participant SM as Charge state machine
  participant Adapter as Charge adapter
  participant Validator as Discount validator
  Worker->>SM: Advance or patch legacy charge
  SM->>Adapter: UpdateCharge
  Adapter->>Validator: Validate empty correlation ID
  Validator-->>Adapter: correlation ID is required
  Note over Adapter: Defensive upsert is never reached
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fdiscount.go%3A39-41%0A**Legacy%20charge%20repair%20is%20blocked**%0A%0AIf%20persisted%20flat-fee%20or%20usage-based%20charges%20have%20discounts%20without%20correlation%20IDs%2C%20the%20new%20validation%20rejects%20them%20during%20%60UpdateCharge%60%20before%20the%20adapters%20reach%20their%20defensive%20backfill%2C%20causing%20charge%20advancement%20and%20patch%20operations%20to%20fail%20with%20%60correlation%20ID%20is%20required%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4891&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fcharge-discount-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcharge-discount-validation%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fdiscount.go%3A39-41%0A**Legacy%20charge%20repair%20is%20blocked**%0A%0AIf%20persisted%20flat-fee%20or%20usage-based%20charges%20have%20discounts%20without%20correlation%20IDs%2C%20the%20new%20validation%20rejects%20them%20during%20%60UpdateCharge%60%20before%20the%20adapters%20reach%20their%20defensive%20backfill%2C%20causing%20charge%20advancement%20and%20patch%20operations%20to%20fail%20with%20%60correlation%20ID%20is%20required%60.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4891&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/billing/discount.go:39-41
**Legacy charge repair is blocked**

If persisted flat-fee or usage-based charges have discounts without correlation IDs, the new validation rejects them during `UpdateCharge` before the adapters reach their defensive backfill, causing charge advancement and patch operations to fail with `correlation ID is required`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: validate billing discount correlati..."](https://github.com/openmeterio/openmeter/commit/6cfd30780f2641ec088499382f69cebc9e306e9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51605302)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->