### PR TITLE
fix(sink): verify durable storage before dropping replays

### DIFF
--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -13,9 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/avast/retry-go/v4"
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -255,7 +254,7 @@ func withStoredAt(storedAt time.Time) MessageTransformerFunc {
 	}
 }
 
-// flush flushes the 1. buffer to storage, 2. sets dedupe and 3. store the offset
+// flush flushes the 1. buffer to storage and 2. stores Kafka offsets.
 // called when max wait time or min commit count reached
 func (s *Sink) flush(ctx context.Context) error {
 	logger := s.config.Logger.With("operation", "flush")
@@ -306,23 +305,9 @@ func (s *Sink) flush(ctx context.Context) error {
 	// Dedupe messages so if we have multiple messages in the same batch
 	dedupedMessages := dedupeSinkMessages(messages)
 
-	// If deduplicator is set, let's reexecute the deduplication to decrease the number of messages double persisted
-	if s.config.Deduplicator != nil && len(dedupedMessages) > 0 {
-		dedupeResults, err := s.config.Deduplicator.CheckUniqueBatch(ctx, lo.Map(dedupedMessages, func(message sinkmodels.SinkMessage, _ int) dedupe.Item {
-			return message.GetDedupeItem()
-		}))
-		if err != nil {
-			return fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
-		}
-
-		updatedDedupedMessages := make([]sinkmodels.SinkMessage, 0, len(dedupedMessages))
-		for _, message := range dedupedMessages {
-			if _, ok := dedupeResults.UniqueItems[message.GetDedupeItem()]; ok {
-				updatedDedupedMessages = append(updatedDedupedMessages, message)
-			}
-		}
-
-		dedupedMessages = updatedDedupedMessages
+	dedupedMessages, err = s.filterMessagesForInsert(ctx, dedupedMessages)
+	if err != nil {
+		return fmt.Errorf("failed to filter messages for insert: %w", err)
 	}
 
 	// 1. Persist to storage
@@ -348,32 +333,7 @@ func (s *Sink) flush(ctx context.Context) error {
 		}
 	}
 
-	// 3. Sink to Redis
-	// Least once guarantee, if Redis write fails we potenitally accept messages with same idempotency key in future.
-	// Deduplicator is an optional dependency so we check if it's set
-	if s.config.Deduplicator != nil && len(dedupedMessages) > 0 {
-		err := s.dedupeSet(ctx, dedupedMessages)
-		if err != nil {
-			// Try to commit offset if dedupe fails to ensure consistency
-			if offsetStoreErr == nil {
-				_, err := s.config.Consumer.Commit()
-				if err != nil {
-					return fmt.Errorf("failed to commit offset: %w", err)
-				}
-			}
-
-			// When both offset commit and dedupe sink fails we need to reconcile the state based on logs
-			if offsetStoreErr != nil {
-				logger.ErrorContext(ctx, "consistency failure", "err", err, "messages", messages)
-			}
-
-			// Return error, stop consuming
-			return fmt.Errorf("failed to sink to redis: %s", err)
-		}
-	}
-
-	// Return offset store error if any as above we don't return error
-	// to ensure we set deduplication IDs in Redis
+	// Return offset store error if any.
 	if offsetStoreErr != nil {
 		return fmt.Errorf("failed to store offset: %w", offsetStoreErr)
 	}
@@ -401,6 +361,48 @@ func (s *Sink) flush(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (s *Sink) filterMessagesForInsert(ctx context.Context, messages []sinkmodels.SinkMessage) ([]sinkmodels.SinkMessage, error) {
+	if s.config.Deduplicator == nil || len(messages) == 0 {
+		return messages, nil
+	}
+
+	filteredMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
+
+	for _, message := range messages {
+		serialized := message.Serialized
+		if serialized == nil {
+			continue
+		}
+
+		ce := event.New()
+		ce.SetID(serialized.Id)
+		ce.SetSource(serialized.Source)
+
+		// Reserve this event ID before insert. Replays can still proceed if storage
+		// has no durable copy yet (for example after a crash before ClickHouse durability).
+		isUnique, err := s.config.Deduplicator.IsUnique(ctx, message.Namespace, ce)
+		if err != nil {
+			return nil, fmt.Errorf("failed to reserve dedupe key for kafka message: %w", err)
+		}
+
+		if isUnique {
+			filteredMessages = append(filteredMessages, message)
+			continue
+		}
+
+		alreadyPersisted, err := s.config.Storage.HasEvent(ctx, message)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify persisted duplicate event: %w", err)
+		}
+
+		if !alreadyPersisted {
+			filteredMessages = append(filteredMessages, message)
+		}
+	}
+
+	return filteredMessages, nil
 }
 
 // reportFlushMetrics reports metrics to OTel
@@ -472,84 +474,6 @@ func (s *Sink) persistToStorage(ctx context.Context, messages []sinkmodels.SinkM
 		logger.Debug("succeeded to sink to storage", "buffer size", len(messages))
 	}
 
-	return nil
-}
-
-// dedupeSet sets the dedupe keys in Deduplicator with retry
-func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage) error {
-	logger := s.config.Logger.With("operation", "dedupeSet")
-	dedupeCtx, dedupeSet := s.config.Tracer.Start(ctx, "dedupe-set")
-	dedupeSet.SetAttributes(
-		attribute.Int("size", len(messages)),
-	)
-
-	dedupeItems := []dedupe.Item{}
-	for _, message := range messages {
-		switch message.Status.State {
-		case sinkmodels.OK:
-			dedupeItems = append(dedupeItems, dedupe.Item{
-				Namespace: message.Namespace,
-				ID:        message.Serialized.Id,
-				Source:    message.Serialized.Source,
-			})
-		case sinkmodels.DROP:
-			// Let's not insert already dropped messages into the deduplicator as this signals
-			// that we had a problem validating the message, we could redo any validation as needed
-			// later but if any error was transient let's retry the message if it's sent again.
-
-			if s.config.LogDroppedEvents {
-				logger.WarnContext(ctx, "event dropped",
-					slog.String("namespace", message.Namespace),
-					slog.String("event", string(message.KafkaMessage.Value)),
-					slog.Any("error", message.Status.DropError),
-					slog.String("status", message.Status.State.String()),
-				)
-			}
-
-			continue
-		default:
-			logger.ErrorContext(ctx, "unknown state type in dedup set", "state", message.Status.State.String())
-		}
-	}
-
-	if len(dedupeItems) == 0 {
-		logger.Debug("no dedupe items to set")
-		return nil
-	}
-
-	// We retry with exponential backoff as it's critical that either step #2 or #3 succeeds.
-	err := retry.Do(
-		func() error {
-			existingItems, err := s.config.Deduplicator.Set(dedupeCtx, dedupeItems...)
-			if err != nil {
-				return err
-			}
-
-			if len(existingItems) > 0 {
-				logger.ErrorContext(ctx, "dedupe: some items already existed in redis",
-					"items", lo.Map(existingItems, func(item dedupe.Item, _ int) string {
-						return item.Key()
-					}),
-					"code", "dedupe_set_failure",
-				)
-			}
-
-			return nil
-		},
-		retry.Context(dedupeCtx),
-		retry.OnRetry(func(n uint, err error) {
-			dedupeSet.AddEvent("retry", trace.WithAttributes(attribute.Int("count", int(n))))
-			logger.WarnContext(ctx, "failed to sink to redis, will retry", "err", err, "retry", n)
-		}),
-	)
-	if err != nil {
-		dedupeSet.SetStatus(codes.Error, "dedupe set failure")
-		dedupeSet.RecordError(err)
-		dedupeSet.End()
-		return fmt.Errorf("failed to sink to redis: %s", err)
-	}
-	dedupeSet.End()
-	logger.Debug("succeeded to sink to redis", "buffer size", len(messages))
 	return nil
 }
 
@@ -958,25 +882,6 @@ func (s *Sink) parseMessage(ctx context.Context, e *kafka.Message) (*sinkmodels.
 	}
 
 	sinkMessage.Serialized = &kafkaCloudEvent
-
-	// Dedupe, this stores key in store which means if sink fails and restarts it will not process the same message again
-	// Dedupe is an optional dependency, so we check if it's set
-	if s.config.Deduplicator != nil {
-		isUnique, err := s.config.Deduplicator.CheckUnique(ctx, sinkMessage.GetDedupeItem())
-		if err != nil {
-			// Stop processing, non-recoverable error
-			return sinkMessage, fmt.Errorf("failed to check uniqueness of kafka message: %w", err)
-		}
-
-		if !isUnique {
-			sinkMessage.Status = sinkmodels.ProcessingStatus{
-				State:     sinkmodels.DROP,
-				DropError: errors.New("skipping non unique message"),
-			}
-
-			return sinkMessage, nil
-		}
-	}
 
 	// Let's resolve affected meters
 	affectedMeters, err := s.meterCache.GetAffectedMeters(ctx, sinkMessage)

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -13,8 +13,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/avast/retry-go/v4"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -254,7 +255,7 @@ func withStoredAt(storedAt time.Time) MessageTransformerFunc {
 	}
 }
 
