### PR TITLE
refactor(ledger): deduplicate route queries

### DIFF
--- a/openmeter/ledger/breakage/adapter/query.go
+++ b/openmeter/ledger/breakage/adapter/query.go
@@ -1,17 +1,12 @@
 package adapter
 
 import (
-	"fmt"
-
-	"entgo.io/ent/dialect"
 	sql "entgo.io/ent/dialect/sql"
-	"github.com/lib/pq"
 
 	dbledgerbreakagerecord "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerbreakagerecord"
-	ledgersubaccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
-	ledgersubaccountroutedb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/internal/routequery"
 )
 
 func expiredRecordRoutePredicate(route ledger.RouteFilter) (predicate.LedgerBreakageRecord, error) {
@@ -19,151 +14,12 @@ func expiredRecordRoutePredicate(route ledger.RouteFilter) (predicate.LedgerBrea
 		return nil, nil
 	}
 
-	query, err := newExpiredRecordRouteQuery(route)
+	query, err := routequery.NewSubAccountIDsByRoute(route)
 	if err != nil {
 		return nil, err
 	}
 
 	return func(s *sql.Selector) {
-		s.Where(query.predicate(s.C(dbledgerbreakagerecord.FieldFboSubAccountID)))
+		s.Where(query.Predicate(s.C(dbledgerbreakagerecord.FieldFboSubAccountID)))
 	}, nil
-}
-
-type expiredRecordRouteQuery struct {
-	Route              ledger.RouteFilter
-	serializedCurrency *string
-	currencyPrefix     bool
-}
-
-func newExpiredRecordRouteQuery(route ledger.RouteFilter) (expiredRecordRouteQuery, error) {
-	query := expiredRecordRouteQuery{Route: route}
-	if route.Currency.Code == "" {
-		return query, nil
-	}
-
-	var serialized []byte
-	var err error
-	if route.Currency.IsCustom() && !route.Currency.IsResolved() {
-		serialized, err = route.Currency.MarshalTextPrefix()
-		query.currencyPrefix = true
-	} else {
-		serialized, err = route.Currency.MarshalText()
-	}
-	if err != nil {
-		return expiredRecordRouteQuery{}, fmt.Errorf("serialize route currency filter: %w", err)
-	}
-	value := string(serialized)
-	query.serializedCurrency = &value
-
-	return query, nil
-}
-
-func (q expiredRecordRouteQuery) predicate(fboSubAccountIDColumn string) *sql.Predicate {
-	return sql.In(fboSubAccountIDColumn, q.selector())
-}
-
-func (q expiredRecordRouteQuery) SQL() (string, []any) {
-	selector := q.selector()
-	selector.SetDialect(dialect.Postgres)
-
-	return selector.Query()
-}
-
-func (q expiredRecordRouteQuery) selector() *sql.Selector {
-	const (
-		subAccountTableAlias = "lsa"
-		routeTableAlias      = "lsar"
-	)
-
-	subAccounts := sql.Table(ledgersubaccountdb.Table).As(subAccountTableAlias)
-	routes := sql.Table(ledgersubaccountroutedb.Table).As(routeTableAlias)
-
-	selector := sql.Select(subAccounts.C(ledgersubaccountdb.FieldID)).
-		From(subAccounts).
-		Join(routes).
-		On(subAccounts.C(ledgersubaccountdb.FieldRouteID), routes.C(ledgersubaccountroutedb.FieldID))
-
-	for _, predicate := range q.selectorPredicates(routes.C, routeTableAlias) {
-		selector.Where(predicate)
-	}
-
-	return selector
-}
-
-func (q expiredRecordRouteQuery) selectorPredicates(routeColumn func(string) string, routeTableAlias string) []*sql.Predicate {
-	predicates := make([]*sql.Predicate, 0, 3)
-
-	if q.serializedCurrency != nil {
-		if q.currencyPrefix {
-			predicates = append(predicates, sql.Like(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency+"%"))
-		} else {
-			predicates = append(predicates, sql.EQ(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency))
-		}
-	}
-
-	if q.Route.Features.IsPresent() {
-		features, _ := q.Route.Features.Get()
-		features = ledger.SortedFeatures(features)
-		if len(features) == 0 {
-			predicates = append(predicates, sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)))
-		} else {
-			predicates = append(predicates, postgresArrayRouteExpression{
-				Column: postgresQualifiedColumn{
-					TableAlias: routeTableAlias,
-					Field:      ledgersubaccountroutedb.FieldFeatures,
-				},
-				Operator: postgresArrayRouteOperatorEqual,
-				Value:    pq.StringArray(features),
-			}.predicate())
-		}
-	}
-
-	if q.Route.MatchFeature != "" {
-		predicates = append(predicates, sql.Or(
-			sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)),
-			postgresArrayRouteExpression{
-				Column: postgresQualifiedColumn{
-					TableAlias: routeTableAlias,
-					Field:      ledgersubaccountroutedb.FieldFeatures,
-				},
-				Operator: postgresArrayRouteOperatorContains,
-				Value:    pq.StringArray{q.Route.MatchFeature},
-			}.predicate(),
-		))
-	}
-
-	return predicates
-}
-
-type postgresArrayRouteOperator string
-
-const (
-	postgresArrayRouteOperatorEqual    postgresArrayRouteOperator = "="
-	postgresArrayRouteOperatorContains postgresArrayRouteOperator = "@>"
-)
-
-type postgresQualifiedColumn struct {
-	TableAlias string
-	Field      string
-}
-
-func (c postgresQualifiedColumn) ident(b *sql.Builder) {
-	b.Ident(c.TableAlias).WriteString(".").Ident(c.Field)
-}
-
-type postgresArrayRouteExpression struct {
-	Column   postgresQualifiedColumn
-	Operator postgresArrayRouteOperator
-	Value    pq.StringArray
-}
-
-func (e postgresArrayRouteExpression) predicate() *sql.Predicate {
-	return sql.P(func(b *sql.Builder) {
-		e.appendSQL(b)
-	})
-}
-
-func (e postgresArrayRouteExpression) appendSQL(b *sql.Builder) {
-	e.Column.ident(b)
-	b.WriteString(" ").WriteString(string(e.Operator)).WriteString(" ").Arg(e.Value)
 }

