### PR TITLE
fix(subscription): preserve item JSON fields

### DIFF
--- a/openmeter/subscription/item.go
+++ b/openmeter/subscription/item.go
@@ -44,73 +44,52 @@ type SubscriptionItem struct {
 }
 
 func (i *SubscriptionItem) UnmarshalJSON(b []byte) error {
-	// First unmarshal the type information to determine which concrete type to use
-	var serdeTyp struct {
-		RateCard productcatalog.RateCardSerde `json:"rateCard"`
-	}
+	type itemAlias SubscriptionItem
 
-	if err := json.Unmarshal(b, &serdeTyp); err != nil {
-		return fmt.Errorf("failed to JSON deserialize SubscriptionItemSpec: %w", err)
-	}
-
-	// Create a temporary struct with the correct concrete type for RateCard
+	var item itemAlias
 	serde := struct {
-		models.NamespacedID  `json:",inline"`
-		models.ManagedModel  `json:",inline"`
-		models.MetadataModel `json:",inline"`
-
-		ActiveFromOverrideRelativeToPhaseStart *datetime.ISODuration `json:"activeFromOverrideRelativeToPhaseStart,omitempty"`
-		ActiveToOverrideRelativeToPhaseStart   *datetime.ISODuration `json:"activeToOverrideRelativeToPhaseStart,omitempty"`
-
-		models.CadencedModel `json:",inline"`
-
-		BillingBehaviorOverride BillingBehaviorOverride `json:"billingBehaviorOverride"`
-
-		SubscriptionId string `json:"subscriptionId"`
-		PhaseId        string `json:"phaseId"`
-		Key            string `json:"itemKey"`
-
-		RateCard productcatalog.RateCard `json:"rateCard"`
-
-		EntitlementID *string `json:"entitlementId,omitempty"`
-		Name          string  `json:"name"`
-		Description   *string `json:"description,omitempty"`
+		*itemAlias
+		RateCard json.RawMessage `json:"rateCard"`
 	}{
-		RateCard: i.RateCard,
+		itemAlias: &item,
 	}
 
-	// Set the concrete type based on the type field
-	switch serdeTyp.RateCard.Type {
-	case productcatalog.FlatFeeRateCardType:
-		serde.RateCard = &productcatalog.FlatFeeRateCard{}
-	case productcatalog.UsageBasedRateCardType:
-		serde.RateCard = &productcatalog.UsageBasedRateCard{}
-	default:
-		return fmt.Errorf("invalid RateCard type: %s", serdeTyp.RateCard.Type)
-	}
-
-	// Unmarshal the full object
 	if err := json.Unmarshal(b, &serde); err != nil {
 		return fmt.Errorf("failed to JSON deserialize SubscriptionItem: %w", err)
 	}
 
-	// Copy all fields from the temporary struct to the actual struct
-	i.NamespacedID = serde.NamespacedID
-	i.ManagedModel = serde.ManagedModel
-	i.MetadataModel = serde.MetadataModel
-	i.ActiveFromOverrideRelativeToPhaseStart = serde.ActiveFromOverrideRelativeToPhaseStart
-	i.ActiveToOverrideRelativeToPhaseStart = serde.ActiveToOverrideRelativeToPhaseStart
-	i.CadencedModel = serde.CadencedModel
-	i.BillingBehaviorOverride = serde.BillingBehaviorOverride
-	i.SubscriptionId = serde.SubscriptionId
-	i.PhaseId = serde.PhaseId
-	i.Key = serde.Key
-	i.RateCard = serde.RateCard
-	i.EntitlementID = serde.EntitlementID
-	i.Name = serde.Name
-	i.Description = serde.Description
+	rateCard, err := unmarshalSubscriptionItemRateCard(serde.RateCard)
+	if err != nil {
+		return err
+	}
+
+	item.RateCard = rateCard
+	*i = SubscriptionItem(item)
 
 	return nil
+}
+
+func unmarshalSubscriptionItemRateCard(data []byte) (productcatalog.RateCard, error) {
+	var serde productcatalog.RateCardSerde
+	if err := json.Unmarshal(data, &serde); err != nil {
+		return nil, fmt.Errorf("failed to JSON deserialize SubscriptionItem rate card type: %w", err)
+	}
+
+	var rateCard productcatalog.RateCard
+	switch serde.Type {
+	case productcatalog.FlatFeeRateCardType:
+		rateCard = &productcatalog.FlatFeeRateCard{}
+	case productcatalog.UsageBasedRateCardType:
+		rateCard = &productcatalog.UsageBasedRateCard{}
+	default:
+		return nil, fmt.Errorf("invalid RateCard type: %s", serde.Type)
+	}
+
+	if err := json.Unmarshal(data, rateCard); err != nil {
+		return nil, fmt.Errorf("failed to JSON deserialize SubscriptionItem rate card: %w", err)
+	}
+
+	return rateCard, nil
 }
 
 func (i SubscriptionItem) GetCadence(phaseCadence models.CadencedModel) models.CadencedModel {

--- a/openmeter/subscription/serialize_test.go
+++ b/openmeter/subscription/serialize_test.go
@@ -82,6 +82,9 @@ func TestSubscriptionItemSerialize(t *testing.T) {
 				"key2": "value2",
 			},
 		},
