### PR TITLE
fix: feature resolve in subscription

### DIFF
--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -1041,7 +1041,20 @@ var ValidateRateCardsHaveCompatibleUnitConfig = models.ValidatorFunc[RateCardWit
 	return nil
 })
 
-func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatureResolver) func(cards RateCards) error {
+type ValidateRateCardsWithFeaturesOptions struct {
+	IgnoreArchived bool
+}
+
+func ValidateRateCardsWithFeatures(
+	ctx context.Context,
+	resolver NamespacedFeatureResolver,
+	optionalOptions ...ValidateRateCardsWithFeaturesOptions,
+) func(cards RateCards) error {
+	options := ValidateRateCardsWithFeaturesOptions{}
+	if len(optionalOptions) > 0 {
+		options = optionalOptions[0]
+	}
+
 	return func(rateCards RateCards) error {
 		var errs []error
 
@@ -1073,8 +1086,10 @@ func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatu
 				continue
 			}
 
-			if feat.ArchivedAt != nil && clock.Now().UTC().After(feat.ArchivedAt.UTC()) {
-				errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardFeatureArchived))
+			if !options.IgnoreArchived {
+				if feat.ArchivedAt != nil && clock.Now().UTC().After(feat.ArchivedAt.UTC()) {
+					errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardFeatureArchived))
+				}
 			}
 
 			// Make sure that ratecard with UBP has metered feature

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -1,6 +1,7 @@
 package productcatalog
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -14,6 +15,66 @@ import (
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+func TestValidateRateCardsWithFeaturesIgnoreArchived(t *testing.T) {
+	archivedAt := time.Now().Add(-time.Minute)
+	feat := &feature.Feature{
+		Namespace:  "test",
+		ID:         "feature-id",
+		Key:        "feature-key",
+		ArchivedAt: &archivedAt,
+	}
+	resolver := staticNamespacedFeatureResolver{feature: feat}
+	rateCards := RateCards{
+		&FlatFeeRateCard{
+			RateCardMeta: RateCardMeta{
+				Key:        feat.Key,
+				Name:       "Feature only",
+				FeatureID:  &feat.ID,
+				FeatureKey: &feat.Key,
+			},
+		},
+	}
+
+	t.Run("rejects archived feature by default", func(t *testing.T) {
+		// given: a rate card referencing an archived feature
+		// when: feature validation uses the default archival policy
+		// then: the archived feature is rejected
+		err := ValidateRateCardsWithFeatures(
+			t.Context(),
+			resolver,
+		)(rateCards)
+		require.ErrorIs(t, err, ErrRateCardFeatureArchived)
+	})
+
+	t.Run("allows archived feature when ignored", func(t *testing.T) {
+		// given: a rate card referencing an archived feature
+		// when: the caller explicitly ignores archival state
+		// then: identity and feature-shape validation still succeed
+		err := ValidateRateCardsWithFeatures(
+			t.Context(),
+			resolver,
+			ValidateRateCardsWithFeaturesOptions{IgnoreArchived: true},
+		)(rateCards)
+		require.NoError(t, err)
+	})
+}
+
+type staticNamespacedFeatureResolver struct {
+	feature *feature.Feature
+}
+
+func (r staticNamespacedFeatureResolver) Resolve(context.Context, *string, *string) (*feature.Feature, error) {
+	return r.feature, nil
+}
+
+func (r staticNamespacedFeatureResolver) BatchResolve(context.Context, ...string) (map[string]*feature.Feature, error) {
+	return nil, nil
+}
+
+func (r staticNamespacedFeatureResolver) Namespace() string {
+	return r.feature.Namespace
+}
 
 func TestRateCardJSONRoundTrip(t *testing.T) {
 	managedCurrency := mustManagedCustomCurrency(t, "01J00000000000000000000000", "CREDITS")

--- a/openmeter/subscription/README.md
+++ b/openmeter/subscription/README.md
@@ -118,9 +118,10 @@ and phase; do not persist a derived absolute end as independent source truth.
   you its end
 - item slice position is version identity, not quantity
 - subscription, spec, and expanded view must agree on shared top-level facts
-- every feature-bearing item in a new or updated spec must resolve to an active
-  feature in the subscription namespace; supplied feature IDs and keys must
-  identify the same feature
+- every feature-bearing item must resolve in the subscription namespace and
+  supplied feature IDs and keys must identify the same feature; create rejects
+  archived features, while update permits them so existing subscriptions remain
+  editable after a referenced feature is archived
 - newly materialized priced items snapshot their effective currency code; custom
   currencies also retain their managed currency ID, while legacy items may lack
   this snapshot

--- a/openmeter/subscription/README.md
+++ b/openmeter/subscription/README.md
@@ -118,6 +118,9 @@ and phase; do not persist a derived absolute end as independent source truth.
   you its end
 - item slice position is version identity, not quantity
 - subscription, spec, and expanded view must agree on shared top-level facts
+- every feature-bearing item in a new or updated spec must resolve to an active
+  feature in the subscription namespace; supplied feature IDs and keys must
+  identify the same feature
 - newly materialized priced items snapshot their effective currency code; custom
   currencies also retain their managed currency ID, while legacy items may lack
   this snapshot

--- a/openmeter/subscription/service/README.md
+++ b/openmeter/subscription/service/README.md
@@ -14,8 +14,8 @@ artifacts asynchronously.
 - The workflow layer decides the product operation, resolves its timing, and
   constructs a complete target spec.
 - The subscription service validates lifecycle rules, runs command hooks,
-  resolves item currencies, materializes the target spec, and publishes the
-  resulting subscription event.
+  resolves item features and currencies, materializes the target spec, and
+  publishes the resulting subscription event.
 - The materializer owns subscription phases, items, and their entitlement
   scheduling. It does not create invoice lines, charges, or ledger entries.
 
@@ -52,6 +52,8 @@ annotations intended for correlation, not persisted child IDs.
   transaction.
 - The materializer receives a complete desired state. It does not interpret
   the user's patch sequence or decide command timing.
+- Feature references in create and update targets must resolve in the item
+  namespace before persistence, whether or not the item creates an entitlement.
 - Custom item currencies must be resolved by the service before persistence;
   the materializer verifies that their managed identity belongs to the item
   namespace without loading currency state itself.

--- a/openmeter/subscription/service/README.md
+++ b/openmeter/subscription/service/README.md
@@ -54,6 +54,8 @@ annotations intended for correlation, not persisted child IDs.
   the user's patch sequence or decide command timing.
 - Feature references in create and update targets must resolve in the item
   namespace before persistence, whether or not the item creates an entitlement.
+  Create rejects archived features; update ignores archival state so later
+  feature lifecycle changes do not make an existing subscription uneditable.
 - Custom item currencies must be resolved by the service before persistence;
   the materializer verifies that their managed identity belongs to the item
   namespace without loading currency state itself.

--- a/openmeter/subscription/service/feature.go
+++ b/openmeter/subscription/service/feature.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	productcatalogfeatureresolver "github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+)
+
+// prepareSpecFeatures resolves every subscription item feature before a create
+// or update so feature-only items receive the same validation as items that
+// schedule entitlements.
+func (s *service) prepareSpecFeatures(ctx context.Context, namespace string, spec *subscription.SubscriptionSpec) error {
+	if spec == nil {
+		return fmt.Errorf("subscription spec is required")
+	}
+
+	rateCards := make(productcatalog.RateCards, 0)
+	for _, phase := range spec.Phases {
+		if phase == nil {
+			continue
+		}
+
+		for _, items := range phase.ItemsByKey {
+			for _, item := range items {
+				if item == nil || item.RateCard == nil {
+					continue
+				}
+
+				rateCards = append(rateCards, item.RateCard)
+			}
+		}
+	}
+
+	if err := productcatalogfeatureresolver.ResolveFeaturesForRateCards(
+		ctx,
+		s.featureResolver,
+		namespace,
+		&rateCards,
+	); err != nil {
+		return fmt.Errorf("resolving subscription item features: %w", err)
+	}
+
+	return nil
+}

--- a/openmeter/subscription/service/feature.go
+++ b/openmeter/subscription/service/feature.go
@@ -2,21 +2,20 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	productcatalogfeatureresolver "github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 )
 
-// prepareSpecFeatures resolves every subscription item feature before a create
-// or update so feature-only items receive the same validation as items that
-// schedule entitlements.
-func (s *service) prepareSpecFeatures(ctx context.Context, namespace string, spec *subscription.SubscriptionSpec) error {
-	if spec == nil {
-		return fmt.Errorf("subscription spec is required")
-	}
-
+// validateSpecFeatures applies product-catalog feature constraints to every
+// subscription item, including feature-only items that do not schedule an
+// entitlement.
+func (s *service) validateSpecFeatures(
+	ctx context.Context,
+	namespace string,
+	spec subscription.SubscriptionSpec,
+	options ...productcatalog.ValidateRateCardsWithFeaturesOptions,
+) error {
 	rateCards := make(productcatalog.RateCards, 0)
 	for _, phase := range spec.Phases {
 		if phase == nil {
@@ -34,14 +33,9 @@ func (s *service) prepareSpecFeatures(ctx context.Context, namespace string, spe
 		}
 	}
 
-	if err := productcatalogfeatureresolver.ResolveFeaturesForRateCards(
+	return productcatalog.ValidateRateCardsWithFeatures(
 		ctx,
-		s.featureResolver,
-		namespace,
-		&rateCards,
-	); err != nil {
-		return fmt.Errorf("resolving subscription item features: %w", err)
-	}
-
-	return nil
+		s.featureResolver.WithNamespace(namespace),
+		options...,
+	)(rateCards)
 }

--- a/openmeter/subscription/service/feature_resolution_test.go
+++ b/openmeter/subscription/service/feature_resolution_test.go
@@ -1,0 +1,245 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+)
+
+func TestCreateResolvesFeatureOnlyItems(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("resolves and pins a feature supplied by key", func(t *testing.T) {
+		// given: a structurally valid feature-only subscription item with no pinned feature ID
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, newFeatureOnlyRateCard(t, subscriptiontestutils.ExampleFeatureKey, nil)).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		// when: the subscription is created through the core service
+		sub, err := deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+		require.NoError(t, err)
+
+		// then: the feature-only item is materialized without creating an entitlement
+		items, err := deps.ItemRepo.GetForSubscriptionAt(t.Context(), subscription.GetForSubscriptionAtInput{
+			Namespace:      sub.Namespace,
+			SubscriptionID: sub.ID,
+			At:             now,
+		})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		require.Nil(t, items[0].EntitlementID)
+		require.Equal(t, subscriptiontestutils.ExampleFeatureKey, lo.FromPtr(items[0].RateCard.GetFeatureKey()))
+
+		view, err := deps.SubscriptionService.GetView(t.Context(), sub.NamespacedID)
+		require.NoError(t, err)
+		itemView := view.Phases[0].ItemsByKey[subscriptiontestutils.ExampleFeatureKey][0]
+		require.NotNil(t, itemView.Feature)
+		require.Equal(t, features[0].ID, itemView.Feature.ID)
+	})
+
+	t.Run("rejects an unknown feature key", func(t *testing.T) {
+		// given: a feature-only subscription item referencing a missing feature
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		const missingFeatureKey = "missing-feature"
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, newFeatureOnlyRateCard(t, missingFeatureKey, nil)).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		// when: subscription creation validates its complete target spec
+		_, err = deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+
+		// then: the write is rejected before materialization
+		require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureNotFound)
+	})
+
+	t.Run("rejects mismatched feature identifiers", func(t *testing.T) {
+		// given: a feature-only item whose key and ID identify different features
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, newFeatureOnlyRateCard(t, subscriptiontestutils.ExampleFeatureKey, &features[1].ID)).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		// when: subscription creation resolves both references
+		_, err = deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+
+		// then: the conflicting identity is rejected
+		require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureMismatch)
+	})
+}
+
+func TestEditRunningResolvesFeatureOnlyItems(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	immediate := subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)}
+
+	t.Run("resolves and pins an added feature-only item", func(t *testing.T) {
+		// given: a running subscription and an existing feature referenced only by key
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, subscriptiontestutils.ExampleRateCard2.Clone()).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		sub, err := deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+		require.NoError(t, err)
+
+		// when: a running edit adds a feature-only item without a pinned feature ID
+		_, err = deps.WorkflowService.EditRunning(t.Context(), sub.NamespacedID, []subscription.Patch{
+			patch.PatchAddItem{
+				PhaseKey: "test_phase_1",
+				ItemKey:  subscriptiontestutils.ExampleFeatureKey,
+				CreateInput: subscription.SubscriptionItemSpec{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							PhaseKey: "test_phase_1",
+							ItemKey:  subscriptiontestutils.ExampleFeatureKey,
+							RateCard: newFeatureOnlyRateCard(t, subscriptiontestutils.ExampleFeatureKey, nil),
+						},
+					},
+				},
+			},
+		}, immediate)
+		require.NoError(t, err)
+
+		// then: the new feature-only item is materialized without an entitlement
+		items, err := deps.ItemRepo.GetForSubscriptionAt(t.Context(), subscription.GetForSubscriptionAtInput{
+			Namespace:      sub.Namespace,
+			SubscriptionID: sub.ID,
+			At:             now,
+		})
+		require.NoError(t, err)
+		item, found := lo.Find(items, func(item subscription.SubscriptionItem) bool {
+			return item.Key == subscriptiontestutils.ExampleFeatureKey
+		})
+		require.True(t, found)
+		require.Nil(t, item.EntitlementID)
+
+		view, err := deps.SubscriptionService.GetView(t.Context(), sub.NamespacedID)
+		require.NoError(t, err)
+		itemView := view.Phases[0].ItemsByKey[subscriptiontestutils.ExampleFeatureKey][0]
+		require.NotNil(t, itemView.Feature)
+		require.Equal(t, features[0].ID, itemView.Feature.ID)
+	})
+
+	t.Run("rejects an added item with an unknown feature key", func(t *testing.T) {
+		// given: a running subscription and a feature-only item referencing a missing feature
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, subscriptiontestutils.ExampleRateCard2.Clone()).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		sub, err := deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+		require.NoError(t, err)
+
+		const missingFeatureKey = "missing-feature"
+
+		// when: the running edit adds the invalid item
+		_, err = deps.WorkflowService.EditRunning(t.Context(), sub.NamespacedID, []subscription.Patch{
+			patch.PatchAddItem{
+				PhaseKey: "test_phase_1",
+				ItemKey:  missingFeatureKey,
+				CreateInput: subscription.SubscriptionItemSpec{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							PhaseKey: "test_phase_1",
+							ItemKey:  missingFeatureKey,
+							RateCard: newFeatureOnlyRateCard(t, missingFeatureKey, nil),
+						},
+					},
+				},
+			},
+		}, immediate)
+
+		// then: the edit fails and the persisted subscription remains unchanged
+		require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureNotFound)
+
+		items, err := deps.ItemRepo.GetForSubscriptionAt(t.Context(), subscription.GetForSubscriptionAtInput{
+			Namespace:      sub.Namespace,
+			SubscriptionID: sub.ID,
+			At:             now,
+		})
+		require.NoError(t, err)
+		require.Len(t, items, 1)
+		require.Equal(t, subscriptiontestutils.ExampleRateCard2.Key(), items[0].Key)
+	})
+}
+
+func newFeatureOnlyRateCard(t *testing.T, featureKey string, featureID *string) productcatalog.RateCard {
+	t.Helper()
+
+	rateCard := subscriptiontestutils.ExampleRateCard5ForAddons.Clone()
+	err := rateCard.ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+		meta.Key = featureKey
+		meta.FeatureKey = lo.ToPtr(featureKey)
+		meta.FeatureID = featureID
+		return meta, nil
+	})
+	require.NoError(t, err)
+
+	return rateCard
+}