--- a/openmeter/ledger/creditvoid/adapter/query.go
+++ b/openmeter/ledger/creditvoid/adapter/query.go
@@ -1,17 +1,12 @@
 package adapter
 
 import (
-	"fmt"
-
-	"entgo.io/ent/dialect"
 	sql "entgo.io/ent/dialect/sql"
-	"github.com/lib/pq"
 
 	dbledgercreditvoidrecord "github.com/openmeterio/openmeter/openmeter/ent/db/ledgercreditvoidrecord"
-	ledgersubaccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
-	ledgersubaccountroutedb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/internal/routequery"
 )
 
 func voidRecordRoutePredicate(route ledger.RouteFilter) (predicate.LedgerCreditVoidRecord, error) {
@@ -19,151 +14,12 @@ func voidRecordRoutePredicate(route ledger.RouteFilter) (predicate.LedgerCreditV
 		return nil, nil
 	}
 
-	query, err := newVoidRecordRouteQuery(route)
+	query, err := routequery.NewSubAccountIDsByRoute(route)
 	if err != nil {
 		return nil, err
 	}
 
 	return func(s *sql.Selector) {
-		s.Where(query.predicate(s.C(dbledgercreditvoidrecord.FieldFboSubAccountID)))
+		s.Where(query.Predicate(s.C(dbledgercreditvoidrecord.FieldFboSubAccountID)))
 	}, nil
-}
-
-type voidRecordRouteQuery struct {
-	Route              ledger.RouteFilter
-	serializedCurrency *string
-	currencyPrefix     bool
-}
-
-func newVoidRecordRouteQuery(route ledger.RouteFilter) (voidRecordRouteQuery, error) {
-	query := voidRecordRouteQuery{Route: route}
-	if route.Currency.Code == "" {
-		return query, nil
-	}
-
-	var serialized []byte
-	var err error
-	if route.Currency.IsCustom() && !route.Currency.IsResolved() {
-		serialized, err = route.Currency.MarshalTextPrefix()
-		query.currencyPrefix = true
-	} else {
-		serialized, err = route.Currency.MarshalText()
-	}
-	if err != nil {
-		return voidRecordRouteQuery{}, fmt.Errorf("serialize route currency filter: %w", err)
-	}
-	value := string(serialized)
-	query.serializedCurrency = &value
-
-	return query, nil
-}
-
-func (q voidRecordRouteQuery) predicate(fboSubAccountIDColumn string) *sql.Predicate {
-	return sql.In(fboSubAccountIDColumn, q.selector())
-}
-
-func (q voidRecordRouteQuery) SQL() (string, []any) {
-	selector := q.selector()
-	selector.SetDialect(dialect.Postgres)
-
-	return selector.Query()
-}
-
-func (q voidRecordRouteQuery) selector() *sql.Selector {
-	const (
-		subAccountTableAlias = "lsa"
-		routeTableAlias      = "lsar"
-	)
-
-	subAccounts := sql.Table(ledgersubaccountdb.Table).As(subAccountTableAlias)
-	routes := sql.Table(ledgersubaccountroutedb.Table).As(routeTableAlias)
-
-	selector := sql.Select(subAccounts.C(ledgersubaccountdb.FieldID)).
-		From(subAccounts).
-		Join(routes).
-		On(subAccounts.C(ledgersubaccountdb.FieldRouteID), routes.C(ledgersubaccountroutedb.FieldID))
-
-	for _, predicate := range q.selectorPredicates(routes.C, routeTableAlias) {
-		selector.Where(predicate)
-	}
-
-	return selector
-}
-
-func (q voidRecordRouteQuery) selectorPredicates(routeColumn func(string) string, routeTableAlias string) []*sql.Predicate {
-	predicates := make([]*sql.Predicate, 0, 3)
-
-	if q.serializedCurrency != nil {
-		if q.currencyPrefix {
-			predicates = append(predicates, sql.Like(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency+"%"))
-		} else {
-			predicates = append(predicates, sql.EQ(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency))
-		}
-	}
-
-	if q.Route.Features.IsPresent() {
-		features, _ := q.Route.Features.Get()
-		features = ledger.SortedFeatures(features)
-		if len(features) == 0 {
-			predicates = append(predicates, sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)))
-		} else {
-			predicates = append(predicates, postgresArrayRouteExpression{
-				Column: postgresQualifiedColumn{
-					TableAlias: routeTableAlias,
-					Field:      ledgersubaccountroutedb.FieldFeatures,
-				},
-				Operator: postgresArrayRouteOperatorEqual,
-				Value:    pq.StringArray(features),
-			}.predicate())
-		}
-	}
-
-	if q.Route.MatchFeature != "" {
-		predicates = append(predicates, sql.Or(
-			sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)),
-			postgresArrayRouteExpression{
-				Column: postgresQualifiedColumn{
-					TableAlias: routeTableAlias,
-					Field:      ledgersubaccountroutedb.FieldFeatures,
-				},
-				Operator: postgresArrayRouteOperatorContains,
-				Value:    pq.StringArray{q.Route.MatchFeature},
-			}.predicate(),
-		))
-	}
-
-	return predicates
-}
-
-type postgresArrayRouteOperator string
-
-const (
-	postgresArrayRouteOperatorEqual    postgresArrayRouteOperator = "="
-	postgresArrayRouteOperatorContains postgresArrayRouteOperator = "@>"
-)
-
-type postgresQualifiedColumn struct {
-	TableAlias string
-	Field      string
-}
-
-func (c postgresQualifiedColumn) ident(b *sql.Builder) {
-	b.Ident(c.TableAlias).WriteString(".").Ident(c.Field)
-}
-
-type postgresArrayRouteExpression struct {
-	Column   postgresQualifiedColumn
-	Operator postgresArrayRouteOperator
-	Value    pq.StringArray
-}
-
-func (e postgresArrayRouteExpression) predicate() *sql.Predicate {
-	return sql.P(func(b *sql.Builder) {
-		e.appendSQL(b)
-	})
-}
-
-func (e postgresArrayRouteExpression) appendSQL(b *sql.Builder) {
-	e.Column.ident(b)
-	b.WriteString(" ").WriteString(string(e.Operator)).WriteString(" ").Arg(e.Value)
 }