+		Annotations: models.Annotations{
+			"annotation-key": "annotation-value",
+		},
 		ActiveFromOverrideRelativeToPhaseStart: lo.ToPtr(datetime.NewISODuration(0, 0, 0, 1, 0, 0, 0)),
 		ActiveToOverrideRelativeToPhaseStart:   lo.ToPtr(datetime.NewISODuration(0, 0, 0, 2, 0, 0, 0)),
 		CadencedModel: models.CadencedModel{
@@ -94,43 +97,75 @@ func TestSubscriptionItemSerialize(t *testing.T) {
 		SubscriptionId: "subscription-id",
 		PhaseId:        "phase-id",
 		Key:            "item-key",
-		RateCard: &productcatalog.UsageBasedRateCard{
-			RateCardMeta: productcatalog.RateCardMeta{
-				Key:         "rate-card-key",
-				Name:        "rate-card-name",
-				Description: lo.ToPtr("rate-card-description"),
-				FeatureKey:  lo.ToPtr("feature-key"),
-				FeatureID:   lo.ToPtr("feature-id"),
-				EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
-					IssueAfterReset: lo.ToPtr(100.0),
-				}),
-				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-					Amount: alpacadecimal.NewFromInt(100),
-				}),
+		EntitlementID:  lo.ToPtr("entitlement-id"),
+		Name:           "item-name",
+		Description:    lo.ToPtr("item-description"),
+	}
+
+	tests := []struct {
+		name     string
+		rateCard productcatalog.RateCard
+	}{
+		{
+			name: "usage-based",
+			rateCard: &productcatalog.UsageBasedRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:         "rate-card-key",
+					Name:        "rate-card-name",
+					Description: lo.ToPtr("rate-card-description"),
+					FeatureKey:  lo.ToPtr("feature-key"),
+					FeatureID:   lo.ToPtr("feature-id"),
+					EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+						IssueAfterReset: lo.ToPtr(100.0),
+					}),
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(100),
+					}),
+				},
+				BillingCadence: datetime.NewISODuration(0, 0, 0, 0, 1, 0, 0),
 			},
-			BillingCadence: datetime.NewISODuration(0, 0, 0, 0, 1, 0, 0),
 		},
-		EntitlementID: lo.ToPtr("entitlement-id"),
-		Name:          "item-name",
-		Description:   lo.ToPtr("item-description"),
+		{
+			name: "flat-fee",
+			rateCard: &productcatalog.FlatFeeRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:  "flat-fee-rate-card-key",
+					Name: "flat-fee-rate-card-name",
+				},
+				BillingCadence: lo.ToPtr(datetime.NewISODuration(0, 0, 0, 0, 1, 0, 0)),
+			},
+		},
 	}
 
