### PR TITLE
docs: improve OSS README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,25 +69,37 @@ example sends one `request` event and queries its metered value.
 <summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-curl -sS -o /dev/null -w '%{http_code}\n' \
-  -X POST http://localhost:48888/api/v1/events \
-  -H 'Content-Type: application/cloudevents+json' \
-  --data-raw '{
-    "specversion": "1.0",
-    "type": "request",
-    "id": "readme-curl-1",
-    "source": "readme",
-    "subject": "readme-curl",
-    "data": { "method": "GET", "route": "/hello" }
-  }'
+(
+  status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST http://localhost:48888/api/v1/events \
+    -H 'Content-Type: application/cloudevents+json' \
+    --data-raw '{
+      "specversion": "1.0",
+      "type": "request",
+      "id": "readme-curl-1",
+      "source": "readme",
+      "subject": "readme-curl",
+      "data": { "method": "GET", "route": "/hello" }
+    }') || exit 1
 
-response=
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
-  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl')
-  printf '%s' "$response" | grep -q '"value":1' && break
-  sleep 1
-done
-printf '%s\n' "$response"
+  if [ "$status" != 204 ]; then
+    printf 'event ingestion failed (HTTP %s)\n' "$status" >&2
+    exit 1
+  fi
+  printf '%s\n' "$status"
+
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl') || exit 1
+    if printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]'; then
+      printf '%s\n' "$response"
+      exit 0
+    fi
+    sleep 1
+  done
+
+  printf '%s\n' 'usage was not processed in time' >&2
+  exit 1
+)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ curl -sS -o /dev/null -w '%{http_code}\n' \
 response=
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
   response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl')
-  printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]' && break
+  printf '%s' "$response" | grep -q '"value":1' && break
   sleep 1
 done
 printf '%s\n' "$response"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 **Meter usage. Enforce access. Bill customers. Keep the stack yours.**
 
 OpenMeter is open-source monetization infrastructure built for AI, API, and
-usage-based products. It turns high-volume events into real-time usage,
-calculates the entitlements your application enforces, and manages credits,
-pricing, subscriptions, and invoices.
+usage-based products. It turns high-volume events into real-time usage, powers
+access enforcement, and handles usage-based billing from pricing and
+subscriptions through credits and invoices.
 
 API-first and composable, it can own the path from raw usage to invoice—or only
 the parts your stack is missing—and work with the payment and tax providers you

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ already use.
 | --- | --- |
 | **What is it best for?** | Products with usage-based or hybrid pricing, prepaid credits, or usage limits that need one source of truth for consumption. |
 | **What is it not?** | A bundled operator UI, payment processor, tax engine, or general-purpose accounting system. If you only need fixed recurring subscriptions, a direct payment-provider integration is usually simpler. |
