### PR TITLE
fix(billing): repair persisted charge discount IDs

### DIFF
--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -40,6 +40,10 @@ func (e *LineEngine) SplitGatheringLine(context.Context, billing.SplitGatheringL
 }
 
 func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
 	stdLines, err := slicesx.MapWithErr(input.GatheringLines, func(gatheringLine billing.GatheringLine) (*billing.StandardLine, error) {
 		stdLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
 		if err != nil {
@@ -50,6 +54,25 @@ func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billin
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	chargesByID, err := e.getChargesForStandardLineEvent(ctx, billing.StandardLineEventInput{
+		Invoice: input.Invoice,
+		Lines:   stdLines,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stdLine := range stdLines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("flat fee charge[%s] not found for gathering line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		stdLine.RateCardDiscounts = billing.Discounts{
+			Percentage: charge.Intent.GetEffectiveIntent().PercentageDiscounts.CloneOrNil(),
+		}
 	}
 
 	return stdLines, nil

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -9,7 +10,9 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -20,6 +23,11 @@ import (
 )
 
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeBackedGatheringLines() {
+	defer s.FlatFeeTestHandler.Reset()
+	s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+		return nil, nil
+	}
+
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-create-pending-lines")
 	s.ProvisionDefaultTaxCodes(ctx, ns)
@@ -145,9 +153,11 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	s.Require().NotNil(result.Lines[1].RateCardDiscounts.Percentage)
 	s.Equal(flatFeeIntent.PercentageDiscounts.CorrelationID, result.Lines[1].RateCardDiscounts.Percentage.CorrelationID)
 
-	// Given the persisted gathering line carries a stale discount snapshot.
-	staleGatheringDiscounts := result.Lines[0].RateCardDiscounts.Clone()
-	staleGatheringDiscounts.Usage.CorrelationID = "stale-gathering-discount"
+	// Given the persisted gathering lines carry stale discount snapshots.
+	staleUsageGatheringDiscounts := result.Lines[0].RateCardDiscounts.Clone()
+	staleUsageGatheringDiscounts.Usage.CorrelationID = "stale-gathering-usage-discount"
+	staleFlatFeeGatheringDiscounts := result.Lines[1].RateCardDiscounts.Clone()
+	staleFlatFeeGatheringDiscounts.Percentage.CorrelationID = "stale-gathering-percentage-discount"
 	persistedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
 		Invoice: result.Invoice.GetInvoiceID(),
 		Expand:  billing.GatheringInvoiceExpands{billing.GatheringInvoiceExpandLines},
@@ -157,15 +167,30 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 		return line.Engine == billing.LineEngineTypeChargeUsageBased
 	})
 	s.Require().True(found)
-	encodedStaleGatheringDiscounts, err := json.Marshal(staleGatheringDiscounts)
+	persistedFlatFeeLine, found := lo.Find(persistedInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.Engine == billing.LineEngineTypeChargeFlatFee
+	})
+	s.Require().True(found)
+	encodedStaleUsageGatheringDiscounts, err := json.Marshal(staleUsageGatheringDiscounts)
 	s.NoError(err)
 	updateResult, err := s.TestDB.PGDriver.DB().ExecContext(ctx,
 		`UPDATE billing_invoice_lines SET ratecard_discounts = $1 WHERE id = $2`,
-		string(encodedStaleGatheringDiscounts),
+		string(encodedStaleUsageGatheringDiscounts),
 		persistedUsageLine.ID,
 	)
 	s.NoError(err)
 	updatedRows, err := updateResult.RowsAffected()
+	s.NoError(err)
+	s.Equal(int64(1), updatedRows)
+	encodedStaleFlatFeeGatheringDiscounts, err := json.Marshal(staleFlatFeeGatheringDiscounts)
+	s.NoError(err)
+	updateResult, err = s.TestDB.PGDriver.DB().ExecContext(ctx,
+		`UPDATE billing_invoice_lines SET ratecard_discounts = $1 WHERE id = $2`,
+		string(encodedStaleFlatFeeGatheringDiscounts),
+		persistedFlatFeeLine.ID,
+	)
+	s.NoError(err)
+	updatedRows, err = updateResult.RowsAffected()
 	s.NoError(err)
 	s.Equal(int64(1), updatedRows)
 
@@ -181,6 +206,20 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	invoicedUsageLine := invoices[0].Lines.OrEmpty()[0]
 	s.Require().NotNil(invoicedUsageLine.RateCardDiscounts.Usage)
 	s.Equal(usageBasedIntent.Discounts.Usage.CorrelationID, invoicedUsageLine.RateCardDiscounts.Usage.CorrelationID)
+
+	// When billing reaches the flat-fee line's invoice time and collects it.
+	clock.FreezeTime(flatLine.InvoiceAt)
+	invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(flatLine.InvoiceAt),
+	})
+	// Then the standard line uses the effective charge discount identity instead of the stale snapshot.
+	s.NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+	invoicedFlatFeeLine := invoices[0].Lines.OrEmpty()[0]
+	s.Require().NotNil(invoicedFlatFeeLine.RateCardDiscounts.Percentage)
+	s.Equal(flatFeeIntent.PercentageDiscounts.CorrelationID, invoicedFlatFeeLine.RateCardDiscounts.Percentage.CorrelationID)
 }
 
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreatedChargesOnFailure() {

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -144,13 +145,36 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	s.Require().NotNil(result.Lines[1].RateCardDiscounts.Percentage)
 	s.Equal(flatFeeIntent.PercentageDiscounts.CorrelationID, result.Lines[1].RateCardDiscounts.Percentage.CorrelationID)
 
-	// Given the pending usage line was created without an internal discount correlation ID.
+	// Given the persisted gathering line carries a stale discount snapshot.
+	staleGatheringDiscounts := result.Lines[0].RateCardDiscounts.Clone()
+	staleGatheringDiscounts.Usage.CorrelationID = "stale-gathering-discount"
+	persistedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: result.Invoice.GetInvoiceID(),
+		Expand:  billing.GatheringInvoiceExpands{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	persistedUsageLine, found := lo.Find(persistedInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.Engine == billing.LineEngineTypeChargeUsageBased
+	})
+	s.Require().True(found)
+	encodedStaleGatheringDiscounts, err := json.Marshal(staleGatheringDiscounts)
+	s.NoError(err)
+	updateResult, err := s.TestDB.PGDriver.DB().ExecContext(ctx,
+		`UPDATE billing_invoice_lines SET ratecard_discounts = $1 WHERE id = $2`,
+		string(encodedStaleGatheringDiscounts),
+		persistedUsageLine.ID,
+	)
+	s.NoError(err)
+	updatedRows, err := updateResult.RowsAffected()
+	s.NoError(err)
+	s.Equal(int64(1), updatedRows)
+
 	// When billing collects the charge-backed usage line into a standard invoice.
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 		Customer: cust.GetID(),
 		AsOf:     lo.ToPtr(servicePeriod.To),
 	})