-// flush flushes the 1. buffer to storage and 2. stores Kafka offsets.
+// flush flushes the 1. buffer to storage, 2. stores Kafka offsets and 3. updates sink dedupe state.
 // called when max wait time or min commit count reached
 func (s *Sink) flush(ctx context.Context) error {
 	logger := s.config.Logger.With("operation", "flush")
@@ -333,6 +334,28 @@ func (s *Sink) flush(ctx context.Context) error {
 		}
 	}
 
+	// 3. Sink dedupe IDs after successful persistence.
+	if s.config.Deduplicator != nil && len(dedupedMessages) > 0 {
+		err := s.dedupeSet(ctx, dedupedMessages)
+		if err != nil {
+			// Try to commit offset if dedupe fails to ensure consistency.
+			if offsetStoreErr == nil {
+				_, err := s.config.Consumer.Commit()
+				if err != nil {
+					return fmt.Errorf("failed to commit offset: %w", err)
+				}
+			}
+
+			// When both offset commit and dedupe sink fails we need to reconcile the state based on logs.
+			if offsetStoreErr != nil {
+				logger.ErrorContext(ctx, "consistency failure", "err", err, "messages", messages)
+			}
+
+			// Return error, stop consuming.
+			return fmt.Errorf("failed to sink to redis: %s", err)
+		}
+	}
+
 	// Return offset store error if any.
 	if offsetStoreErr != nil {
 		return fmt.Errorf("failed to store offset: %w", offsetStoreErr)
@@ -368,41 +391,64 @@ func (s *Sink) filterMessagesForInsert(ctx context.Context, messages []sinkmodel
 		return messages, nil
 	}
 
-	filteredMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
+	dedupeItems := lo.Map(messages, func(message sinkmodels.SinkMessage, _ int) dedupe.Item {
+		return message.GetDedupeItem()
+	})
+
+	dedupeResults, err := s.config.Deduplicator.CheckUniqueBatch(ctx, dedupeItems)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
+	}
+
+	uniqueMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
+	alreadyProcessedMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
 
 	for _, message := range messages {
-		serialized := message.Serialized
-		if serialized == nil {
+		item := message.GetDedupeItem()
+		if _, ok := dedupeResults.UniqueItems[item]; ok {
+			uniqueMessages = append(uniqueMessages, message)
 			continue
 		}
-
-		ce := event.New()
-		ce.SetID(serialized.Id)
-		ce.SetSource(serialized.Source)
-
-		// Reserve this event ID before insert. Replays can still proceed if storage
-		// has no durable copy yet (for example after a crash before ClickHouse durability).
-		isUnique, err := s.config.Deduplicator.IsUnique(ctx, message.Namespace, ce)
-		if err != nil {
-			return nil, fmt.Errorf("failed to reserve dedupe key for kafka message: %w", err)
+		if _, ok := dedupeResults.AlreadyProcessedItems[item]; ok {
+			alreadyProcessedMessages = append(alreadyProcessedMessages, message)
+			continue
 		}
+	}
 
-		if isUnique {
+	// Batch-check potentially unsafe replay windows:
+	// - unique+durable means crash happened after storage and before dedupe set,
+	// - existing+not-durable means crash happened before storage but dedupe key was already set.
+	uniqueDurableItems, err := s.config.Storage.HasEvents(ctx, sinkMessagesToDedupeItems(uniqueMessages))
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify durable state for unique messages: %w", err)
+	}
+
+	alreadyProcessedDurableItems, err := s.config.Storage.HasEvents(ctx, sinkMessagesToDedupeItems(alreadyProcessedMessages))
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify durable state for already processed messages: %w", err)
+	}
+
+	filteredMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
+	for _, message := range uniqueMessages {
+		if _, exists := uniqueDurableItems[message.GetDedupeItem()]; !exists {
 			filteredMessages = append(filteredMessages, message)
-			continue
 		}
-
-		alreadyPersisted, err := s.config.Storage.HasEvent(ctx, message)
-		if err != nil {
-			return nil, fmt.Errorf("failed to verify persisted duplicate event: %w", err)
-		}
-
-		if !alreadyPersisted {
+	}
+	for _, message := range alreadyProcessedMessages {
+		if _, exists := alreadyProcessedDurableItems[message.GetDedupeItem()]; !exists {
 			filteredMessages = append(filteredMessages, message)
 		}
 	}
 
 	return filteredMessages, nil
+}
+
+func sinkMessagesToDedupeItems(messages []sinkmodels.SinkMessage) []dedupe.Item {
+	items := make([]dedupe.Item, 0, len(messages))
+	for _, message := range messages {
+		items = append(items, message.GetDedupeItem())
+	}
+	return items
 }
 
 // reportFlushMetrics reports metrics to OTel
@@ -474,6 +520,84 @@ func (s *Sink) persistToStorage(ctx context.Context, messages []sinkmodels.SinkM
 		logger.Debug("succeeded to sink to storage", "buffer size", len(messages))
 	}
 
+	return nil
+}
+
+// dedupeSet sets the dedupe keys in Deduplicator with retry.
+func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage) error {
+	logger := s.config.Logger.With("operation", "dedupeSet")
+	dedupeCtx, dedupeSet := s.config.Tracer.Start(ctx, "dedupe-set")
+	dedupeSet.SetAttributes(
+		attribute.Int("size", len(messages)),
+	)
+
+	dedupeItems := []dedupe.Item{}
+	for _, message := range messages {
+		switch message.Status.State {
+		case sinkmodels.OK:
+			dedupeItems = append(dedupeItems, dedupe.Item{
+				Namespace: message.Namespace,
+				ID:        message.Serialized.Id,
+				Source:    message.Serialized.Source,
+			})
+		case sinkmodels.DROP:
+			// Let's not insert already dropped messages into the deduplicator as this signals
+			// that we had a problem validating the message, we could redo any validation as needed
+			// later but if any error was transient let's retry the message if it's sent again.
+
+			if s.config.LogDroppedEvents {
+				logger.WarnContext(ctx, "event dropped",
+					slog.String("namespace", message.Namespace),
+					slog.String("event", string(message.KafkaMessage.Value)),
+					slog.Any("error", message.Status.DropError),
+					slog.String("status", message.Status.State.String()),
+				)
+			}
+
+			continue
+		default:
+			logger.ErrorContext(ctx, "unknown state type in dedup set", "state", message.Status.State.String())
+		}
+	}
+
+	if len(dedupeItems) == 0 {
+		logger.Debug("no dedupe items to set")
+		return nil
+	}
+
+	// We retry with exponential backoff as it's critical that either step #2 or #3 succeeds.
+	err := retry.Do(
+		func() error {
+			existingItems, err := s.config.Deduplicator.Set(dedupeCtx, dedupeItems...)
+			if err != nil {
+				return err
+			}
+
+			if len(existingItems) > 0 {
+				logger.ErrorContext(ctx, "dedupe: some items already existed in redis",
+					"items", lo.Map(existingItems, func(item dedupe.Item, _ int) string {
+						return item.Key()
+					}),
+					"code", "dedupe_set_failure",
+				)
+			}
+
+			return nil
+		},
+		retry.Context(dedupeCtx),
+		retry.OnRetry(func(n uint, err error) {
+			dedupeSet.AddEvent("retry", trace.WithAttributes(attribute.Int("count", int(n))))
+			logger.WarnContext(ctx, "failed to sink to redis, will retry", "err", err, "retry", n)
+		}),
+	)
+	if err != nil {
+		dedupeSet.SetStatus(codes.Error, "dedupe set failure")
+		dedupeSet.RecordError(err)
+		dedupeSet.End()
+		return fmt.Errorf("failed to sink to redis: %s", err)
+	}
+	dedupeSet.End()
+	logger.Debug("succeeded to sink to redis", "buffer size", len(messages))
 	return nil
 }
 

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -453,8 +453,9 @@ func (s *Sink) planFlushMessages(ctx context.Context, messages []sinkmodels.Sink
 			if !isDurable {
 				plan.messagesToInsert = append(plan.messagesToInsert, message)
 			}
+		default:
+			return flushMessagePlan{}, fmt.Errorf("dedupe result did not classify item %s", item.Key())
 		}