--- a/openmeter/ledger/internal/routequery/subaccount_ids.go
+++ b/openmeter/ledger/internal/routequery/subaccount_ids.go
@@ -1,0 +1,152 @@
+package routequery
+
+import (
+	"fmt"
+
+	"entgo.io/ent/dialect"
+	sql "entgo.io/ent/dialect/sql"
+	"github.com/lib/pq"
+
+	ledgersubaccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
+	ledgersubaccountroutedb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+)
+
+// SubAccountIDsByRoute selects ledger subaccount IDs whose persisted route matches a filter.
+type SubAccountIDsByRoute struct {
+	route              ledger.RouteFilter
+	serializedCurrency *string
+	currencyPrefix     bool
+}
+
+// NewSubAccountIDsByRoute prepares a route query, including its persisted currency representation.
+func NewSubAccountIDsByRoute(route ledger.RouteFilter) (SubAccountIDsByRoute, error) {
+	query := SubAccountIDsByRoute{route: route}
+	if route.Currency.Code == "" {
+		return query, nil
+	}
+
+	var serialized []byte
+	var err error
+	if route.Currency.IsCustom() && !route.Currency.IsResolved() {
+		serialized, err = route.Currency.MarshalTextPrefix()
+		query.currencyPrefix = true
+	} else {
+		serialized, err = route.Currency.MarshalText()
+	}
+	if err != nil {
+		return SubAccountIDsByRoute{}, fmt.Errorf("serialize route currency filter: %w", err)
+	}
+
+	value := string(serialized)
+	query.serializedCurrency = &value
+
+	return query, nil
+}
+
+// Predicate matches a subaccount ID column against the selected IDs.
+func (q SubAccountIDsByRoute) Predicate(subAccountIDColumn string) *sql.Predicate {
+	return sql.In(subAccountIDColumn, q.selector())
+}
+
+func (q SubAccountIDsByRoute) sql() (string, []any) {
+	selector := q.selector()
+	selector.SetDialect(dialect.Postgres)
+
+	return selector.Query()
+}
+
+func (q SubAccountIDsByRoute) selector() *sql.Selector {
+	const (
+		subAccountTableAlias = "lsa"
+		routeTableAlias      = "lsar"
+	)
+
+	subAccounts := sql.Table(ledgersubaccountdb.Table).As(subAccountTableAlias)
+	routes := sql.Table(ledgersubaccountroutedb.Table).As(routeTableAlias)
+
+	selector := sql.Select(subAccounts.C(ledgersubaccountdb.FieldID)).
+		From(subAccounts).
+		Join(routes).
+		On(subAccounts.C(ledgersubaccountdb.FieldRouteID), routes.C(ledgersubaccountroutedb.FieldID))
+
+	for _, predicate := range q.selectorPredicates(routes.C, routeTableAlias) {
+		selector.Where(predicate)
+	}
+
+	return selector
+}
+
+func (q SubAccountIDsByRoute) selectorPredicates(routeColumn func(string) string, routeTableAlias string) []*sql.Predicate {
+	predicates := make([]*sql.Predicate, 0, 3)
+
+	if q.serializedCurrency != nil {
+		if q.currencyPrefix {
+			predicates = append(predicates, sql.Like(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency+"%"))
+		} else {
+			predicates = append(predicates, sql.EQ(routeColumn(ledgersubaccountroutedb.FieldCurrency), *q.serializedCurrency))
+		}
+	}
+
+	if q.route.Features.IsPresent() {
+		features, _ := q.route.Features.Get()
+		features = ledger.SortedFeatures(features)
+		if len(features) == 0 {
+			predicates = append(predicates, sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)))
+		} else {
+			predicates = append(predicates, postgresArrayRouteExpression{
+				column: postgresQualifiedColumn{
+					tableAlias: routeTableAlias,
+					field:      ledgersubaccountroutedb.FieldFeatures,
+				},
+				operator: postgresArrayRouteOperatorEqual,
+				value:    pq.StringArray(features),
+			}.predicate())
+		}
+	}
+
+	if q.route.MatchFeature != "" {
+		predicates = append(predicates, sql.Or(
+			sql.IsNull(routeColumn(ledgersubaccountroutedb.FieldFeatures)),
+			postgresArrayRouteExpression{
+				column: postgresQualifiedColumn{
+					tableAlias: routeTableAlias,
+					field:      ledgersubaccountroutedb.FieldFeatures,
+				},
+				operator: postgresArrayRouteOperatorContains,
+				value:    pq.StringArray{q.route.MatchFeature},
+			}.predicate(),
+		))
+	}
+
+	return predicates
+}
+
+type postgresArrayRouteOperator string
+
+const (
+	postgresArrayRouteOperatorEqual    postgresArrayRouteOperator = "="
+	postgresArrayRouteOperatorContains postgresArrayRouteOperator = "@>"
+)
+
+type postgresQualifiedColumn struct {
+	tableAlias string
+	field      string
+}
+
+func (c postgresQualifiedColumn) appendSQL(b *sql.Builder) {
+	b.Ident(c.tableAlias).WriteString(".").Ident(c.field)
+}
+
+type postgresArrayRouteExpression struct {
+	column   postgresQualifiedColumn
+	operator postgresArrayRouteOperator
+	value    pq.StringArray
+}
+
+func (e postgresArrayRouteExpression) predicate() *sql.Predicate {
+	return sql.P(func(b *sql.Builder) {
+		e.column.appendSQL(b)
+		b.WriteString(" ").WriteString(string(e.operator)).WriteString(" ").Arg(e.value)
+	})
+}

