### PR TITLE
refactor(credit): simplify grant prioritization

### DIFF
--- a/openmeter/credit/engine/grant.go
+++ b/openmeter/credit/engine/grant.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"cmp"
 	"slices"
 	"sort"
 	"strings"
@@ -167,63 +168,37 @@ func (e *engine) filterRelevantGrants(grants []grant.Grant, bm balance.Map, peri
 	return relevant
 }
 
-// The correct order to burn down grants is:
-// 1. Grants with higher priority are burned down first
-// 2. Grants with earlier expiration date are burned down first
-// 3. For a deterministic order, we sort by our general cursor which is created_at + id
-//
-// TODO: figure out if this needs to return an error or not
-func PrioritizeGrants(grants []grant.Grant) error {
-	if len(grants) == 0 {
-		// we don't do a thing, return early
-		// return fmt.Errorf("no grants to prioritize")
-		return nil
+// PrioritizeGrants orders grants in place by burn-down precedence.
+// Lower priority numbers, earlier expirations, and earlier creation cursors burn down first.
+func PrioritizeGrants(grants []grant.Grant) {
+	slices.SortStableFunc(grants, compareGrantsByBurnDownOrder)
+}
+
+func compareGrantsByBurnDownOrder(i, j grant.Grant) int {
+	if priorityOrder := cmp.Compare(i.Priority, j.Priority); priorityOrder != 0 {
+		return priorityOrder
 	}
 
-	// 3. As a tie breaker, we use our general cursor which is created_at then id
-	slices.SortStableFunc(grants, func(i, j grant.Grant) int {
-		switch {
-		case i.CreatedAt.Before(j.CreatedAt):
-			return -1
-		case i.CreatedAt.After(j.CreatedAt):
-			return 1
-		default:
-			return strings.Compare(i.ID, j.ID)
+	iExpiration := i.GetExpiration()
+	jExpiration := j.GetExpiration()
+
+	if iExpiration == nil && jExpiration != nil {
+		return 1
+	}
+
+	if iExpiration != nil && jExpiration == nil {
+		return -1
+	}
+
+	if iExpiration != nil && jExpiration != nil {
+		if expirationOrder := cmp.Compare(iExpiration.Unix(), jExpiration.Unix()); expirationOrder != 0 {
+			return expirationOrder
 		}
-	})
+	}
 
-	// 2. Grants with earlier expiration date are burned down first
-	slices.SortStableFunc(grants, func(i, j grant.Grant) int {
-		exp1 := i.GetExpiration()
-		exp2 := j.GetExpiration()
+	if creationOrder := i.CreatedAt.Compare(j.CreatedAt); creationOrder != 0 {
+		return creationOrder
+	}
 
-		switch {
-		// If both have no expiration, we keep the order
-		case exp1 == nil && exp2 == nil:
-			return 0
-		// If the second has an expiration, we put it first
-		case exp1 == nil && exp2 != nil:
-			return 1
-		// If the first has an expiration, we put it first
-		case exp2 == nil && exp1 != nil:
-			return -1
-		}
-
-		// Otherwise we compare the expiration dates
-		switch u1, u2 := exp1.Unix(), exp2.Unix(); {
-		case u1 < u2:
-			return -1
-		case u1 > u2:
-			return 1
-		default:
-			return 0
-		}
-	})
-
-	// 1. Order grant balances by priority
-	sort.SliceStable(grants, func(i, j int) bool {
-		return grants[i].Priority < grants[j].Priority
-	})
-
-	return nil
+	return strings.Compare(i.ID, j.ID)
 }

--- a/openmeter/credit/engine/grant_test.go
+++ b/openmeter/credit/engine/grant_test.go
@@ -1,0 +1,79 @@
+package engine_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/engine"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestPrioritizeGrants(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expiresAfterHour := &grant.ExpirationPeriod{
+		Duration: grant.ExpirationPeriodDurationHour,
+		Count:    1,
+	}
+
+	grants := []grant.Grant{
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-4 * time.Hour)},
+			ID:           "no-expiration",
+			Priority:     1,
+		},
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-4 * time.Hour)},
+			ID:           "lower-priority",
+			Priority:     2,
+			EffectiveAt:  base.Add(-time.Hour),
+			Expiration:   expiresAfterHour,
+		},
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-2 * time.Hour)},
+			ID:           "created-first",
+			Priority:     1,
+			EffectiveAt:  base.Add(900 * time.Millisecond),
+			Expiration:   expiresAfterHour,
+		},
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-time.Hour)},
+			ID:           "cursor-b",
+			Priority:     1,
+			EffectiveAt:  base.Add(500 * time.Millisecond),
+			Expiration:   expiresAfterHour,
+		},
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-time.Hour)},
+			ID:           "cursor-a",
+			Priority:     1,
+			EffectiveAt:  base.Add(100 * time.Millisecond),
+			Expiration:   expiresAfterHour,
+		},
+		{
+			ManagedModel: models.ManagedModel{CreatedAt: base.Add(-3 * time.Hour)},
+			ID:           "later-expiration",
+			Priority:     1,
+			EffectiveAt:  base.Add(time.Hour),
+			Expiration:   expiresAfterHour,
+		},
+	}
+
+	engine.PrioritizeGrants(grants)
+
+	grantIDs := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		grantIDs = append(grantIDs, grant.ID)
+	}
+
+	require.Equal(t, []string{
+		"created-first",
+		"cursor-a",
+		"cursor-b",
+		"later-expiration",
+		"no-expiration",
+		"lower-priority",
+	}, grantIDs)
+}