-	// Then charge rating can reuse the persisted discount identity while generating detailed lines.
+	// Then the standard line uses the effective charge discount identity while generating detailed lines.
 	s.NoError(err)
 	s.Require().Len(invoices, 1)
 	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -209,6 +209,7 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 
 	// When billing reaches the flat-fee line's invoice time and collects it.
 	clock.FreezeTime(flatLine.InvoiceAt)
+	defer clock.UnFreeze()
 	invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 		Customer: cust.GetID(),
 		AsOf:     lo.ToPtr(flatLine.InvoiceAt),

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -105,6 +105,10 @@ func (e *LineEngine) SplitGatheringLine(_ context.Context, input billing.SplitGa
 }
 
 func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
 	stdLines, err := slicesx.MapWithErr(input.GatheringLines, func(gatheringLine billing.GatheringLine) (*billing.StandardLine, error) {
 		stdLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
 		if err != nil {
@@ -115,6 +119,23 @@ func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billin
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	chargesByID, err := e.getChargesForStandardLineEvent(ctx, billing.StandardLineEventInput{
+		Invoice: input.Invoice,
+		Lines:   stdLines,
+	}, nil, "building standard invoice lines")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stdLine := range stdLines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("usage based charge[%s] not found for gathering line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		stdLine.RateCardDiscounts = charge.Intent.GetEffectiveIntent().Discounts.Clone()
 	}
 
 	return stdLines, nil

--- a/tools/migrate/charge_discount_correlation_ids_test.go
+++ b/tools/migrate/charge_discount_correlation_ids_test.go
@@ -2,6 +2,7 @@ package migrate_test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,7 @@ import (
 )
 
 const chargeDiscountCorrelationIDMigration = "20260809152600_backfill_charge_discount_correlation_ids.up.sql"
+const persistedChargeDiscountCorrelationIDMigration = "20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql"
 
 func TestBackfillChargeDiscountCorrelationIDs(t *testing.T) {
 	up := readMigration(t, chargeDiscountCorrelationIDMigration)
@@ -40,6 +42,39 @@ func TestBackfillChargeDiscountCorrelationIDs(t *testing.T) {
 	_, err = conn.ExecContext(t.Context(), up)
 	require.NoError(t, err)
 	require.Equal(t, afterFirstRun, readGatheringLineDiscounts(t, conn))
+}
+
+func TestBackfillPersistedChargeDiscountCorrelationIDs(t *testing.T) {
+	up := readMigration(t, persistedChargeDiscountCorrelationIDMigration)
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	defer testDB.PGDriver.Close()
+
+	conn, err := testDB.PGDriver.DB().Conn(t.Context())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	createPersistedChargeDiscountCorrelationIDMigrationFixtures(t, conn)
+
+	_, err = conn.ExecContext(t.Context(), up)
+	require.NoError(t, err)
+
+	for _, table := range []string{"charge_usage_based", "charge_usage_based_overrides"} {
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "percentage")
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "usage")
+		assertPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "percentage", "existing-percentage")
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "usage")
+	}
+
+	for _, table := range []string{"charge_flat_fees", "charge_flat_fee_overrides"} {
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "percentage")
+		assertPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "percentage", "existing-percentage")
+	}
+
+	afterFirstRun := readPersistedChargeDiscounts(t, conn)
+	_, err = conn.ExecContext(t.Context(), up)
+	require.NoError(t, err)
+	require.Equal(t, afterFirstRun, readPersistedChargeDiscounts(t, conn))
 }
 
 func createChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.Conn) {
@@ -106,6 +141,57 @@ func createChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.
 	require.NoError(t, err)
 }
 
