### PR TITLE
fix: validate billing feature references

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -118,6 +118,7 @@ asynchronously; webhook delivery is not part of the invoice lifecycle.
   transaction and customer update lock
 - every invoice contains one fiat currency
 - a customer cannot have two active gathering invoices for the same currency
+- pending-line creation resolves every supplied feature; metered prices require the feature's meter
 - gathering-to-standard conversion preserves line IDs
 - line engines cannot silently change the identity or count of callback output
 - immutable invoice drift is recorded as validation issues rather than

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -86,6 +86,9 @@ when an active override hides it.
   complete, not merely that rating or line creation finished.
 - Lifecycle entry points run in database transactions. Flat-fee and usage-based
   advancement and patching also take charge-scoped locks.
+- Charge creation resolves every supplied feature reference before persistence.
+  Usage-based features require a meter; flat-fee features are optional and may
+  be meterless.
 - `UpdateCharge` persists the concrete base row. Expanded realizations are read
   model state and are written through dedicated adapter operations.
 - Persisted charge discounts have stable correlation IDs allocated at their

--- a/openmeter/billing/charges/charge.go
+++ b/openmeter/billing/charges/charge.go
@@ -13,9 +13,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/ref"
 )
 
 type Charge struct {
@@ -463,8 +463,8 @@ func (i ChargeIntents) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-func (i ChargeIntents) CollectFeatureRefs() ([]ref.IDOrKey, error) {
-	refs := make([]ref.IDOrKey, 0, len(i))
+func (i ChargeIntents) CollectFeatureMeterRefs() ([]feature.FeatureMeterRef, error) {
+	refs := make([]feature.FeatureMeterRef, 0, len(i))
 
 	for idx, ch := range i {
 		switch ch.Type() {
@@ -478,14 +478,20 @@ func (i ChargeIntents) CollectFeatureRefs() ([]ref.IDOrKey, error) {
 				return nil, fmt.Errorf("getting feature ref for flat fee intent[%d]: %w", idx, err)
 			}
 			if featureRef != nil {
-				refs = append(refs, *featureRef)
+				refs = append(refs, feature.FeatureMeterRef{
+					IDOrKey:      *featureRef,
+					RequireMeter: false,
+				})
 			}
 		case meta.ChargeTypeUsageBased:
 			usageBased, err := ch.AsUsageBasedIntent()
 			if err != nil {
 				return nil, fmt.Errorf("converting usage based intent[%d]: %w", idx, err)
 			}
-			refs = append(refs, usageBased.GetFeatureRef())
+			refs = append(refs, feature.FeatureMeterRef{
+				IDOrKey:      usageBased.GetFeatureRef(),
+				RequireMeter: true,
+			})
 		case meta.ChargeTypeCreditPurchase:
 			continue
 		default:

--- a/openmeter/billing/charges/charge_test.go
+++ b/openmeter/billing/charges/charge_test.go
@@ -1,0 +1,33 @@
+package charges
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+)
+
+func TestChargeIntentsCollectFeatureMeterRefs(t *testing.T) {
+	// given:
+	// - flat-fee and usage-based intents reference the same feature
+	// when:
+	// - their feature meter references are collected
+	// then:
+	// - both refs are retained with the meter requirement derived from the charge type
+	const featureKey = "api-requests"
+
+	refs, err := (ChargeIntents{
+		NewChargeIntent(flatfee.Intent{FeatureKey: lo.ToPtr(featureKey)}),
+		NewChargeIntent(usagebased.Intent{FeatureKey: featureKey}),
+	}).CollectFeatureMeterRefs()
+
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	require.Equal(t, featureKey, refs[0].IDOrKey.Key)
+	require.False(t, refs[0].RequireMeter)
+	require.Equal(t, featureKey, refs[1].IDOrKey.Key)
+	require.True(t, refs[1].RequireMeter)
+}

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -62,7 +62,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 			var featureID *string
 			if featureRef != nil {
-				featureMeter, err := feature.ResolveByRef(input.FeatureMeters, feature.FeatureMeterRef{
+				featureMeter, err := input.FeatureMeters.Resolve(feature.FeatureMeterRef{
 					IDOrKey:      *featureRef,
 					RequireMeter: false,
 				})

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -156,12 +156,12 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			return nil, err
 		}
 
-		featureRefs, err := input.Intents.CollectFeatureRefs()
+		featureMeterRefs, err := input.Intents.CollectFeatureMeterRefs()
 		if err != nil {
-			return nil, fmt.Errorf("collecting feature refs: %w", err)
+			return nil, fmt.Errorf("collecting feature meter refs: %w", err)
 		}
 
-		createFeatureMeters, err := s.featureService.ResolveFeatureMeters(ctx, input.Namespace, featureRefs...)
+		createFeatureMeters, err := s.featureService.ResolveFeatureMeters(ctx, input.Namespace, featureMeterRefs...)
 		if err != nil {
 			return nil, fmt.Errorf("resolve create feature meters: %w", err)
 		}

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -580,6 +580,74 @@ func (s *ChargeFeatureIDTestSuite) TestCreateUsageBasedRequiresFeatureMeterBefor
 	s.Empty(listed.Items)
 }
 
+func (s *ChargeFeatureIDTestSuite) TestCreateUsageBasedMissingFeatureTakesPrecedenceOverMeterValidation() {
+	// given:
+	// - one usage-based intent references a missing feature and another a meterless feature
+	// when:
+	// - both charges are created in one request
+	// then:
+	// - the missing feature rejects the whole request as not-found before anything is persisted
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-mixed-feature-errors")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "usage-mixed-feature-errors")
+	meterlessFeature, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "meterless feature",
+		Key:       "meterless-feature",
+	})
+	s.Require().NoError(err)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-06-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-07-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	_, err = s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				name:       "usage-missing-feature",
+				managedBy:  billing.ManuallyManagedLine,
+				featureKey: "this-usage-feature-does-not-exist",
+			}),
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				name:       "usage-without-feature-meter",
+				managedBy:  billing.ManuallyManagedLine,
+				featureKey: meterlessFeature.Key,
+			}),
+		},
+	})
+
+	s.Require().Error(err)
+	s.True(models.IsGenericNotFoundError(err), "expected not found error, got %v", err)
+	s.False(models.IsGenericValidationError(err), "not found error must take precedence over validation: %v", err)
+
+	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+	})
+	s.Require().NoError(listErr)
+	s.Empty(listed.Items)
+}
+
 // TestCreateCustomerChargeByIDResolvesLatestFeatureVersion pins the version semantics of
 // feature_id: it names a feature, it does not pin the version the caller passed. Passing
 // an archived ID resolves through its key to the current version, matching key-based and

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -44,7 +44,7 @@ func (s *ChargeFeatureIDTestSuite) TearDownTest() {
 	s.BaseSuite.TearDownTest()
 }
 
