### PR TITLE
feat(customcurrency): backfill subscription items with currency

### DIFF
--- a/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.down.sql
+++ b/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+UPDATE subscription_items
+SET
+  currency = NULL,
+  annotations = CASE
+    WHEN annotations - 'dbmigration:backfill_subscription_item_currencies' = '{}'::jsonb
+      THEN NULL
+    ELSE annotations - 'dbmigration:backfill_subscription_item_currencies'
+  END,
+  updated_at = CURRENT_TIMESTAMP
+WHERE annotations ? 'dbmigration:backfill_subscription_item_currencies';
+
+COMMIT;

--- a/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.up.sql
+++ b/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.up.sql
@@ -33,22 +33,4 @@ WHERE item.phase_id = phase.id
     false
   );
 
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM subscription_items
-    WHERE price IS NOT NULL
-      AND currency IS NULL
-      AND NOT COALESCE(
-        annotations ? 'dbmigration:backfill_subscription_item_currencies',
-        false
-      )
-  ) THEN
-    RAISE EXCEPTION
-      'priced subscription items still have missing currency after backfill';
-  END IF;
-END
-$$;
-
 COMMIT;

--- a/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.up.sql
+++ b/tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.up.sql
@@ -1,0 +1,54 @@
+-- Materialize the inherited subscription fiat currency on legacy priced items.
+-- Mark modified rows so the data change is attributable and reversible.
+BEGIN;
+
+UPDATE subscription_items AS item
+SET
+  currency = subscription.currency,
+  annotations =
+    CASE
+      WHEN item.annotations IS NULL OR item.annotations = 'null'::jsonb
+        THEN '{}'::jsonb
+      ELSE item.annotations
+    END ||
+    jsonb_build_object(
+      'dbmigration:backfill_subscription_item_currencies',
+      to_char(
+        CURRENT_TIMESTAMP AT TIME ZONE 'UTC',
+        'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      )
+    ),
+  updated_at = CURRENT_TIMESTAMP
+FROM subscription_phases AS phase
+JOIN subscriptions AS subscription
+  ON subscription.id = phase.subscription_id
+ AND subscription.namespace = phase.namespace
+WHERE item.phase_id = phase.id
+  AND item.namespace = phase.namespace
+  AND item.price IS NOT NULL
+  AND item.currency IS NULL
+  AND item.custom_currency_id IS NULL
+  AND NOT COALESCE(
+    item.annotations ? 'dbmigration:backfill_subscription_item_currencies',
+    false
+  );
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM subscription_items
+    WHERE price IS NOT NULL
+      AND currency IS NULL
+      AND NOT COALESCE(
+        annotations ? 'dbmigration:backfill_subscription_item_currencies',
+        false
+      )
+  ) THEN
+    RAISE EXCEPTION
+      'priced subscription items still have missing currency after backfill';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:44cGPeEScNyIbrMVPZTuYswI7hXw1rLWATC6deM15FE=
+h1:qQ2co2sTyG72iVoNplZWSSkDqj7CejTF288EZ/DbBZk=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -261,3 +261,4 @@ h1:44cGPeEScNyIbrMVPZTuYswI7hXw1rLWATC6deM15FE=
 20260807155244_credit_purchase_cost_basis_level_2_only.up.sql h1:rMuXE2Vtccs1zEZrt1Dxr2PmKujrkbY7BzdOU7ebjBw=
 20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:dkNWwhYido6AriEp87nX077MA19pje+McrNfNshdNYM=
 20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql h1:Ybb0TjDQ+u/OYhFRtPHIau+NK1PS/DO+sMdTLn5XJHY=
+20260810064730_backfill_subscription_item_currencies.up.sql h1:O2XzUcgA1jq9zNsnlAhepxDyn/wl3RmblMuX8fc1Y/c=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qQ2co2sTyG72iVoNplZWSSkDqj7CejTF288EZ/DbBZk=
+h1:iYbLe7xchx350mUsm3ilkoKruAZTRyuDGQpkGYkdKVo=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -261,4 +261,4 @@ h1:qQ2co2sTyG72iVoNplZWSSkDqj7CejTF288EZ/DbBZk=
 20260807155244_credit_purchase_cost_basis_level_2_only.up.sql h1:rMuXE2Vtccs1zEZrt1Dxr2PmKujrkbY7BzdOU7ebjBw=
 20260809152600_backfill_charge_discount_correlation_ids.up.sql h1:dkNWwhYido6AriEp87nX077MA19pje+McrNfNshdNYM=
 20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql h1:Ybb0TjDQ+u/OYhFRtPHIau+NK1PS/DO+sMdTLn5XJHY=