+func createPersistedChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, conn *sql.Conn) {
+	t.Helper()
+
+	_, err := conn.ExecContext(t.Context(), `
+		CREATE SEQUENCE migration_test_ulid_sequence;
+		CREATE FUNCTION om_func_generate_ulid()
+		RETURNS text
+		AS $$
+			SELECT 'generated-' || nextval('migration_test_ulid_sequence')::text
+		$$
+		LANGUAGE sql
+		VOLATILE;
+
+		CREATE TEMP TABLE charge_usage_based (
+			id text PRIMARY KEY,
+			discounts jsonb NULL,
+			updated_at timestamptz NOT NULL DEFAULT '2026-08-01T00:00:00Z'
+		);
+		CREATE TEMP TABLE charge_usage_based_overrides (
+			id text PRIMARY KEY,
+			discounts jsonb NOT NULL
+		);
+		CREATE TEMP TABLE charge_flat_fees (
+			id text PRIMARY KEY,
+			discounts jsonb NULL,
+			updated_at timestamptz NOT NULL DEFAULT '2026-08-01T00:00:00Z'
+		);
+		CREATE TEMP TABLE charge_flat_fee_overrides (
+			id text PRIMARY KEY,
+			discounts jsonb NULL
+		);
+
+		INSERT INTO charge_usage_based (id, discounts) VALUES
+			('missing', '{"percentage":{"percentage":10},"usage":{"quantity":"5"}}'),
+			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"},"usage":{"quantity":"3","correlationID":""}}'),
+			('none', NULL);
+		INSERT INTO charge_usage_based_overrides (id, discounts) VALUES
+			('missing', '{"percentage":{"percentage":10},"usage":{"quantity":"5"}}'),
+			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"},"usage":{"quantity":"3","correlationID":""}}');
+		INSERT INTO charge_flat_fees (id, discounts) VALUES
+			('missing', '{"percentage":{"percentage":10}}'),
+			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"}}'),
+			('none', NULL);
+		INSERT INTO charge_flat_fee_overrides (id, discounts) VALUES
+			('missing', '{"percentage":{"percentage":10}}'),
+			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"}}'),
+			('none', NULL);
+	`)
+	require.NoError(t, err)
+}
+
 func assertGatheringLineDiscountCorrelationID(t *testing.T, conn *sql.Conn, id, discountType, expected string) {
 	t.Helper()
 
@@ -134,6 +220,32 @@ func assertGeneratedGatheringLineDiscountCorrelationID(t *testing.T, conn *sql.C
 	return actual
 }
 
+func assertPersistedChargeDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType, expected string) {
+	t.Helper()
+
+	var actual string
+	err := conn.QueryRowContext(t.Context(),
+		fmt.Sprintf(`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM %s WHERE id = $2`, table),
+		discountType,
+		id,
+	).Scan(&actual)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func assertGeneratedPersistedChargeDiscountCorrelationID(t *testing.T, conn *sql.Conn, table, id, discountType string) {
+	t.Helper()
+
+	var actual string
+	err := conn.QueryRowContext(t.Context(),
+		fmt.Sprintf(`SELECT discounts #>> ARRAY[$1, 'correlationID'] FROM %s WHERE id = $2`, table),
+		discountType,
+		id,
+	).Scan(&actual)
+	require.NoError(t, err)
+	require.Contains(t, actual, "generated-")
+}
+
 func readUntouchedDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
 	t.Helper()
 
@@ -160,6 +272,24 @@ func readGatheringLineDiscounts(t *testing.T, conn *sql.Conn) map[string]string 
 	rows, err := conn.QueryContext(t.Context(), `
 		SELECT id, COALESCE(ratecard_discounts::text, 'null')
 		FROM billing_gathering_invoice_lines
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	return scanDiscounts(t, rows)
+}
+
+func readPersistedChargeDiscounts(t *testing.T, conn *sql.Conn) map[string]string {
+	t.Helper()
+
+	rows, err := conn.QueryContext(t.Context(), `
+		SELECT 'usage:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based
+		UNION ALL
+		SELECT 'usage-override:' || id, COALESCE(discounts::text, 'null') FROM charge_usage_based_overrides
+		UNION ALL
+		SELECT 'flat-fee:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fees
+		UNION ALL
+		SELECT 'flat-fee-override:' || id, COALESCE(discounts::text, 'null') FROM charge_flat_fee_overrides
 	`)
 	require.NoError(t, err)
 	defer rows.Close()

--- a/tools/migrate/charge_discount_correlation_ids_test.go
+++ b/tools/migrate/charge_discount_correlation_ids_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 )
 
-const chargeDiscountCorrelationIDMigration = "20260809152600_backfill_charge_discount_correlation_ids.up.sql"
-const persistedChargeDiscountCorrelationIDMigration = "20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql"
+const (
+	chargeDiscountCorrelationIDMigration          = "20260809152600_backfill_charge_discount_correlation_ids.up.sql"
+	persistedChargeDiscountCorrelationIDMigration = "20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql"
+)
 
 func TestBackfillChargeDiscountCorrelationIDs(t *testing.T) {
 	up := readMigration(t, chargeDiscountCorrelationIDMigration)
@@ -62,12 +64,15 @@ func TestBackfillPersistedChargeDiscountCorrelationIDs(t *testing.T) {
 	for _, table := range []string{"charge_usage_based", "charge_usage_based_overrides"} {
 		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "percentage")
 		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "usage")
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "json-null", "percentage")
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "json-null", "usage")
 		assertPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "percentage", "existing-percentage")
 		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "usage")
 	}
 
 	for _, table := range []string{"charge_flat_fees", "charge_flat_fee_overrides"} {
 		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "missing", "percentage")
+		assertGeneratedPersistedChargeDiscountCorrelationID(t, conn, table, "json-null", "percentage")
 		assertPersistedChargeDiscountCorrelationID(t, conn, table, "existing", "percentage", "existing-percentage")
 	}
 
@@ -175,17 +180,21 @@ func createPersistedChargeDiscountCorrelationIDMigrationFixtures(t *testing.T, c
 
 		INSERT INTO charge_usage_based (id, discounts) VALUES
 			('missing', '{"percentage":{"percentage":10},"usage":{"quantity":"5"}}'),
+			('json-null', '{"percentage":{"percentage":12,"correlationID":null},"usage":{"quantity":"2","correlationID":null}}'),
 			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"},"usage":{"quantity":"3","correlationID":""}}'),
 			('none', NULL);
 		INSERT INTO charge_usage_based_overrides (id, discounts) VALUES
 			('missing', '{"percentage":{"percentage":10},"usage":{"quantity":"5"}}'),
+			('json-null', '{"percentage":{"percentage":12,"correlationID":null},"usage":{"quantity":"2","correlationID":null}}'),
 			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"},"usage":{"quantity":"3","correlationID":""}}');
 		INSERT INTO charge_flat_fees (id, discounts) VALUES
 			('missing', '{"percentage":{"percentage":10}}'),
+			('json-null', '{"percentage":{"percentage":12,"correlationID":null}}'),
 			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"}}'),
 			('none', NULL);
 		INSERT INTO charge_flat_fee_overrides (id, discounts) VALUES
 			('missing', '{"percentage":{"percentage":10}}'),
+			('json-null', '{"percentage":{"percentage":12,"correlationID":null}}'),
 			('existing', '{"percentage":{"percentage":15,"correlationID":"existing-percentage"}}'),
 			('none', NULL);
 	`)

--- a/tools/migrate/migrations/20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql
+++ b/tools/migrate/migrations/20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql
@@ -1,0 +1,113 @@
+-- Repair persisted charge intent discounts missed by the gathering-line backfill.
+-- Existing IDs are preserved; missing IDs are generated independently.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp.upsert_discount_correlation_id(
+  discounts jsonb,
+  discount_type text,
+  correlation_id text
+)
+RETURNS jsonb
+AS $$
+  SELECT CASE
+    WHEN jsonb_typeof(discounts -> discount_type) = 'object'
+      AND COALESCE(discounts #>> ARRAY[discount_type, 'correlationID'], '') = ''
+    THEN jsonb_set(
+      discounts,
+      ARRAY[discount_type, 'correlationID'],
+      to_jsonb(correlation_id),
+      true
+    )
+    ELSE discounts
+  END
+$$
+LANGUAGE sql
+IMMUTABLE;
+
+UPDATE charge_usage_based
+SET
+  discounts = pg_temp.upsert_discount_correlation_id(
+    pg_temp.upsert_discount_correlation_id(discounts, 'percentage', om_func_generate_ulid()),
+    'usage',
+    om_func_generate_ulid()
+  ),
+  updated_at = now()
+WHERE (
+  jsonb_typeof(discounts -> 'percentage') = 'object'
+  AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+) OR (
+  jsonb_typeof(discounts -> 'usage') = 'object'
+  AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+);
+
+UPDATE charge_usage_based_overrides
+SET discounts = pg_temp.upsert_discount_correlation_id(
+  pg_temp.upsert_discount_correlation_id(discounts, 'percentage', om_func_generate_ulid()),
+  'usage',
+  om_func_generate_ulid()
+)
+WHERE (
+  jsonb_typeof(discounts -> 'percentage') = 'object'
+  AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+) OR (
+  jsonb_typeof(discounts -> 'usage') = 'object'
+  AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+);
+
+UPDATE charge_flat_fees
+SET
+  discounts = pg_temp.upsert_discount_correlation_id(
+    pg_temp.upsert_discount_correlation_id(discounts, 'percentage', om_func_generate_ulid()),
+    'usage',
+    om_func_generate_ulid()
+  ),
+  updated_at = now()
+WHERE (
+  jsonb_typeof(discounts -> 'percentage') = 'object'
+  AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+) OR (
+  jsonb_typeof(discounts -> 'usage') = 'object'
+  AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+);
+
+UPDATE charge_flat_fee_overrides
+SET discounts = pg_temp.upsert_discount_correlation_id(
+  pg_temp.upsert_discount_correlation_id(discounts, 'percentage', om_func_generate_ulid()),
+  'usage',
+  om_func_generate_ulid()
+)
+WHERE (
+  jsonb_typeof(discounts -> 'percentage') = 'object'
+  AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+) OR (
+  jsonb_typeof(discounts -> 'usage') = 'object'
+  AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT discounts FROM charge_usage_based
+      UNION ALL
+      SELECT discounts FROM charge_usage_based_overrides
+      UNION ALL
+      SELECT discounts FROM charge_flat_fees
+      UNION ALL
+      SELECT discounts FROM charge_flat_fee_overrides
+    ) persisted_charge_discounts
+    WHERE (
+      jsonb_typeof(discounts -> 'percentage') = 'object'
+      AND COALESCE(discounts #>> '{percentage,correlationID}', '') = ''
+    ) OR (
+      jsonb_typeof(discounts -> 'usage') = 'object'
+      AND COALESCE(discounts #>> '{usage,correlationID}', '') = ''
+    )
+  ) THEN
+    RAISE EXCEPTION 'persisted charge discounts still have missing correlation IDs after repair';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:U8Ez0xcas0hz8b5pTtFvY8VNNdnUF70k50KmRjPM8pQ=
+h1:44cGPeEScNyIbrMVPZTuYswI7hXw1rLWATC6deM15FE=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -260,3 +260,4 @@ h1:U8Ez0xcas0hz8b5pTtFvY8VNNdnUF70k50KmRjPM8pQ=
 20260807145338_enforce_charge_cost_basis_relationships.up.sql h1:+eRqMO8jr7BRn3MW1zJCgjr/+kzx1hSDYrfuTguO/ZI=
 20260807155244_credit_purchase_cost_basis_level_2_only.up.sql h1:rMuXE2Vtccs1zEZrt1Dxr2PmKujrkbY7BzdOU7ebjBw=
 20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:dkNWwhYido6AriEp87nX077MA19pje+McrNfNshdNYM=
+20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql h1:Ybb0TjDQ+u/OYhFRtPHIau+NK1PS/DO+sMdTLn5XJHY=


### PR DESCRIPTION
## Summary

- backfill missing correlation IDs in persisted usage-based and flat-fee charge intents and overrides
- refresh gathering-line discount snapshots from the effective charge intent when building standard invoice lines
- add migration and service regressions for legacy persisted charges and stale gathering snapshots

## Root cause

The previous repair only updated gathering invoice-line snapshots. Detailed rating reads discounts from the persisted charge's effective intent, so legacy charges could still reach rating without a correlation ID. Create-time normalization does not repair those existing rows, and the rating failure occurs before the later persistence fallback can run.

## Impact

Legacy charge-backed invoice lines can be collected and rated after deployment. Existing correlation IDs are preserved; only missing or empty IDs are generated. Standard-line construction also treats the effective charge intent as the authoritative discount identity instead of carrying a stale gathering snapshot forward.

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/... ./tools/migrate`
- `make migrate-check-lint migrate-check-validate`
- `nix develop --impure .#ci -c golangci-lint run --config .golangci-fast.yaml ./openmeter/billing/charges/... ./tools/migrate/...`
- pre-commit commitizen check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice generation now applies the latest percentage discounts for flat-fee and usage-based charges.
  * Missing charge references are reported as errors instead of producing incomplete invoice lines.
  * Corrected invoice discount correlation IDs when stored data contains outdated values.

* **Data Integrity**
  * Added a migration to restore missing discount correlation IDs while preserving existing values.
  * Verified migration behavior across charge and override records, including repeat-safe execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up repairs legacy persisted charge discount identities and refreshes gathering-line discount snapshots from effective charge intents during standard invoice construction.
- Backfills missing percentage and usage discount correlation IDs across base and override charge records while preserving existing IDs.
- Reloads flat-fee and usage-based charges when converting gathering lines and copies their effective discounts to the resulting standard lines.
- Adds migration idempotency coverage and service regressions for stale gathering snapshots.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/service/lineengine.go | Validates collection input, reloads referenced flat-fee charges, and snapshots effective percentage discounts onto standard lines. |
| openmeter/billing/charges/usagebased/service/lineengine.go | Validates collection input, reloads referenced usage-based charges, and snapshots effective discounts onto standard lines. |
| tools/migrate/migrations/20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql | Idempotently fills empty correlation IDs in persisted base and override discount objects while preserving existing values. |
| tools/migrate/charge_discount_correlation_ids_test.go | Covers missing, null, existing, and repeat-run migration behavior across all affected charge tables. |
| openmeter/billing/charges/service/pendinglines_test.go | Verifies collection replaces stale gathering discount identities with those from effective charge intents. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant DB as Persisted charge
  participant G as Gathering line
  participant E as Charge line engine
  participant S as Standard invoice line
  DB->>DB: Migration fills missing correlation IDs
  G->>E: Collect eligible gathering line
  E->>DB: Load charge and effective intent
  DB-->>E: Effective discount snapshot
  E->>S: Build line with authoritative discounts
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(billing): pair frozen clock cleanup"](https://github.com/openmeterio/openmeter/commit/6237e0d8235edec4d481c2f5c9f252ee342f3b33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51611542)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->