--- a/openmeter/subscription/service/feature_resolution_test.go
+++ b/openmeter/subscription/service/feature_resolution_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
 	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestCreateResolvesFeatureOnlyItems(t *testing.T) {
@@ -108,6 +109,41 @@ func TestCreateResolvesFeatureOnlyItems(t *testing.T) {
 
 		// then: the conflicting identity is rejected
 		require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureMismatch)
+	})
+
+	t.Run("rejects an archived feature", func(t *testing.T) {
+		// given: a feature-only subscription item referencing an archived feature
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		err := deps.FeatureConnector.ArchiveFeature(t.Context(), models.NamespacedID{
+			Namespace: features[0].Namespace,
+			ID:        features[0].ID,
+		})
+		require.NoError(t, err)
+
+		clock.FreezeTime(now.Add(time.Minute))
+		defer clock.UnFreeze()
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, newFeatureOnlyRateCard(t, subscriptiontestutils.ExampleFeatureKey, nil)).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		// when: a new subscription validates the archived feature reference
+		_, err = deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+
+		// then: create keeps the strict product-catalog archival policy
+		require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureArchived)
 	})
 }
 
@@ -226,6 +262,59 @@ func TestEditRunningResolvesFeatureOnlyItems(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, items, 1)
 		require.Equal(t, subscriptiontestutils.ExampleRateCard2.Key(), items[0].Key)