-20260810064730_backfill_subscription_item_currencies.up.sql h1:O2XzUcgA1jq9zNsnlAhepxDyn/wl3RmblMuX8fc1Y/c=
+20260810064730_backfill_subscription_item_currencies.up.sql h1:e2UeY1pD0Icov44B3IRkjQlx8Xn3DIS1httVx36CYI8=

--- a/tools/migrate/subscription_item_currency_backfill_test.go
+++ b/tools/migrate/subscription_item_currency_backfill_test.go
@@ -1,0 +1,229 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+const subscriptionItemCurrencyBackfillAnnotation = "dbmigration:backfill_subscription_item_currencies"
+
+type subscriptionItemCurrencyMigrationState struct {
+	Currency         sql.NullString
+	CustomCurrencyID sql.NullString
+	Annotations      map[string]any
+}
+
+func querySubscriptionItemCurrencyMigrationStates(t testing.TB, db *sql.DB, phaseID string) map[string]subscriptionItemCurrencyMigrationState {
+	t.Helper()
+
+	rows, err := db.QueryContext(t.Context(), `
+		SELECT id, currency, custom_currency_id, annotations::text
+		FROM subscription_items
+		WHERE phase_id = $1
+	`, phaseID)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	states := map[string]subscriptionItemCurrencyMigrationState{}
+	for rows.Next() {
+		var (
+			id              string
+			state           subscriptionItemCurrencyMigrationState
+			annotationsJSON sql.NullString
+		)
+
+		require.NoError(t, rows.Scan(&id, &state.Currency, &state.CustomCurrencyID, &annotationsJSON))
+		if annotationsJSON.Valid && annotationsJSON.String != "null" {
+			require.NoError(t, json.Unmarshal([]byte(annotationsJSON.String), &state.Annotations))
+		}
+
+		states[id] = state
+	}
+	require.NoError(t, rows.Err())
+
+	return states
+}
+
+func TestBackfillSubscriptionItemCurrenciesMigration(t *testing.T) {
+	const (
+		namespace       = "default"
+		previousVersion = uint(20260809172658)
+		targetVersion   = uint(20260810064730)
+	)
+
+	// given:
+	// - legacy priced items with and without annotations, including a soft-deleted item
+	// - a legacy priced item already carrying the migration annotation
+	// - already materialized fiat and custom-currency items, plus an unpriced item
+	// when:
+	// - the currency backfill is migrated up and then down
+	// then:
+	// - only legacy priced items are marked and backfilled, and rollback restores only those rows
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	t.Cleanup(func() { testDB.Close(t) })
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           testutils.NewLogger(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sourceErr, databaseErr := migrator.Close()
+		require.NoError(t, errors.Join(sourceErr, databaseErr))
+	})
+	require.NoError(t, migrator.Migrate(previousVersion))
+
+	db := testDB.PGDriver.DB()
+	customerID := ulid.Make().String()
+	subscriptionID := ulid.Make().String()
+	phaseID := ulid.Make().String()
+	customCurrencyID := ulid.Make().String()
+	legacyItemID := ulid.Make().String()
+	legacyAnnotatedItemID := ulid.Make().String()
+	deletedLegacyItemID := ulid.Make().String()
+	alreadyAnnotatedItemID := ulid.Make().String()
+	explicitFiatItemID := ulid.Make().String()
+	explicitCustomItemID := ulid.Make().String()
+	unpricedItemID := ulid.Make().String()
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO customers (id, namespace, created_at, updated_at, key, name, currency)
+		VALUES ($1, $2, NOW(), NOW(), 'legacy-customer', 'Legacy Customer', 'USD')
+	`, customerID, namespace)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO subscriptions (
+			id, namespace, created_at, updated_at, active_from, customer_id, currency,
+			billing_anchor, billing_cadence, pro_rating_config
+		)
+		VALUES (
+			$1, $2, NOW(), NOW(), '2024-01-01', $3, 'USD', '2024-01-01', 'P1M',
+			'{"enabled":true,"mode":"prorate_prices"}'::jsonb
+		)
+	`, subscriptionID, namespace, customerID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO subscription_phases (
+			id, namespace, created_at, updated_at, key, name, subscription_id, active_from
+		)
+		VALUES ($1, $2, NOW(), NOW(), 'default', 'Default', $3, '2024-01-01')
+	`, phaseID, namespace, subscriptionID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO custom_currencies (id, namespace, created_at, updated_at, code, name, symbol)
+		VALUES ($1, $2, NOW(), NOW(), 'CREDITS', 'Credits', 'CR')
+	`, customCurrencyID, namespace)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO subscription_items (
+			id, namespace, created_at, updated_at, deleted_at, active_from, key, name,
+			phase_id, price, currency, custom_currency_id, annotations
+		)
+		VALUES
+			($1, $2, NOW(), NOW(), NULL, '2024-01-01', 'legacy', 'Legacy', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, NULL, NULL, NULL),
+			($4, $2, NOW(), NOW(), NULL, '2024-01-01', 'legacy-annotated', 'Legacy Annotated', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, NULL, NULL, '{"existing":"preserved"}'::jsonb),
+			($5, $2, NOW(), NOW(), NOW(), '2024-01-01', 'legacy-deleted', 'Legacy Deleted', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, NULL, NULL, NULL),
+			($6, $2, NOW(), NOW(), NULL, '2024-01-01', 'explicit-fiat', 'Explicit Fiat', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, 'EUR', NULL, '{"explicit":"fiat"}'::jsonb),
+			($7, $2, NOW(), NOW(), NULL, '2024-01-01', 'explicit-custom', 'Explicit Custom', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, 'CREDITS', $8, '{"explicit":"custom"}'::jsonb),
+			($9, $2, NOW(), NOW(), NULL, '2024-01-01', 'unpriced', 'Unpriced', $3,
+				NULL, NULL, NULL, '{"unpriced":true}'::jsonb),
+			($10, $2, NOW(), NOW(), NULL, '2024-01-01', 'already-annotated', 'Already Annotated', $3,
+				'{"type":"flat","amount":"10","paymentTerm":"in_advance"}'::jsonb, NULL, NULL,
+				'{"dbmigration:backfill_subscription_item_currencies":"2026-08-09T12:00:00Z","existing":"preserved"}'::jsonb)
+	`,
+		legacyItemID,
+		namespace,
+		phaseID,
+		legacyAnnotatedItemID,
+		deletedLegacyItemID,
+		explicitFiatItemID,
+		explicitCustomItemID,
+		customCurrencyID,
+		unpricedItemID,
+		alreadyAnnotatedItemID,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, migrator.Migrate(targetVersion))
+
+	states := querySubscriptionItemCurrencyMigrationStates(t, db, phaseID)
+	backfilledItemIDs := []string{legacyItemID, legacyAnnotatedItemID, deletedLegacyItemID}
+	var migrationTimestamp string
+	for _, itemID := range backfilledItemIDs {
+		state := states[itemID]
+		require.Equal(t, "USD", state.Currency.String)
+		require.False(t, state.CustomCurrencyID.Valid)
+
+		annotation, ok := state.Annotations[subscriptionItemCurrencyBackfillAnnotation]
+		require.True(t, ok)
+		annotationTimestamp, ok := annotation.(string)
+		require.True(t, ok)
+		_, err := time.Parse(time.RFC3339Nano, annotationTimestamp)
+		require.NoError(t, err)
+
+		if migrationTimestamp == "" {
+			migrationTimestamp = annotationTimestamp
+		} else {
+			require.Equal(t, migrationTimestamp, annotationTimestamp)
+		}
+	}
+	require.Equal(t, "preserved", states[legacyAnnotatedItemID].Annotations["existing"])
+	require.False(t, states[alreadyAnnotatedItemID].Currency.Valid)
+	require.False(t, states[alreadyAnnotatedItemID].CustomCurrencyID.Valid)
+	require.Equal(t, "2026-08-09T12:00:00Z", states[alreadyAnnotatedItemID].Annotations[subscriptionItemCurrencyBackfillAnnotation])
+	require.Equal(t, "preserved", states[alreadyAnnotatedItemID].Annotations["existing"])
+
+	require.Equal(t, "EUR", states[explicitFiatItemID].Currency.String)
+	require.False(t, states[explicitFiatItemID].CustomCurrencyID.Valid)
+	require.Equal(t, "fiat", states[explicitFiatItemID].Annotations["explicit"])
+	require.NotContains(t, states[explicitFiatItemID].Annotations, subscriptionItemCurrencyBackfillAnnotation)
+
+	require.Equal(t, "CREDITS", states[explicitCustomItemID].Currency.String)
+	require.Equal(t, customCurrencyID, states[explicitCustomItemID].CustomCurrencyID.String)
+	require.Equal(t, "custom", states[explicitCustomItemID].Annotations["explicit"])
+	require.NotContains(t, states[explicitCustomItemID].Annotations, subscriptionItemCurrencyBackfillAnnotation)
+
+	require.False(t, states[unpricedItemID].Currency.Valid)
+	require.False(t, states[unpricedItemID].CustomCurrencyID.Valid)
+	require.Equal(t, true, states[unpricedItemID].Annotations["unpriced"])
+	require.NotContains(t, states[unpricedItemID].Annotations, subscriptionItemCurrencyBackfillAnnotation)
+
+	require.NoError(t, migrator.Migrate(previousVersion))
+
+	states = querySubscriptionItemCurrencyMigrationStates(t, db, phaseID)
+	for _, itemID := range backfilledItemIDs {
+		require.False(t, states[itemID].Currency.Valid)
+		require.False(t, states[itemID].CustomCurrencyID.Valid)
+		require.NotContains(t, states[itemID].Annotations, subscriptionItemCurrencyBackfillAnnotation)
+	}
+	require.Nil(t, states[legacyItemID].Annotations)
+	require.Equal(t, "preserved", states[legacyAnnotatedItemID].Annotations["existing"])
+	require.Nil(t, states[deletedLegacyItemID].Annotations)
+	require.False(t, states[alreadyAnnotatedItemID].Currency.Valid)
+	require.NotContains(t, states[alreadyAnnotatedItemID].Annotations, subscriptionItemCurrencyBackfillAnnotation)
+	require.Equal(t, "preserved", states[alreadyAnnotatedItemID].Annotations["existing"])
+
+	require.Equal(t, "EUR", states[explicitFiatItemID].Currency.String)
+	require.Equal(t, "CREDITS", states[explicitCustomItemID].Currency.String)
+	require.Equal(t, customCurrencyID, states[explicitCustomItemID].CustomCurrencyID.String)
+	require.False(t, states[unpricedItemID].Currency.Valid)
+}


### PR DESCRIPTION
## Overview

### What

Add a database migration that backfills missing currency codes on legacy priced subscription items and marks updated rows with a timestamped migration annotation.

### Why

New subscription items already persist their effective currency, but legacy priced items may still have no currency. These rows must be backfilled before enforcing stricter currency constraints.

### How

The migration copies the owning subscription’s fiat currency to unannotated priced items with no currency reference. It preserves existing annotations and explicit fiat/custom currencies. Updated rows receive a `dbmigration:backfill_subscription_item_currencies` RFC3339 annotation, which also supports targeted rollback. PostgreSQL migration tests cover backfill, exclusion, preservation, and rollback behavior.

This must be merged prior: #4744.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a data migration that materializes inherited subscription currency on legacy priced items and marks changed rows for rollback.
- Backfills eligible subscription items from their owning subscription.
- Preserves explicit fiat and custom currencies during migration-up.
- Adds PostgreSQL coverage for migration-up and rollback behavior.
- Updates the Atlas migration checksum.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because rollback can corrupt rows that had the migration marker before migration-up.

The up migration skips pre-marked rows, while the down migration still treats every marked row as migration-owned and clears its currency and marker; this previously reported rollback defect remains outstanding.

**Files Needing Attention:** tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.down.sql

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.up.sql | Backfills missing fiat currencies on eligible priced subscription items and records a timestamped migration annotation. |
| tools/migrate/migrations/20260810064730_backfill_subscription_item_currencies.down.sql | Reverts rows selected by the migration annotation. |
| tools/migrate/subscription_item_currency_backfill_test.go | Covers eligible and excluded rows, annotation preservation, timestamps, and migration rollback. |
| tools/migrate/migrations/atlas.sum | Registers the new up migration in the Atlas checksum manifest. |

<sub>Reviews (2): Last reviewed commit: ["refactor: rm validation from up migratio..."](https://github.com/openmeterio/openmeter/commit/66fbeff454b2cf2fd22f1f050a6ea5ad4ad18fdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51727767)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Legacy subscription items now inherit their subscription currency when eligible.
  * Existing custom, explicit, deleted, annotated, and unpriced items remain unchanged.
  * Updates include migration tracking and timestamps while preserving existing metadata.

* **Rollback**
  * Backfilled currency values and migration annotations can be safely reverted without removing pre-existing data.

* **Tests**
  * Added coverage for backfill eligibility, metadata preservation, timestamps, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->