-func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndFlatFeeCharges() {
+func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndMeterlessFlatFeeCharges() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-id-create")
 	s.ProvisionDefaultTaxCodes(ctx, ns)
@@ -54,11 +54,15 @@ func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndF
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 
 	usageMeter := newTestMeter(ns, "usage-meter")
-	flatFeeMeter := newTestMeter(ns, "flat-fee-meter")
-	s.installMeters(ctx, usageMeter, flatFeeMeter)
+	s.installMeters(ctx, usageMeter)
 
 	usageFeature := s.createFeature(ctx, ns, "usage-feature", usageMeter.ID)
-	flatFeeFeature := s.createFeature(ctx, ns, "flat-fee-feature", flatFeeMeter.ID)
+	flatFeeFeature, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "flat-fee-feature",
+		Key:       "flat-fee-feature",
+	})
+	s.Require().NoError(err)
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
@@ -449,6 +453,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyRe
 	s.Require().Error(err)
 	s.ErrorContains(err, "resolve create feature meter")
 	s.True(models.IsGenericNotFoundError(err), "expected not found error, got %v", err)
+	s.False(models.IsGenericValidationError(err), "not found error must not be wrapped as validation: %v", err)
 
 	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:   ns,
@@ -497,6 +502,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateUsageBasedWithUnresolvableFeatureKe
 
 	s.Require().Error(err)
 	s.True(models.IsGenericNotFoundError(err), "expected not found error, got %v", err)
+	s.False(models.IsGenericValidationError(err), "not found error must not be wrapped as validation: %v", err)
 
 	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:   ns,

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -400,11 +400,16 @@ func (s *ChargeFeatureIDTestSuite) TestCreateCustomerChargeResolvesFeatureByID()
 	})
 }
 
-// TestCreateFlatFeeWithUnresolvableFeatureKeyReturnsError covers the key-only producers
-// (subscription sync, pending lines, invoice-line mappers) reaching the flat-fee create
-// path with a feature that no longer resolves. Those intents carry no feature ID, so the
-// failure branch must not reach for one.
+// TestCreateFlatFeeWithUnresolvableFeatureKeyReturnsError covers key-only producers
+// (subscription sync, pending lines, invoice-line mappers) reaching the shared charge
+// creation boundary with a feature that no longer resolves.
 func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyReturnsError() {
+	// given:
+	// - a flat-fee intent carrying only a feature key, for a feature that does not exist
+	// when:
+	// - the charge is created
+	// then:
+	// - creation returns a not-found error without persisting a charge
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-key-unresolvable")
 	s.ProvisionDefaultTaxCodes(ctx, ns)
@@ -421,9 +426,6 @@ func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyRe
 	clock.SetTime(servicePeriod.From.Add(-time.Hour))
 	defer clock.UnFreeze()
 
-	// given:
-	// - a flat-fee intent carrying only a feature key, for a feature that does not exist
-	// when:
 	_, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
@@ -444,10 +446,132 @@ func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyRe
 		},
 	})
 
-	// then:
-	// - it surfaces as an error rather than panicking on a nil feature ID
 	s.Require().Error(err)