--- a/openmeter/ledger/internal/routequery/subaccount_ids_test.go
+++ b/openmeter/ledger/internal/routequery/subaccount_ids_test.go
@@ -1,4 +1,4 @@
-package adapter
+package routequery
 
 import (
 	"testing"
@@ -12,7 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
-func TestExpiredRecordRouteQuerySQL(t *testing.T) {
+func TestSubAccountIDsByRouteSQL(t *testing.T) {
 	tests := []struct {
 		name     string
 		route    ledger.RouteFilter
@@ -30,6 +30,15 @@ func TestExpiredRecordRouteQuerySQL(t *testing.T) {
 				"USD",
 				pq.StringArray{"feature-a", "feature-b"},
 			},
+		},
+		{
+			name: "unrestricted exact route",
+			route: ledger.RouteFilter{
+				Currency: currencies.NewCurrencyReference(currencyx.Code("USD")),
+				Features: mo.Some[[]string](nil),
+			},
+			wantSQL:  `SELECT "lsa"."id" FROM "ledger_sub_accounts" AS "lsa" JOIN "ledger_sub_account_routes" AS "lsar" ON "lsa"."route_id" = "lsar"."id" WHERE "lsar"."currency" = $1 AND "lsar"."features" IS NULL`,
+			wantArgs: []any{"USD"},
 		},
 		{
 			name: "match feature route",
@@ -55,9 +64,9 @@ func TestExpiredRecordRouteQuerySQL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			query, err := newExpiredRecordRouteQuery(tt.route)
+			query, err := NewSubAccountIDsByRoute(tt.route)
 			require.NoError(t, err)
-			gotSQL, gotArgs := query.SQL()
+			gotSQL, gotArgs := query.sql()
 
 			require.Equal(t, tt.wantSQL, gotSQL)
 			require.Equal(t, tt.wantArgs, gotArgs)


### PR DESCRIPTION
## What changed

- extract the duplicated subaccount route SQL into `ledger/internal/routequery`
- use the shared query from breakage and credit-void adapters
- move and expand exact SQL-shape coverage for route filters

## Why

Breakage and credit-void maintained equivalent Ent SQL independently. Keeping the query in one ledger-internal package prevents the two persistence paths from drifting while avoiding a new public repository abstraction.

## Impact

No intended behavior change. Route filtering continues to support exact feature sets, unrestricted routes, feature containment, and unresolved custom-currency prefixes.

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/ledger/breakage/adapter ./openmeter/ledger/creditvoid/adapter ./openmeter/ledger/internal/routequery -count=1`
- `go vet -tags=dynamic ./openmeter/ledger/breakage/adapter ./openmeter/ledger/creditvoid/adapter ./openmeter/ledger/internal/routequery`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates identical breakage and credit-void route-filter SQL into a ledger-internal package without changing query behavior.

- Adds `routequery.SubAccountIDsByRoute` as the shared route-query implementation.
- Updates both adapters to use the shared predicate.
- Moves and expands SQL-shape tests, including unrestricted and unresolved custom-currency routes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regressions identified.

The shared implementation preserves the removed query construction, parameter serialization, joins, feature filtering, and adapter predicate behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/ledger/internal/routequery/subaccount_ids.go | Directly extracts the two equivalent route-query implementations while preserving currency, feature, join, and predicate semantics. |
| openmeter/ledger/breakage/adapter/query.go | Replaces the local implementation with the equivalent shared query and retains the same breakage-record predicate integration. |
| openmeter/ledger/creditvoid/adapter/query.go | Replaces the local implementation with the equivalent shared query and retains the same credit-void predicate integration. |
| openmeter/ledger/internal/routequery/subaccount_ids_test.go | Moves SQL-shape coverage alongside the shared implementation and adds an unrestricted exact-route case. |

<sub>Reviews (1): Last reviewed commit: ["refactor(ledger): deduplicate route quer..."](https://github.com/openmeterio/openmeter/commit/ff86229844c70f589bc058b6c06ff2f0fd9e834d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52130588)</sub>

**Context used:**

- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route-based ledger filtering for expired and voided records.
  - Added support for currency, feature, and match-feature filters, including exact, prefix, null, and array-based matching.
  - Preserved behavior for unrestricted routes and correctly handles invalid query configurations.

- **Tests**
  - Expanded coverage for route query generation, including unrestricted exact-route scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->