-| **Who enforces access?** | OpenMeter calculates balances and access decisions; your application acts on the result. |
 | **How mature is it?** | Releases are beta and can include breaking changes. The [OpenMeter metering engine](https://openmeter.io/) has run in production for years and processed billions of usage events. Review [releases](https://github.com/openmeterio/openmeter/releases) and [migration guides](docs/migration-guides) when upgrading. |
 
 ## What OpenMeter provides

--- a/README.md
+++ b/README.md
@@ -69,37 +69,25 @@ example sends one `request` event and queries its metered value.
 <summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-(
-  status=$(curl -sS -o /dev/null -w '%{http_code}' \
-    -X POST http://localhost:48888/api/v1/events \
-    -H 'Content-Type: application/cloudevents+json' \
-    --data-raw '{
-      "specversion": "1.0",
-      "type": "request",
-      "id": "readme-curl-1",
-      "source": "readme",
-      "subject": "readme-curl",
-      "data": { "method": "GET", "route": "/hello" }
-    }') || exit 1
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:48888/api/v1/events \
+  -H 'Content-Type: application/cloudevents+json' \
+  --data-raw '{
+    "specversion": "1.0",
+    "type": "request",
+    "id": "readme-curl-1",
+    "source": "readme",
+    "subject": "readme-curl",
+    "data": { "method": "GET", "route": "/hello" }
+  }'
 
-  if [ "$status" != 204 ]; then
-    printf 'event ingestion failed (HTTP %s)\n' "$status" >&2
-    exit 1
-  fi
-  printf '%s\n' "$status"
-
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
-    response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl') || exit 1
-    if printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]'; then
-      printf '%s\n' "$response"
-      exit 0
-    fi
-    sleep 1
-  done
-
-  printf '%s\n' 'usage was not processed in time' >&2
-  exit 1
-)
+response=
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl')
+  printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]' && break
+  sleep 1
+done
+printf '%s\n' "$response"
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -214,10 +214,9 @@ query progress; Svix is used when webhook delivery is enabled. The
 [architecture guide](https://openmeter.io/docs/open-source/architecture)
 explains the complete runtime and data flow.
 
-For production, use the official
-[Helm chart for Kubernetes](https://openmeter.io/docs/open-source/kubernetes),
-operate stateful dependencies outside the chart, enable optional services for
-the capabilities you use, and pin OpenMeter to a release instead of `latest`.
+The official
+[Helm chart for Kubernetes](https://openmeter.io/docs/open-source/kubernetes)
+is intended for development deployments, not production.
 
 ## Project and community
 

--- a/README.md
+++ b/README.md
@@ -1,160 +1,235 @@
 <div align="center">
 
-![OpenMeter logo](assets/logo.png)
+<a href="https://openmeter.io">
+  <img src="assets/logo.png" width="100" alt="OpenMeter logo" />
+</a>
 
 # OpenMeter
 
-The open-source metering and billing platform
-for AI, agentic and DevTool monetization.
+**Meter usage. Enforce access. Bill customers. Keep the stack yours.**
 
-[Docs](https://openmeter.io/docs) |
-[Hosted](https://cloud.konghq.com/register?utm_campaign=metering_and_billing) |
-[Blog](https://openmeter.io/blog) |
-[Contributing](CONTRIBUTING.md)
+OpenMeter is open-source monetization infrastructure built for AI, API, and
+usage-based products. It turns high-volume events into real-time usage,
+calculates the entitlements your application enforces, and manages credits,
+pricing, subscriptions, and invoices.
+
+API-first and composable, it can own the path from raw usage to invoice—or only
+the parts your stack is missing—and work with the payment and tax providers you
+already use.
+
+[Quickstart](#quickstart) ·
+[Documentation](https://openmeter.io/docs) ·
+[API reference](https://openmeter.io/docs/api/open-source) ·
+[Community](https://github.com/openmeterio/openmeter/discussions)
 
 [![GitHub Release](https://img.shields.io/github/v/release/openmeterio/openmeter?style=flat-square)](https://github.com/openmeterio/openmeter/releases/latest)
 [![CI Status](https://img.shields.io/github/actions/workflow/status/openmeterio/openmeter/ci.yaml?style=flat-square)](https://github.com/openmeterio/openmeter/actions/workflows/ci.yaml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/openmeterio/openmeter?style=flat-square)](https://goreportcard.com/report/github.com/openmeterio/openmeter)
-![GitHub Stars](https://img.shields.io/github/stars/openmeterio/openmeter?style=flat-square)
+[![License](https://img.shields.io/github/license/openmeterio/openmeter?style=flat-square)](LICENSE)
 
 </div>
 
----
+## How it fits together
 
-OpenMeter is a real-time metering and billing engine that
-helps you track usage, enforce limits, manage subscriptions,
-and automate invoicing — all in one platform. Ingest events
-via a simple API, define meters with flexible aggregations,
-and connect usage data to billing, entitlements, and
-customer-facing dashboards.
+![Usage events flow through OpenMeter's meters into queries, access decisions, and billing](assets/how-openmeter-works.svg)
 
-## Features
+## Is OpenMeter a fit?
 
-- **Usage Metering** — Ingest events in
-  [CloudEvents](https://cloudevents.io) format, define meters
-  with flexible aggregations (SUM, COUNT, AVG, MIN, MAX),
-  and query usage in real time.
-- **Usage-Based Billing** — Generate invoices from metered
-  usage. Supports tiered, graduated, and flat-fee pricing
-  with automated invoice lifecycle management.
-- **Usage Limits and Entitlements** — Enforce usage quotas
-  per feature with real-time balance tracking, boolean
-  feature flags, and grace periods.
-- **Product Catalog** — Define plans, add-ons, features, and
-  rate cards. Manage subscriptions with mid-cycle changes,
-  prorating, and alignment.
-- **Prepaid Credits** — Support paid or promotional credit grants
-  with priority-based burn-down and expiration.
-- **Customer Portal** — Token-based self-service dashboards
-  so your customers can see their own usage.
-- **Notifications** — Webhook-based alerts with configurable
-  rules and channels for usage thresholds and billing events.
-- **LLM Cost Tracking** — First-class support for metering
-  AI token usage and computing model-specific costs.
+| Question | Answer |
+| --- | --- |
+| **What is it best for?** | Products with usage-based or hybrid pricing, prepaid credits, or usage limits that need one source of truth for consumption. |
+| **What is it not?** | A bundled operator UI, payment processor, tax engine, or general-purpose accounting system. If you only need fixed recurring subscriptions, a direct payment-provider integration is usually simpler. |
+| **Who enforces access?** | OpenMeter calculates balances and access decisions; your application acts on the result. |
+| **How mature is it?** | Releases are beta and can include breaking changes. The [OpenMeter metering engine](https://openmeter.io/) has run in production for years and processed billions of usage events. Review [releases](https://github.com/openmeterio/openmeter/releases) and [migration guides](docs/migration-guides) when upgrading. |
 
-## Getting Started
+## What OpenMeter provides
 
-### Cloud
+| Capability | What it covers |
+| --- | --- |
+| **[Meter usage](https://openmeter.io/docs/metering/overview)** | Ingest CloudEvents, attribute usage to customers, aggregate it in real time, and query it by time window or dimension. |
+| **[Model products and pricing](https://openmeter.io/docs/product-catalog/overview)** | Define versioned plans, features, add-ons, and flat, recurring, per-unit, tiered, package, or dynamic prices; then assign customer subscriptions. |
+| **[Control access](https://openmeter.io/docs/billing/entitlements/overview)** | Calculate feature access and usage-limit balances for your application to enforce, with one-time or recurring entitlement grants. |
+| **[Bill usage](https://openmeter.io/docs/billing/overview)** | Rate flat and usage-based charges, manage customer credit balances and subscription changes, and run the invoice lifecycle. |
+| **[Integrate](https://openmeter.io/docs/api/open-source)** | Use the OSS REST API and JavaScript, Python, or Go SDKs, send webhooks, and connect external invoicing providers. |
 
-The fastest way to start.
-[Start for free](https://cloud.konghq.com/register?utm_campaign=metering_and_billing)
-and begin metering and billing in minutes —
-no infrastructure to manage.
+## Quickstart
 
-### Self-Hosted
-
-Run OpenMeter locally with Docker Compose:
+The local evaluation stack requires [Git](https://git-scm.com/) and
+[Docker with Compose](https://docs.docker.com/compose/). Use `curl`, Node.js
+22+, or Python 3.9+ for the examples below.
 
 ```sh
-git clone git@github.com:openmeterio/openmeter.git
+git clone https://github.com/openmeterio/openmeter.git
 cd openmeter/quickstart
-docker compose up -d
+docker compose up -d --wait
 ```
 
-Then ingest your first event:
+The stack includes an `api_requests_total` meter. Choose a client below; each
+example sends one `request` event and queries its metered value.
+
+<details open>
+<summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-curl -X POST http://localhost:48888/api/v1/events \
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:48888/api/v1/events \
   -H 'Content-Type: application/cloudevents+json' \
   --data-raw '{
     "specversion": "1.0",
     "type": "request",
-    "id": "00001",
-    "time": "2026-07-07T00:00:00.001Z",
-    "source": "my-service",
-    "subject": "customer-1",
-    "data": { "method": "GET", "route": "/api/hello" }
+    "id": "readme-curl-1",
+    "source": "readme",
+    "subject": "readme-curl",
+    "data": { "method": "GET", "route": "/hello" }
   }'
+
+response=
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=readme-curl')
+  printf '%s' "$response" | grep -q '"value":1' && break
+  sleep 1
+done
+printf '%s\n' "$response"
 ```
 
-Query your usage:
+</details>
+
+<details>
+<summary><strong>TypeScript SDK</strong></summary>
+
+Install the [OpenMeter TypeScript SDK](https://www.npmjs.com/package/@openmeter/sdk):
 
 ```sh
-curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?windowSize=HOUR' | jq
+npm install @openmeter/sdk tsx
 ```
 
-See the full [quickstart guide](/quickstart) for more details.
+Save as `quickstart.ts`, then run `npx tsx quickstart.ts`:
 
-### Deploy to Production
+```ts
+import { OpenMeter } from '@openmeter/sdk'
 
-Deploy to Kubernetes using our
-[Helm chart](https://openmeter.io/docs/deploy/kubernetes).
+const openmeter = new OpenMeter({ baseUrl: 'http://localhost:48888' })
 
-## SDKs
+const queryUsage = () =>
+  openmeter.meters.query('api_requests_total', {
+    subject: ['readme-typescript'],
+  })
 
-| Language             | Package                                                                        | Source                                             |
-|----------------------|--------------------------------------------------------------------------------|----------------------------------------------------|
-| Go                   | [openmeter](https://pkg.go.dev/github.com/openmeterio/openmeter/api/client/go) | [api/client/go](/api/client/go)                    |
-| JavaScript / Node.js | [@openmeter/sdk](https://www.npmjs.com/package/@openmeter/sdk)                 | [api/client/javascript](/api/client/javascript)    |
-| Python               | [openmeter](https://pypi.org/project/openmeter)                                | [api/client/python](/api/client/python)            |
+async function main() {
+  await openmeter.events.ingest({
+    type: 'request',
+    id: 'readme-typescript-1',
+    source: 'readme',
+    subject: 'readme-typescript',
+    data: { method: 'GET', route: '/hello' },
+  })
 
-Don't see your language? Use the
-[OpenAPI spec](https://github.com/openmeterio/openmeter/blob/main/api/openapi.yaml)
-directly or
-[request an SDK](https://github.com/openmeterio/openmeter/issues/new?assignees=&labels=area%2Fapi%2Ckind%2Ffeature&projects=&template=feature_request.yaml).
+  let usage = await queryUsage()
+  for (let attempt = 1; usage.data[0]?.value !== 1 && attempt < 10; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    usage = await queryUsage()
+  }
 
-## Architecture
+  if (usage.data[0]?.value !== 1) {
+    throw new Error('usage was not processed in time')
+  }
+  console.log(usage.data[0].value)
+}
 
-OpenMeter is built in Go with a stack optimized for
-high-volume event ingestion and real-time aggregation:
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})
+```
 
-| Component                | Role                                                     |
-|--------------------------|----------------------------------------------------------|
-| **PostgreSQL** (Ent ORM) | Billing, subscriptions, entitlements, product catalog    |
-| **ClickHouse**           | Real-time usage aggregation and analytics                |
-| **Kafka**                | Event streaming and ingestion pipeline                   |
-| **TypeSpec**             | API-first design — OpenAPI spec and SDKs from TypeSpec   |
+</details>
 
-See [Architecture and data flow](docs/architecture.md) for a
-diagram of the runtime components and their primary interactions.
+<details>
+<summary><strong>Python SDK</strong></summary>
 
-## Community
-
-We'd love to have you involved:
-
-- **[Contributing](CONTRIBUTING.md)** — Start here if you
-  want to contribute code.
-- **[Code of Conduct](CODE_OF_CONDUCT.md)** — Our community
-  guidelines.
-- **[Blog](https://openmeter.io/blog)** — Product updates
-  and engineering deep dives.
-
-## Development
-
-Prerequisites: [Nix](https://nixos.org/download.html) and
-[direnv](https://direnv.net/docs/installation.html) are
-recommended. See [CONTRIBUTING.md](CONTRIBUTING.md) for
-detailed setup instructions.
+The Python SDK is in preview, so install it with pre-releases enabled:
 
 ```sh
-make up       # Start dependencies (Postgres, Kafka, ClickHouse)
-make server   # Run the API server with hot reload
-make test     # Run tests
-make lint     # Run linters
+python -m pip install --pre openmeter
 ```
+
+Save as `quickstart.py`, then run `python quickstart.py`:
+
+```python
+import time
+
+from openmeter import Client
+from openmeter.models import Event
+
+with Client(endpoint="http://localhost:48888") as openmeter:
+    openmeter.events.ingest_event(
+        Event(
+            id="readme-python-1",
+            source="readme",
+            specversion="1.0",
+            type="request",
+            subject="readme-python",
+            data={"method": "GET", "route": "/hello"},
+        )
+    )
+
+    for _ in range(10):
+        usage = openmeter.meters.query_json(
+            "api_requests_total",
+            subject=["readme-python"],
+        )
+        if usage.data and usage.data[0].value == 1:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("usage was not processed in time")
+
+    print(usage.data[0].value)
+```
+
+</details>
+
+Event processing is asynchronous. A successful example ends with a metered
+value of `1`.
+
+> [!NOTE]
+> This Compose setup is a local evaluation stack. It runs the OpenMeter API and
+> workers together with Kafka, ClickHouse, PostgreSQL, Redis, and Svix using
+> `latest` OpenMeter images; it is not a production topology.
+
+Continue with the [full OSS quickstart](quickstart/README.md), try a
+[metering example](https://openmeter.io/docs/metering/guides/common-examples),
+add [entitlements and usage limits](https://openmeter.io/docs/billing/entitlements/quickstart),
+or model [plans and subscriptions](https://openmeter.io/docs/product-catalog/overview).
+
+When you are done, remove the containers and their local data volumes:
+
+```sh
+docker compose down -v
+```
+
+## Running OpenMeter
+
+The core runtime is OpenMeter's API and worker processes plus Kafka,
+ClickHouse, and PostgreSQL. Redis is optional for distributed deduplication and
+query progress; Svix is used when webhook delivery is enabled. The
+[architecture guide](https://openmeter.io/docs/open-source/architecture)
+explains the complete runtime and data flow.
+
+For production, use the official
+[Helm chart for Kubernetes](https://openmeter.io/docs/open-source/kubernetes),
+operate stateful dependencies outside the chart, enable optional services for
+the capabilities you use, and pin OpenMeter to a release instead of `latest`.
+
+## Project and community
+
+| Need | Go to |
+| --- | --- |
+| Ask a question or discuss an approach | [GitHub Discussions](https://github.com/openmeterio/openmeter/discussions) |
+| Report a reproducible bug or request a feature | [GitHub Issues](https://github.com/openmeterio/openmeter/issues) |
+| Track changes | [Releases](https://github.com/openmeterio/openmeter/releases) and [migration guides](docs/migration-guides) |
+| Report a vulnerability | [Security policy](SECURITY.md) |
+| Build or contribute | [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) |
 
 ## License
 
-Licensed under [Apache 2.0](LICENSE).
-
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B38090%2Fgithub.com%2Fopenmeterio%2Fopenmeter.svg?type=large)](https://app.fossa.com/projects/custom%2B38090%2Fgithub.com%2Fopenmeterio%2Fopenmeter?ref=badge_large)
+OpenMeter is licensed under the [Apache License 2.0](LICENSE).

--- a/assets/how-openmeter-works.svg
+++ b/assets/how-openmeter-works.svg
@@ -1,0 +1,149 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title description">
+  <title id="title">How OpenMeter connects metering, access decisions, and billing</title>
+  <desc id="description">Usage events enter meters and branch into usage queries, entitlement access decisions enforced by the application, and rating and invoices sent to external payment and tax providers. Catalog and subscriptions feed access and billing, while the customer credit ledger feeds billing.</desc>
+
+  <defs>
+    <pattern id="grid" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="#20252d"/>
+    </pattern>
+    <linearGradient id="canvas" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0d1014"/>
+      <stop offset="1" stop-color="#090b0e"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#11151a"/>
+      <stop offset="1" stop-color="#0e1115"/>
+    </linearGradient>
+    <linearGradient id="nodeFill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#171c23"/>
+      <stop offset="1" stop-color="#12161c"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="8" stdDeviation="14" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrow-blue" markerUnits="userSpaceOnUse" markerWidth="13" markerHeight="13" refX="12" refY="6.5" orient="auto">
+      <path d="M 1 1.5 L 12 6.5 L 1 11.5 Z" fill="#4f86ff"/>
+    </marker>
+    <marker id="arrow-gray" markerUnits="userSpaceOnUse" markerWidth="11" markerHeight="11" refX="10" refY="5.5" orient="auto">
+      <path d="M 1 1.2 L 10 5.5 L 1 9.8 Z" fill="#aeb6c2"/>
+    </marker>
+    <style>
+      .label     { fill: #f5f7fa; font: 600 19px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .7px; }
+      .label-sm  { fill: #f5f7fa; font: 600 17px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .5px; }
+      .label-xs  { fill: #f5f7fa; font: 600 16px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: .4px; }
+      .eyebrow   { fill: #8b95a3; font: 600 12.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 1.8px; }
+      .sub       { fill: #97a0ad; font: 400 14.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .legend    { fill: #8b95a3; font: 600 12.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 1.4px; }
+      .node      { fill: url(#nodeFill); stroke: #3d4550; stroke-width: 1.5; }
+      .external  { fill: #101419; stroke: #59626f; stroke-width: 1.5; stroke-dasharray: 5 5; }
+      .usage     { fill: none; stroke: #4f86ff; stroke-width: 2.75; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-blue); }
+      .domain    { fill: none; stroke: #aeb6c2; stroke-width: 1.9; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-gray); }
+      .port-blue { fill: #4f86ff; }
+      .port-gray { fill: #aeb6c2; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#canvas)"/>
+  <rect width="1600" height="900" fill="url(#grid)" opacity="0.6"/>
+
+  <!-- OpenMeter boundary -->
+  <rect x="280" y="48" width="1040" height="804" rx="32" fill="url(#panel)" stroke="#3f4752" stroke-width="1.5"/>
+
+  <!-- Header -->
+  <g transform="translate(676 92)">
+    <g transform="skewX(-25)">
+      <rect x="0" y="4" width="13" height="28" rx="1" fill="#f5f7fa"/>
+      <rect x="19" y="4" width="13" height="28" rx="1" fill="#f5f7fa"/>
+      <rect x="38" y="4" width="13" height="28" rx="1" fill="#f5f7fa"/>
+    </g>
+    <text x="78" y="27" class="label" style="font-size:22px; letter-spacing:5px;">OPENMETER</text>
+  </g>
+  <path d="M 316 162 H 1284" stroke="#242a33" stroke-width="1"/>
+
+  <!-- Usage flow: events -> meters -> queries / access decisions / rating -->
+  <path class="usage" d="M 244 400 H 316"/>
+  <path class="usage" d="M 486 400 H 1044"/>
+  <path class="usage" d="M 551 400 V 276 Q 551 256 571 256 H 617"/>
+  <path class="usage" d="M 551 400 V 770 Q 551 790 571 790 H 1044"/>
+
+  <!-- Product and balance context -->
+  <path class="domain" d="M 913 534 C 972 534, 985 430, 1044 430"/>
+  <path class="domain" d="M 913 578 C 976 578, 982 724, 1044 724"/>
+  <path class="domain" d="M 913 688 C 972 688, 985 758, 1044 758"/>
+
+  <!-- Boundary crossings -->
+  <path class="domain" d="M 1284 400 H 1356"/>
+  <path class="domain" d="M 1284 758 H 1356"/>
+
+  <!-- External input -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="356" width="204" height="88" rx="14" class="external"/>
+    <text x="142" y="406" class="label-sm" text-anchor="middle">USAGE EVENTS</text>
+  </g>
+
+  <!-- Core nodes -->
+  <g filter="url(#shadow)">
+    <rect x="316" y="352" width="170" height="96" rx="16" class="node"/>
+    <text x="401" y="407" class="label" text-anchor="middle">METERS</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="617" y="208" width="296" height="96" rx="16" class="node"/>
+    <text x="765" y="262" class="label-sm" text-anchor="middle">USAGE QUERIES</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="617" y="508" width="296" height="96" rx="16" class="node"/>
+    <text x="765" y="547" class="eyebrow" text-anchor="middle">PRODUCT MODEL</text>
+    <text x="765" y="571" class="label-xs" text-anchor="middle">CATALOG + SUBSCRIPTIONS</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="617" y="640" width="296" height="96" rx="16" class="node"/>
+    <text x="765" y="679" class="eyebrow" text-anchor="middle">BALANCE</text>
+    <text x="765" y="703" class="label-xs" text-anchor="middle">CUSTOMER CREDIT LEDGER</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="1044" y="342" width="240" height="116" rx="16" class="node"/>
+    <text x="1164" y="390" class="eyebrow" text-anchor="middle">ENTITLEMENTS</text>
+    <text x="1164" y="416" class="label" text-anchor="middle">ACCESS DECISIONS</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="1044" y="700" width="240" height="116" rx="16" class="node"/>
+    <text x="1164" y="751" class="label" text-anchor="middle">RATING +</text>
+    <text x="1164" y="778" class="label" text-anchor="middle">INVOICES</text>
+  </g>
+
+  <!-- External outputs -->
+  <g filter="url(#shadow)">
+    <rect x="1356" y="352" width="204" height="96" rx="14" class="external"/>
+    <text x="1458" y="394" class="label-xs" text-anchor="middle">YOUR APPLICATION</text>
+    <text x="1458" y="418" class="sub" text-anchor="middle">enforces access</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="1356" y="710" width="204" height="96" rx="14" class="external"/>
+    <text x="1458" y="752" class="label-xs" text-anchor="middle">PAYMENT + TAX</text>
+    <text x="1458" y="776" class="sub" text-anchor="middle">external providers</text>
+  </g>
+
+  <!-- Connection ports -->
+  <circle cx="244" cy="400" r="4.5" class="port-blue"/>
+  <circle cx="486" cy="400" r="4.5" class="port-blue"/>
+  <circle cx="551" cy="400" r="6.5" class="port-blue"/>
+  <circle cx="913" cy="534" r="4" class="port-gray"/>
+  <circle cx="913" cy="578" r="4" class="port-gray"/>
+  <circle cx="913" cy="688" r="4" class="port-gray"/>
+  <circle cx="1284" cy="400" r="4" class="port-gray"/>
+  <circle cx="1284" cy="758" r="4" class="port-gray"/>
+
+  <!-- Legend -->
+  <g>
+    <path d="M 316 694 H 352" stroke="#4f86ff" stroke-width="2.75" stroke-linecap="round"/>
+    <text x="364" y="699" class="legend">METERED USAGE</text>
+    <path d="M 316 730 H 352" stroke="#aeb6c2" stroke-width="1.9" stroke-linecap="round"/>
+    <text x="364" y="735" class="legend">PRODUCT &amp; BALANCE</text>
+  </g>
+</svg>

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -38,25 +38,37 @@ polls until its asynchronous processing completes.
 <summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-curl -sS -o /dev/null -w '%{http_code}\n' \
-  -X POST http://localhost:48888/api/v1/events \
-  -H 'Content-Type: application/cloudevents+json' \
-  --data-raw '{
-    "specversion": "1.0",
-    "type": "request",
-    "id": "quickstart-curl-1",
-    "source": "quickstart",
-    "subject": "quickstart-curl",
-    "data": { "method": "GET", "route": "/hello" }
-  }'
+(
+  status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X POST http://localhost:48888/api/v1/events \
+    -H 'Content-Type: application/cloudevents+json' \
+    --data-raw '{
+      "specversion": "1.0",
+      "type": "request",
+      "id": "quickstart-curl-1",
+      "source": "quickstart",
+      "subject": "quickstart-curl",
+      "data": { "method": "GET", "route": "/hello" }
+    }') || exit 1
 
-response=
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
-  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl')
-  printf '%s' "$response" | grep -q '"value":1' && break
-  sleep 1
-done
-printf '%s\n' "$response"
+  if [ "$status" != 204 ]; then
+    printf 'event ingestion failed (HTTP %s)\n' "$status" >&2
+    exit 1
+  fi
+  printf '%s\n' "$status"
+
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl') || exit 1
+    if printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]'; then
+      printf '%s\n' "$response"
+      exit 0
+    fi
+    sleep 1
+  done
+
+  printf '%s\n' 'usage was not processed in time' >&2
+  exit 1
+)
 ```
 
 The ingest prints `204`; the query response contains

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -38,37 +38,25 @@ polls until its asynchronous processing completes.
 <summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-(
-  status=$(curl -sS -o /dev/null -w '%{http_code}' \
-    -X POST http://localhost:48888/api/v1/events \
-    -H 'Content-Type: application/cloudevents+json' \
-    --data-raw '{
-      "specversion": "1.0",
-      "type": "request",
-      "id": "quickstart-curl-1",
-      "source": "quickstart",
-      "subject": "quickstart-curl",
-      "data": { "method": "GET", "route": "/hello" }
-    }') || exit 1
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:48888/api/v1/events \
+  -H 'Content-Type: application/cloudevents+json' \
+  --data-raw '{
+    "specversion": "1.0",
+    "type": "request",
+    "id": "quickstart-curl-1",
+    "source": "quickstart",
+    "subject": "quickstart-curl",
+    "data": { "method": "GET", "route": "/hello" }
+  }'
 
-  if [ "$status" != 204 ]; then
-    printf 'event ingestion failed (HTTP %s)\n' "$status" >&2
-    exit 1
-  fi
-  printf '%s\n' "$status"
-
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
-    response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl') || exit 1
-    if printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]'; then
-      printf '%s\n' "$response"
-      exit 0
-    fi
-    sleep 1
-  done
-
-  printf '%s\n' 'usage was not processed in time' >&2
-  exit 1
-)
+response=
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl')
+  printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]' && break
+  sleep 1
+done
+printf '%s\n' "$response"
 ```
 
 The ingest prints `204`; the query response contains

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,176 +1,188 @@
-# Quickstart
+# OpenMeter OSS quickstart
+
+Run a complete local OpenMeter stack, send a usage event, and query its metered
+value.
 
 ## Prerequisites
 
-- Docker (with Compose)
-- curl
-- jq
+- [Docker with Compose](https://docs.docker.com/compose/)
+- [Git](https://git-scm.com/)
+- one of:
+  - Bash and `curl`
+  - Node.js 22+ and npm for TypeScript
+  - Python 3.9+ and pip for Python
 
-Clone the repository:
+## 1. Start OpenMeter
 
 ```sh
-git clone git@github.com:openmeterio/openmeter.git
+git clone https://github.com/openmeterio/openmeter.git
 cd openmeter/quickstart
+docker compose up -d --wait
 ```
 
-## 1. Launch OpenMeter
+The API is available at `http://localhost:48888`. The Compose stack also starts
+OpenMeter's workers and local Kafka, ClickHouse, PostgreSQL, Redis, and Svix
+dependencies.
 
-Launch OpenMeter and its dependencies via:
+> [!NOTE]
+> This setup uses `latest` OpenMeter images and development-grade dependencies.
+> It is intended for local evaluation, not production.
+
+## 2. Meter an event
+
+The included configuration defines an `api_requests_total` meter that counts
+events with type `request`. Choose a client; each example sends one event and
+polls until its asynchronous processing completes.
+
+<details open>
+<summary><strong>Bash (curl)</strong></summary>
 
 ```sh
-docker compose up -d
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:48888/api/v1/events \
+  -H 'Content-Type: application/cloudevents+json' \
+  --data-raw '{
+    "specversion": "1.0",
+    "type": "request",
+    "id": "quickstart-curl-1",
+    "source": "quickstart",
+    "subject": "quickstart-curl",
+    "data": { "method": "GET", "route": "/hello" }
+  }'
+
+response=
+for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl')
+  printf '%s' "$response" | grep -q '"value":1' && break
+  sleep 1
+done
+printf '%s\n' "$response"
 ```
 
-## 2. Ingest usage event(s)
+The ingest prints `204`; the query response contains
+`"subject":"quickstart-curl"` and `"value":1`.
 
-Ingest usage events in [CloudEvents](https://cloudevents.io/) format:
+</details>
+
+<details>
+<summary><strong>TypeScript SDK</strong></summary>
+
+Install the [OpenMeter TypeScript SDK](https://www.npmjs.com/package/@openmeter/sdk):
 
 ```sh
-curl -X POST http://localhost:48888/api/v1/events \
--H 'Content-Type: application/cloudevents+json' \
---data-raw '
-{
-  "specversion" : "1.0",
-  "type": "request",
-  "id": "00001",
-  "time": "2026-07-07T00:00:00.001Z",
-  "source": "service-0",
-  "subject": "customer-1",
-  "data": {
-    "method": "GET",
-    "route": "/hello",
-    "duration_ms": 10
+npm install @openmeter/sdk tsx
+```
+
+Save as `quickstart.ts`, then run `npx tsx quickstart.ts`:
+
+```ts
+import { OpenMeter } from '@openmeter/sdk'
+
+const openmeter = new OpenMeter({ baseUrl: 'http://localhost:48888' })
+
+const queryUsage = () =>
+  openmeter.meters.query('api_requests_total', {
+    subject: ['quickstart-typescript'],
+  })
+
+async function main() {
+  await openmeter.events.ingest({
+    type: 'request',
+    id: 'quickstart-typescript-1',
+    source: 'quickstart',
+    subject: 'quickstart-typescript',
+    data: { method: 'GET', route: '/hello' },
+  })
+
+  let usage = await queryUsage()
+  for (let attempt = 1; usage.data[0]?.value !== 1 && attempt < 10; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    usage = await queryUsage()
   }
-}
-'
-```
 
-Note how ID is different:
-
-```sh
-curl -X POST http://localhost:48888/api/v1/events \
--H 'Content-Type: application/cloudevents+json' \
---data-raw '
-{
-  "specversion" : "1.0",
-  "type": "request",
-  "id": "00002",
-  "time": "2026-07-07T00:00:00.001Z",
-  "source": "service-0",
-  "subject": "customer-1",
-  "data": {
-    "method": "GET",
-    "route": "/hello",
-    "duration_ms": 20
+  if (usage.data[0]?.value !== 1) {
+    throw new Error('usage was not processed in time')
   }
+  console.log(usage.data[0].value)
 }
-'
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})
 ```
 
-Note how ID and time are different:
+The script prints `1`.
+
+</details>
+
+<details>
+<summary><strong>Python SDK</strong></summary>
+
+The Python SDK is in preview, so install it with pre-releases enabled:
 
 ```sh
-curl -X POST http://localhost:48888/api/v1/events \
--H 'Content-Type: application/cloudevents+json' \
---data-raw '
-{
-  "specversion" : "1.0",
-  "type": "request",
-  "id": "00003",
-  "time": "2026-07-08T00:00:00.001Z",
-  "source": "service-0",
-  "subject": "customer-1",
-  "data": {
-    "method": "GET",
-    "route": "/hello",
-    "duration_ms": 30
-  }
-}
-'
+python -m pip install --pre openmeter
 ```
 
-## 3. Query Usage
+Save as `quickstart.py`, then run `python quickstart.py`:
 
-Query the usage hourly:
+```python
+import time
+
+from openmeter import Client
+from openmeter.models import Event
+
+with Client(endpoint="http://localhost:48888") as openmeter:
+    openmeter.events.ingest_event(
+        Event(
+            id="quickstart-python-1",
+            source="quickstart",
+            specversion="1.0",
+            type="request",
+            subject="quickstart-python",
+            data={"method": "GET", "route": "/hello"},
+        )
+    )
+
+    for _ in range(10):
+        usage = openmeter.meters.query_json(
+            "api_requests_total",
+            subject=["quickstart-python"],
+        )
+        if usage.data and usage.data[0].value == 1:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("usage was not processed in time")
+
+    print(usage.data[0].value)
+```
+
+The script prints `1.0`.
+
+</details>
+
+## 3. Explore
+
+Group usage by hour, method, and route:
 
 ```sh
-curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?windowSize=HOUR&groupBy=method&groupBy=route' | jq
+curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?windowSize=HOUR&groupBy=method&groupBy=route'
 ```
 
-```json
-{
-  "windowSize": "HOUR",
-  "data": [
-    {
-      "value": 2,
-      "windowStart": "2026-07-07T00:00:00Z",
-      "windowEnd": "2026-07-07T01:00:00Z",
-      "subject": null,
-      "groupBy": {
-        "method": "GET",
-        "route": "/hello"
-      }
-    },
-    {
-      "value": 1,
-      "windowStart": "2026-07-08T00:00:00Z",
-      "windowEnd": "2026-07-08T01:00:00Z",
-      "subject": null,
-      "groupBy": {
-        "method": "GET",
-        "route": "/hello"
-      }
-    }
-  ]
-}
-```
+Then continue with:
 
-Query the total usage for `customer-1`:
-
-```sh
-curl 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=customer-1' | jq
-```
-
-```json
-{
-  "data": [
-    {
-      "value": 3,
-      "windowStart": "2026-07-07T00:00:00Z",
-      "windowEnd": "2026-07-08T00:01:00Z",
-      "subject": "customer-1",
-      "groupBy": {}
-    }
-  ]
-}
-```
-
-## 4. Configure additional meter(s) _(optional)_
-
-In this example we will meter LLM token usage, groupped by AI model and prompt type.
-You can think about it how OpenAI [charges](https://openai.com/pricing) by tokens for ChatGPT.
-
-Configure how OpenMeter should process your usage events in this new `tokens_total` meter.
-
-```yaml
-# ...
-
-meters:
-  # Sample meter to count LLM Token Usage
-  - slug: tokens_total
-    description: AI Token Usage
-    eventType: prompt               # Filter events by type
-    aggregation: SUM
-    valueProperty: $.tokens         # JSONPath to parse usage value
-    groupBy:
-      model: $.model                # AI model used: gpt4-turbo, etc.
-      type: $.type                  # Prompt type: input, output, system
-
-```
+- how [meters and customer attribution](https://openmeter.io/docs/metering/overview) work
+- common [AI, API, and compute metering examples](https://openmeter.io/docs/metering/guides/common-examples)
+- [entitlements and usage limits](https://openmeter.io/docs/billing/entitlements/quickstart)
+- [plans, pricing, and subscriptions](https://openmeter.io/docs/product-catalog/overview)
+- the [OSS API reference](https://openmeter.io/docs/api/open-source)
+- the [Kubernetes deployment guide](https://openmeter.io/docs/open-source/kubernetes)
 
 ## Cleanup
 
-Once you are done, stop any running instances:
+Remove the quickstart containers and their data volumes:
 
 ```sh
 docker compose down -v

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -53,7 +53,7 @@ curl -sS -o /dev/null -w '%{http_code}\n' \
 response=
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
   response=$(curl -fsS 'http://localhost:48888/api/v1/meters/api_requests_total/query?subject=quickstart-curl')
-  printf '%s' "$response" | grep -Eq '"value"[[:space:]]*:[[:space:]]*1[[:space:]]*[,}]' && break
+  printf '%s' "$response" | grep -q '"value":1' && break
   sleep 1
 done
 printf '%s\n' "$response"


### PR DESCRIPTION
I've been thinking for a long while that our README is sub-par but wasn't really sure what should be included... I'm really liking this direction and I think its significantly better.

See preview here https://github.com/openmeterio/openmeter/tree/codex/improve-oss-readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the main documentation to clarify OpenMeter’s monetization capabilities, product fit, runtime guidance, production considerations, community resources, and licensing.
  * Added a streamlined local evaluation guide covering prerequisites, stack setup, readiness checks, and cleanup.
  * Added Bash, TypeScript, and Python quickstart examples for ingesting events and checking meter usage.
  * Documented asynchronous processing and local-environment limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR substantially rewrites the OSS documentation to clarify OpenMeter’s capabilities, intended use, runtime guidance, and community resources.

- Adds Bash, TypeScript, and Python quickstart paths with asynchronous usage polling.
- Expands the standalone quickstart with setup, exploration, and cleanup instructions.
- Adds an architecture graphic showing how metering feeds access decisions and billing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Reworks the project overview, capability guidance, quickstart examples, deployment notes, and community links without an eligible blocking issue. |
| assets/how-openmeter-works.svg | Adds an accessible architecture illustration for the metering, entitlement, and billing flow. |
| quickstart/README.md | Replaces the previous walkthrough with streamlined Bash and SDK examples plus clearer local-stack guidance; the previously raised polling concern was withdrawn. |

<sub>Reviews (7): Last reviewed commit: ["docs: clarify Helm chart scope"](https://github.com/openmeterio/openmeter/commit/92975dc39d31a7cff303c1b3873e1a7f6e45efdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52194234)</sub>

<!-- /greptile_comment -->