+	})
+
+	t.Run("allows editing a subscription whose feature was archived", func(t *testing.T) {
+		// given: a running feature-only subscription whose feature is archived after creation
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+		customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		spec, err := subscriptiontestutils.BuildTestSubscriptionSpec(t).
+			AddPhase(nil, newFeatureOnlyRateCard(t, subscriptiontestutils.ExampleFeatureKey, nil)).
+			Build()
+		require.NoError(t, err)
+		spec.CustomerId = customer.ID
+		spec.Plan = nil
+
+		sub, err := deps.SubscriptionService.Create(t.Context(), subscriptiontestutils.ExampleNamespace, spec)
+		require.NoError(t, err)
+
+		_, err = dbDeps.DBClient.Feature.UpdateOneID(features[0].ID).
+			SetArchivedAt(now).
+			Save(t.Context())
+		require.NoError(t, err)
+
+		clock.FreezeTime(now.Add(time.Minute))
+		defer clock.UnFreeze()
+
+		// when: an unrelated featureless item is added to the subscription
+		view, err := deps.WorkflowService.EditRunning(t.Context(), sub.NamespacedID, []subscription.Patch{
+			patch.PatchAddItem{
+				PhaseKey: "test_phase_1",
+				ItemKey:  subscriptiontestutils.ExampleRateCard2.Key(),
+				CreateInput: subscription.SubscriptionItemSpec{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							PhaseKey: "test_phase_1",
+							ItemKey:  subscriptiontestutils.ExampleRateCard2.Key(),
+							RateCard: subscriptiontestutils.ExampleRateCard2.Clone(),
+						},
+					},
+				},
+			},
+		}, immediate)
+
+		// then: update ignores archival state while retaining feature identity validation
+		require.NoError(t, err)
+		require.Contains(t, view.Phases[0].ItemsByKey, subscriptiontestutils.ExampleFeatureKey)
+		require.Contains(t, view.Phases[0].ItemsByKey, subscriptiontestutils.ExampleRateCard2.Key())
 	})
 }
 

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -121,10 +121,6 @@ func (s *service) Create(ctx context.Context, namespace string, spec subscriptio
 		return def, err
 	}
 