-		// else: unexpected classification, ignore to avoid false positives.
 	}
 
 	return plan, nil

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -306,15 +306,15 @@ func (s *Sink) flush(ctx context.Context) error {
 	// Dedupe messages so if we have multiple messages in the same batch
 	dedupedMessages := dedupeSinkMessages(messages)
 
-	dedupedMessages, err = s.filterMessagesForInsert(ctx, dedupedMessages)
+	flushPlan, err := s.planFlushMessages(ctx, dedupedMessages)
 	if err != nil {
-		return fmt.Errorf("failed to filter messages for insert: %w", err)
+		return fmt.Errorf("failed to plan flush messages: %w", err)
 	}
 
 	// 1. Persist to storage
-	if len(dedupedMessages) > 0 {
+	if len(flushPlan.messagesToInsert) > 0 {
 		// Persist events to permanent storage
-		err := s.persistToStorage(ctx, dedupedMessages)
+		err := s.persistToStorage(ctx, flushPlan.messagesToInsert)
 		if err != nil {
 			return fmt.Errorf("failed to persist: %w", err)
 		}
@@ -335,8 +335,8 @@ func (s *Sink) flush(ctx context.Context) error {
 	}
 
 	// 3. Sink dedupe IDs after successful persistence.
-	if s.config.Deduplicator != nil && len(dedupedMessages) > 0 {
-		err := s.dedupeSet(ctx, dedupedMessages)
+	if s.config.Deduplicator != nil && len(flushPlan.dedupeItemsToSet) > 0 {
+		err := s.dedupeSet(ctx, flushPlan.dedupeItemsToSet)
 		if err != nil {
 			// Try to commit offset if dedupe fails to ensure consistency.
 			if offsetStoreErr == nil {
@@ -386,68 +386,106 @@ func (s *Sink) flush(ctx context.Context) error {
 	return nil
 }
 
-func (s *Sink) filterMessagesForInsert(ctx context.Context, messages []sinkmodels.SinkMessage) ([]sinkmodels.SinkMessage, error) {
-	if s.config.Deduplicator == nil || len(messages) == 0 {
-		return messages, nil
+type flushMessagePlan struct {
+	messagesToInsert []sinkmodels.SinkMessage
+	dedupeItemsToSet []dedupe.Item
+}
+
+func (s *Sink) planFlushMessages(ctx context.Context, messages []sinkmodels.SinkMessage) (flushMessagePlan, error) {
+	plan := flushMessagePlan{
+		messagesToInsert: messages,
+		dedupeItemsToSet: nil,
 	}
 
-	dedupeItems := lo.Map(messages, func(message sinkmodels.SinkMessage, _ int) dedupe.Item {
-		return message.GetDedupeItem()
-	})
+	if s.config.Deduplicator == nil || len(messages) == 0 {
+		return plan, nil
+	}
+
+	validMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
+	dedupeItems := make([]dedupe.Item, 0, len(messages))
+
+	for _, message := range messages {
+		item, ok := dedupeItemFromMessage(message)
+		if !ok {
+			continue
+		}
+
+		validMessages = append(validMessages, message)
+		dedupeItems = append(dedupeItems, item)
+	}
+
+	if len(validMessages) == 0 {
+		plan.messagesToInsert = nil
+		return plan, nil
+	}
 
 	dedupeResults, err := s.config.Deduplicator.CheckUniqueBatch(ctx, dedupeItems)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
-	}
-
-	uniqueMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
-	alreadyProcessedMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
-
-	for _, message := range messages {
-		item := message.GetDedupeItem()
-		if _, ok := dedupeResults.UniqueItems[item]; ok {
-			uniqueMessages = append(uniqueMessages, message)
-			continue
-		}
-		if _, ok := dedupeResults.AlreadyProcessedItems[item]; ok {
-			alreadyProcessedMessages = append(alreadyProcessedMessages, message)
-			continue
-		}
+		return flushMessagePlan{}, fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
 	}
 
 	// Batch-check potentially unsafe replay windows:
 	// - unique+durable means crash happened after storage and before dedupe set,
 	// - existing+not-durable means crash happened before storage but dedupe key was already set.
-	uniqueDurableItems, err := s.config.Storage.HasEvents(ctx, sinkMessagesToDedupeItems(uniqueMessages))
+	durableItems, err := s.config.Storage.HasEvents(ctx, dedupeItems)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify durable state for unique messages: %w", err)
+		return flushMessagePlan{}, fmt.Errorf("failed to verify durable state for flush messages: %w", err)
 	}
 
-	alreadyProcessedDurableItems, err := s.config.Storage.HasEvents(ctx, sinkMessagesToDedupeItems(alreadyProcessedMessages))
-	if err != nil {
-		return nil, fmt.Errorf("failed to verify durable state for already processed messages: %w", err)
-	}
+	plan.messagesToInsert = make([]sinkmodels.SinkMessage, 0, len(validMessages))
+	plan.dedupeItemsToSet = make([]dedupe.Item, 0, len(validMessages))
 
-	filteredMessages := make([]sinkmodels.SinkMessage, 0, len(messages))
-	for _, message := range uniqueMessages {
-		if _, exists := uniqueDurableItems[message.GetDedupeItem()]; !exists {
-			filteredMessages = append(filteredMessages, message)
+	for _, message := range validMessages {
+		item := message.GetDedupeItem()
+		_, isUnique := dedupeResults.UniqueItems[item]
+		_, isAlreadyProcessed := dedupeResults.AlreadyProcessedItems[item]
+		_, isDurable := durableItems[item]
+
+		switch {
+		case isUnique:
+			// Always set unique keys post-persist, including unique+durable rows,
+			// so future replays do not keep triggering durable storage lookups.
+			plan.dedupeItemsToSet = append(plan.dedupeItemsToSet, item)
+			if !isDurable {
+				plan.messagesToInsert = append(plan.messagesToInsert, message)
+			}
+		case isAlreadyProcessed:
+			if !isDurable {
+				plan.messagesToInsert = append(plan.messagesToInsert, message)
+			}
 		}
-	}
-	for _, message := range alreadyProcessedMessages {
-		if _, exists := alreadyProcessedDurableItems[message.GetDedupeItem()]; !exists {
-			filteredMessages = append(filteredMessages, message)
-		}
+		// else: unexpected classification, ignore to avoid false positives.
 	}
 
-	return filteredMessages, nil
+	return plan, nil
 }
 
-func sinkMessagesToDedupeItems(messages []sinkmodels.SinkMessage) []dedupe.Item {
+func dedupeItemFromMessage(message sinkmodels.SinkMessage) (dedupe.Item, bool) {
+	if message.Status.State != sinkmodels.OK {
+		return dedupe.Item{}, false
+	}
+
+	if message.Serialized == nil {
+		return dedupe.Item{}, false
+	}
+
+	item := message.GetDedupeItem()
+	if item.Namespace == "" || item.Source == "" || item.ID == "" {
+		return dedupe.Item{}, false
+	}
+
+	return item, true
+}
+
+func dedupeItemsFromMessages(messages []sinkmodels.SinkMessage) []dedupe.Item {
 	items := make([]dedupe.Item, 0, len(messages))
 	for _, message := range messages {
-		items = append(items, message.GetDedupeItem())
+		item, ok := dedupeItemFromMessage(message)
+		if ok {
+			items = append(items, item)
+		}
 	}
+
 	return items
 }
 
@@ -524,41 +562,12 @@ func (s *Sink) persistToStorage(ctx context.Context, messages []sinkmodels.SinkM
 }
 
 // dedupeSet sets the dedupe keys in Deduplicator with retry.
-func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage) error {
+func (s *Sink) dedupeSet(ctx context.Context, dedupeItems []dedupe.Item) error {
 	logger := s.config.Logger.With("operation", "dedupeSet")
 	dedupeCtx, dedupeSet := s.config.Tracer.Start(ctx, "dedupe-set")
 	dedupeSet.SetAttributes(
-		attribute.Int("size", len(messages)),
+		attribute.Int("size", len(dedupeItems)),
 	)
-
-	dedupeItems := []dedupe.Item{}
-	for _, message := range messages {
-		switch message.Status.State {
-		case sinkmodels.OK:
-			dedupeItems = append(dedupeItems, dedupe.Item{
-				Namespace: message.Namespace,
-				ID:        message.Serialized.Id,
-				Source:    message.Serialized.Source,
-			})
-		case sinkmodels.DROP:
-			// Let's not insert already dropped messages into the deduplicator as this signals
-			// that we had a problem validating the message, we could redo any validation as needed
-			// later but if any error was transient let's retry the message if it's sent again.
-
-			if s.config.LogDroppedEvents {
-				logger.WarnContext(ctx, "event dropped",
-					slog.String("namespace", message.Namespace),
-					slog.String("event", string(message.KafkaMessage.Value)),
-					slog.Any("error", message.Status.DropError),
-					slog.String("status", message.Status.State.String()),
-				)
-			}
-
-			continue
-		default:
-			logger.ErrorContext(ctx, "unknown state type in dedup set", "state", message.Status.State.String())
-		}
-	}
 
 	if len(dedupeItems) == 0 {
 		logger.Debug("no dedupe items to set")
@@ -597,7 +606,7 @@ func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage)
 		return fmt.Errorf("failed to sink to redis: %s", err)
 	}
 	dedupeSet.End()
-	logger.Debug("succeeded to sink to redis", "buffer size", len(messages))
+	logger.Debug("succeeded to sink to redis", "buffer size", len(dedupeItems))
 	return nil
 }
 
@@ -1060,6 +1069,10 @@ func dedupeSinkMessages(events []sinkmodels.SinkMessage) []sinkmodels.SinkMessag
 	for _, event := range events {
 		switch event.Status.State {
 		case sinkmodels.OK:
+			if event.Serialized == nil {
+				continue
+			}
+
 			key := dedupe.Item{
 				Namespace: event.Namespace,
 				ID:        event.Serialized.Id,

--- a/openmeter/sink/sink_dedupe_test.go
+++ b/openmeter/sink/sink_dedupe_test.go
@@ -2,48 +2,141 @@ package sink
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/openmeter/dedupe"
-	"github.com/openmeterio/openmeter/openmeter/dedupe/memorydedupe"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
 	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
 )
 
-type durableProbeStorage struct {
-	persisted map[dedupe.Item]struct{}
-	inserts   int
+type countingDeduplicator struct {
+	existing              dedupe.ItemSet
+	checkUniqueBatchCalls int
+	checkUniqueBatchSizes []int
+	checkUniqueCalls      int
+	isUniqueCalls         int
+	setCalls              int
+	setBatchSizes         []int
 }
 
-func newDurableProbeStorage() *durableProbeStorage {
-	return &durableProbeStorage{
-		persisted: map[dedupe.Item]struct{}{},
+func newCountingDeduplicator(existing []dedupe.Item) *countingDeduplicator {
+	itemSet := dedupe.ItemSet{}
+	for _, item := range existing {
+		itemSet[item] = struct{}{}
+	}
+
+	return &countingDeduplicator{
+		existing: itemSet,
 	}
 }
 
-func (s *durableProbeStorage) BatchInsert(_ context.Context, messages []sinkmodels.SinkMessage) error {
-	for _, message := range messages {
-		s.persisted[message.GetDedupeItem()] = struct{}{}
+func (d *countingDeduplicator) IsUnique(context.Context, string, event.Event) (bool, error) {
+	d.isUniqueCalls++
+	return false, nil
+}
+
+func (d *countingDeduplicator) CheckUnique(context.Context, dedupe.Item) (bool, error) {
+	d.checkUniqueCalls++
+	return false, nil
+}
+
+func (d *countingDeduplicator) Set(_ context.Context, items ...dedupe.Item) ([]dedupe.Item, error) {
+	d.setCalls++
+	d.setBatchSizes = append(d.setBatchSizes, len(items))
+
+	existingItems := []dedupe.Item{}
+	for _, item := range items {
+		if _, ok := d.existing[item]; ok {
+			existingItems = append(existingItems, item)
+			continue
+		}
+		d.existing[item] = struct{}{}
 	}
 
-	s.inserts += len(messages)
+	return existingItems, nil
+}
 
+func (d *countingDeduplicator) CheckUniqueBatch(_ context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+	d.checkUniqueBatchCalls++
+	d.checkUniqueBatchSizes = append(d.checkUniqueBatchSizes, len(items))
+
+	result := dedupe.CheckUniqueBatchResult{
+		UniqueItems:           make(dedupe.ItemSet, len(items)),
+		AlreadyProcessedItems: make(dedupe.ItemSet, len(items)),
+	}
+
+	for _, item := range items {
+		if _, ok := d.existing[item]; ok {
+			result.AlreadyProcessedItems[item] = struct{}{}
+			continue
+		}
+		result.UniqueItems[item] = struct{}{}
+	}
+
+	return result, nil
+}
+
+func (d *countingDeduplicator) Close() error {
 	return nil
 }
 
-func (s *durableProbeStorage) HasEvent(_ context.Context, message sinkmodels.SinkMessage) (bool, error) {
-	_, ok := s.persisted[message.GetDedupeItem()]
-	return ok, nil
+type countingStorage struct {
+	durable        dedupe.ItemSet
+	hasEventsCalls int
+	hasEventsSizes []int
 }
 
-func TestFilterMessagesForInsert_ReplaysCrashBeforeDurability(t *testing.T) {
-	deduplicator, err := memorydedupe.NewDeduplicator(64)
-	require.NoError(t, err)
+func newCountingStorage(durable []dedupe.Item) *countingStorage {
+	itemSet := dedupe.ItemSet{}
+	for _, item := range durable {
+		itemSet[item] = struct{}{}
+	}
 
-	storage := newDurableProbeStorage()
+	return &countingStorage{
+		durable: itemSet,
+	}
+}
+
+func (s *countingStorage) BatchInsert(_ context.Context, _ []sinkmodels.SinkMessage) error {
+	return nil
+}
+
+func (s *countingStorage) HasEvents(_ context.Context, items []dedupe.Item) (dedupe.ItemSet, error) {
+	s.hasEventsCalls++
+	s.hasEventsSizes = append(s.hasEventsSizes, len(items))
+
+	result := dedupe.ItemSet{}
+	for _, item := range items {
+		if _, ok := s.durable[item]; ok {
+			result[item] = struct{}{}
+		}
+	}
+
+	return result, nil
+}
+
+func TestFilterMessagesForInsert_BatchedAndCrashSafeBoundaries(t *testing.T) {
+	redisExistingNotDurable := testSinkMessage("tenant-a", "evt-redis-not-durable", "gateway")
+	redisExistingDurable := testSinkMessage("tenant-a", "evt-redis-durable", "gateway")
+	redisUniqueDurable := testSinkMessage("tenant-a", "evt-unique-durable", "gateway")
+	redisUniqueNotDurable := testSinkMessage("tenant-a", "evt-unique-not-durable", "gateway")
+
+	deduplicator := newCountingDeduplicator([]dedupe.Item{
+		redisExistingNotDurable.GetDedupeItem(),
+		redisExistingDurable.GetDedupeItem(),
+	})
+	storage := newCountingStorage([]dedupe.Item{
+		redisExistingDurable.GetDedupeItem(),
+		redisUniqueDurable.GetDedupeItem(),
+	})
+
 	s := &Sink{
 		config: SinkConfig{
 			Deduplicator: deduplicator,
@@ -51,28 +144,49 @@ func TestFilterMessagesForInsert_ReplaysCrashBeforeDurability(t *testing.T) {
 		},
 	}
 
-	ctx := t.Context()
-	message := testSinkMessage("tenant-a", "evt-1", "gateway")
-
-	// First delivery reserves the dedupe key and is selected for insert.
-	firstAttempt, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
+	filtered, err := s.filterMessagesForInsert(t.Context(), []sinkmodels.SinkMessage{
+		redisExistingNotDurable,
+		redisExistingDurable,
+		redisUniqueDurable,
+		redisUniqueNotDurable,
+	})
 	require.NoError(t, err)
-	require.Len(t, firstAttempt, 1)
+	require.Equal(t, []sinkmodels.SinkMessage{
+		redisUniqueNotDurable,
+		redisExistingNotDurable,
+	}, filtered)
 
-	// Crash before durable insert: key exists in dedupe, storage still has no row.
-	replayAfterCrash, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
+	require.Equal(t, 1, deduplicator.checkUniqueBatchCalls)
+	require.Equal(t, []int{4}, deduplicator.checkUniqueBatchSizes)
+	require.Equal(t, 0, deduplicator.isUniqueCalls)
+	require.Equal(t, 0, deduplicator.checkUniqueCalls)
+
+	require.Equal(t, 2, storage.hasEventsCalls)
+	require.Equal(t, []int{2, 2}, storage.hasEventsSizes)
+}
+
+func TestDedupeSet_UsesSingleBatchCall(t *testing.T) {
+	deduplicator := newCountingDeduplicator(nil)
+	storage := newCountingStorage(nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	s := &Sink{
+		config: SinkConfig{
+			Logger:       logger,
+			Tracer:       noop.NewTracerProvider().Tracer("test"),
+			Deduplicator: deduplicator,
+			Storage:      storage,
+		},
+	}
+
+	err := s.dedupeSet(t.Context(), []sinkmodels.SinkMessage{
+		testSinkMessage("tenant-a", "evt-1", "gateway"),
+		testSinkMessage("tenant-a", "evt-2", "gateway"),
+		testSinkMessage("tenant-a", "evt-3", "gateway"),
+	})
 	require.NoError(t, err)
-	require.Len(t, replayAfterCrash, 1)
-
-	// Replay inserts the row exactly once.
-	require.NoError(t, storage.BatchInsert(ctx, replayAfterCrash))
-	require.Equal(t, 1, storage.inserts)
-
-	// Crash after durable insert: replay should be filtered out.
-	replayAfterDurableInsert, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
-	require.NoError(t, err)
-	require.Empty(t, replayAfterDurableInsert)
-	require.Equal(t, 1, storage.inserts)
+	require.Equal(t, 1, deduplicator.setCalls)
+	require.Equal(t, []int{3}, deduplicator.setBatchSizes)
 }
 
 func testSinkMessage(namespace, id, source string) sinkmodels.SinkMessage {

--- a/openmeter/sink/sink_dedupe_test.go
+++ b/openmeter/sink/sink_dedupe_test.go
@@ -1,0 +1,93 @@
+package sink
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
+	"github.com/openmeterio/openmeter/openmeter/dedupe/memorydedupe"
+	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
+	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
+)
+
+type durableProbeStorage struct {
+	persisted map[dedupe.Item]struct{}
+	inserts   int
+}
+
+func newDurableProbeStorage() *durableProbeStorage {
+	return &durableProbeStorage{
+		persisted: map[dedupe.Item]struct{}{},
+	}
+}
+
+func (s *durableProbeStorage) BatchInsert(_ context.Context, messages []sinkmodels.SinkMessage) error {
+	for _, message := range messages {
+		s.persisted[message.GetDedupeItem()] = struct{}{}
+	}
+
+	s.inserts += len(messages)
+
+	return nil
+}
+
+func (s *durableProbeStorage) HasEvent(_ context.Context, message sinkmodels.SinkMessage) (bool, error) {
+	_, ok := s.persisted[message.GetDedupeItem()]
+	return ok, nil
+}
+
+func TestFilterMessagesForInsert_ReplaysCrashBeforeDurability(t *testing.T) {
+	deduplicator, err := memorydedupe.NewDeduplicator(64)
+	require.NoError(t, err)
+
+	storage := newDurableProbeStorage()
+	s := &Sink{
+		config: SinkConfig{
+			Deduplicator: deduplicator,
+			Storage:      storage,
+		},
+	}
+
+	ctx := t.Context()
+	message := testSinkMessage("tenant-a", "evt-1", "gateway")
+
+	// First delivery reserves the dedupe key and is selected for insert.
+	firstAttempt, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
+	require.NoError(t, err)
+	require.Len(t, firstAttempt, 1)
+
+	// Crash before durable insert: key exists in dedupe, storage still has no row.
+	replayAfterCrash, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
+	require.NoError(t, err)
+	require.Len(t, replayAfterCrash, 1)
+
+	// Replay inserts the row exactly once.
+	require.NoError(t, storage.BatchInsert(ctx, replayAfterCrash))
+	require.Equal(t, 1, storage.inserts)
+
+	// Crash after durable insert: replay should be filtered out.
+	replayAfterDurableInsert, err := s.filterMessagesForInsert(ctx, []sinkmodels.SinkMessage{message})
+	require.NoError(t, err)
+	require.Empty(t, replayAfterDurableInsert)
+	require.Equal(t, 1, storage.inserts)
+}
+
+func testSinkMessage(namespace, id, source string) sinkmodels.SinkMessage {
+	return sinkmodels.SinkMessage{
+		Namespace: namespace,
+		Serialized: &serializer.CloudEventsKafkaPayload{
+			Id:      id,
+			Source:  source,
+			Type:    "model.inference",
+			Subject: "subject-1",
+			Time:    time.Now().Unix(),
+			Data:    `{"tokens":42}`,
+		},
+		Status: sinkmodels.ProcessingStatus{
+			State: sinkmodels.OK,
+		},
+	}
+}

--- a/openmeter/sink/sink_dedupe_test.go
+++ b/openmeter/sink/sink_dedupe_test.go
@@ -92,6 +92,17 @@ func (d *countingDeduplicator) Close() error {
 	return nil
 }
 
+type unclassifiedDeduplicator struct {
+	*countingDeduplicator
+}
+
+func (d *unclassifiedDeduplicator) CheckUniqueBatch(_ context.Context, _ []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+	return dedupe.CheckUniqueBatchResult{
+		UniqueItems:           dedupe.ItemSet{},
+		AlreadyProcessedItems: dedupe.ItemSet{},
+	}, nil
+}
+
 type countingStorage struct {
 	durable        dedupe.ItemSet
 	hasEventsCalls int
@@ -207,6 +218,19 @@ func TestPlanFlushMessages_ExistingNotDurableReinsertsWithoutSet(t *testing.T) {
 	err = s.dedupeSet(t.Context(), plan.dedupeItemsToSet)
 	require.NoError(t, err)
 	require.Equal(t, 0, deduplicator.setCalls)
+}
+
+func TestPlanFlushMessages_RejectsUnclassifiedDedupeResult(t *testing.T) {
+	message := testSinkMessage("tenant-a", "evt-unclassified", "gateway")
+	deduplicator := &unclassifiedDeduplicator{
+		countingDeduplicator: newCountingDeduplicator(nil),
+	}
+	storage := newCountingStorage(nil)
+
+	s := newTestSink(deduplicator, storage)
+
+	_, err := s.planFlushMessages(t.Context(), []sinkmodels.SinkMessage{message})
+	require.ErrorContains(t, err, "dedupe result did not classify item")
 }
 
 func TestPlanFlushMessages_BatchesChecksAndSingleSetPipeline(t *testing.T) {

--- a/openmeter/sink/sink_dedupe_test.go
+++ b/openmeter/sink/sink_dedupe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,10 +21,12 @@ type countingDeduplicator struct {
 	existing              dedupe.ItemSet
 	checkUniqueBatchCalls int
 	checkUniqueBatchSizes []int
+	checkUniqueBatchItems [][]dedupe.Item
 	checkUniqueCalls      int
 	isUniqueCalls         int
 	setCalls              int
 	setBatchSizes         []int
+	setBatchItems         [][]dedupe.Item
 }
 
 func newCountingDeduplicator(existing []dedupe.Item) *countingDeduplicator {
@@ -50,6 +53,7 @@ func (d *countingDeduplicator) CheckUnique(context.Context, dedupe.Item) (bool, 
 func (d *countingDeduplicator) Set(_ context.Context, items ...dedupe.Item) ([]dedupe.Item, error) {
 	d.setCalls++
 	d.setBatchSizes = append(d.setBatchSizes, len(items))
+	d.setBatchItems = append(d.setBatchItems, slices.Clone(items))
 
 	existingItems := []dedupe.Item{}
 	for _, item := range items {
@@ -66,6 +70,7 @@ func (d *countingDeduplicator) Set(_ context.Context, items ...dedupe.Item) ([]d
 func (d *countingDeduplicator) CheckUniqueBatch(_ context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
 	d.checkUniqueBatchCalls++
 	d.checkUniqueBatchSizes = append(d.checkUniqueBatchSizes, len(items))
+	d.checkUniqueBatchItems = append(d.checkUniqueBatchItems, slices.Clone(items))
 
 	result := dedupe.CheckUniqueBatchResult{
 		UniqueItems:           make(dedupe.ItemSet, len(items)),
@@ -91,6 +96,7 @@ type countingStorage struct {
 	durable        dedupe.ItemSet
 	hasEventsCalls int
 	hasEventsSizes []int
+	hasEventsItems [][]dedupe.Item
 }
 
 func newCountingStorage(durable []dedupe.Item) *countingStorage {
@@ -111,6 +117,7 @@ func (s *countingStorage) BatchInsert(_ context.Context, _ []sinkmodels.SinkMess
 func (s *countingStorage) HasEvents(_ context.Context, items []dedupe.Item) (dedupe.ItemSet, error) {
 	s.hasEventsCalls++
 	s.hasEventsSizes = append(s.hasEventsSizes, len(items))
+	s.hasEventsItems = append(s.hasEventsItems, slices.Clone(items))
 
 	result := dedupe.ItemSet{}
 	for _, item := range items {
@@ -122,55 +129,10 @@ func (s *countingStorage) HasEvents(_ context.Context, items []dedupe.Item) (ded
 	return result, nil
 }
 
-func TestFilterMessagesForInsert_BatchedAndCrashSafeBoundaries(t *testing.T) {
-	redisExistingNotDurable := testSinkMessage("tenant-a", "evt-redis-not-durable", "gateway")
-	redisExistingDurable := testSinkMessage("tenant-a", "evt-redis-durable", "gateway")
-	redisUniqueDurable := testSinkMessage("tenant-a", "evt-unique-durable", "gateway")
-	redisUniqueNotDurable := testSinkMessage("tenant-a", "evt-unique-not-durable", "gateway")
-
-	deduplicator := newCountingDeduplicator([]dedupe.Item{
-		redisExistingNotDurable.GetDedupeItem(),
-		redisExistingDurable.GetDedupeItem(),
-	})
-	storage := newCountingStorage([]dedupe.Item{
-		redisExistingDurable.GetDedupeItem(),
-		redisUniqueDurable.GetDedupeItem(),
-	})
-
-	s := &Sink{
-		config: SinkConfig{
-			Deduplicator: deduplicator,
-			Storage:      storage,
-		},
-	}
-
-	filtered, err := s.filterMessagesForInsert(t.Context(), []sinkmodels.SinkMessage{
-		redisExistingNotDurable,
-		redisExistingDurable,
-		redisUniqueDurable,
-		redisUniqueNotDurable,
-	})
-	require.NoError(t, err)
-	require.Equal(t, []sinkmodels.SinkMessage{
-		redisUniqueNotDurable,
-		redisExistingNotDurable,
-	}, filtered)
-
-	require.Equal(t, 1, deduplicator.checkUniqueBatchCalls)
-	require.Equal(t, []int{4}, deduplicator.checkUniqueBatchSizes)
-	require.Equal(t, 0, deduplicator.isUniqueCalls)
-	require.Equal(t, 0, deduplicator.checkUniqueCalls)
-
-	require.Equal(t, 2, storage.hasEventsCalls)
-	require.Equal(t, []int{2, 2}, storage.hasEventsSizes)
-}
-
-func TestDedupeSet_UsesSingleBatchCall(t *testing.T) {
-	deduplicator := newCountingDeduplicator(nil)
-	storage := newCountingStorage(nil)
+func newTestSink(deduplicator dedupe.Deduplicator, storage Storage) *Sink {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	s := &Sink{
+	return &Sink{
 		config: SinkConfig{
 			Logger:       logger,
 			Tracer:       noop.NewTracerProvider().Tracer("test"),
@@ -178,11 +140,138 @@ func TestDedupeSet_UsesSingleBatchCall(t *testing.T) {
 			Storage:      storage,
 		},
 	}
+}
 
-	err := s.dedupeSet(t.Context(), []sinkmodels.SinkMessage{
-		testSinkMessage("tenant-a", "evt-1", "gateway"),
-		testSinkMessage("tenant-a", "evt-2", "gateway"),
-		testSinkMessage("tenant-a", "evt-3", "gateway"),
+func TestPlanFlushMessages_IgnoresDropMissingIdentity(t *testing.T) {
+	uniqueNotDurable := testSinkMessage("tenant-a", "evt-unique-not-durable", "gateway")
+	dropMissingIdentity := sinkmodels.SinkMessage{
+		Status: sinkmodels.ProcessingStatus{
+			State: sinkmodels.DROP,
+		},
+	}
+
+	deduplicator := newCountingDeduplicator(nil)
+	storage := newCountingStorage(nil)
+
+	s := newTestSink(deduplicator, storage)
+
+	plan, err := s.planFlushMessages(t.Context(), []sinkmodels.SinkMessage{
+		dropMissingIdentity,
+		uniqueNotDurable,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []sinkmodels.SinkMessage{uniqueNotDurable}, plan.messagesToInsert)
+	require.Equal(t, []dedupe.Item{uniqueNotDurable.GetDedupeItem()}, plan.dedupeItemsToSet)
+
+	require.Equal(t, 1, deduplicator.checkUniqueBatchCalls)
+	require.Equal(t, []int{1}, deduplicator.checkUniqueBatchSizes)
+	require.Equal(t, 0, deduplicator.isUniqueCalls)
+	require.Equal(t, 0, deduplicator.checkUniqueCalls)
+
+	require.Equal(t, 1, storage.hasEventsCalls)
+	require.Equal(t, []int{1}, storage.hasEventsSizes)
+}
+
+func TestPlanFlushMessages_UniqueDurableSetsDedupeWithoutInsert(t *testing.T) {
+	uniqueDurable := testSinkMessage("tenant-a", "evt-unique-durable", "gateway")
+
+	deduplicator := newCountingDeduplicator(nil)
+	storage := newCountingStorage([]dedupe.Item{uniqueDurable.GetDedupeItem()})
+
+	s := newTestSink(deduplicator, storage)
+
+	plan, err := s.planFlushMessages(t.Context(), []sinkmodels.SinkMessage{uniqueDurable})
+	require.NoError(t, err)
+	require.Empty(t, plan.messagesToInsert)
+	require.Equal(t, []dedupe.Item{uniqueDurable.GetDedupeItem()}, plan.dedupeItemsToSet)
+
+	err = s.dedupeSet(t.Context(), plan.dedupeItemsToSet)
+	require.NoError(t, err)
+	require.Equal(t, 1, deduplicator.setCalls)
+	require.Equal(t, []int{1}, deduplicator.setBatchSizes)
+}
+
+func TestPlanFlushMessages_ExistingNotDurableReinsertsWithoutSet(t *testing.T) {
+	existingNotDurable := testSinkMessage("tenant-a", "evt-existing-not-durable", "gateway")
+
+	deduplicator := newCountingDeduplicator([]dedupe.Item{existingNotDurable.GetDedupeItem()})
+	storage := newCountingStorage(nil)
+
+	s := newTestSink(deduplicator, storage)
+
+	plan, err := s.planFlushMessages(t.Context(), []sinkmodels.SinkMessage{existingNotDurable})
+	require.NoError(t, err)
+	require.Equal(t, []sinkmodels.SinkMessage{existingNotDurable}, plan.messagesToInsert)
+	require.Empty(t, plan.dedupeItemsToSet)
+
+	err = s.dedupeSet(t.Context(), plan.dedupeItemsToSet)
+	require.NoError(t, err)
+	require.Equal(t, 0, deduplicator.setCalls)
+}
+
+func TestPlanFlushMessages_BatchesChecksAndSingleSetPipeline(t *testing.T) {
+	uniqueNotDurable := testSinkMessage("tenant-a", "evt-unique-not-durable", "gateway")
+	uniqueDurable := testSinkMessage("tenant-a", "evt-unique-durable", "gateway")
+	existingNotDurable := testSinkMessage("tenant-a", "evt-existing-not-durable", "gateway")
+	existingDurable := testSinkMessage("tenant-a", "evt-existing-durable", "gateway")
+
+	deduplicator := newCountingDeduplicator([]dedupe.Item{
+		existingNotDurable.GetDedupeItem(),
+		existingDurable.GetDedupeItem(),
+	})
+	storage := newCountingStorage([]dedupe.Item{
+		uniqueDurable.GetDedupeItem(),
+		existingDurable.GetDedupeItem(),
+	})
+
+	s := newTestSink(deduplicator, storage)
+
+	plan, err := s.planFlushMessages(t.Context(), []sinkmodels.SinkMessage{
+		uniqueNotDurable,
+		uniqueDurable,
+		existingNotDurable,
+		existingDurable,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []sinkmodels.SinkMessage{
+		uniqueNotDurable,
+		existingNotDurable,
+	}, plan.messagesToInsert)
+	require.Equal(t, []dedupe.Item{
+		uniqueNotDurable.GetDedupeItem(),
+		uniqueDurable.GetDedupeItem(),
+	}, plan.dedupeItemsToSet)
+
+	require.Equal(t, 1, deduplicator.checkUniqueBatchCalls)
+	require.Equal(t, []int{4}, deduplicator.checkUniqueBatchSizes)
+	require.Equal(t, 1, storage.hasEventsCalls)
+	require.Equal(t, []int{4}, storage.hasEventsSizes)
+
+	err = s.dedupeSet(t.Context(), plan.dedupeItemsToSet)
+	require.NoError(t, err)
+	require.Equal(t, 1, deduplicator.setCalls)
+	require.Equal(t, []int{2}, deduplicator.setBatchSizes)
+	require.Equal(t, []dedupe.Item{
+		uniqueNotDurable.GetDedupeItem(),
+		uniqueDurable.GetDedupeItem(),
+	}, deduplicator.setBatchItems[0])
+}
+
+func TestDedupeSet_UsesSingleBatchCall(t *testing.T) {
+	deduplicator := newCountingDeduplicator(nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := &Sink{
+		config: SinkConfig{
+			Logger:       logger,
+			Tracer:       noop.NewTracerProvider().Tracer("test"),
+			Deduplicator: deduplicator,
+		},
+	}
+
+	err := s.dedupeSet(t.Context(), []dedupe.Item{
+		{Namespace: "tenant-a", ID: "evt-1", Source: "gateway"},
+		{Namespace: "tenant-a", ID: "evt-2", Source: "gateway"},
+		{Namespace: "tenant-a", ID: "evt-3", Source: "gateway"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, deduplicator.setCalls)

--- a/openmeter/sink/storage.go
+++ b/openmeter/sink/storage.go
@@ -11,10 +11,12 @@ import (
 	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/filter"
 )
 
 type Storage interface {
 	BatchInsert(ctx context.Context, messages []sinkmodels.SinkMessage) error
+	HasEvent(ctx context.Context, message sinkmodels.SinkMessage) (bool, error)
 }
 
 type ClickHouseStorageConfig struct {
@@ -71,4 +73,38 @@ func (c *ClickHouseStorage) BatchInsert(ctx context.Context, messages []sinkmode
 	}
 
 	return nil
+}
+
+func (c *ClickHouseStorage) HasEvent(ctx context.Context, message sinkmodels.SinkMessage) (bool, error) {
+	if message.Serialized == nil {
+		return false, fmt.Errorf("failed to check event durability: message payload is missing")
+	}
+
+	if message.Namespace == "" {
+		return false, fmt.Errorf("failed to check event durability: namespace is missing")
+	}
+
+	if message.Serialized.Id == "" || message.Serialized.Source == "" {
+		return false, fmt.Errorf("failed to check event durability: id and source are required")
+	}
+
+	limit := 1
+	id := message.Serialized.Id
+	source := message.Serialized.Source
+
+	events, err := c.config.Streaming.ListEventsV2(ctx, streaming.ListEventsV2Params{
+		Namespace: message.Namespace,
+		Limit:     &limit,
+		ID: &filter.FilterString{
+			Eq: &id,
+		},
+		Source: &filter.FilterString{
+			Eq: &source,
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to check event durability: %w", err)
+	}
+
+	return len(events) > 0, nil
 }

--- a/openmeter/sink/storage.go
+++ b/openmeter/sink/storage.go
@@ -3,20 +3,23 @@ package sink
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
 	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/filter"
+	"github.com/openmeterio/openmeter/pkg/pagination/v2"
 )
 
 type Storage interface {
 	BatchInsert(ctx context.Context, messages []sinkmodels.SinkMessage) error
-	HasEvent(ctx context.Context, message sinkmodels.SinkMessage) (bool, error)
+	HasEvents(ctx context.Context, items []dedupe.Item) (dedupe.ItemSet, error)
 }
 
 type ClickHouseStorageConfig struct {
@@ -44,6 +47,8 @@ func NewClickhouseStorage(config ClickHouseStorageConfig) (*ClickHouseStorage, e
 type ClickHouseStorage struct {
 	config ClickHouseStorageConfig
 }
+
+const existsQueryBatchSize = 200
 
 // BatchInsert inserts multiple messages into ClickHouse.
 func (c *ClickHouseStorage) BatchInsert(ctx context.Context, messages []sinkmodels.SinkMessage) error {
@@ -75,36 +80,107 @@ func (c *ClickHouseStorage) BatchInsert(ctx context.Context, messages []sinkmode
 	return nil
 }
 
-func (c *ClickHouseStorage) HasEvent(ctx context.Context, message sinkmodels.SinkMessage) (bool, error) {
-	if message.Serialized == nil {
-		return false, fmt.Errorf("failed to check event durability: message payload is missing")
+func (c *ClickHouseStorage) HasEvents(ctx context.Context, items []dedupe.Item) (dedupe.ItemSet, error) {
+	durableItems := make(dedupe.ItemSet, len(items))
+
+	if len(items) == 0 {
+		return durableItems, nil
 	}
 
-	if message.Namespace == "" {
-		return false, fmt.Errorf("failed to check event durability: namespace is missing")
+	type groupKey struct {
+		namespace string
+		source    string
 	}
 
-	if message.Serialized.Id == "" || message.Serialized.Source == "" {
-		return false, fmt.Errorf("failed to check event durability: id and source are required")
+	groupedItems := map[groupKey][]string{}
+
+	for _, item := range items {
+		if item.Namespace == "" || item.Source == "" || item.ID == "" {
+			return nil, fmt.Errorf("failed to check event durability: namespace, source and id are required")
+		}
+
+		key := groupKey{namespace: item.Namespace, source: item.Source}
+		groupedItems[key] = append(groupedItems[key], item.ID)
 	}
 
-	limit := 1
-	id := message.Serialized.Id
-	source := message.Serialized.Source
+	for key, ids := range groupedItems {
+		ids = lo.Uniq(ids)
+		slices.Sort(ids)
 
-	events, err := c.config.Streaming.ListEventsV2(ctx, streaming.ListEventsV2Params{
-		Namespace: message.Namespace,
-		Limit:     &limit,
-		ID: &filter.FilterString{
-			Eq: &id,
-		},
-		Source: &filter.FilterString{
-			Eq: &source,
-		},
-	})
-	if err != nil {
-		return false, fmt.Errorf("failed to check event durability: %w", err)
+		for offset := 0; offset < len(ids); offset += existsQueryBatchSize {
+			end := min(offset+existsQueryBatchSize, len(ids))
+			batchIDs := ids[offset:end]
+
+			foundItems, err := c.queryExistingItemsByNamespaceAndSource(ctx, key.namespace, key.source, batchIDs)
+			if err != nil {
+				return nil, err
+			}
+
+			for item := range foundItems {
+				durableItems[item] = struct{}{}
+			}
+		}
 	}
 
-	return len(events) > 0, nil
+	return durableItems, nil
+}
+
+func (c *ClickHouseStorage) queryExistingItemsByNamespaceAndSource(ctx context.Context, namespace string, source string, ids []string) (dedupe.ItemSet, error) {
+	result := dedupe.ItemSet{}
+
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	pageLimit := min(len(ids)*2, 1000)
+	if pageLimit < 100 {
+		pageLimit = 100
+	}
+
+	idFilter := filter.FilterString{In: &ids}
+	sourceFilter := filter.FilterString{Eq: &source}
+
+	var cursor *pagination.Cursor
+	expectedIDs := map[string]struct{}{}
+	for _, id := range ids {
+		expectedIDs[id] = struct{}{}
+	}
+
+	for {
+		events, err := c.config.Streaming.ListEventsV2(ctx, streaming.ListEventsV2Params{
+			Namespace: namespace,
+			Cursor:    cursor,
+			Limit:     &pageLimit,
+			ID:        &idFilter,
+			Source:    &sourceFilter,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to check event durability: %w", err)
+		}
+
+		if len(events) == 0 {
+			break
+		}
+
+		for _, event := range events {
+			item := dedupe.Item{
+				Namespace: namespace,
+				Source:    source,
+				ID:        event.ID,
+			}
+			result[item] = struct{}{}
+		}
+
+		if len(result) == len(expectedIDs) || len(events) < pageLimit {
+			break
+		}
+
+		last := events[len(events)-1]
+		cursor = &pagination.Cursor{
+			ID:   last.StoreRowID,
+			Time: last.Time,
+		}
+	}
+
+	return result, nil
 }

--- a/openmeter/sink/storage_test.go
+++ b/openmeter/sink/storage_test.go
@@ -2,38 +2,70 @@ package sink
 
 import (
 	"context"
+	"sort"
 	"testing"
+	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 )
 
 type hasEventStreamingStub struct {
 	*testutils.MockStreamingConnector
-	events     []streaming.RawEvent
-	err        error
-	lastParams *streaming.ListEventsV2Params
+	err    error
+	calls  []streaming.ListEventsV2Params
+	exists map[dedupe.Item]struct{}
 }
 
 func newHasEventStreamingStub(t testing.TB) *hasEventStreamingStub {
 	return &hasEventStreamingStub{
 		MockStreamingConnector: testutils.NewMockStreamingConnector(t),
+		exists:                 map[dedupe.Item]struct{}{},
 	}
 }
 
 func (s *hasEventStreamingStub) ListEventsV2(_ context.Context, params streaming.ListEventsV2Params) ([]streaming.RawEvent, error) {
-	s.lastParams = &params
+	s.calls = append(s.calls, params)
 
 	if s.err != nil {
 		return nil, s.err
 	}
 
-	return s.events, nil
+	source := lo.Empty[string]()
+	if params.Source != nil && params.Source.Eq != nil {
+		source = *params.Source.Eq
+	}
+
+	events := []streaming.RawEvent{}
+	ids := lo.FromPtr(params.ID.In)
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		item := dedupe.Item{
+			Namespace: params.Namespace,
+			Source:    source,
+			ID:        id,
+		}
+		if _, ok := s.exists[item]; !ok {
+			continue
+		}
+		events = append(events, streaming.RawEvent{
+			Namespace:  params.Namespace,
+			ID:         id,
+			Source:     source,
+			Time:       time.Now(),
+			StoreRowID: id + "-row",
+		})
+	}
+
+	return events, nil
 }
 
-func TestClickHouseStorageHasEvent(t *testing.T) {
+func TestClickHouseStorageHasEvents_BatchesByNamespaceAndSource(t *testing.T) {
 	stub := newHasEventStreamingStub(t)
 	storage := &ClickHouseStorage{
 		config: ClickHouseStorageConfig{
@@ -41,31 +73,30 @@ func TestClickHouseStorageHasEvent(t *testing.T) {
 		},
 	}
 
-	message := testSinkMessage("tenant-b", "evt-2", "gateway")
-
-	found, err := storage.HasEvent(t.Context(), message)
-	require.NoError(t, err)
-	require.False(t, found)
-	require.NotNil(t, stub.lastParams)
-	require.Equal(t, "tenant-b", stub.lastParams.Namespace)
-	require.NotNil(t, stub.lastParams.ID)
-	require.NotNil(t, stub.lastParams.ID.Eq)
-	require.Equal(t, "evt-2", *stub.lastParams.ID.Eq)
-	require.NotNil(t, stub.lastParams.Source)
-	require.NotNil(t, stub.lastParams.Source.Eq)
-	require.Equal(t, "gateway", *stub.lastParams.Source.Eq)
-	require.NotNil(t, stub.lastParams.Limit)
-	require.Equal(t, 1, *stub.lastParams.Limit)
-
-	stub.events = []streaming.RawEvent{
-		{
-			Namespace: "tenant-b",
-			ID:        "evt-2",
-			Source:    "gateway",
-		},
+	items := []dedupe.Item{
+		{Namespace: "tenant-b", Source: "gateway", ID: "evt-1"},
+		{Namespace: "tenant-b", Source: "gateway", ID: "evt-2"},
+		{Namespace: "tenant-b", Source: "worker", ID: "evt-3"},
+		{Namespace: "tenant-c", Source: "gateway", ID: "evt-4"},
 	}
 
-	found, err = storage.HasEvent(t.Context(), message)
+	stub.exists[items[0]] = struct{}{}
+	stub.exists[items[2]] = struct{}{}
+
+	found, err := storage.HasEvents(t.Context(), items)
 	require.NoError(t, err)
-	require.True(t, found)
+	require.Equal(t, dedupe.ItemSet{
+		items[0]: {},
+		items[2]: {},
+	}, found)
+
+	require.Len(t, stub.calls, 3)
+	for _, call := range stub.calls {
+		require.NotNil(t, call.ID)
+		require.NotNil(t, call.ID.In)
+		require.NotNil(t, call.Source)
+		require.NotNil(t, call.Source.Eq)
+		require.NotNil(t, call.Limit)
+		require.LessOrEqual(t, len(*call.ID.In), existsQueryBatchSize)
+	}
 }

--- a/openmeter/sink/storage_test.go
+++ b/openmeter/sink/storage_test.go
@@ -1,0 +1,71 @@
+package sink
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+)
+
+type hasEventStreamingStub struct {
+	*testutils.MockStreamingConnector
+	events     []streaming.RawEvent
+	err        error
+	lastParams *streaming.ListEventsV2Params
+}
+
+func newHasEventStreamingStub(t testing.TB) *hasEventStreamingStub {
+	return &hasEventStreamingStub{
+		MockStreamingConnector: testutils.NewMockStreamingConnector(t),
+	}
+}
+
+func (s *hasEventStreamingStub) ListEventsV2(_ context.Context, params streaming.ListEventsV2Params) ([]streaming.RawEvent, error) {
+	s.lastParams = &params
+
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.events, nil
+}
+
+func TestClickHouseStorageHasEvent(t *testing.T) {
+	stub := newHasEventStreamingStub(t)
+	storage := &ClickHouseStorage{
+		config: ClickHouseStorageConfig{
+			Streaming: stub,
+		},
+	}
+
+	message := testSinkMessage("tenant-b", "evt-2", "gateway")
+
+	found, err := storage.HasEvent(t.Context(), message)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.NotNil(t, stub.lastParams)
+	require.Equal(t, "tenant-b", stub.lastParams.Namespace)
+	require.NotNil(t, stub.lastParams.ID)
+	require.NotNil(t, stub.lastParams.ID.Eq)
+	require.Equal(t, "evt-2", *stub.lastParams.ID.Eq)
+	require.NotNil(t, stub.lastParams.Source)
+	require.NotNil(t, stub.lastParams.Source.Eq)
+	require.Equal(t, "gateway", *stub.lastParams.Source.Eq)
+	require.NotNil(t, stub.lastParams.Limit)
+	require.Equal(t, 1, *stub.lastParams.Limit)
+
+	stub.events = []streaming.RawEvent{
+		{
+			Namespace: "tenant-b",
+			ID:        "evt-2",
+			Source:    "gateway",
+		},
+	}
+
+	found, err = storage.HasEvent(t.Context(), message)
+	require.NoError(t, err)
+	require.True(t, found)
+}


### PR DESCRIPTION
## Overview

Sink-side dedupe can classify a Kafka replay as already processed even when the corresponding event is absent from durable storage. This creates a post-accept loss window: the API succeeds and Kafka retains the event, but the replacement sink worker drops replay solely because Redis contains the stable ID.

We observed this during an EKS node rollout: 77 seconds of audited usage were absent from ClickHouse despite successful API responses and healthy producer metrics.

This change moves replay classification to flush planning and combines two batched checks:

- Redis `CheckUniqueBatch` determines whether each ID is new or already known.
- A batched ClickHouse existence lookup confirms whether each exact `(namespace, source, id)` is durable.

The resulting state machine is:

- unique + not durable: insert, then set dedupe
- unique + durable: do not insert; restore the missing dedupe key
- existing + durable: do not insert
- existing + not durable: reinsert without rewriting the existing dedupe key

Invalid/dropped events stay outside durability checks, and incomplete dedupe classifications fail closed instead of silently discarding an event.

## Notes for reviewer

The implementation preserves batch behavior: one Redis classification call, one Redis Set pipeline, and ClickHouse existence queries grouped by namespace/source and chunked to 200 IDs. It removes the unsafe parse-time duplicate drop.

The tests deterministically cover both crash boundaries, dropped/missing identities, state restoration, incomplete classifications, and batch call counts.

Verification:

```text
go test ./openmeter/sink/...
```

Companion repair tooling: https://github.com/voltagepark/takao/pull/2850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event deduplication during batch processing and replay scenarios.
  - Prevented duplicate events from being persisted when durable storage already contains them.
  - Preserved offset reconciliation when deduplication encounters errors.
  - Skipped invalid or incomplete events safely during deduplication.

- **Performance**
  - Added batched storage checks and deduplication writes to reduce redundant operations.

- **Tests**
  - Added coverage for durable storage, replay handling, missing identities, invalid results, batching, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves replay classification from parse time into flush planning, combining Redis dedupe classification with ClickHouse durability checks to close the post-accept event-loss window.

- Adds a four-state flush plan for unique/existing and durable/non-durable events.
- Adds batched, namespace/source-grouped ClickHouse existence checks.
- Defers dedupe-key updates until after successful persistence and Kafka offset handling.
- Adds deterministic tests for replay recovery states, incomplete classifications, batching, and dedupe pipelines.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking cleanup needed for suppressed dropped-event warnings and an unused helper.

The durability-aware replay paths are coherently implemented and tested, while the accepted issues affect operational diagnostics and maintainability rather than durable event correctness.

**Files Needing Attention:** openmeter/sink/sink.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/sink/sink.go | Introduces durability-aware flush planning and removes parse-time replay dropping; also suppresses configured DROP-event warnings and leaves one dead helper. |
| openmeter/sink/storage.go | Extends sink storage with grouped and chunked exact-identity existence checks using the streaming query API. |
| openmeter/sink/sink_dedupe_test.go | Covers the replay state matrix, incomplete dedupe classifications, and batched dedupe behavior. |
| openmeter/sink/storage_test.go | Verifies existence checks are grouped by namespace and source and respect the query batch limit. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Buffered valid event] --> B[Redis CheckUniqueBatch]
  B --> C[ClickHouse HasEvents]
  C --> D{Dedupe and durability state}
  D -->|Unique, not durable| E[Insert event]
  D -->|Unique, durable| F[Skip insert]
  D -->|Existing, not durable| G[Reinsert event]
  D -->|Existing, durable| H[Skip insert]
  E --> I[Store Kafka offset]
  F --> I
  G --> I
  H --> I
  I --> J{Unique in Redis?}
  J -->|Yes| K[Set or restore dedupe key]
  J -->|No| L[Keep existing dedupe key]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fsink%2Fsink.go%3A407-410%0A**Dropped-event%20warnings%20are%20suppressed**%0A%0AWith%20a%20deduplicator%20configured%2C%20filtering%20%60DROP%60%20messages%20out%20of%20the%20flush%20plan%20prevents%20them%20from%20reaching%20the%20existing%20%60LogDroppedEvents%60%20branch%20in%20%60persistToStorage%60%2C%20so%20configured%20warnings%20disappear%20while%20their%20Kafka%20offsets%20still%20advance.%0A%0A%23%23%23%20Issue%202%0Aopenmeter%2Fsink%2Fsink.go%3A481-491%0A**Remove%20the%20unused%20dedupe%20helper**%0A%0A%60dedupeItemsFromMessages%60%20has%20no%20callers%20and%20duplicates%20the%20iteration%20already%20performed%20by%20%60planFlushMessages%60%2C%20adding%20misleading%20maintenance%20surface%20without%20encapsulating%20any%20reused%20behavior.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4902&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22fix%2Fsink-exactly-once-v1beta231%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsink-exactly-once-v1beta231%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fsink%2Fsink.go%3A407-410%0A**Dropped-event%20warnings%20are%20suppressed**%0A%0AWith%20a%20deduplicator%20configured%2C%20filtering%20%60DROP%60%20messages%20out%20of%20the%20flush%20plan%20prevents%20them%20from%20reaching%20the%20existing%20%60LogDroppedEvents%60%20branch%20in%20%60persistToStorage%60%2C%20so%20configured%20warnings%20disappear%20while%20their%20Kafka%20offsets%20still%20advance.%0A%0A%23%23%23%20Issue%202%0Aopenmeter%2Fsink%2Fsink.go%3A481-491%0A**Remove%20the%20unused%20dedupe%20helper**%0A%0A%60dedupeItemsFromMessages%60%20has%20no%20callers%20and%20duplicates%20the%20iteration%20already%20performed%20by%20%60planFlushMessages%60%2C%20adding%20misleading%20maintenance%20surface%20without%20encapsulating%20any%20reused%20behavior.%0A%0A%60%60%60suggestion%0A%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4902&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/sink/sink.go:407-410
**Dropped-event warnings are suppressed**

With a deduplicator configured, filtering `DROP` messages out of the flush plan prevents them from reaching the existing `LogDroppedEvents` branch in `persistToStorage`, so configured warnings disappear while their Kafka offsets still advance.

### Issue 2
openmeter/sink/sink.go:481-491
**Remove the unused dedupe helper**

`dedupeItemsFromMessages` has no callers and duplicates the iteration already performed by `planFlushMessages`, adding misleading maintenance surface without encapsulating any reused behavior.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sink): reject incomplete dedupe clas..."](https://github.com/openmeterio/openmeter/commit/e95fd486f8880e15a5c1bc3299888a39f40ae1f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52009545)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/openmeterio/openmeter/blob/main/AGENTS.md))
- Knowledge Base — [Ingest, Dedupe, and Metering Flow](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/ingest-metering.md)

<!-- /greptile_comment -->