-	s.ErrorContains(err, "resolve flat fee feature")
+	s.ErrorContains(err, "resolve create feature meter")
+	s.True(models.IsGenericNotFoundError(err), "expected not found error, got %v", err)
+
+	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+	})
+	s.Require().NoError(listErr)
+	s.Empty(listed.Items)
+}
+
+func (s *ChargeFeatureIDTestSuite) TestCreateUsageBasedWithUnresolvableFeatureKeyReturnsError() {
+	// given:
+	// - a usage-based intent references a feature key that does not exist
+	// when:
+	// - the charge is created
+	// then:
+	// - creation returns a not-found error without persisting a charge
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-feature-key-unresolvable")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "usage-feature-key-unresolvable")
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-06-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-07-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				name:       "usage-missing-feature",
+				managedBy:  billing.ManuallyManagedLine,
+				featureKey: "this-usage-feature-does-not-exist",
+			}),
+		},
+	})
+
+	s.Require().Error(err)
+	s.True(models.IsGenericNotFoundError(err), "expected not found error, got %v", err)
+
+	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+	})
+	s.Require().NoError(listErr)
+	s.Empty(listed.Items)
+}
+
+func (s *ChargeFeatureIDTestSuite) TestCreateUsageBasedRequiresFeatureMeterBeforeCreatingAnyCharge() {
+	// given:
+	// - a valid flat-fee intent and a usage-based intent backed by a meterless feature
+	// when:
+	// - both charges are created in one request
+	// then:
+	// - validation rejects the whole request before either charge is persisted
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-feature-meter-required")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "usage-feature-meter-required")
+	meterlessFeature, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "meterless feature",
+		Key:       "meterless-feature",
+	})
+	s.Require().NoError(err)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-06-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-07-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	_, err = s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:      "valid-featureless-flat-fee",
+				managedBy: billing.ManuallyManagedLine,
+			}),
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				name:       "usage-without-feature-meter",
+				managedBy:  billing.ManuallyManagedLine,
+				featureKey: meterlessFeature.Key,
+			}),
+		},
+	})
+
+	s.Require().Error(err)
+	s.True(models.IsGenericValidationError(err), "expected validation error, got %v", err)
+	s.ErrorContains(err, "has no meter associated")
+
+	listed, listErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+	})
+	s.Require().NoError(listErr)
+	s.Empty(listed.Items)
 }
 
 // TestCreateCustomerChargeByIDResolvesLatestFeatureVersion pins the version semantics of

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -14,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	featurepkg "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -221,6 +223,162 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	invoicedFlatFeeLine := invoices[0].Lines.OrEmpty()[0]
 	s.Require().NotNil(invoicedFlatFeeLine.RateCardDiscounts.Percentage)
 	s.Equal(flatFeeIntent.PercentageDiscounts.CorrelationID, invoicedFlatFeeLine.RateCardDiscounts.Percentage.CorrelationID)