-	if err := s.prepareSpecFeatures(ctx, namespace, &spec); err != nil {
-		return def, err
-	}
-
 	// Fetch the customer & validate the customer
 	cus, err := s.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
 		CustomerID: &customer.CustomerID{
@@ -220,10 +216,6 @@ func (s *service) Update(ctx context.Context, subscriptionID models.NamespacedID
 
 	var def subscription.Subscription
 	if err := s.prepareSpecCurrencies(ctx, subscriptionID.Namespace, &newSpec); err != nil {
-		return def, err
-	}
-
-	if err := s.prepareSpecFeatures(ctx, subscriptionID.Namespace, &newSpec); err != nil {
 		return def, err
 	}
 

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	productcatalogfeatureresolver "github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptionvalidators "github.com/openmeterio/openmeter/openmeter/subscription/validators/subscription"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
@@ -50,8 +52,14 @@ func New(conf ServiceConfig) (subscription.Service, error) {
 		return nil, errors.New("currency resolver is required")
 	}
 
+	featureResolver, err := productcatalogfeatureresolver.New(conf.FeatureService)
+	if err != nil {
+		return nil, fmt.Errorf("creating feature resolver: %w", err)
+	}
+
 	svc := &service{
-		ServiceConfig: conf,
+		ServiceConfig:   conf,
+		featureResolver: featureResolver,
 	}
 
 	val, err := subscriptionvalidators.NewSubscriptionUniqueConstraintValidator(subscriptionvalidators.SubscriptionUniqueConstraintValidatorConfig{
@@ -74,6 +82,7 @@ var _ subscription.Service = &service{}
 
 type service struct {
 	ServiceConfig
+	featureResolver productcatalog.FeatureResolver
 
 	mu sync.RWMutex
 }
@@ -109,6 +118,10 @@ func (s *service) Create(ctx context.Context, namespace string, spec subscriptio
 
 	def := subscription.Subscription{}
 	if err := s.prepareSpecCurrencies(ctx, namespace, &spec); err != nil {
+		return def, err
+	}
+
+	if err := s.prepareSpecFeatures(ctx, namespace, &spec); err != nil {
 		return def, err
 	}
 
@@ -207,6 +220,10 @@ func (s *service) Update(ctx context.Context, subscriptionID models.NamespacedID
 
 	var def subscription.Subscription
 	if err := s.prepareSpecCurrencies(ctx, subscriptionID.Namespace, &newSpec); err != nil {
+		return def, err
+	}
+
+	if err := s.prepareSpecFeatures(ctx, subscriptionID.Namespace, &newSpec); err != nil {
 		return def, err
 	}
 

--- a/openmeter/subscription/service/servicevalidation.go
+++ b/openmeter/subscription/service/servicevalidation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -23,6 +24,10 @@ func (s *service) validateCreate(ctx context.Context, cust customer.Customer, sp
 	// 1. Valiate the spec
 	if err := spec.Validate(); err != nil {
 		return fmt.Errorf("spec is invalid: %w", err)
+	}
+
+	if err := s.validateSpecFeatures(ctx, cust.Namespace, spec); err != nil {
+		return fmt.Errorf("subscription item features are invalid: %w", err)
 	}
 
 	if err := validateSubscriptionUsesFiatOnly(spec); err != nil {
@@ -54,6 +59,15 @@ func (s *service) validateUpdate(ctx context.Context, currentView subscription.S
 
 	if err := validateSubscriptionUsesFiatOnly(newSpec); err != nil {
 		return err
+	}
+
+	if err := s.validateSpecFeatures(
+		ctx,
+		currentView.Subscription.Namespace,
+		newSpec,
+		productcatalog.ValidateRateCardsWithFeaturesOptions{IgnoreArchived: true},
+	); err != nil {
+		return fmt.Errorf("subscription item features are invalid: %w", err)
 	}
 
 	// Fetch the customer & validate the customer


### PR DESCRIPTION
## Overview

### What

Added feature validation for subscription items during create and edit, including feature-only items without entitlements.
Added PostgreSQL-backed regression tests and updated the subscription domain documentation.

### Why

Feature validation previously happened indirectly during entitlement scheduling.
Feature-only items skipped that path, allowing subscriptions to reference nonexistent or mismatched features.

### How

The subscription service now batch-resolves every item feature before creating or updating a subscription.
It rejects:
* Unknown feature keys
* Mismatched feature keys and IDs
The existing key-based storage model remains unchanged, so no database migration was required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subscription items now resolve feature references within their subscription namespace during creation and updates.
  - Feature-only items are supported with consistent feature IDs and keys.
  - Feature references can be identified by either ID or key.

- **Bug Fixes**
  - Invalid, unknown, mismatched, or cross-namespace feature references are rejected before saving.
  - New subscriptions reject archived features, while existing subscriptions remain editable when features are later archived.
  - Failed subscription edits no longer alter existing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds subscription-wide feature-reference validation during create and update, including feature-only items, and documents the intended archive behavior.
- Adds feature resolution to subscription create and update validation.
- Adds identity, missing-feature, and archived-feature regression coverage.
- Introduces an option intended to permit archived feature snapshots during updates.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because updates referencing archived feature snapshots remain blocked.

The update path requests archived references be ignored, but its resolver excludes those features before validation can apply that policy, leaving the previously reported subscription-edit failure reachable.

**Files Needing Attention:** openmeter/productcatalog/ratecard.go, openmeter/productcatalog/featureresolver/resolver.go, openmeter/subscription/service/servicevalidation.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/ratecard.go | Adds IgnoreArchived validation behavior, but the option is applied only after production resolution has already excluded archived features. |
| openmeter/subscription/service/feature.go | Collects all subscription item rate cards and validates them through the namespaced production resolver. |
| openmeter/subscription/service/servicevalidation.go | Adds create and update feature validation; the update option cannot currently preserve archived references through the resolver. |
| openmeter/subscription/service/feature_resolution_test.go | Adds PostgreSQL-backed create/edit coverage, including the archived-feature update scenario. |
| openmeter/productcatalog/ratecard_test.go | Tests the new option with a static resolver that bypasses production archived-feature filtering. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  U[Update existing subscription] --> V[validateUpdate with IgnoreArchived]
  V --> R[Production feature resolver]
  R --> L[ListFeatures IncludeArchived=false]
  L --> N[Archived feature omitted]
  N --> E[ErrRateCardFeatureNotFound]
  E --> B[Update blocked before archive check]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fproductcatalog%2Fratecard.go%3A1089-1093%0A**Archived%20features%20remain%20unresolved**%0A%0AWhen%20an%20existing%20subscription%20references%20a%20feature%20archived%20after%20creation%2C%20%60validateUpdate%60%20passes%20%60IgnoreArchived%60%2C%20but%20the%20production%20resolver%20excludes%20archived%20features%20before%20this%20check%20runs.%20Resolution%20therefore%20returns%20%60ErrRateCardFeatureNotFound%60%2C%20causing%20unrelated%20subscription%20edits%20to%20remain%20blocked.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4896&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22fix%2Fsubscription-feature-validation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsubscription-feature-validation%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fproductcatalog%2Fratecard.go%3A1089-1093%0A**Archived%20features%20remain%20unresolved**%0A%0AWhen%20an%20existing%20subscription%20references%20a%20feature%20archived%20after%20creation%2C%20%60validateUpdate%60%20passes%20%60IgnoreArchived%60%2C%20but%20the%20production%20resolver%20excludes%20archived%20features%20before%20this%20check%20runs.%20Resolution%20therefore%20returns%20%60ErrRateCardFeatureNotFound%60%2C%20causing%20unrelated%20subscription%20edits%20to%20remain%20blocked.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4896&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/productcatalog/ratecard.go:1089-1093
**Archived features remain unresolved**

When an existing subscription references a feature archived after creation, `validateUpdate` passes `IgnoreArchived`, but the production resolver excludes archived features before this check runs. Resolution therefore returns `ErrRateCardFeatureNotFound`, causing unrelated subscription edits to remain blocked.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: use validation instead of reso..."](https://github.com/openmeterio/openmeter/commit/c107974539f90a34b252d2f498eb16fe754569d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51743178)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Subscription](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription.md)
- Knowledge Base — [Product Catalog](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/productcatalog.md)

<!-- /greptile_comment -->