--- a/openmeter/credit/engine/reset.go
+++ b/openmeter/credit/engine/reset.go
@@ -43,9 +43,7 @@ func (e *engine) reset(grants []grant.Grant, snap balance.Snapshot, behavior gra
 	}
 
 	prioritizedGrants := slices.Clone(grants)
-	if err := PrioritizeGrants(prioritizedGrants); err != nil {
-		return balance.Snapshot{}, fmt.Errorf("failed to prioritize grants: %w", err)
-	}
+	PrioritizeGrants(prioritizedGrants)
 
 	rolledOver, _, startingOverage = e.burnDownGrants(rolledOver, prioritizedGrants, startingOverage)
 

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -137,10 +137,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 	}
 	phases := phasePlan.phases
 
-	err = PrioritizeGrants(grants)
-	if err != nil {
-		return RunResult{}, fmt.Errorf("failed to prioritize grants: %w", err)
-	}
+	PrioritizeGrants(grants)
 
 	// Only respect balances that we know the grants of, otherwise we cannot guarantee
 	// that the output balance is correct for said grants.
@@ -178,10 +175,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 	for _, phase := range phases {
 		// reprioritize grants if needed
 		if rePrioritize {
-			err = PrioritizeGrants(grants)
-			if err != nil {
-				return RunResult{}, fmt.Errorf("failed to prioritize grants: %w", err)
-			}
+			PrioritizeGrants(grants)
 			rePrioritize = false
 		}
 


### PR DESCRIPTION
## Summary

- replace three chained stable sorts with one compound burn-down comparator
- remove the impossible error return and dead caller-side error handling
- add direct characterization coverage for the complete ordering contract

## Why

`PrioritizeGrants` performed three full stable sorts to build one lexicographic order and exposed an error that it could never return. The new comparator expresses the precedence directly while preserving priority, Unix-second expiration, creation time, and ID ordering.

## Validation

- `go test -tags=dynamic ./openmeter/credit/engine -count=1`
- `go vet -tags=dynamic ./openmeter/credit/engine`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR simplifies grant prioritization by replacing three chained stable sorts with one compound comparator and removes an error return that could never produce an error.
- Preserves ordering by priority, Unix-second expiration, creation time, and ID.
- Updates reset and run paths for the simplified function signature.
- Adds direct characterization coverage for the ordering contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the grant burn-down ordering preserved.

The compound comparator reproduces the previous stable-sort precedence, and removing the error result is safe because the prior implementation returned nil on every path and all repository callers were updated.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/credit/engine/grant.go | Replaces chained stable sorts with an equivalent compound burn-down comparator and removes the unreachable error return. |
| openmeter/credit/engine/grant_test.go | Adds coverage for priority, expiration, creation-time, ID, and non-expiring grant ordering. |
| openmeter/credit/engine/reset.go | Updates reset processing to call the now-infallible prioritization function directly. |
| openmeter/credit/engine/run.go | Removes unreachable prioritization error handling from initial and phase-triggered sorting. |

<sub>Reviews (1): Last reviewed commit: ["refactor(credit): simplify grant priorit..."](https://github.com/openmeterio/openmeter/commit/65ba70406d9f4218dbff43683d76987eb28d3217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52124950)</sub>

**Context used:**

- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Credit grants are now consistently prioritized by priority, expiration, creation time, and ID.
  * Grant processing no longer reports prioritization failures, providing simpler and more reliable execution.
* **Tests**
  * Added coverage to verify grant ordering across different priorities, dates, expiration settings, and IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->