+}
+
+func (s *InvoicableChargesTestSuite) TestBillingCreatePendingInvoiceLinesResolvesRequiredFeatureMeters() {
+	// given:
+	// - usage pending lines whose feature dependencies are missing or meterless
+	// when:
+	// - each pending line is created through the billing service
+	// then:
+	// - validation rejects each request without creating a gathering invoice
+	testCases := []struct {
+		name               string
+		createFeature      bool
+		expectedErrorCheck func(error) bool
+		expectedError      string
+	}{
+		{
+			name:               "missing feature",
+			expectedErrorCheck: models.IsGenericNotFoundError,
+			expectedError:      "not found",
+		},
+		{
+			name:               "feature without meter",
+			createFeature:      true,
+			expectedErrorCheck: models.IsGenericValidationError,
+			expectedError:      "has no meter associated",
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.Run(testCase.name, func() {
+			ctx := s.T().Context()
+			ns := s.GetUniqueNamespace("billing-create-pending-line-feature-meter")
+			cust := s.CreateTestCustomer(ns, "test-subject")
+			customInvoicing := s.SetupCustomInvoicing(ns)
+			_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID())
+
+			featureKey := "pending-line-feature"
+			if testCase.createFeature {
+				_, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+					Namespace: ns,
+					Name:      featureKey,
+					Key:       featureKey,
+				})
+				s.Require().NoError(err)
+			}
+
+			servicePeriod := timeutil.ClosedPeriod{
+				From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+				To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+			}
+			line := billing.GatheringLine{
+				GatheringLineBase: billing.GatheringLineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Namespace: ns,
+						Name:      "manual usage",
+					}),
+					ManagedBy:     billing.ManuallyManagedLine,
+					Currency:      currencyx.FiatCode(USD),
+					ServicePeriod: servicePeriod,
+					InvoiceAt:     servicePeriod.To,
+					Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(2),
+					})),
+					FeatureKey: featureKey,
+				},
+			}
+
+			result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+				Customer: cust.GetID(),
+				Currency: currencyx.FiatCode(USD),
+				Lines:    []billing.GatheringLine{line},
+			})
+
+			s.Nil(result)
+			s.Require().Error(err)
+			var validationErr billing.ValidationError
+			s.True(errors.As(err, &validationErr), "expected billing validation error, got %T: %v", err, err)
+			s.True(testCase.expectedErrorCheck(err), "unexpected error type: %T: %v", err, err)
+			s.ErrorContains(err, testCase.expectedError)
+
+			listed, listErr := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+				Namespaces: []string{ns},
+				Customers:  []string{cust.ID},
+			})
+			s.Require().NoError(listErr)
+			s.Empty(listed.Items)
+		})
+	}
+}
+
+func (s *InvoicableChargesTestSuite) TestChargeCreatePendingInvoiceLinesRequiresFeatureMeter() {
+	// given:
+	// - a charge-backed usage pending line references a feature without a meter
+	// when:
+	// - the pending line is created through the charge service
+	// then:
+	// - validation rejects the request without creating a charge or gathering invoice
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charge-create-pending-line-feature-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	featureKey := "pending-line-feature"
+	_, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      featureKey,
+		Key:       featureKey,
+	})
+	s.Require().NoError(err)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: ns,
+				Name:      "manual usage",
+			}),
+			ManagedBy:     billing.ManuallyManagedLine,
+			Engine:        billing.LineEngineTypeInvoice,
+			Currency:      currencyx.FiatCode(USD),
+			ServicePeriod: servicePeriod,
+			InvoiceAt:     servicePeriod.To,
+			Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromInt(2),
+			})),
+			FeatureKey: featureKey,
+		},
+	}
+
+	result, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
+		Customer: cust.GetID(),
+		Currency: currencyx.FiatCode(USD),
+		Lines:    []billing.GatheringLine{line},
+	})
+
+	s.Nil(result)
+	s.Require().Error(err)
+	s.True(models.IsGenericValidationError(err), "expected validation error, got %T: %v", err, err)
+	s.ErrorContains(err, "has no meter associated")
+
+	listedCharges, listChargesErr := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+	})
+	s.Require().NoError(listChargesErr)
+	s.Empty(listedCharges.Items)
+
+	listedInvoices, listInvoicesErr := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+	})
+	s.Require().NoError(listInvoicesErr)
+	s.Empty(listedInvoices.Items)
 }
 
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreatedChargesOnFailure() {

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -211,16 +211,12 @@ func (c Charge) GetFeatureKeyOrID() ref.IDOrKey {
 }
 
 func (c Charge) ResolveFeatureMeter(featureMeters feature.FeatureMeters) (feature.FeatureMeter, error) {
-	const requireMeter = true
-
-	featureRef := c.GetFeatureKeyOrID()
-	if featureRef.ID != "" {
-		return featureMeters.GetByID(featureRef.ID, requireMeter)
-	}
-
-	featureMeter, err := featureMeters.Get(featureRef.Key, requireMeter)
+	featureMeter, err := featureMeters.Resolve(feature.FeatureMeterRef{
+		IDOrKey:      c.GetFeatureKeyOrID(),
+		RequireMeter: true,
+	})
 	if err != nil {
-		return feature.FeatureMeter{}, fmt.Errorf("get feature meter: %w", err)
+		return feature.FeatureMeter{}, fmt.Errorf("resolve feature meter: %w", err)
 	}
 
 	return featureMeter, nil
@@ -229,9 +225,12 @@ func (c Charge) ResolveFeatureMeter(featureMeters feature.FeatureMeters) (featur
 // GetFeatureKeysOrIDs returns the unique state-aware feature references for the charges.
 // Each charge contributes the ref returned by GetFeatureKeyOrID, so created charges use keys,
 // deleted charges prefer IDs and fall back to keys, and all other states use IDs.
-func (c Charges) GetFeatureKeysOrIDs() []ref.IDOrKey {
-	return lo.Uniq(lo.Map(c, func(charge Charge, _ int) ref.IDOrKey {
-		return charge.GetFeatureKeyOrID()
+func (c Charges) GetFeatureKeysOrIDs() []feature.FeatureMeterRef {
+	return lo.Uniq(lo.Map(c, func(charge Charge, _ int) feature.FeatureMeterRef {
+		return feature.FeatureMeterRef{
+			IDOrKey:      charge.GetFeatureKeyOrID(),
+			RequireMeter: true,
+		}
 	}))
 }
 

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -48,9 +48,9 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 				}
 			}
 
-			featureMeter, err := feature.ResolveByRef(input.FeatureMeters, feature.FeatureMeterRef{
+			featureMeter, err := input.FeatureMeters.Resolve(feature.FeatureMeterRef{
 				IDOrKey:      chargeIntent.GetFeatureRef(),
-				RequireMeter: false,
+				RequireMeter: true,
 			})
 			if err != nil {
 				return usagebased.CreateIntent{}, fmt.Errorf("resolve usage based feature for key %+v: %w", chargeIntent.GetFeatureRef(), err)

--- a/openmeter/billing/charges/usagebased/service/currenttotals.go
+++ b/openmeter/billing/charges/usagebased/service/currenttotals.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
@@ -38,7 +39,10 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("get customer override: %w", err)
 	}
 
-	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, charge.GetFeatureKeyOrID())
+	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, feature.FeatureMeterRef{
+		IDOrKey:      charge.GetFeatureKeyOrID(),
+		RequireMeter: true,
+	})
 	if err != nil {
 		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("resolve feature meters: %w", err)
 	}

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -15,9 +15,9 @@ import (
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
-	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -95,8 +95,11 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 	}
 
 	// Fetch all references featureMeters in bulk
-	referencedFeatureMeters := lo.Uniq(lo.Map(charges, func(charge usagebased.Charge, _ int) ref.IDOrKey {
-		return charge.GetFeatureKeyOrID()
+	referencedFeatureMeters := lo.Uniq(lo.Map(charges, func(charge usagebased.Charge, _ int) feature.FeatureMeterRef {
+		return feature.FeatureMeterRef{
+			IDOrKey:      charge.GetFeatureKeyOrID(),
+			RequireMeter: true,
+		}
 	}))
 
 	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, namespace, referencedFeatureMeters...)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -437,8 +438,11 @@ func (e *LineEngine) createManualInvoiceLines(ctx context.Context, input billing
 
 	namespace := input.Invoice.GetInvoiceID().Namespace
 	intents := lo.Map(created, func(line manualCreatedInvoiceLine, _ int) usagebased.Intent { return line.intent })
-	featureMeters, err := e.service.featureService.ResolveFeatureMeters(ctx, namespace, lo.Map(intents, func(intent usagebased.Intent, _ int) ref.IDOrKey {
-		return ref.IDOrKey{Key: intent.FeatureKey}
+	featureMeters, err := e.service.featureService.ResolveFeatureMeters(ctx, namespace, lo.Map(intents, func(intent usagebased.Intent, _ int) feature.FeatureMeterRef {
+		return feature.FeatureMeterRef{
+			IDOrKey:      ref.IDOrKey{Key: intent.FeatureKey},
+			RequireMeter: true,
+		}
 	})...)
 	if err != nil {
 		return nil, fmt.Errorf("resolving manually created usage-based charge feature meters: %w", err)

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -211,7 +212,10 @@ func (s *service) getStateMachineConfigForCharge(ctx context.Context, charge usa
 	}
 
 	featureRef := charge.GetFeatureKeyOrID()
-	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, featureRef)
+	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, charge.Namespace, feature.FeatureMeterRef{
+		IDOrKey:      featureRef,
+		RequireMeter: true,
+	})
 	if err != nil {
 		return StateMachineConfig{}, fmt.Errorf("resolve feature meters: %w", err)
 	}

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -12,12 +12,14 @@ import (
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/expand"
 	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/sortx"
 	timeutil "github.com/openmeterio/openmeter/pkg/timeutil"
@@ -273,6 +275,26 @@ func (l GatheringLines) Validate() error {
 			return nil
 		})...,
 	)
+}
+
+// CollectFeatureMeterRefs returns the feature dependencies that must resolve before
+// the lines can be persisted. Metered prices require a meter; flat prices may attach
+// a feature without one.
+func (l GatheringLines) CollectFeatureMeterRefs() []feature.FeatureMeterRef {
+	refs := make([]feature.FeatureMeterRef, 0, len(l))
+
+	for _, line := range l {
+		if line.FeatureKey == "" {
+			continue
+		}
+
+		refs = append(refs, feature.FeatureMeterRef{
+			IDOrKey:      ref.IDOrKey{Key: line.FeatureKey},
+			RequireMeter: line.Price.Type() != productcatalog.FlatPriceType,
+		})
+	}
+
+	return lo.Uniq(refs)
 }
 
 func (l GatheringLines) AsGenericLines() []GenericInvoiceLine {

--- a/openmeter/billing/gatheringinvoice_test.go
+++ b/openmeter/billing/gatheringinvoice_test.go
@@ -90,3 +90,48 @@ func TestGatheringLineUnitConfigSnapshotPropagation(t *testing.T) {
 		require.True(t, unitConfig.Equal(base.UnitConfig), "clone must not share the pointer with the original")
 	})
 }
+
+func TestGatheringLinesCollectFeatureMeterRefs(t *testing.T) {
+	// given:
+	// - flat, usage-based, and featureless gathering lines
+	// when:
+	// - their feature meter references are collected
+	// then:
+	// - only feature-backed lines are returned with price-specific meter requirements
+	featureKey := "api-requests"
+	lines := GatheringLines{
+		{
+			GatheringLineBase: GatheringLineBase{
+				FeatureKey: featureKey,
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      decimal.NewFromInt(1),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+			},
+		},
+		{
+			GatheringLineBase: GatheringLineBase{
+				FeatureKey: featureKey,
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: decimal.NewFromInt(1),
+				})),
+			},
+		},
+		{
+			GatheringLineBase: GatheringLineBase{
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      decimal.NewFromInt(1),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+			},
+		},
+	}
+
+	refs := lines.CollectFeatureMeterRefs()
+
+	require.Len(t, refs, 2)
+	require.Equal(t, featureKey, refs[0].IDOrKey.Key)
+	require.False(t, refs[0].RequireMeter)
+	require.Equal(t, featureKey, refs[1].IDOrKey.Key)
+	require.True(t, refs[1].RequireMeter)
+}

--- a/openmeter/billing/service/featuremeter.go
+++ b/openmeter/billing/service/featuremeter.go
@@ -21,8 +21,10 @@ func (s *Service) resolveFeatureMeters(ctx context.Context, namespace string, li
 		return nil, fmt.Errorf("getting referenced feature keys: %w", err)
 	}
 
-	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, namespace, lo.Map(keys, func(key string, _ int) ref.IDOrKey {
-		return ref.IDOrKey{Key: key}
+	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, namespace, lo.Map(keys, func(key string, _ int) feature.FeatureMeterRef {
+		return feature.FeatureMeterRef{
+			IDOrKey: ref.IDOrKey{Key: key},
+		}
 	})...)
 	if err != nil {
 		return nil, fmt.Errorf("resolving feature meters: %w", err)

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -55,6 +55,14 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 		}
 	}
 
+	featureMeterRefs := billing.GatheringLines(input.Lines).CollectFeatureMeterRefs()
+	_, err = s.featureService.ResolveFeatureMeters(ctx, input.Customer.Namespace, featureMeterRefs...)
+	if err != nil {
+		return nil, billing.ValidationError{
+			Err: fmt.Errorf("resolving pending line feature meters: %w", err),
+		}
+	}
+
 	maxPeriodEnd := lo.FromPtr(cust.DeletedAt)
 	if !maxPeriodEnd.IsZero() {
 		var errs []error

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -152,8 +152,14 @@ func newTestEnv(t *testing.T) *testEnv {
 	featureMeters, err := featureService.ResolveFeatureMeters(
 		t.Context(),
 		base.Namespace,
-		ref.IDOrKey{Key: testFeatureKey},
-		ref.IDOrKey{ID: featureEntity.ID},
+		feature.FeatureMeterRef{
+			IDOrKey:      ref.IDOrKey{Key: testFeatureKey},
+			RequireMeter: true,
+		},
+		feature.FeatureMeterRef{
+			IDOrKey:      ref.IDOrKey{ID: featureEntity.ID},
+			RequireMeter: true,
+		},
 	)
 	require.NoError(t, err)
 

--- a/openmeter/productcatalog/feature/connector.go
+++ b/openmeter/productcatalog/feature/connector.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
-	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/sortx"
 )
 
@@ -68,7 +67,7 @@ type FeatureConnector interface {
 	// ResolveFeatureMeters resolves the feature meters for a given namespace and feature refs.
 	// Keys always resolve to the latest available feature for that key.
 	// Explicit IDs are returned in the ID index, and also in the key index when they are the latest feature for that key.
-	ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...ref.IDOrKey) (FeatureMeters, error)
+	ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...FeatureMeterRef) (FeatureMeters, error)
 }
 
 type IncludeArchivedFeature bool

--- a/openmeter/productcatalog/feature/featuremeter.go
+++ b/openmeter/productcatalog/feature/featuremeter.go
@@ -155,16 +155,14 @@ func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace s
 	}
 
 	// Let's make sure that all the feature refs are available in the output.
-	missingRefErrs := models.NewNillableGenericValidationError(
-		errors.Join(lo.Map(featureRefs, func(featureRef FeatureMeterRef, _ int) error {
-			if _, err := out.Resolve(featureRef); err != nil {
-				return err
-			}
-			return nil
-		})...),
-	)
-	if missingRefErrs != nil {
-		return nil, missingRefErrs
+	featureRefErrs := errors.Join(lo.Map(featureRefs, func(featureRef FeatureMeterRef, _ int) error {
+		if _, err := out.Resolve(featureRef); err != nil {
+			return err
+		}
+		return nil
+	})...)
+	if featureRefErrs != nil {
+		return nil, featureRefErrs
 	}
 
 	return out, nil

--- a/openmeter/productcatalog/feature/featuremeter.go
+++ b/openmeter/productcatalog/feature/featuremeter.go
@@ -155,14 +155,24 @@ func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace s
 	}
 
 	// Let's make sure that all the feature refs are available in the output.
-	featureRefErrs := errors.Join(lo.Map(featureRefs, func(featureRef FeatureMeterRef, _ int) error {
+	// Missing features take precedence over other validation failures so a mixed
+	// batch preserves the not-found error category at the API boundary.
+	var notFoundErrs, validationErrs []error
+	for _, featureRef := range featureRefs {
 		if _, err := out.Resolve(featureRef); err != nil {
-			return err
+			if models.IsGenericNotFoundError(err) {
+				notFoundErrs = append(notFoundErrs, err)
+			} else {
+				validationErrs = append(validationErrs, err)
+			}
 		}
-		return nil
-	})...)
-	if featureRefErrs != nil {
-		return nil, featureRefErrs
+	}
+
+	if err := errors.Join(notFoundErrs...); err != nil {
+		return nil, err
+	}
+	if err := errors.Join(validationErrs...); err != nil {
+		return nil, err
 	}
 
 	return out, nil

--- a/openmeter/productcatalog/feature/featuremeter.go
+++ b/openmeter/productcatalog/feature/featuremeter.go
@@ -2,6 +2,7 @@ package feature
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ type FeatureMeter struct {
 type FeatureMeters interface {
 	Get(featureKey string, requireMeter bool) (FeatureMeter, error)
 	GetByID(featureID string, requireMeter bool) (FeatureMeter, error)
+	Resolve(ref FeatureMeterRef) (FeatureMeter, error)
 }
 
 type FeatureMeterCollection struct {
@@ -58,20 +60,25 @@ type FeatureMeterRef struct {
 	RequireMeter bool
 }
 
-func ResolveByRef(fm FeatureMeters, r FeatureMeterRef) (FeatureMeter, error) {
+func (f FeatureMeterCollection) Resolve(r FeatureMeterRef) (FeatureMeter, error) {
+	var featureMeter FeatureMeter
+	var err error
+
 	switch {
 	case r.IDOrKey.Key != "" && r.IDOrKey.ID != "":
 		return FeatureMeter{}, fmt.Errorf("feature reference must have either key or ID, not both")
 	case r.IDOrKey.Key != "":
-		return fm.Get(r.IDOrKey.Key, r.RequireMeter)
+		featureMeter, err = f.Get(r.IDOrKey.Key, r.RequireMeter)
 	case r.IDOrKey.ID != "":
-		return fm.GetByID(r.IDOrKey.ID, r.RequireMeter)
+		featureMeter, err = f.GetByID(r.IDOrKey.ID, r.RequireMeter)
 	default:
 		return FeatureMeter{}, fmt.Errorf("feature reference must have either key or ID")
 	}
+
+	return featureMeter, err
 }
 
-func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...ref.IDOrKey) (FeatureMeters, error) {
+func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...FeatureMeterRef) (FeatureMeters, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -83,9 +90,9 @@ func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace s
 		}, nil
 	}
 
-	featuresToResolve := lo.Uniq(lo.FlatMap(featureRefs, func(featureRef ref.IDOrKey, _ int) []string {
-		out := featureRef.GetKeys()
-		out = append(out, featureRef.GetIDs()...)
+	featuresToResolve := lo.Uniq(lo.FlatMap(featureRefs, func(featureRef FeatureMeterRef, _ int) []string {
+		out := featureRef.IDOrKey.GetKeys()
+		out = append(out, featureRef.IDOrKey.GetIDs()...)
 		return out
 	}))
 
@@ -100,9 +107,6 @@ func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace s
 	}
 
 	out := resolveFeatureMeters(features.Items)
-	if err := ensureFeatureIDsResolved(featureRefs, out); err != nil {
-		return nil, err
-	}
 
 	metersToResolve := lo.Uniq(
 		lo.Filter(
@@ -150,6 +154,19 @@ func (c *featureConnector) ResolveFeatureMeters(ctx context.Context, namespace s
 		}
 	}
 
+	// Let's make sure that all the feature refs are available in the output.
+	missingRefErrs := models.NewNillableGenericValidationError(
+		errors.Join(lo.Map(featureRefs, func(featureRef FeatureMeterRef, _ int) error {
+			if _, err := out.Resolve(featureRef); err != nil {
+				return err
+			}
+			return nil
+		})...),
+	)
+	if missingRefErrs != nil {
+		return nil, missingRefErrs
+	}
+
 	return out, nil
 }
 
@@ -172,18 +189,6 @@ func resolveFeatureMeters(features []Feature) FeatureMeterCollection {
 	}
 
 	return out
-}
-
-func ensureFeatureIDsResolved(featureRefs []ref.IDOrKey, resolved FeatureMeterCollection) error {
-	for _, featureID := range lo.Uniq(lo.FlatMap(featureRefs, func(featureRef ref.IDOrKey, _ int) []string {
-		return featureRef.GetIDs()
-	})) {
-		if _, ok := resolved.ByID[featureID]; !ok {
-			return models.NewGenericNotFoundError(fmt.Errorf("feature[%s] not found", featureID))
-		}
-	}
-
-	return nil
 }
 
 type lastEntityAccessor[T any] interface {

--- a/openmeter/productcatalog/feature/featuremeter_test.go
+++ b/openmeter/productcatalog/feature/featuremeter_test.go
@@ -89,20 +89,44 @@ func TestResolveFeatureMeters(t *testing.T) {
 		require.Equal(t, "tokens", byArchivedID.Feature.Key)
 	})
 
-	t.Run("requested ids must all resolve", func(t *testing.T) {
+	t.Run("references must resolve", func(t *testing.T) {
+		// given:
+		// - a feature meter collection containing current and archived features
+		// when:
+		// - an existing and a missing feature ID are resolved
+		// then:
+		// - the existing ID resolves and the missing ID returns a not-found error
 		out := resolveFeatureMeters(features)
 
-		require.NoError(t, ensureFeatureIDsResolved([]ref.IDOrKey{
-			{ID: "feature-old"},
-			{ID: "feature-new"},
-		}, out))
+		_, existingErr := out.Resolve(FeatureMeterRef{
+			IDOrKey: ref.IDOrKey{ID: "feature-old"},
+		})
+		_, missingErr := out.Resolve(FeatureMeterRef{
+			IDOrKey: ref.IDOrKey{ID: "missing-feature"},
+		})
 
-		err := ensureFeatureIDsResolved([]ref.IDOrKey{
-			{ID: "feature-old"},
-			{ID: "missing-feature"},
-		}, out)
+		require.NoError(t, existingErr)
+		require.Error(t, missingErr)
+		require.True(t, models.IsGenericNotFoundError(missingErr))
+		require.ErrorContains(t, missingErr, "missing-feature")
+	})
+
+	t.Run("required meter rejects a meterless feature", func(t *testing.T) {
+		// given:
+		// - a resolved feature without an associated meter
+		// when:
+		// - the feature is resolved with a meter requirement
+		// then:
+		// - resolution returns a validation error
+		out := resolveFeatureMeters(features)
+
+		_, err := out.Resolve(FeatureMeterRef{
+			IDOrKey:      ref.IDOrKey{Key: "requests"},
+			RequireMeter: true,
+		})
+
 		require.Error(t, err)
-		require.True(t, models.IsGenericNotFoundError(err))
-		require.ErrorContains(t, err, "missing-feature")
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "has no meter associated")
 	})
 }

--- a/openmeter/productcatalog/feature/featuremeter_test.go
+++ b/openmeter/productcatalog/feature/featuremeter_test.go
@@ -98,7 +98,7 @@ func TestResolveFeatureMeters(t *testing.T) {
 		// - the existing ID resolves and the missing ID returns a not-found error
 		out := resolveFeatureMeters(features)
 
-		_, existingErr := out.Resolve(FeatureMeterRef{
+		existing, existingErr := out.Resolve(FeatureMeterRef{
 			IDOrKey: ref.IDOrKey{ID: "feature-old"},
 		})
 		_, missingErr := out.Resolve(FeatureMeterRef{
@@ -106,6 +106,7 @@ func TestResolveFeatureMeters(t *testing.T) {
 		})
 
 		require.NoError(t, existingErr)
+		require.Equal(t, "feature-old", existing.Feature.ID)
 		require.Error(t, missingErr)
 		require.True(t, models.IsGenericNotFoundError(missingErr))
 		require.ErrorContains(t, missingErr, "missing-feature")

--- a/openmeter/productcatalog/feature/featuremeter_test.go
+++ b/openmeter/productcatalog/feature/featuremeter_test.go
@@ -129,4 +129,34 @@ func TestResolveFeatureMeters(t *testing.T) {
 		require.True(t, models.IsGenericValidationError(err))
 		require.ErrorContains(t, err, "has no meter associated")
 	})
+
+	t.Run("reference with ID and key is rejected", func(t *testing.T) {
+		// given:
+		// - a feature reference containing both an ID and a key
+		// when:
+		// - the malformed reference is resolved
+		// then:
+		// - resolution rejects the ambiguous reference
+		out := resolveFeatureMeters(features)
+
+		_, err := out.Resolve(FeatureMeterRef{
+			IDOrKey: ref.IDOrKey{ID: "feature-old", Key: "tokens"},
+		})
+
+		require.ErrorContains(t, err, "either key or ID, not both")
+	})
+
+	t.Run("reference without ID or key is rejected", func(t *testing.T) {
+		// given:
+		// - a feature reference containing neither an ID nor a key
+		// when:
+		// - the malformed reference is resolved
+		// then:
+		// - resolution rejects the empty reference
+		out := resolveFeatureMeters(features)
+
+		_, err := out.Resolve(FeatureMeterRef{})
+
+		require.ErrorContains(t, err, "either key or ID")
+	})
 }

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1059,7 +1059,7 @@ func (n NoopFeatureConnector) ArchiveFeature(ctx context.Context, featureID mode
 	return nil
 }
 
-func (n NoopFeatureConnector) ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...ref.IDOrKey) (feature.FeatureMeters, error) {
+func (n NoopFeatureConnector) ResolveFeatureMeters(ctx context.Context, namespace string, featureRefs ...feature.FeatureMeterRef) (feature.FeatureMeters, error) {
 	return feature.FeatureMeterCollection{}, nil
 }
 


### PR DESCRIPTION
## Summary

- reject pending-line and charge creation when a supplied feature reference does not resolve
- require usage-based feature references to resolve to a feature with an associated meter
- centralize ID/key feature-meter resolution and validate batches before persisting any charge or gathering invoice
- add regression coverage and document the creation-time consistency guarantees

## Root cause

Feature references were accepted without being resolved at creation time. This allowed dangling feature keys to be persisted and deferred the failure until invoice quantity snapshotting, where invoice creation failed with `feature[...] not found`.

## Impact

Invalid requests now fail atomically at the creation boundary. Flat-fee features remain optional and do not require a meter; usage-based features must exist and have a meter.

## Validation

- `make lint-go-fast` — 0 issues
- `make test-nocache` — 6,909 tests passed, 9 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Billing now validates every referenced feature before creating charges or pending invoice lines.
  - Usage-based features must have an associated meter.
  - Meterless flat-fee features are supported.
  - Invalid, missing, or incomplete feature references are rejected without creating partial billing records.
  - Missing feature errors are reported before meter validation errors.

- **Documentation**
  - Updated billing documentation to describe feature and meter validation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR validates feature references before persisting charges or pending invoice lines, requires meters for usage-based features, and preserves not-found classification when validation failures coexist.
- Introduces requirement-aware feature-meter references and centralized ID/key resolution.
- Validates complete batches before charge or gathering-invoice persistence.
- Adds regression coverage for missing, meterless, mixed-error, and atomicity scenarios.
- Documents the new billing consistency guarantees.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/feature/featuremeter.go | Centralizes feature resolution, validates every requested reference, and gives not-found errors precedence in mixed batches. |
| openmeter/billing/charges/service/create.go | Resolves all requirement-aware feature references before creating any charge. |
| openmeter/billing/service/stdinvoiceline.go | Validates pending-line feature dependencies before gathering-invoice persistence while preserving underlying typed errors. |
| openmeter/billing/charges/charge.go | Derives meter requirements from charge type while retaining duplicate references with distinct requirements. |
| openmeter/billing/gatheringinvoice.go | Collects feature dependencies from gathering lines with price-specific meter requirements. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Billing
    participant Features
    participant Storage
    Client->>Billing: Create charges or pending lines
    Billing->>Features: Resolve feature refs with meter requirements
    alt Missing feature
        Features-->>Billing: Not-found error
        Billing-->>Client: Reject as not found
    else Required meter missing
        Features-->>Billing: Validation error
        Billing-->>Client: Reject as invalid
    else All references valid
        Features-->>Billing: Resolved feature meters
        Billing->>Storage: Persist atomically
        Billing-->>Client: Creation result
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: prioritize missing feature errors"](https://github.com/openmeterio/openmeter/commit/595d54a0ba093cadcfc7a4a9f7e77db8ad52b3de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51756410)</sub>

<!-- /greptile_comment -->