### PR TITLE
fix(subscription): correct spec path JSON

### DIFF
--- a/openmeter/subscription/specpath.go
+++ b/openmeter/subscription/specpath.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -8,6 +9,9 @@ import (
 	"github.com/samber/lo"
 )
 
+// SpecPath identifies a phase, item, or item version within a subscription spec.
+// It reserves "/" as the path separator but otherwise treats key segments as opaque;
+// productcatalog validation owns the validity of phase and item keys.
 type SpecPath string
 
 const (
@@ -24,19 +28,23 @@ const (
 	SpecPathTypeItemVersion SpecPathType = "item_version"
 )
 
-// Lets implement JSON Unmarshaler for Path
 func (p *SpecPath) UnmarshalJSON(data []byte) error {
-	if err := SpecPath(data).Validate(); err != nil {
-		return fmt.Errorf("path validation failed: %s", err)
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("decode path: %w", err)
 	}
 
-	*p = SpecPath(data)
+	path := SpecPath(value)
+	if err := path.Validate(); err != nil {
+		return fmt.Errorf("path validation failed: %w", err)
+	}
+
+	*p = path
 	return nil
 }
 
-// Lets implement JSON Marshaler for Path
 func (p SpecPath) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, p)), nil
+	return json.Marshal(string(p))
 }
 
 func (p SpecPath) seg() []string {
@@ -62,7 +70,7 @@ func (p SpecPath) IsParentOf(other SpecPath) bool {
 	return true
 }
 
-// Lets implement validation for Path
+// Validate checks the path structure, not the contents of phase or item key segments.
 func (p SpecPath) Validate() error {
 	strVal := string(p)
 

--- a/openmeter/subscription/specpath_test.go
+++ b/openmeter/subscription/specpath_test.go
@@ -1,0 +1,105 @@
+package subscription_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+)
+
+func TestSpecPathJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     subscription.SpecPath
+		wantJSON string
+	}{
+		{
+			name:     "phase",
+			path:     subscription.NewPhasePath("phase"),
+			wantJSON: `"/phases/phase"`,
+		},
+		{
+			name:     "item",
+			path:     subscription.NewItemPath("phase", "item"),
+			wantJSON: `"/phases/phase/items/item"`,
+		},
+		{
+			name:     "item version",
+			path:     subscription.NewItemVersionPath("phase", "item", 1),
+			wantJSON: `"/phases/phase/items/item/idx/1"`,
+		},
+		{
+			name:     "opaque key content",
+			path:     subscription.NewPhasePath(`phase"key\suffix`),
+			wantJSON: `"/phases/phase\"key\\suffix"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.path.Validate())
+
+			serialized, err := json.Marshal(tt.path)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantJSON, string(serialized))
+
+			var deserialized subscription.SpecPath
+			err = json.Unmarshal(serialized, &deserialized)
+			require.NoError(t, err)
+			require.Equal(t, tt.path, deserialized)
+		})
+	}
+}
+
+func TestSpecPathJSONUnmarshalRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name           string
+		data           string
+		wantValidation bool
+	}{
+		{
+			name: "malformed JSON",
+			data: `"/phases/phase`,
+		},
+		{
+			name: "non-string JSON",
+			data: `42`,
+		},
+		{
+			name:           "null",
+			data:           `null`,
+			wantValidation: true,
+		},
+		{
+			name:           "wrong prefix",
+			data:           `"/items/item"`,
+			wantValidation: true,
+		},
+		{
+			name:           "wrong segment count",
+			data:           `"/phases/phase/items"`,
+			wantValidation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := subscription.NewPhasePath("original")
+			path := original
+
+			err := json.Unmarshal([]byte(tt.data), &path)
+
+			require.Error(t, err)
+			require.Equal(t, original, path)
+
+			var validationError *subscription.PatchValidationError
+			if tt.wantValidation {
+				require.ErrorAs(t, err, &validationError)
+			} else {
+				require.NotErrorAs(t, err, &validationError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`SpecPath.UnmarshalJSON` validated the raw JSON bytes, including the surrounding quotes, so it rejected valid encoded paths. `MarshalJSON` manually added quotes without escaping path contents.

## Impact

JSON boundaries using `SpecPath` could not decode valid paths and could emit invalid JSON for otherwise structurally valid paths containing escapable characters.

## Fix

- delegate string encoding and decoding to `encoding/json`
- validate the decoded path before updating the receiver
- document that `SpecPath` owns path structure while product catalog owns key validation
- cover every path shape, escaping, malformed and non-string JSON, invalid paths, typed validation errors, and receiver immutability

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/subscription -count=1`
- `go vet -tags=dynamic ./openmeter/subscription`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON import and export support for subscription specification paths.
  * Preserves escaped path keys during JSON round trips.
  * Validates path structure while treating phase and item keys as opaque values.

* **Bug Fixes**
  * Improved error handling for malformed, non-string, null, incorrectly prefixed, and incorrectly segmented JSON paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects `SpecPath` JSON serialization by decoding JSON strings before structural validation and relying on `encoding/json` for proper escaping.
- Preserves receiver state when decoding or validation fails.
- Retains typed path-validation errors through error wrapping.
- Adds round-trip and rejection tests covering every path shape, escaped content, malformed input, invalid paths, and non-string values.
- Clarifies the boundary between path structure and product-catalog key validation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The implementation preserves the plain JSON-string contract while fixing decoding and escaping, validates before mutating the receiver, and exercises success and failure behavior with targeted tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/subscription/specpath.go | Replaces manual JSON handling with standard-library encoding and validates decoded paths before assignment; no actionable regression found. |
| openmeter/subscription/specpath_test.go | Adds focused coverage for valid round trips, escaping, invalid JSON shapes, typed errors, and receiver immutability. |

<sub>Reviews (1): Last reviewed commit: ["fix(subscription): correct spec path JSO..."](https://github.com/openmeterio/openmeter/commit/03164ed9575241f3539b2949305b21c1c8814669) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52138961)</sub>

**Context used:**

- Knowledge Base — [Subscription](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription.md)

<!-- /greptile_comment -->