-	// Now let's marshal and unmarshal the subscription item
-	siBytes, err := json.MarshalIndent(si, "", "  ")
-	if err != nil {
-		t.Fatalf("failed to marshal subscription item: %v", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			si.RateCard = test.rateCard
+
+			// Now let's marshal and unmarshal the subscription item
+			siBytes, err := json.MarshalIndent(si, "", "  ")
+			if err != nil {
+				t.Fatalf("failed to marshal subscription item: %v", err)
+			}
+
+			bt2 := bytes.Clone(siBytes)
+
+			var si2 subscription.SubscriptionItem
+			err = json.Unmarshal(bt2, &si2)
+			if err != nil {
+				t.Fatalf("failed to unmarshal subscription item: %v", err)
+			}
+
+			// Now let's compare the two
+			if !reflect.DeepEqual(si, si2) {
+				t.Fatalf("subscription item is not equal \n\ninput: %v\n\n serialized: \n%s\n\n unserialized: \n%v\n\n", si, string(bt2), si2)
+			}
+		})
 	}
+}
 
-	bt2 := bytes.Clone(siBytes)
-
-	var si2 subscription.SubscriptionItem
-	err = json.Unmarshal(bt2, &si2)
-	if err != nil {
-		t.Fatalf("failed to unmarshal subscription item: %v", err)
-	}
-
-	// Now let's compare the two
-	if !reflect.DeepEqual(si, si2) {
-		t.Fatalf("subscription item is not equal \n\ninput: %v\n\n serialized: \n%s\n\n unserialized: \n%v\n\n", si, string(bt2), si2)
+func TestSubscriptionItemDeserializeRejectsUnknownRateCardType(t *testing.T) {
+	var item subscription.SubscriptionItem
+	if err := json.Unmarshal([]byte(`{"rateCard":{"type":"unknown"}}`), &item); err == nil {
+		t.Fatal("expected unknown rate card type to fail deserialization")
 	}
 }


### PR DESCRIPTION
## Summary

- deserialize regular `SubscriptionItem` fields through a type alias instead of a manually mirrored struct
- keep polymorphic rate-card decoding isolated to the `rateCard` field
- cover annotations, both concrete rate-card types, and unknown discriminators

## Why

The custom JSON decoder manually copied every subscription item field. Fields added later, such as annotations, were serialized but silently lost during deserialization. Using the item shape itself prevents the decoder from drifting as the model evolves.

## Validation

- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/subscription -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription item deserialization for usage-based and flat-fee rate cards.
  * Preserved annotations during subscription item serialization and deserialization.
  * Added validation to reject unknown rate card types with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents regular `SubscriptionItem` JSON fields from being dropped by decoding through an alias while handling the polymorphic rate card separately.
- Preserves fields such as annotations without maintaining a mirrored decoding struct.
- Supports both flat-fee and usage-based rate cards.
- Adds round-trip and unknown-discriminator test coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The alias-based decoder preserves ordinary subscription item fields, isolates polymorphic rate-card decoding, and retains validation for both supported and unknown rate-card discriminators.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/subscription/item.go | Refactors custom JSON decoding to preserve the complete item shape while retaining concrete rate-card discriminator validation. |
| openmeter/subscription/serialize_test.go | Extends round-trip coverage to annotations and both supported rate-card types, and verifies rejection of unknown discriminators. |

<sub>Reviews (1): Last reviewed commit: ["fix(subscription): preserve item JSON fi..."](https://github.com/openmeterio/openmeter/commit/2fcf84123e38a4715489c2010598868a13f4c85a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51856185)</sub>

**Context used:**

- Knowledge Base — [Subscription](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription.md)

<!-- /greptile_comment -->