### PR TITLE
fix(ci): run harden runner in audit mode

### DIFF
--- a/.github/workflows/aip-npm-release.yaml
+++ b/.github/workflows/aip-npm-release.yaml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/analysis-scorecard.yaml
+++ b/.github/workflows/analysis-scorecard.yaml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -160,6 +161,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -65,6 +66,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -145,6 +147,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -215,6 +218,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -262,6 +266,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -329,6 +334,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -366,6 +372,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -450,6 +457,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -499,6 +507,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -636,6 +645,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -656,6 +666,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -680,6 +691,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -815,6 +827,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/release-go-sdk.yaml
+++ b/.github/workflows/release-go-sdk.yaml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -122,6 +123,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -204,6 +206,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -302,6 +305,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/sdk-python-dev-release.yaml
+++ b/.github/workflows/sdk-python-dev-release.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -46,6 +47,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -69,6 +71,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 

--- a/.github/workflows/untrusted-artifacts.yaml
+++ b/.github/workflows/untrusted-artifacts.yaml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
@@ -67,6 +68,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
+          egress-policy: audit
           use-policy-store: true
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 


### PR DESCRIPTION
## Overview

Configure every StepSecurity Harden-Runner step with egress-policy: audit. This preserves network monitoring while preventing the default block policy from denying DNS and network access when a Policy Store policy cannot be loaded.

## Notes for reviewer

The previous configuration defaulted to block mode. In reusable workflow jobs where the StepSecurity API key was unavailable, Harden-Runner loaded an empty allowlist and blocked all outbound traffic, surfacing as getaddrinfo EAI_AGAIN errors.

## Testing

- actionlint
- Verified all 32 Harden-Runner steps have the exact audit configuration
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated automated build, test, release, and scanning workflows to monitor outbound network activity in audit mode.
  * Improved visibility into workflow network connections without blocking existing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->