### PR TITLE
refactor(productcatalog): separate plan validation

### DIFF
--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -287,12 +287,12 @@ func ValidatePlanWithCurrencies() models.ValidatorFunc[Plan] {
 // This is the validation boundary for inline plans that are not persisted catalog resources.
 func ValidatePlanStructure() models.ValidatorFunc[Plan] {
 	return func(p Plan) error {
-		return p.ValidateWith(
-			validatePlanMetaStructure(),
-			ValidatePlanPhases(),
-			ValidatePlanCurrencyCodes(),
-			ValidatePlanBillingCadenceLiteral(),
-			ValidatePlanHasAlignedBillingCadences(),
+		return errors.Join(
+			validatePlanMetaStructure()(p),
+			ValidatePlanPhases()(p),
+			ValidatePlanCurrencyCodes()(p),
+			ValidatePlanBillingCadenceLiteral()(p),
+			ValidatePlanHasAlignedBillingCadences()(p),
 		)
 	}
 }

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -91,13 +91,7 @@ func ValidatePlanMeta() models.ValidatorFunc[Plan] {
 // ValidatePlanVersioning validates the fields required before catalog versioning assigns a version.
 func ValidatePlanVersioning() models.ValidatorFunc[Plan] {
 	return func(p Plan) error {
-		return p.PlanMeta.validateVersioning()
-	}
-}
-
-func validatePlanMetaStructure() models.ValidatorFunc[Plan] {
-	return func(p Plan) error {
-		return p.PlanMeta.validateStructure()
+		return validatePlanMetaVersioning()(p.PlanMeta)
 	}
 }
 
@@ -288,7 +282,7 @@ func ValidatePlanWithCurrencies() models.ValidatorFunc[Plan] {
 func ValidatePlanStructure() models.ValidatorFunc[Plan] {
 	return func(p Plan) error {
 		return errors.Join(
-			validatePlanMetaStructure()(p),
+			validatePlanMetaStructure()(p.PlanMeta),
 			ValidatePlanPhases()(p),
 			ValidatePlanCurrencyCodes()(p),
 			ValidatePlanBillingCadenceLiteral()(p),
@@ -324,9 +318,10 @@ func (p Plan) Equal(o Plan) bool {
 }
 
 var (
-	_ models.Validator             = (*PlanMeta)(nil)
-	_ models.CustomValidator[Plan] = (*Plan)(nil)
-	_ models.Equaler[PlanMeta]     = (*PlanMeta)(nil)
+	_ models.Validator                 = (*PlanMeta)(nil)
+	_ models.CustomValidator[Plan]     = (*Plan)(nil)
+	_ models.CustomValidator[PlanMeta] = (*PlanMeta)(nil)
+	_ models.Equaler[PlanMeta]         = (*PlanMeta)(nil)
 )
 
 type PlanMeta struct {
@@ -362,47 +357,55 @@ type PlanMeta struct {
 
 // Validate validates the PlanMeta.
 func (p PlanMeta) Validate() error {
-	return models.NewNillableGenericValidationError(errors.Join(
-		p.validateStructure(),
-		p.validateVersioning(),
-	))
+	return p.ValidateWith(
+		validatePlanMetaStructure(),
+		validatePlanMetaVersioning(),
+	)
 }
 
-func (p PlanMeta) validateStructure() error {
-	var errs []error
-
-	if err := p.Currency.Validate(); err != nil {
-		errs = append(errs, models.ErrorWithFieldPrefix(
-			models.NewFieldSelectorGroup(models.NewFieldSelector("currency")),
-			err,
-		))
-	}
-
-	if err := p.EffectivePeriod.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invalid effective period: %w", err))
-	}
-
-	if p.Name == "" {
-		errs = append(errs, ErrResourceNameEmpty)
-	}
-
-	if p.BillingCadence.IsZero() {
-		errs = append(errs, fmt.Errorf("invalid BillingCadence: must not be empty"))
-	}
-
-	if err := p.ProRatingConfig.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invalid ProRatingConfig: %s", err))
-	}
-
-	return errors.Join(errs...)
+func (p PlanMeta) ValidateWith(validators ...models.ValidatorFunc[PlanMeta]) error {
+	return models.Validate(p, validators...)
 }
 
-func (p PlanMeta) validateVersioning() error {
-	if p.Key == "" {
-		return ErrResourceKeyEmpty
-	}
+func validatePlanMetaStructure() models.ValidatorFunc[PlanMeta] {
+	return func(p PlanMeta) error {
+		var errs []error
 
-	return nil
+		if err := p.Currency.Validate(); err != nil {
+			errs = append(errs, models.ErrorWithFieldPrefix(
+				models.NewFieldSelectorGroup(models.NewFieldSelector("currency")),
+				err,
+			))
+		}
+
+		if err := p.EffectivePeriod.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid effective period: %w", err))
+		}
+
+		if p.Name == "" {
+			errs = append(errs, ErrResourceNameEmpty)
+		}
+
+		if p.BillingCadence.IsZero() {
+			errs = append(errs, fmt.Errorf("invalid BillingCadence: must not be empty"))
+		}
+
+		if err := p.ProRatingConfig.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid ProRatingConfig: %s", err))
+		}
+
+		return errors.Join(errs...)
+	}
+}
+
+func validatePlanMetaVersioning() models.ValidatorFunc[PlanMeta] {
+	return func(p PlanMeta) error {
+		if p.Key == "" {
+			return ErrResourceKeyEmpty
+		}
+
+		return nil
+	}
 }
 
 // Equal returns true if the two PlanMetas are equal.

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -81,9 +81,23 @@ func (p Plan) HasCurrencyOverrides() bool {
 	})
 }
 
+// ValidatePlanMeta validates both the identity and structure of plan metadata.
 func ValidatePlanMeta() models.ValidatorFunc[Plan] {
 	return func(p Plan) error {
 		return p.PlanMeta.Validate()
+	}
+}
+
+// ValidatePlanVersioning validates the fields required before catalog versioning assigns a version.
+func ValidatePlanVersioning() models.ValidatorFunc[Plan] {
+	return func(p Plan) error {
+		return p.PlanMeta.validateVersioning()
+	}
+}
+
+func validatePlanMetaStructure() models.ValidatorFunc[Plan] {
+	return func(p Plan) error {
+		return p.PlanMeta.validateStructure()
 	}
 }
 
@@ -269,13 +283,24 @@ func ValidatePlanWithCurrencies() models.ValidatorFunc[Plan] {
 	}
 }
 
+// ValidatePlanStructure validates the plan contents independently of its key and version.
+// This is the validation boundary for inline plans that are not persisted catalog resources.
+func ValidatePlanStructure() models.ValidatorFunc[Plan] {
+	return func(p Plan) error {
+		return p.ValidateWith(
+			validatePlanMetaStructure(),
+			ValidatePlanPhases(),
+			ValidatePlanCurrencyCodes(),
+			ValidatePlanBillingCadenceLiteral(),
+			ValidatePlanHasAlignedBillingCadences(),
+		)
+	}
+}
+
 func (p Plan) Validate() error {
 	return p.ValidateWith(
-		ValidatePlanMeta(),
-		ValidatePlanPhases(),
-		ValidatePlanCurrencyCodes(),
-		ValidatePlanBillingCadenceLiteral(),
-		ValidatePlanHasAlignedBillingCadences(),
+		ValidatePlanVersioning(),
+		ValidatePlanStructure(),
 	)
 }
 
@@ -337,6 +362,13 @@ type PlanMeta struct {
 
 // Validate validates the PlanMeta.
 func (p PlanMeta) Validate() error {
+	return models.NewNillableGenericValidationError(errors.Join(
+		p.validateStructure(),
+		p.validateVersioning(),
+	))
+}
+
+func (p PlanMeta) validateStructure() error {
 	var errs []error
 
 	if err := p.Currency.Validate(); err != nil {
@@ -348,10 +380,6 @@ func (p PlanMeta) Validate() error {
 
 	if err := p.EffectivePeriod.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("invalid effective period: %w", err))
-	}
-
-	if p.Key == "" {
-		errs = append(errs, ErrResourceKeyEmpty)
 	}
 
 	if p.Name == "" {
@@ -366,7 +394,15 @@ func (p PlanMeta) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid ProRatingConfig: %s", err))
 	}
 
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
+	return errors.Join(errs...)
+}
+
+func (p PlanMeta) validateVersioning() error {
+	if p.Key == "" {
+		return ErrResourceKeyEmpty
+	}
+
+	return nil
 }
 
 // Equal returns true if the two PlanMetas are equal.

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -174,7 +174,10 @@ func (i CreatePlanInput) Validate() error {
 		errs = append(errs, productcatalog.ErrNamespaceEmpty)
 	}
 
-	if err := i.Plan.Validate(); err != nil {
+	if err := i.Plan.ValidateWith(
+		productcatalog.ValidatePlanVersioning(),
+		productcatalog.ValidatePlanStructure(),
+	); err != nil {
 		errs = append(errs, fmt.Errorf("invalid plan: %w", err))
 	}
 

--- a/openmeter/productcatalog/plan_test.go
+++ b/openmeter/productcatalog/plan_test.go
@@ -36,6 +36,16 @@ func TestPlanValidationLayers(t *testing.T) {
 
 		require.ErrorIs(t, plan.Validate(), productcatalog.ErrResourceKeyEmpty)
 	})
+
+	t.Run("full validation wraps structural errors once", func(t *testing.T) {
+		plan := input.Plan
+		plan.Name = ""
+
+		err := plan.Validate()
+		require.Error(t, err)
+		require.True(t, models.IsGenericValidationError(err))
+		require.NotContains(t, err.Error(), "validation error: validation error:")
+	})
 }
 
 func TestCreatePlanInputValidationAllowsUnassignedVersion(t *testing.T) {

--- a/openmeter/productcatalog/plan_test.go
+++ b/openmeter/productcatalog/plan_test.go
@@ -12,11 +12,41 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	productcatalogtestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+func TestPlanValidationLayers(t *testing.T) {
+	input := productcatalogtestutils.NewTestPlan(t, "namespace")
+
+	t.Run("structure does not require catalog identity", func(t *testing.T) {
+		plan := input.Plan
+		plan.Key = ""
+		plan.Version = 0
+
+		require.NoError(t, plan.ValidateWith(productcatalog.ValidatePlanStructure()))
+	})
+
+	t.Run("full validation requires key", func(t *testing.T) {
+		plan := input.Plan
+		plan.Key = ""
+
+		require.ErrorIs(t, plan.Validate(), productcatalog.ErrResourceKeyEmpty)
+	})
+}
+
+func TestCreatePlanInputValidationAllowsUnassignedVersion(t *testing.T) {
+	input := productcatalogtestutils.NewTestPlan(t, "namespace")
+	require.Zero(t, input.Version)
+
+	require.NoError(t, input.Validate())
+
+	input.Key = ""
+	require.ErrorIs(t, input.Validate(), productcatalog.ErrResourceKeyEmpty)
+}
 
 func TestValidatePlanWithCurrencies(t *testing.T) {
 	custom := currencyx.Code("CREDITS")

--- a/openmeter/productcatalog/subscription/service/plan.go
+++ b/openmeter/productcatalog/subscription/service/plan.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
@@ -44,15 +42,7 @@ func (s *service) getPlanByVersion(ctx context.Context, namespace string, ref pl
 func PlanFromPlanInput(input plan.CreatePlanInput) (subscription.Plan, error) {
 	p := input.Plan
 
-	// We need to cheat a bit as plan validation fails without key and reference
-	// There isn't a meaningful type to what we're using here
-	// TODO: we could either
-	// 1. redifine this partial type in `productcatalog` (though its only meaningful here)
-	// 2. define the type here and figure out how to reuse the validations etc...
-	// 3. accept the fact that we're cheating and remove this comment
-
-	if !lo.IsEmpty(p.Key) || !lo.IsEmpty(p.Version) {
-		// Let's safeguard ourselves
+	if p.Key != "" || p.Version != 0 {
 		return nil, fmt.Errorf("plan key and version must be empty")
 	}
 
@@ -61,18 +51,10 @@ func PlanFromPlanInput(input plan.CreatePlanInput) (subscription.Plan, error) {
 		p.SettlementMode = productcatalog.CreditThenInvoiceSettlementMode
 	}
 
-	// Let's set the fields for the validation to pass
-	p.Key = "cheat"
-	p.Version = 1
-
-	if err := p.Validate(); err != nil {
+	if err := p.ValidateWith(productcatalog.ValidatePlanStructure()); err != nil {
 		return nil, models.ErrorWithFieldPrefix(models.NewFieldSelectorGroup(
 			models.NewFieldSelector("plan")), err)
 	}
-
-	// Let's unset the fields
-	p.Key = ""
-	p.Version = 0
 
 	return &plansubscription.Plan{
 		Plan: p,

--- a/openmeter/productcatalog/subscription/service/plan_test.go
+++ b/openmeter/productcatalog/subscription/service/plan_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -14,6 +15,24 @@ import (
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 )
+
+func TestPlanFromPlanInputUsesStructuralValidation(t *testing.T) {
+	input := subscriptiontestutils.GetExamplePlanInput(t)
+	input.Plan.Key = ""
+	input.Plan.Version = 0
+
+	customPlan, err := service.PlanFromPlanInput(input)
+	require.NoError(t, err)
+
+	plan, ok := customPlan.(*plansubscription.Plan)
+	require.True(t, ok)
+	require.Empty(t, plan.Key)
+	require.Zero(t, plan.Version)
+
+	input.Plan.Name = ""
+	_, err = service.PlanFromPlanInput(input)
+	require.ErrorIs(t, err, productcatalog.ErrResourceNameEmpty)
+}
 
 func TestDiscountPersisting(t *testing.T) {
 	logger := testutils.NewLogger(t)


### PR DESCRIPTION
## What changed

- add a canonical structural validator for plans
- keep catalog versioning validation separate from structural validation
- validate inline subscription plans without temporarily injecting a fake key and version
- add coverage for structural, catalog, and inline-plan validation boundaries

## Why

Inline subscription plans intentionally have no catalog identity, but the shared plan validator required a key. The conversion path worked around that by mutating the plan with fake identity fields before validation. Separating structural validation from catalog versioning removes that mutation and keeps the full validator list in one place.

This preserves the existing versioning rules: a catalog plan requires a key, while its numeric version is assigned later and is not newly validated here.

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/productcatalog/... -count=1`
- `go vet -tags=dynamic ./openmeter/productcatalog/...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plan validation by separating structural checks from version and key requirements.
  - Plan creation now supports unassigned versions while still requiring valid plan keys.
  - Subscription plan conversion now validates names and structure without relying on placeholder values.
  - Validation errors remain clearly associated with their relevant fields.

- **Tests**
  - Added coverage for layered plan validation and plan creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates structural plan validation from catalog identity validation, allowing inline subscription plans to remain keyless while catalog plans still require a key.
- Adds dedicated structural and versioning validators for plans.
- Removes temporary key and version mutation from inline-plan conversion.
- Adds tests for catalog, structural, and inline validation boundaries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/plan.go | Separates structural and catalog versioning validation while ensuring the outer validation boundary applies only one generic validation wrapper. |
| openmeter/productcatalog/plan/service.go | Explicitly applies both versioning and structural validation when creating catalog plans. |
| openmeter/productcatalog/subscription/service/plan.go | Validates inline plans structurally without injecting temporary catalog identity fields. |
| openmeter/productcatalog/plan_test.go | Covers keyless structural validation, catalog key enforcement, unassigned versions, and single-wrapper diagnostics. |
| openmeter/productcatalog/subscription/service/plan_test.go | Verifies inline-plan conversion preserves empty identity fields and rejects structural errors. |

<sub>Reviews (3): Last reviewed commit: ["refactor(productcatalog): move plan meta..."](https://github.com/openmeterio/openmeter/commit/0dd2c2c1944c29bf5769f342e84b9c89ac367777) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52161203)</sub>

**Context used:**

- Knowledge Base — [Product Catalog](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/productcatalog.md)

<!-- /greptile_comment -->