### PR TITLE
feat(creditpurchase): resolve cost basis before realization

### DIFF
--- a/api/v3/handlers/customers/credits/convert.go
+++ b/api/v3/handlers/customers/credits/convert.go
@@ -97,13 +97,17 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 
 	switch settlement.Type() {
 	case creditpurchase.SettlementTypeInvoice:
-		resolvedCostBasis, err := charge.GetResolvedCostBasis()
+		purchaseAmount, err := charge.GetFiatSettlementAmount()
 		if err != nil {
-			return nil, fmt.Errorf("getting resolved cost basis: %w", err)
+			return nil, fmt.Errorf("getting fiat settlement amount: %w", err)
 		}
 
-		costBasis := resolvedCostBasis.Rate.String()
-		purchaseAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
+		fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting settlement fiat currency: %w", err)
+		}
+
+		costBasis := charge.State.ResolvedCostBasis.CostBasis.String()
 		settlementStatus := api.BillingCreditPurchasePaymentSettlementStatusPending
 
 		if charge.Realizations.InvoiceSettlement != nil {
@@ -112,7 +116,7 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 
 		return &api.BillingCreditGrantPurchase{
 			Amount:           purchaseAmount.String(),
-			Currency:         api.CurrencyCode(resolvedCostBasis.FiatCurrency.GetFiatCode()),
+			Currency:         api.CurrencyCode(fiatCurrency.GetFiatCode()),
 			PerUnitCostBasis: &costBasis,
 			SettlementStatus: &settlementStatus,
 		}, nil
@@ -123,13 +127,17 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 			return nil, fmt.Errorf("getting external settlement: %w", err)
 		}
 
-		resolvedCostBasis, err := charge.GetResolvedCostBasis()
+		purchaseAmount, err := charge.GetFiatSettlementAmount()
 		if err != nil {
-			return nil, fmt.Errorf("getting resolved cost basis: %w", err)
+			return nil, fmt.Errorf("getting fiat settlement amount: %w", err)
 		}
 
-		costBasis := resolvedCostBasis.Rate.String()
-		purchaseAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
+		fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting settlement fiat currency: %w", err)
+		}
+
+		costBasis := charge.State.ResolvedCostBasis.CostBasis.String()
 		availPolicy, err := toAPIBillingCreditAvailabilityPolicy(ext.InitialStatus)
 		if err != nil {
 			return nil, fmt.Errorf("converting availability policy: %w", err)
@@ -142,7 +150,7 @@ func toAPICreditGrantPurchase(charge creditpurchase.Charge) (*api.BillingCreditG
 
 		return &api.BillingCreditGrantPurchase{
 			Amount:             purchaseAmount.String(),
-			Currency:           api.CurrencyCode(resolvedCostBasis.FiatCurrency.GetFiatCode()),
+			Currency:           api.CurrencyCode(fiatCurrency.GetFiatCode()),
 			PerUnitCostBasis:   &costBasis,
 			AvailabilityPolicy: &availPolicy,
 			SettlementStatus:   &settlementStatus,

--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -316,12 +316,14 @@ func NewChargesCreditPurchaseService(
 	creditPurchaseHandler creditpurchase.Handler,
 	lineageService lineage.Service,
 	metaAdapter meta.Adapter,
+	currenciesService currencies.Service,
 ) (creditpurchase.Service, error) {
 	creditPurchaseSvc, err := creditpurchaseservice.New(creditpurchaseservice.Config{
 		Adapter:     creditPurchaseAdapter,
 		Handler:     creditPurchaseHandler,
 		Lineage:     lineageService,
 		MetaAdapter: metaAdapter,
+		Currencies:  currenciesService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create charges credit purchase service: %w", err)
@@ -522,7 +524,7 @@ func newChargesRegistry(
 		return nil, err
 	}
 
-	creditPurchaseSvc, err := NewChargesCreditPurchaseService(creditPurchaseAdapter, creditPurchaseHandler, lineageService, metaAdapter)
+	creditPurchaseSvc, err := NewChargesCreditPurchaseService(creditPurchaseAdapter, creditPurchaseHandler, lineageService, metaAdapter, currenciesService)
 	if err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -200,10 +200,10 @@ but credit purchases reject it until their lifecycle can resolve the rate
 before monetary realization.
 
 Persisted credit purchases read settlement and cost basis only from their
-dedicated fields. Fiat purchases reconstruct resolved state from their scalar
-rate and immutable creation time; custom-currency purchases reference durable
-shared cost-basis state. The legacy settlement JSON column is deprecated and
-ignored.
+dedicated fields. Fiat purchases persist their scalar rate on the charge row;
+custom-currency purchases reference durable shared cost-basis state. Resolution
+time and charge creation time are not a validation invariant. The legacy
+settlement JSON column is deprecated and ignored.
 
 A credit grant, payment authorization, and payment settlement are separate
 durable facts. A later state cannot be inferred from the presence of an earlier

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -192,14 +192,18 @@ external settlement additionally supports a direct-paid path that records both
 facts in order.
 
 Payment-backed credit purchases also carry a charge-level cost basis. Fiat
-credit uses a fixed scalar rate in the charge currency. Custom-currency credit
-reuses the shared manual, pinned, or dynamic cost-basis intent and its durable
-resolved state; the shared model remains custom-currency-only.
+credit uses a fixed scalar intent in the charge currency and materializes its
+deterministic resolved state at charge creation. Custom-currency credit reuses
+the shared manual or pinned cost-basis intent and its durable resolved state;
+the shared model remains custom-currency-only. Dynamic intent is representable
+but credit purchases reject it until their lifecycle can resolve the rate
+before monetary realization.
 
 Persisted credit purchases read settlement and cost basis only from their
-dedicated fields. Fiat purchases store their scalar rate on the charge;
-custom-currency purchases reference durable shared cost-basis state. The legacy
-settlement JSON column is deprecated and ignored.
+dedicated fields. Fiat purchases reconstruct resolved state from their scalar
+rate and immutable creation time; custom-currency purchases reference durable
+shared cost-basis state. The legacy settlement JSON column is deprecated and
+ignored.
 
 A credit grant, payment authorization, and payment settlement are separate
 durable facts. A later state cannot be inferred from the presence of an earlier

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -189,15 +189,21 @@ Payment-backed credit purchases grant credits before entering payment pending,
 then record authorization and settlement as separate state-machine transitions.
 Invoice settlement requires billing's authorization callback before settlement;
 external settlement additionally supports a direct-paid path that records both
-facts in order.
+facts in order. An invoice-settled credit purchase has one standard invoice
+line; duplicate lines for the same charge are rejected before lifecycle events
+because the transition and its payment realization are bound to that line.
 
 Payment-backed credit purchases also carry a charge-level cost basis. Fiat
 credit uses a fixed scalar intent in the charge currency and materializes its
 deterministic resolved state at charge creation. Custom-currency credit reuses
-the shared manual or pinned cost-basis intent and its durable resolved state;
-the shared model remains custom-currency-only. Dynamic intent is representable
-but credit purchases reject it until their lifecycle can resolve the rate
-before monetary realization.
+the shared manual, pinned, or dynamic cost-basis intent and its durable resolved
+state; the shared model remains custom-currency-only. Dynamic intent is
+persisted unresolved, then pinned to the rate effective at the purchase's
+service-period start by the credit-purchase state machine. Invoice-settled
+purchases enter billing with a provisional zero-value line. When billing creates
+the standard invoice, the state machine resolves the cost basis before booking
+the credit grant; the line engine then requires that resolution and replaces the
+provisional amount with the resolved fiat value.
 
 Persisted credit purchases read settlement and cost basis only from their
 dedicated fields. Fiat purchases persist their scalar rate on the charge row;

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -199,11 +199,12 @@ deterministic resolved state at charge creation. Custom-currency credit reuses
 the shared manual, pinned, or dynamic cost-basis intent and its durable resolved
 state; the shared model remains custom-currency-only. Dynamic intent is
 persisted unresolved, then pinned to the rate effective at the purchase's
-service-period start by the credit-purchase state machine. Invoice-settled
-purchases enter billing with a provisional zero-value line. When billing creates
+service-period start by the credit-purchase state machine. Externally settled
+purchases resolve immediately before their credit grant. Invoice-settled
+purchases enter billing with a provisional zero-value line; when billing creates
 the standard invoice, the state machine resolves the cost basis before booking
-the credit grant; the line engine then requires that resolution and replaces the
-provisional amount with the resolved fiat value.
+the credit grant. The line engine then requires that resolution and replaces
+the provisional amount with the resolved fiat value.
 
 Persisted credit purchases read settlement and cost basis only from their
 dedicated fields. Fiat purchases persist their scalar rate on the charge row;

--- a/openmeter/billing/charges/creditpurchase/adapter.go
+++ b/openmeter/billing/charges/creditpurchase/adapter.go
@@ -27,8 +27,8 @@ type Adapter interface {
 }
 
 type ChargeAdapter interface {
-	CreateCharge(ctx context.Context, in CreateChargeInput) (Charge, error)
-	SetResolvedCostBasis(ctx context.Context, input SetResolvedCostBasisInput) (costbasis.CostBasis, error)
+	CreateCharge(ctx context.Context, in CreateChargeAdapterInput) (Charge, error)
+	SetResolvedCostBasis(ctx context.Context, input SetResolvedCostBasisAdapterInput) (costbasis.State, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	MarkVoided(ctx context.Context, input MarkVoidedAdapterInput) (ChargeBase, error)
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
@@ -37,15 +37,15 @@ type ChargeAdapter interface {
 	ListFundedCreditActivities(ctx context.Context, input ListFundedCreditActivitiesInput) (ListFundedCreditActivitiesResult, error)
 }
 
-type SetResolvedCostBasisInput struct {
+type SetResolvedCostBasisAdapterInput struct {
 	ChargeID          meta.ChargeID
 	ChargeCostBasisID string
 	State             costbasis.State
 }
 
-var _ models.Validator = SetResolvedCostBasisInput{}
+var _ models.Validator = SetResolvedCostBasisAdapterInput{}
 
-func (i SetResolvedCostBasisInput) Validate() error {
+func (i SetResolvedCostBasisAdapterInput) Validate() error {
 	var errs []error
 
 	if err := i.ChargeID.Validate(); err != nil {
@@ -63,7 +63,7 @@ func (i SetResolvedCostBasisInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-type CreateChargeInput struct {
+type CreateChargeAdapterInput struct {
 	CreateInput
 
 	// InitialCostBasisState is persisted only for manual and pinned custom-currency
@@ -72,9 +72,9 @@ type CreateChargeInput struct {
 	InitialCostBasisState *costbasis.State
 }
 
-var _ models.Validator = (*CreateChargeInput)(nil)
+var _ models.Validator = (*CreateChargeAdapterInput)(nil)
 
-func (i CreateChargeInput) Validate() error {
+func (i CreateChargeAdapterInput) Validate() error {
 	var errs []error
 
 	if err := i.CreateInput.Validate(); err != nil {

--- a/openmeter/billing/charges/creditpurchase/adapter.go
+++ b/openmeter/billing/charges/creditpurchase/adapter.go
@@ -28,6 +28,7 @@ type Adapter interface {
 
 type ChargeAdapter interface {
 	CreateCharge(ctx context.Context, in CreateChargeInput) (Charge, error)
+	SetResolvedCostBasis(ctx context.Context, input SetResolvedCostBasisInput) (costbasis.CostBasis, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	MarkVoided(ctx context.Context, input MarkVoidedAdapterInput) (ChargeBase, error)
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
@@ -36,10 +37,39 @@ type ChargeAdapter interface {
 	ListFundedCreditActivities(ctx context.Context, input ListFundedCreditActivitiesInput) (ListFundedCreditActivitiesResult, error)
 }
 
+type SetResolvedCostBasisInput struct {
+	ChargeID          meta.ChargeID
+	ChargeCostBasisID string
+	State             costbasis.State
+}
+
+var _ models.Validator = SetResolvedCostBasisInput{}
+
+func (i SetResolvedCostBasisInput) Validate() error {
+	var errs []error
+
+	if err := i.ChargeID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	if i.ChargeCostBasisID == "" {
+		errs = append(errs, errors.New("charge cost basis ID is required"))
+	}
+
+	if err := i.State.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("state: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 type CreateChargeInput struct {
 	CreateInput
 
-	ResolvedCostBasis *costbasis.State
+	// InitialCostBasisState is persisted only for manual and pinned custom-currency
+	// cost bases. Fiat state is reconstructed from immutable charge-row fields,
+	// while dynamic custom-currency state is resolved at realization time.
+	InitialCostBasisState *costbasis.State
 }
 
 var _ models.Validator = (*CreateChargeInput)(nil)
@@ -51,46 +81,27 @@ func (i CreateChargeInput) Validate() error {
 		errs = append(errs, err)
 	}
 
-	if i.ResolvedCostBasis != nil {
-		if err := i.ResolvedCostBasis.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("resolved cost basis: %w", err))
-		}
-	}
-
-	dynamicCostBasis := false
-	if i.Intent.CostBasis != nil && i.Intent.CostBasis.Type() == CostBasisTypeCustomCurrency {
-		customCostBasis, err := i.Intent.CostBasis.AsCustomCurrency()
-		if err == nil {
-			dynamicCostBasis = customCostBasis.Kind() == costbasis.ModeDynamic
-		}
-	}
-
 	switch i.Intent.Settlement.Type() {
 	case SettlementTypePromotional:
-		if i.ResolvedCostBasis != nil {
-			errs = append(errs, errors.New("promotional credit purchase cannot have resolved cost-basis state"))
+		if i.InitialCostBasisState != nil {
+			errs = append(errs, errors.New("promotional credit purchase cannot have initial cost-basis state"))
 		}
 	case SettlementTypeInvoice, SettlementTypeExternal:
-		if dynamicCostBasis {
-			// TODO: Support dynamic cost basis once credit-purchase lifecycle
-			// resolution can pin the rate before the first monetary realization.
-			errs = append(errs, errors.New("dynamic cost basis is not supported for credit purchases"))
-		} else if i.ResolvedCostBasis == nil {
-			errs = append(errs, errors.New("payment-backed credit purchase requires resolved cost-basis state"))
-		}
-	}
-
-	if i.ResolvedCostBasis != nil && i.Intent.CostBasis != nil && i.Intent.CostBasis.Type() == CostBasisTypeFiat {
-		fiatCostBasis, err := i.Intent.CostBasis.AsFiat()
-		if err != nil {
-			errs = append(errs, fmt.Errorf("fiat cost basis: %w", err))
-		} else {
-			if i.ResolvedCostBasis.CostBasisID != nil {
-				errs = append(errs, errors.New("fiat resolved cost basis cannot reference a currency cost basis"))
+		switch i.Intent.CostBasis.Type() {
+		case CostBasisTypeFiat:
+			if i.InitialCostBasisState != nil {
+				errs = append(errs, errors.New("fiat credit purchase cannot have initial cost-basis state"))
 			}
-
-			if !i.ResolvedCostBasis.CostBasis.Equal(fiatCostBasis.Rate) {
-				errs = append(errs, errors.New("fiat resolved cost basis must match the intent rate"))
+		case CostBasisTypeCustomCurrency:
+			switch i.Intent.CostBasis.GetCustomCurrencyModeOrEmpty() {
+			case costbasis.ModeDynamic:
+				if i.InitialCostBasisState != nil {
+					errs = append(errs, errors.New("dynamic credit purchase cannot have initial cost-basis state"))
+				}
+			case costbasis.ModeManual, costbasis.ModePinned:
+				if i.InitialCostBasisState == nil {
+					errs = append(errs, errors.New("manual or pinned credit purchase requires initial cost-basis state"))
+				}
 			}
 		}
 	}

--- a/openmeter/billing/charges/creditpurchase/adapter.go
+++ b/openmeter/billing/charges/creditpurchase/adapter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -26,13 +27,75 @@ type Adapter interface {
 }
 
 type ChargeAdapter interface {
-	CreateCharge(ctx context.Context, in CreateInput) (Charge, error)
+	CreateCharge(ctx context.Context, in CreateChargeInput) (Charge, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	MarkVoided(ctx context.Context, input MarkVoidedAdapterInput) (ChargeBase, error)
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, id GetByIDInput) (Charge, error)
 	ListCharges(ctx context.Context, input ListChargesInput) (pagination.Result[Charge], error)
 	ListFundedCreditActivities(ctx context.Context, input ListFundedCreditActivitiesInput) (ListFundedCreditActivitiesResult, error)
+}
+
+type CreateChargeInput struct {
+	CreateInput
+
+	ResolvedCostBasis *costbasis.State
+}
+
+var _ models.Validator = (*CreateChargeInput)(nil)
+
+func (i CreateChargeInput) Validate() error {
+	var errs []error
+
+	if err := i.CreateInput.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if i.ResolvedCostBasis != nil {
+		if err := i.ResolvedCostBasis.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("resolved cost basis: %w", err))
+		}
+	}
+
+	dynamicCostBasis := false
+	if i.Intent.CostBasis != nil && i.Intent.CostBasis.Type() == CostBasisTypeCustomCurrency {
+		customCostBasis, err := i.Intent.CostBasis.AsCustomCurrency()
+		if err == nil {
+			dynamicCostBasis = customCostBasis.Kind() == costbasis.ModeDynamic
+		}
+	}
+
+	switch i.Intent.Settlement.Type() {
+	case SettlementTypePromotional:
+		if i.ResolvedCostBasis != nil {
+			errs = append(errs, errors.New("promotional credit purchase cannot have resolved cost-basis state"))
+		}
+	case SettlementTypeInvoice, SettlementTypeExternal:
+		if dynamicCostBasis {
+			// TODO: Support dynamic cost basis once credit-purchase lifecycle
+			// resolution can pin the rate before the first monetary realization.
+			errs = append(errs, errors.New("dynamic cost basis is not supported for credit purchases"))
+		} else if i.ResolvedCostBasis == nil {
+			errs = append(errs, errors.New("payment-backed credit purchase requires resolved cost-basis state"))
+		}
+	}
+
+	if i.ResolvedCostBasis != nil && i.Intent.CostBasis != nil && i.Intent.CostBasis.Type() == CostBasisTypeFiat {
+		fiatCostBasis, err := i.Intent.CostBasis.AsFiat()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("fiat cost basis: %w", err))
+		} else {
+			if i.ResolvedCostBasis.CostBasisID != nil {
+				errs = append(errs, errors.New("fiat resolved cost basis cannot reference a currency cost basis"))
+			}
+
+			if !i.ResolvedCostBasis.CostBasis.Equal(fiatCostBasis.Rate) {
+				errs = append(errs, errors.New("fiat resolved cost basis must match the intent rate"))
+			}
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type ExternalPaymentAdapter interface {

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -158,7 +158,7 @@ func (i applyCostBasisInput) Validate() error {
 		errs = append(errs, errors.New("create is required"))
 	}
 
-	if i.Charge.Intent.CostBasis == nil {
+	if i.Charge.Intent.CostBasis.IsEmpty() {
 		errs = append(errs, errors.New("payment-backed credit purchase requires a cost basis"))
 	}
 
@@ -192,7 +192,7 @@ func (a *adapter) applyCostBasis(ctx context.Context, in applyCostBasisInput) (*
 			},
 			CurrencyID: in.Charge.Intent.Currency.ID,
 			Intent:     customCostBasis,
-			State:      in.Charge.ResolvedCostBasis,
+			State:      in.Charge.InitialCostBasisState,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("building custom-currency cost basis: %w", err)
@@ -201,14 +201,6 @@ func (a *adapter) applyCostBasis(ctx context.Context, in applyCostBasisInput) (*
 		createdCostBasis, err := costBasisCreate.Save(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("creating custom-currency cost basis: %w", err)
-		}
-
-		mappedCostBasis, err := costbasis.Get(createdCostBasis)
-		if err != nil {
-			return nil, fmt.Errorf("mapping created custom-currency cost basis: %w", err)
-		}
-		if mappedCostBasis.State == nil {
-			return nil, errors.New("created custom-currency cost basis is unresolved")
 		}
 
 		in.Create.SetCostBasisID(createdCostBasis.ID)

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -62,7 +62,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge creditpurchase.Charge
 	})
 }
 
-func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateInput) (creditpurchase.Charge, error) {
+func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChargeInput) (creditpurchase.Charge, error) {
 	if err := in.Validate(); err != nil {
 		return creditpurchase.Charge{}, err
 	}
@@ -146,7 +146,7 @@ func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateInpu
 
 type applyCostBasisInput struct {
 	Create *db.ChargeCreditPurchaseCreate
-	Charge creditpurchase.CreateInput
+	Charge creditpurchase.CreateChargeInput
 }
 
 var _ models.Validator = (*applyCostBasisInput)(nil)
@@ -185,10 +185,6 @@ func (a *adapter) applyCostBasis(ctx context.Context, in applyCostBasisInput) (*
 		if err != nil {
 			return nil, fmt.Errorf("getting custom-currency cost basis: %w", err)
 		}
-		if customCostBasis.Kind() != costbasis.ModeManual {
-			return nil, errors.New("custom-currency cost basis requires resolver integration")
-		}
-
 		costBasisCreate, err := costbasis.Create(a.db.ChargeCreditPurchaseCostBasis.Create(), costbasis.CreateInput{
 			NamespacedID: models.NamespacedID{
 				Namespace: in.Charge.Namespace,
@@ -196,6 +192,7 @@ func (a *adapter) applyCostBasis(ctx context.Context, in applyCostBasisInput) (*
 			},
 			CurrencyID: in.Charge.Intent.Currency.ID,
 			Intent:     customCostBasis,
+			State:      in.Charge.ResolvedCostBasis,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("building custom-currency cost basis: %w", err)

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -62,7 +62,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge creditpurchase.Charge
 	})
 }
 
-func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChargeInput) (creditpurchase.Charge, error) {
+func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChargeAdapterInput) (creditpurchase.Charge, error) {
 	if err := in.Validate(); err != nil {
 		return creditpurchase.Charge{}, err
 	}
@@ -146,7 +146,7 @@ func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChar
 
 type applyCostBasisInput struct {
 	Create *db.ChargeCreditPurchaseCreate
-	Charge creditpurchase.CreateChargeInput
+	Charge creditpurchase.CreateChargeAdapterInput
 }
 
 var _ models.Validator = (*applyCostBasisInput)(nil)

--- a/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
@@ -41,13 +41,13 @@ func (a *adapter) loadCostBasisEdge(ctx context.Context, entity *entdb.ChargeCre
 	return nil
 }
 
-func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase.SetResolvedCostBasisInput) (costbasis.CostBasis, error) {
+func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase.SetResolvedCostBasisAdapterInput) (costbasis.State, error) {
 	if err := input.Validate(); err != nil {
-		return costbasis.CostBasis{}, err
+		return costbasis.State{}, err
 	}
 
-	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (costbasis.CostBasis, error) {
-		entity, err := tx.db.ChargeCreditPurchaseCostBasis.UpdateOneID(input.ChargeCostBasisID).
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (costbasis.State, error) {
+		_, err := tx.db.ChargeCreditPurchaseCostBasis.UpdateOneID(input.ChargeCostBasisID).
 			Where(
 				dbchargecreditpurchasecostbasis.Namespace(input.ChargeID.Namespace),
 				costBasisOwnedByCharge(input.ChargeID),
@@ -57,7 +57,7 @@ func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase
 			SetResolvedAt(input.State.ResolvedAt.UTC()).
 			Save(ctx)
 		if entdb.IsNotFound(err) {
-			return costbasis.CostBasis{}, models.NewGenericNotFoundError(
+			return costbasis.State{}, models.NewGenericNotFoundError(
 				fmt.Errorf(
 					"credit purchase cost basis not found [charge_id=%s,cost_basis_id=%s]",
 					input.ChargeID.ID,
@@ -66,7 +66,7 @@ func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase
 			)
 		}
 		if err != nil {
-			return costbasis.CostBasis{}, fmt.Errorf(
+			return costbasis.State{}, fmt.Errorf(
 				"setting resolved credit purchase cost basis [charge_id=%s,cost_basis_id=%s]: %w",
 				input.ChargeID.ID,
 				input.ChargeCostBasisID,
@@ -74,12 +74,10 @@ func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase
 			)
 		}
 
-		persisted, err := costbasis.Get(entity)
-		if err != nil {
-			return costbasis.CostBasis{}, fmt.Errorf("mapping resolved credit purchase cost basis: %w", err)
-		}
+		persistedState := input.State
+		persistedState.ResolvedAt = persistedState.ResolvedAt.UTC()
 
-		return persisted, nil
+		return persistedState, nil
 	})
 }
 

--- a/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/costbasis.go
@@ -4,8 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"entgo.io/ent/dialect/sql"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargecreditpurchase "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchase"
 	dbchargecreditpurchasecostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchasecostbasis"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func (a *adapter) loadCostBasisEdge(ctx context.Context, entity *entdb.ChargeCreditPurchase) error {
@@ -30,4 +39,63 @@ func (a *adapter) loadCostBasisEdge(ctx context.Context, entity *entdb.ChargeCre
 	entity.Edges.CostBasis = costBasisEntity
 
 	return nil
+}
+
+func (a *adapter) SetResolvedCostBasis(ctx context.Context, input creditpurchase.SetResolvedCostBasisInput) (costbasis.CostBasis, error) {
+	if err := input.Validate(); err != nil {
+		return costbasis.CostBasis{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (costbasis.CostBasis, error) {
+		entity, err := tx.db.ChargeCreditPurchaseCostBasis.UpdateOneID(input.ChargeCostBasisID).
+			Where(
+				dbchargecreditpurchasecostbasis.Namespace(input.ChargeID.Namespace),
+				costBasisOwnedByCharge(input.ChargeID),
+			).
+			SetOrClearResolvedCostBasisID(input.State.CostBasisID).
+			SetResolvedCostBasis(input.State.CostBasis).
+			SetResolvedAt(input.State.ResolvedAt.UTC()).
+			Save(ctx)
+		if entdb.IsNotFound(err) {
+			return costbasis.CostBasis{}, models.NewGenericNotFoundError(
+				fmt.Errorf(
+					"credit purchase cost basis not found [charge_id=%s,cost_basis_id=%s]",
+					input.ChargeID.ID,
+					input.ChargeCostBasisID,
+				),
+			)
+		}
+		if err != nil {
+			return costbasis.CostBasis{}, fmt.Errorf(
+				"setting resolved credit purchase cost basis [charge_id=%s,cost_basis_id=%s]: %w",
+				input.ChargeID.ID,
+				input.ChargeCostBasisID,
+				err,
+			)
+		}
+
+		persisted, err := costbasis.Get(entity)
+		if err != nil {
+			return costbasis.CostBasis{}, fmt.Errorf("mapping resolved credit purchase cost basis: %w", err)
+		}
+
+		return persisted, nil
+	})
+}
+
+func costBasisOwnedByCharge(chargeID meta.ChargeID) predicate.ChargeCreditPurchaseCostBasis {
+	return predicate.ChargeCreditPurchaseCostBasis(func(selector *sql.Selector) {
+		chargeTable := sql.Table(dbchargecreditpurchase.Table)
+		ownedCostBasisIDs := sql.Select(chargeTable.C(dbchargecreditpurchase.FieldCostBasisID)).
+			From(chargeTable).
+			Where(sql.And(
+				sql.EQ(chargeTable.C(dbchargecreditpurchase.FieldID), chargeID.ID),
+				sql.EQ(chargeTable.C(dbchargecreditpurchase.FieldNamespace), chargeID.Namespace),
+			))
+
+		selector.Where(sql.In(
+			selector.C(dbchargecreditpurchasecostbasis.FieldID),
+			ownedCostBasisIDs,
+		))
+	})
 }

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper.go
@@ -132,7 +132,9 @@ func fromDBCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.C
 		return mappedCostBasis{
 			CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: *dbEntity.FiatCostBasis})),
 			ResolvedCostBasis: &costbasis.State{
-				CostBasis:  *dbEntity.FiatCostBasis,
+				CostBasis: *dbEntity.FiatCostBasis,
+				// CreatedAt is the only persisted timestamp available when
+				// reconstructing fiat cost-basis state - it's an acceptable fallback.
 				ResolvedAt: dbEntity.CreatedAt.In(time.UTC),
 			},
 		}, nil

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper.go
@@ -129,7 +129,13 @@ func fromDBCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.C
 			return mappedCostBasis{}, errors.New("fiat credit purchase contains custom-currency cost-basis state")
 		}
 
-		return mappedCostBasis{CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: *dbEntity.FiatCostBasis}))}, nil
+		return mappedCostBasis{
+			CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: *dbEntity.FiatCostBasis})),
+			ResolvedCostBasis: &costbasis.State{
+				CostBasis:  *dbEntity.FiatCostBasis,
+				ResolvedAt: dbEntity.CreatedAt.In(time.UTC),
+			},
+		}, nil
 	}
 
 	if dbEntity.FiatCostBasis != nil {

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper.go
@@ -61,6 +61,7 @@ func fromDBBase(dbEntity *entdb.ChargeCreditPurchase, mappedMeta meta.Charge) (c
 		},
 		State: creditpurchase.State{
 			VoidedAt:          convert.SafeToUTC(dbEntity.VoidedAt),
+			ChargeCostBasisID: mappedCostBasis.ChargeCostBasisID,
 			ResolvedCostBasis: mappedCostBasis.ResolvedCostBasis,
 		},
 	}
@@ -104,7 +105,8 @@ func fromDBSettlement(dbEntity *entdb.ChargeCreditPurchase) (creditpurchase.Sett
 }
 
 type mappedCostBasis struct {
-	CostBasis         *creditpurchase.CostBasis
+	CostBasis         creditpurchase.CostBasis
+	ChargeCostBasisID *string
 	ResolvedCostBasis *costbasis.State
 }
 
@@ -130,7 +132,7 @@ func fromDBCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.C
 		}
 
 		return mappedCostBasis{
-			CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: *dbEntity.FiatCostBasis})),
+			CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: *dbEntity.FiatCostBasis}),
 			ResolvedCostBasis: &costbasis.State{
 				CostBasis: *dbEntity.FiatCostBasis,
 				// CreatedAt is the only persisted timestamp available when
@@ -157,15 +159,13 @@ func fromDBCostBasis(dbEntity *entdb.ChargeCreditPurchase, currency currencies.C
 	if err != nil {
 		return mappedCostBasis{}, fmt.Errorf("mapping custom-currency cost basis: %w", err)
 	}
+
 	if mappedCustomCostBasis.CurrencyID != currency.ID {
 		return mappedCostBasis{}, fmt.Errorf("custom-currency cost basis currency mismatch [currency_id=%s,cost_basis_currency_id=%s]", currency.ID, mappedCustomCostBasis.CurrencyID)
 	}
-	if mappedCustomCostBasis.State == nil {
-		return mappedCostBasis{}, errors.New("custom-currency cost basis is unresolved")
-	}
-
 	return mappedCostBasis{
-		CostBasis:         lo.ToPtr(creditpurchase.NewCostBasis(mappedCustomCostBasis.Intent)),
+		CostBasis:         creditpurchase.NewCostBasis(mappedCustomCostBasis.Intent),
+		ChargeCostBasisID: dbEntity.CostBasisID,
 		ResolvedCostBasis: mappedCustomCostBasis.State,
 	}, nil
 }

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
@@ -41,8 +41,8 @@ func TestFromDBCostBasis(t *testing.T) {
 		require.False(t, mapped.CostBasis.IsEmpty())
 		require.Nil(t, mapped.ChargeCostBasisID)
 		require.NotNil(t, mapped.ResolvedCostBasis)
-		require.Equal(t, rate, mapped.ResolvedCostBasis.CostBasis)
-		require.False(t, mapped.ResolvedCostBasis.ResolvedAt.IsZero())
+		require.Equal(t, rate.InexactFloat64(), mapped.ResolvedCostBasis.CostBasis.InexactFloat64())
+		require.Equal(t, createdAt, mapped.ResolvedCostBasis.ResolvedAt)
 	})
 
 	t.Run("dedicated custom currency maps persisted state", func(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
@@ -38,7 +38,8 @@ func TestFromDBCostBasis(t *testing.T) {
 			CreatedAt:      createdAt,
 		}, currenciestestutils.NewFiatCurrency(t, "USD"))
 		require.NoError(t, err)
-		require.NotNil(t, mapped.CostBasis)
+		require.False(t, mapped.CostBasis.IsEmpty())
+		require.Nil(t, mapped.ChargeCostBasisID)
 		require.NotNil(t, mapped.ResolvedCostBasis)
 		require.Equal(t, rate, mapped.ResolvedCostBasis.CostBasis)
 		require.False(t, mapped.ResolvedCostBasis.ResolvedAt.IsZero())
@@ -70,13 +71,44 @@ func TestFromDBCostBasis(t *testing.T) {
 			},
 		}, customCurrency)
 		require.NoError(t, err)
-		require.NotNil(t, mapped.CostBasis)
+		require.False(t, mapped.CostBasis.IsEmpty())
+		require.Equal(t, &costBasisID, mapped.ChargeCostBasisID)
 		require.NotNil(t, mapped.ResolvedCostBasis)
 		require.Equal(t, resolvedAt, mapped.ResolvedCostBasis.ResolvedAt)
 
 		intent, err := mapped.CostBasis.AsCustomCurrency()
 		require.NoError(t, err)
 		require.Equal(t, costbasis.ModeManual, intent.Kind())
+	})
+
+	t.Run("dedicated dynamic custom currency maps unresolved state", func(t *testing.T) {
+		customCurrency := currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)
+		customCurrency.Namespace = "ns"
+		costBasisID := "01J00000000000000000000000"
+
+		mapped, err := fromDBCostBasis(&db.ChargeCreditPurchase{
+			SettlementType: &invoiceSettlementType,
+			CostBasisID:    &costBasisID,
+			Edges: db.ChargeCreditPurchaseEdges{
+				CostBasis: &db.ChargeCreditPurchaseCostBasis{
+					ID:           costBasisID,
+					Namespace:    customCurrency.Namespace,
+					Mode:         costbasis.ModeDynamic,
+					FiatCurrency: fiatCode,
+					CurrencyID:   customCurrency.ID,
+					CreatedAt:    createdAt,
+					UpdatedAt:    createdAt,
+				},
+			},
+		}, customCurrency)
+		require.NoError(t, err)
+		require.False(t, mapped.CostBasis.IsEmpty())
+		require.Equal(t, &costBasisID, mapped.ChargeCostBasisID)
+		require.Nil(t, mapped.ResolvedCostBasis)
+
+		intent, err := mapped.CostBasis.AsCustomCurrency()
+		require.NoError(t, err)
+		require.Equal(t, costbasis.ModeDynamic, intent.Kind())
 	})
 }
 

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
@@ -31,7 +31,7 @@ func TestFromDBCostBasis(t *testing.T) {
 		require.ErrorContains(t, err, "fiat cost basis is required")
 	})
 
-	t.Run("dedicated fiat materializes resolved state at charge creation", func(t *testing.T) {
+	t.Run("dedicated fiat materializes resolved state", func(t *testing.T) {
 		mapped, err := fromDBCostBasis(&db.ChargeCreditPurchase{
 			SettlementType: &invoiceSettlementType,
 			FiatCostBasis:  &rate,
@@ -39,10 +39,9 @@ func TestFromDBCostBasis(t *testing.T) {
 		}, currenciestestutils.NewFiatCurrency(t, "USD"))
 		require.NoError(t, err)
 		require.NotNil(t, mapped.CostBasis)
-		require.Equal(t, &costbasis.State{
-			CostBasis:  rate,
-			ResolvedAt: createdAt,
-		}, mapped.ResolvedCostBasis)
+		require.NotNil(t, mapped.ResolvedCostBasis)
+		require.Equal(t, rate, mapped.ResolvedCostBasis.CostBasis)
+		require.False(t, mapped.ResolvedCostBasis.ResolvedAt.IsZero())
 	})
 
 	t.Run("dedicated custom currency maps persisted state", func(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper_test.go
@@ -31,6 +31,20 @@ func TestFromDBCostBasis(t *testing.T) {
 		require.ErrorContains(t, err, "fiat cost basis is required")
 	})
 
+	t.Run("dedicated fiat materializes resolved state at charge creation", func(t *testing.T) {
+		mapped, err := fromDBCostBasis(&db.ChargeCreditPurchase{
+			SettlementType: &invoiceSettlementType,
+			FiatCostBasis:  &rate,
+			CreatedAt:      createdAt,
+		}, currenciestestutils.NewFiatCurrency(t, "USD"))
+		require.NoError(t, err)
+		require.NotNil(t, mapped.CostBasis)
+		require.Equal(t, &costbasis.State{
+			CostBasis:  rate,
+			ResolvedAt: createdAt,
+		}, mapped.ResolvedCostBasis)
+	})
+
 	t.Run("dedicated custom currency maps persisted state", func(t *testing.T) {
 		customCurrency := currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)
 		customCurrency.Namespace = "ns"

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -67,16 +67,24 @@ func (c ChargeBase) validateCostBasis() error {
 		return errors.New("persisted payment-backed credit purchase requires a cost basis")
 	}
 
-	if !c.Intent.Currency.IsCustom() {
-		if c.State.ResolvedCostBasis != nil {
-			return errors.New("fiat credit purchase cannot have custom-currency cost-basis state")
-		}
-
-		return nil
+	if c.State.ResolvedCostBasis == nil {
+		return errors.New("payment-backed credit purchase requires resolved cost-basis state")
 	}
 
-	if c.State.ResolvedCostBasis == nil {
-		return errors.New("custom-currency credit purchase requires resolved cost-basis state")
+	if !c.Intent.Currency.IsCustom() {
+		fiatCostBasis, err := c.Intent.CostBasis.AsFiat()
+		if err != nil {
+			return fmt.Errorf("getting fiat cost basis: %w", err)
+		}
+		if c.State.ResolvedCostBasis.CostBasisID != nil {
+			return errors.New("fiat resolved cost basis cannot reference a currency cost basis")
+		}
+		if !c.State.ResolvedCostBasis.CostBasis.Equal(fiatCostBasis.Rate) {
+			return errors.New("fiat resolved cost basis must match the intent rate")
+		}
+		if !c.State.ResolvedCostBasis.ResolvedAt.Equal(c.CreatedAt) {
+			return errors.New("fiat resolved cost-basis time must match charge creation time")
+		}
 	}
 
 	return nil
@@ -308,8 +316,9 @@ type State struct {
 	// ledger void flow; the breakage records stay the accounting source of truth.
 	VoidedAt *time.Time `json:"voidedAt,omitempty"`
 
-	// ResolvedCostBasis applies only to custom-currency credit purchases. Fiat
-	// cost basis is immutable intent stored on the charge row.
+	// ResolvedCostBasis is required for every payment-backed credit purchase.
+	// Fiat state is reconstructed from immutable charge-row fields, while custom
+	// currency state is persisted on the shared cost-basis child.
 	ResolvedCostBasis *chargecostbasis.State `json:"resolvedCostBasis,omitempty"`
 }
 

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -47,44 +48,7 @@ func (c ChargeBase) Validate() error {
 		errs = append(errs, fmt.Errorf("state: %w", err))
 	}
 
-	if err := c.validateCostBasis(); err != nil {
-		errs = append(errs, fmt.Errorf("cost basis: %w", err))
-	}
-
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
-func (c ChargeBase) validateCostBasis() error {
-	if c.Intent.Settlement.Type() == SettlementTypePromotional {
-		if c.State.ResolvedCostBasis != nil {
-			return errors.New("promotional credit purchase cannot have cost-basis state")
-		}
-
-		return nil
-	}
-
-	if c.Intent.CostBasis == nil {
-		return errors.New("persisted payment-backed credit purchase requires a cost basis")
-	}
-
-	if c.State.ResolvedCostBasis == nil {
-		return errors.New("payment-backed credit purchase requires resolved cost-basis state")
-	}
-
-	if !c.Intent.Currency.IsCustom() {
-		fiatCostBasis, err := c.Intent.CostBasis.AsFiat()
-		if err != nil {
-			return fmt.Errorf("getting fiat cost basis: %w", err)
-		}
-		if c.State.ResolvedCostBasis.CostBasisID != nil {
-			return errors.New("fiat resolved cost basis cannot reference a currency cost basis")
-		}
-		if !c.State.ResolvedCostBasis.CostBasis.Equal(fiatCostBasis.Rate) {
-			return errors.New("fiat resolved cost basis must match the intent rate")
-		}
-	}
-
-	return nil
 }
 
 func (c ChargeBase) GetChargeID() meta.ChargeID {
@@ -153,13 +117,37 @@ func (c Charge) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// GetFiatSettlementAmount returns the purchased credit's value in its
+// settlement currency using the resolved cost basis.
+func (c Charge) GetFiatSettlementAmount() (alpacadecimal.Decimal, error) {
+	fiatCurrency, err := c.Intent.GetSettlementFiatCurrency()
+	if err != nil {
+		return alpacadecimal.Zero, fmt.Errorf("getting settlement fiat currency: %w", err)
+	}
+
+	if c.State.ResolvedCostBasis == nil {
+		return alpacadecimal.Zero, errors.New("cost basis is unresolved")
+	}
+
+	fiatAmount, err := meta.CalculateFiatAmount(
+		c.Intent.CreditAmount,
+		c.State.ResolvedCostBasis.CostBasis,
+		fiatCurrency,
+	)
+	if err != nil {
+		return alpacadecimal.Zero, fmt.Errorf("calculating fiat settlement amount: %w", err)
+	}
+
+	return fiatAmount, nil
+}
+
 type Intent struct {
 	meta.Intent
 	IntentMutableFields
 
 	// CostBasis describes the purchase price independently from the payment
 	// settlement mechanism. Promotional purchases do not have one.
-	CostBasis *CostBasis `json:"costBasis,omitempty"`
+	CostBasis CostBasis `json:"costBasis,omitzero"`
 
 	// Key is the optional idempotency key: a retried create with the same key returns a conflict.
 	Key *string `json:"key,omitempty"`
@@ -274,13 +262,13 @@ func (i Intent) Validate() error {
 func (i Intent) validateCostBasis() error {
 	switch i.Settlement.Type() {
 	case SettlementTypePromotional:
-		if i.CostBasis != nil {
+		if !i.CostBasis.IsEmpty() {
 			return errors.New("promotional credit purchase cannot have a cost basis")
 		}
 
 		return nil
 	case SettlementTypeInvoice, SettlementTypeExternal:
-		if i.CostBasis == nil {
+		if i.CostBasis.IsEmpty() {
 			return errors.New("payment-backed credit purchase requires a cost basis")
 		}
 	default:
@@ -307,20 +295,71 @@ func (i Intent) validateCostBasis() error {
 	return nil
 }
 
+// GetSettlementFiatCurrency returns the fiat currency in which a
+// payment-backed credit purchase is settled.
+func (i Intent) GetSettlementFiatCurrency() (*currencyx.FiatCurrency, error) {
+	switch i.Settlement.Type() {
+	case SettlementTypeInvoice, SettlementTypeExternal:
+	case SettlementTypePromotional:
+		return nil, errors.New("promotional credit purchase does not have a settlement fiat currency")
+	default:
+		return nil, fmt.Errorf("unsupported credit purchase settlement type: %s", i.Settlement.Type())
+	}
+
+	if i.CostBasis.IsEmpty() {
+		return nil, errors.New("credit purchase cost basis is required")
+	}
+
+	switch i.CostBasis.Type() {
+	case CostBasisTypeFiat:
+		if i.Currency.IsCustom() {
+			return nil, errors.New("fiat cost basis requires a fiat purchase currency")
+		}
+
+		fiatCurrency, err := currencyx.NewFiatCurrency(i.Currency.GetCode())
+		if err != nil {
+			return nil, fmt.Errorf("mapping purchase currency to fiat currency: %w", err)
+		}
+
+		return fiatCurrency, nil
+	case CostBasisTypeCustomCurrency:
+		costBasisIntent, err := i.CostBasis.AsCustomCurrency()
+		if err != nil {
+			return nil, err
+		}
+
+		fiatCurrency, err := costBasisIntent.GetFiatCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting custom-currency fiat currency: %w", err)
+		}
+
+		return fiatCurrency, nil
+	default:
+		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", i.CostBasis.Type())
+	}
+}
+
 // State holds durable base-row scheduling fields for the credit purchase charge.
 type State struct {
 	// VoidedAt is set when the remaining value was forfeited through the
 	// ledger void flow; the breakage records stay the accounting source of truth.
 	VoidedAt *time.Time `json:"voidedAt,omitempty"`
+	// ChargeCostBasisID references the persisted custom-currency cost-basis
+	// intent and state owned by this charge. Fiat purchases do not have one.
+	ChargeCostBasisID *string `json:"chargeCostBasisID,omitempty"`
 
-	// ResolvedCostBasis is required for every payment-backed credit purchase.
+	// ResolvedCostBasis is populated before the first monetary realization.
 	// Fiat state is reconstructed from immutable charge-row fields, while custom
-	// currency state is persisted on the shared cost-basis child.
+	// currency state is persisted on the shared cost-basis child. Dynamic custom
+	// currency intent remains unresolved until that realization boundary.
 	ResolvedCostBasis *chargecostbasis.State `json:"resolvedCostBasis,omitempty"`
 }
 
 func (s State) Validate() error {
 	var errs []error
+	if s.ChargeCostBasisID != nil && *s.ChargeCostBasisID == "" {
+		errs = append(errs, errors.New("charge cost basis ID cannot be empty"))
+	}
 
 	if s.ResolvedCostBasis != nil {
 		if err := s.ResolvedCostBasis.Validate(); err != nil {

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -82,9 +82,6 @@ func (c ChargeBase) validateCostBasis() error {
 		if !c.State.ResolvedCostBasis.CostBasis.Equal(fiatCostBasis.Rate) {
 			return errors.New("fiat resolved cost basis must match the intent rate")
 		}
-		if !c.State.ResolvedCostBasis.ResolvedAt.Equal(c.CreatedAt) {
-			return errors.New("fiat resolved cost-basis time must match charge creation time")
-		}
 	}
 
 	return nil

--- a/openmeter/billing/charges/creditpurchase/charge_test.go
+++ b/openmeter/billing/charges/creditpurchase/charge_test.go
@@ -255,7 +255,7 @@ func TestCreateInputValidateRejectsExpiryWithoutEffectiveAt(t *testing.T) {
 	}
 }
 
-func TestCreateChargeInputValidateInitialCostBasisState(t *testing.T) {
+func TestCreateChargeAdapterInputValidateInitialCostBasisState(t *testing.T) {
 	period := timeutil.ClosedPeriod{
 		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
@@ -266,7 +266,7 @@ func TestCreateChargeInputValidateInitialCostBasisState(t *testing.T) {
 		CostBasis:  alpacadecimal.NewFromInt(1),
 		ResolvedAt: period.From,
 	}
-	input := CreateChargeInput{CreateInput: CreateInput{
+	input := CreateChargeAdapterInput{CreateInput: CreateInput{
 		Namespace: "test",
 		Intent: Intent{
 			Intent: meta.Intent{
@@ -383,8 +383,8 @@ func TestCreateChargeInputValidateInitialCostBasisState(t *testing.T) {
 	})
 }
 
-func TestSetResolvedCostBasisInputValidate(t *testing.T) {
-	valid := SetResolvedCostBasisInput{
+func TestSetResolvedCostBasisAdapterInputValidate(t *testing.T) {
+	valid := SetResolvedCostBasisAdapterInput{
 		ChargeID: meta.ChargeID{
 			Namespace: "test",
 			ID:        "charge-1",

--- a/openmeter/billing/charges/creditpurchase/charge_test.go
+++ b/openmeter/billing/charges/creditpurchase/charge_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -146,6 +148,46 @@ func TestCreateInputValidateRejectsExpiryWithoutEffectiveAt(t *testing.T) {
 			require.ErrorContains(t, err, "expires at must be after effective at")
 		})
 	}
+}
+
+func TestCreateChargeInputValidateRejectsDynamicCostBasis(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+	}
+	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	input := CreateChargeInput{CreateInput: CreateInput{
+		Namespace: "test",
+		Intent: Intent{
+			Intent: meta.Intent{
+				ManagedBy:  billing.ManuallyManagedLine,
+				CustomerID: "customer-1",
+				Currency:   currenciestestutils.NewCustomCurrency(t, "TOKENS", 2),
+				TaxConfig: productcatalog.TaxCodeConfig{
+					TaxCodeID: "tax-code-1",
+				},
+			},
+			IntentMutableFields: IntentMutableFields{
+				IntentMutableFields: meta.IntentMutableFields{
+					Name:              "dynamic credit purchase",
+					ServicePeriod:     period,
+					FullServicePeriod: period,
+					BillingPeriod:     period,
+				},
+				CreditAmount: alpacadecimal.NewFromInt(1),
+				Settlement:   NewInvoiceSettlement(),
+			},
+			CostBasis: lo.ToPtr(NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
+				FiatCurrency: fiatCurrency,
+			}))),
+		},
+	}}
+
+	err = input.Validate()
+	require.ErrorContains(t, err, "dynamic cost basis is not supported for credit purchases")
+	require.NotContains(t, err.Error(), "requires resolved cost-basis state")
 }
 
 func TestFeatureFiltersNormalize(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/charge_test.go
+++ b/openmeter/billing/charges/creditpurchase/charge_test.go
@@ -47,6 +47,111 @@ func TestIntentNormalizedPinsServicePeriodsToEffectiveAt(t *testing.T) {
 	require.Equal(t, expectedPeriod, got.BillingPeriod)
 }
 
+func TestIntentGetSettlementFiatCurrency(t *testing.T) {
+	t.Run("fiat purchase settles in its purchase currency", func(t *testing.T) {
+		intent := Intent{
+			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
+			IntentMutableFields: IntentMutableFields{
+				Settlement: NewInvoiceSettlement(),
+			},
+			CostBasis: NewCostBasis(FiatCostBasis{Rate: alpacadecimal.NewFromInt(1)}),
+		}
+
+		fiatCurrency, err := intent.GetSettlementFiatCurrency()
+		require.NoError(t, err)
+		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
+	})
+
+	t.Run("custom currency purchase settles in its cost basis currency", func(t *testing.T) {
+		usd, err := currencyx.NewFiatCurrency("USD")
+		require.NoError(t, err)
+
+		intent := Intent{
+			Intent: meta.Intent{Currency: currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)},
+			IntentMutableFields: IntentMutableFields{
+				Settlement: NewSettlement(ExternalSettlement{
+					InitialStatus: CreatedInitialPaymentSettlementStatus,
+				}),
+			},
+			CostBasis: NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				FiatCurrency: usd,
+				Rate:         alpacadecimal.NewFromInt(1),
+			})),
+		}
+
+		fiatCurrency, err := intent.GetSettlementFiatCurrency()
+		require.NoError(t, err)
+		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
+	})
+
+	t.Run("promotional purchase has no settlement fiat currency", func(t *testing.T) {
+		intent := Intent{
+			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
+			IntentMutableFields: IntentMutableFields{
+				Settlement: NewSettlement(PromotionalSettlement{}),
+			},
+		}
+
+		_, err := intent.GetSettlementFiatCurrency()
+		require.ErrorContains(t, err, "does not have a settlement fiat currency")
+	})
+
+	t.Run("payment-backed purchase requires a cost basis", func(t *testing.T) {
+		intent := Intent{
+			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
+			IntentMutableFields: IntentMutableFields{
+				Settlement: NewInvoiceSettlement(),
+			},
+		}
+
+		_, err := intent.GetSettlementFiatCurrency()
+		require.ErrorContains(t, err, "cost basis is required")
+	})
+}
+
+func TestChargeGetFiatSettlementAmount(t *testing.T) {
+	usd, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	testCases := map[string]Intent{
+		"fiat purchase": {
+			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
+			IntentMutableFields: IntentMutableFields{
+				CreditAmount: alpacadecimal.NewFromFloat(100.12),
+				Settlement:   NewInvoiceSettlement(),
+			},
+			CostBasis: NewCostBasis(FiatCostBasis{Rate: alpacadecimal.NewFromFloat(0.5)}),
+		},
+		"custom currency purchase": {
+			Intent: meta.Intent{Currency: currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)},
+			IntentMutableFields: IntentMutableFields{
+				CreditAmount: alpacadecimal.NewFromFloat(100.12),
+				Settlement:   NewInvoiceSettlement(),
+			},
+			CostBasis: NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				FiatCurrency: usd,
+				Rate:         alpacadecimal.NewFromFloat(0.5),
+			})),
+		},
+	}
+
+	for name, intent := range testCases {
+		t.Run(name, func(t *testing.T) {
+			charge := Charge{ChargeBase: ChargeBase{
+				Intent: intent,
+				State: State{ResolvedCostBasis: &chargecostbasis.State{
+					CostBasis:  alpacadecimal.NewFromFloat(0.5),
+					ResolvedAt: time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC),
+				}},
+			}}
+
+			amount, err := charge.GetFiatSettlementAmount()
+			require.NoError(t, err)
+			require.Equal(t, float64(50.06), amount.InexactFloat64())
+		})
+	}
+}
+
 func TestIntentMutableFieldsCalculateEffectiveAtDoesNotBackdateToServicePeriod(t *testing.T) {
 	now := time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)
 	clock.FreezeTime(now)
@@ -135,9 +240,9 @@ func TestCreateInputValidateRejectsExpiryWithoutEffectiveAt(t *testing.T) {
 						ExpiresAt:    lo.ToPtr(tc.expiresAt),
 						Settlement:   NewInvoiceSettlement(),
 					},
-					CostBasis: lo.ToPtr(NewCostBasis(FiatCostBasis{
+					CostBasis: NewCostBasis(FiatCostBasis{
 						Rate: alpacadecimal.NewFromInt(1),
-					})),
+					}),
 				},
 			}
 
@@ -150,14 +255,17 @@ func TestCreateInputValidateRejectsExpiryWithoutEffectiveAt(t *testing.T) {
 	}
 }
 
-func TestCreateChargeInputValidateRejectsDynamicCostBasis(t *testing.T) {
+func TestCreateChargeInputValidateInitialCostBasisState(t *testing.T) {
 	period := timeutil.ClosedPeriod{
 		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
 	}
 	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
 	require.NoError(t, err)
-
+	initialState := &chargecostbasis.State{
+		CostBasis:  alpacadecimal.NewFromInt(1),
+		ResolvedAt: period.From,
+	}
 	input := CreateChargeInput{CreateInput: CreateInput{
 		Namespace: "test",
 		Intent: Intent{
@@ -171,7 +279,7 @@ func TestCreateChargeInputValidateRejectsDynamicCostBasis(t *testing.T) {
 			},
 			IntentMutableFields: IntentMutableFields{
 				IntentMutableFields: meta.IntentMutableFields{
-					Name:              "dynamic credit purchase",
+					Name:              "credit purchase",
 					ServicePeriod:     period,
 					FullServicePeriod: period,
 					BillingPeriod:     period,
@@ -179,15 +287,138 @@ func TestCreateChargeInputValidateRejectsDynamicCostBasis(t *testing.T) {
 				CreditAmount: alpacadecimal.NewFromInt(1),
 				Settlement:   NewInvoiceSettlement(),
 			},
-			CostBasis: lo.ToPtr(NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
+			CostBasis: NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
 				FiatCurrency: fiatCurrency,
-			}))),
+			})),
 		},
 	}}
 
-	err = input.Validate()
-	require.ErrorContains(t, err, "dynamic cost basis is not supported for credit purchases")
-	require.NotContains(t, err.Error(), "requires resolved cost-basis state")
+	t.Run("dynamic custom currency requires empty initial state", func(t *testing.T) {
+		// given: a dynamic custom-currency purchase with pre-resolved state
+		input := input
+		input.InitialCostBasisState = initialState
+
+		// when: the adapter create input is validated
+		err := input.Validate()
+
+		// then: creation rejects the state because resolution belongs to realization
+		require.ErrorContains(t, err, "dynamic credit purchase cannot have initial cost-basis state")
+
+		input.InitialCostBasisState = nil
+		require.NoError(t, input.Validate())
+	})
+
+	for name, tc := range map[string]struct {
+		costBasis    CostBasis
+		initialState *chargecostbasis.State
+	}{
+		"manual": {
+			costBasis: NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				FiatCurrency: fiatCurrency,
+				Rate:         alpacadecimal.NewFromInt(1),
+			})),
+			initialState: initialState,
+		},
+		"pinned": {
+			costBasis: NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.PinnedIntent{
+				FiatCurrency:        fiatCurrency,
+				CurrencyCostBasisID: "currency-cost-basis-1",
+			})),
+			initialState: &chargecostbasis.State{
+				CostBasisID: lo.ToPtr("currency-cost-basis-1"),
+				CostBasis:   alpacadecimal.NewFromInt(1),
+				ResolvedAt:  period.From,
+			},
+		},
+	} {
+		t.Run(name+" custom currency requires initial state", func(t *testing.T) {
+			// given: a resolvable custom-currency purchase without its initial state
+			input := input
+			input.Intent.CostBasis = tc.costBasis
+
+			// when: the adapter create input is validated
+			err := input.Validate()
+
+			// then: creation requires the resolver output for persistence
+			require.ErrorContains(t, err, "manual or pinned credit purchase requires initial cost-basis state")
+
+			input.InitialCostBasisState = tc.initialState
+			require.NoError(t, input.Validate())
+		})
+	}
+
+	t.Run("fiat requires empty initial state", func(t *testing.T) {
+		// given: a fiat purchase with redundant derived state
+		input := input
+		input.Intent.Currency = currenciestestutils.NewFiatCurrency(t, "USD")
+		input.Intent.CostBasis = NewCostBasis(FiatCostBasis{Rate: alpacadecimal.NewFromInt(1)})
+		input.InitialCostBasisState = initialState
+
+		// when: the adapter create input is validated
+		err := input.Validate()
+
+		// then: creation rejects state that the read mapper reconstructs from intent
+		require.ErrorContains(t, err, "fiat credit purchase cannot have initial cost-basis state")
+
+		input.InitialCostBasisState = nil
+		require.NoError(t, input.Validate())
+	})
+
+	t.Run("promotional requires empty initial state", func(t *testing.T) {
+		// given: a promotional purchase with cost-basis state
+		input := input
+		input.Intent.Currency = currenciestestutils.NewFiatCurrency(t, "USD")
+		input.Intent.Settlement = NewSettlement(PromotionalSettlement{})
+		input.Intent.CostBasis = CostBasis{}
+		input.InitialCostBasisState = initialState
+
+		// when: the adapter create input is validated
+		err := input.Validate()
+
+		// then: creation rejects monetary state for a free grant
+		require.ErrorContains(t, err, "promotional credit purchase cannot have initial cost-basis state")
+
+		input.InitialCostBasisState = nil
+		require.NoError(t, input.Validate())
+	})
+}
+
+func TestSetResolvedCostBasisInputValidate(t *testing.T) {
+	valid := SetResolvedCostBasisInput{
+		ChargeID: meta.ChargeID{
+			Namespace: "test",
+			ID:        "charge-1",
+		},
+		ChargeCostBasisID: "charge-cost-basis-1",
+		State: chargecostbasis.State{
+			CostBasis:   alpacadecimal.NewFromInt(1),
+			CostBasisID: lo.ToPtr("currency-cost-basis-1"),
+			ResolvedAt:  time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	require.NoError(t, valid.Validate())
+
+	t.Run("requires charge ID", func(t *testing.T) {
+		input := valid
+		input.ChargeID = meta.ChargeID{}
+
+		require.ErrorContains(t, input.Validate(), "charge ID")
+	})
+
+	t.Run("requires charge cost basis ID", func(t *testing.T) {
+		input := valid
+		input.ChargeCostBasisID = ""
+
+		require.ErrorContains(t, input.Validate(), "charge cost basis ID is required")
+	})
+
+	t.Run("validates state", func(t *testing.T) {
+		input := valid
+		input.State.CostBasis = alpacadecimal.Zero
+
+		require.ErrorContains(t, input.Validate(), "state")
+	})
 }
 
 func TestFeatureFiltersNormalize(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -271,6 +272,36 @@ func (c CostBasis) AsCustomCurrency() (chargecostbasis.Intent, error) {
 	return c.customCurrency.Clone(), nil
 }
 
+func (c CostBasis) GetFiatCurrency(purchaseCurrency currencies.Currency) (*currencyx.FiatCurrency, error) {
+	switch c.Type() {
+	case CostBasisTypeFiat:
+		if purchaseCurrency.IsCustom() {
+			return nil, errors.New("fiat cost basis requires a fiat purchase currency")
+		}
+
+		fiatCurrency, err := currencyx.NewFiatCurrency(purchaseCurrency.GetCode())
+		if err != nil {
+			return nil, fmt.Errorf("mapping purchase currency to fiat currency: %w", err)
+		}
+
+		return fiatCurrency, nil
+	case CostBasisTypeCustomCurrency:
+		intent, err := c.AsCustomCurrency()
+		if err != nil {
+			return nil, err
+		}
+
+		fiatCurrency, err := intent.GetFiatCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting custom-currency fiat currency: %w", err)
+		}
+
+		return fiatCurrency, nil
+	default:
+		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", c.Type())
+	}
+}
+
 type ResolvedCostBasis struct {
 	FiatCurrency *currencyx.FiatCurrency
 	Rate         alpacadecimal.Decimal
@@ -308,46 +339,19 @@ func (c ChargeBase) GetResolvedCostBasis() (ResolvedCostBasis, error) {
 	if c.Intent.CostBasis == nil {
 		return ResolvedCostBasis{}, errors.New("cost basis is required")
 	}
-
-	switch c.Intent.CostBasis.Type() {
-	case CostBasisTypeFiat:
-		costBasis, err := c.Intent.CostBasis.AsFiat()
-		if err != nil {
-			return ResolvedCostBasis{}, err
-		}
-
-		fiatCurrency, err := currencyx.NewFiatCurrency(c.Intent.Currency.GetCode())
-		if err != nil {
-			return ResolvedCostBasis{}, fmt.Errorf("mapping credit currency to fiat currency: %w", err)
-		}
-
-		resolved := ResolvedCostBasis{
-			FiatCurrency: fiatCurrency,
-			Rate:         costBasis.Rate,
-		}
-
-		return resolved, resolved.Validate()
-	case CostBasisTypeCustomCurrency:
-		intent, err := c.Intent.CostBasis.AsCustomCurrency()
-		if err != nil {
-			return ResolvedCostBasis{}, err
-		}
-
-		fiatCurrency, err := intent.GetFiatCurrency()
-		if err != nil {
-			return ResolvedCostBasis{}, fmt.Errorf("getting custom-currency fiat currency: %w", err)
-		}
-		if c.State.ResolvedCostBasis == nil {
-			return ResolvedCostBasis{}, errors.New("custom-currency cost basis is unresolved")
-		}
-
-		resolved := ResolvedCostBasis{
-			FiatCurrency: fiatCurrency,
-			Rate:         c.State.ResolvedCostBasis.CostBasis,
-		}
-
-		return resolved, resolved.Validate()
-	default:
-		return ResolvedCostBasis{}, fmt.Errorf("unsupported credit purchase cost basis type: %s", c.Intent.CostBasis.Type())
+	if c.State.ResolvedCostBasis == nil {
+		return ResolvedCostBasis{}, errors.New("cost basis is unresolved")
 	}
+
+	fiatCurrency, err := c.Intent.CostBasis.GetFiatCurrency(c.Intent.Currency)
+	if err != nil {
+		return ResolvedCostBasis{}, fmt.Errorf("getting fiat currency: %w", err)
+	}
+
+	resolved := ResolvedCostBasis{
+		FiatCurrency: fiatCurrency,
+		Rate:         c.State.ResolvedCostBasis.CostBasis,
+	}
+
+	return resolved, resolved.Validate()
 }

--- a/openmeter/billing/charges/creditpurchase/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis.go
@@ -10,7 +10,6 @@ import (
 	"github.com/samber/lo"
 
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -65,7 +64,7 @@ type CostBasis struct {
 	customCurrency *chargecostbasis.Intent
 }
 
-var _ models.Validator = (*CostBasis)(nil)
+var _ models.Validator = CostBasis{}
 
 type costBasisJSON struct {
 	Type                CostBasisType          `json:"type"`
@@ -96,7 +95,26 @@ func (c CostBasis) Type() CostBasisType {
 	return c.kind
 }
 
+// IsEmpty reports whether the union has no selected cost-basis variant.
+func (c CostBasis) IsEmpty() bool {
+	return c.kind == ""
+}
+
+// GetCustomCurrencyModeOrEmpty returns the shared cost-basis mode for a valid
+// custom-currency variant, or the zero mode for every other representation.
+func (c CostBasis) GetCustomCurrencyModeOrEmpty() chargecostbasis.Mode {
+	if c.kind != CostBasisTypeCustomCurrency || c.customCurrency == nil {
+		return ""
+	}
+
+	return c.customCurrency.Kind()
+}
+
 func (c CostBasis) MarshalJSON() ([]byte, error) {
+	if c.IsEmpty() {
+		return []byte("null"), nil
+	}
+
 	if err := c.Validate(); err != nil {
 		return nil, fmt.Errorf("validating credit purchase cost basis: %w", err)
 	}
@@ -140,9 +158,15 @@ func (c CostBasis) MarshalJSON() ([]byte, error) {
 }
 
 func (c *CostBasis) UnmarshalJSON(data []byte) error {
-	var serde costBasisJSON
+	var serde *costBasisJSON
 	if err := json.Unmarshal(data, &serde); err != nil {
 		return fmt.Errorf("deserializing credit purchase cost basis: %w", err)
+	}
+
+	if serde == nil {
+		*c = CostBasis{}
+
+		return nil
 	}
 
 	var decoded CostBasis
@@ -167,39 +191,17 @@ func (c *CostBasis) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("mapping custom-currency fiat currency: %w", err)
 		}
 
-		switch serde.Mode {
-		case chargecostbasis.ModeDynamic:
-			if serde.Rate != nil || serde.CurrencyCostBasisID != nil {
-				return errors.New("dynamic cost basis contains resolved fields")
-			}
-			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
-				FiatCurrency: fiatCurrency,
-			}))
-		case chargecostbasis.ModePinned:
-			if serde.CurrencyCostBasisID == nil {
-				return errors.New("pinned currency cost basis ID is required")
-			}
-			if serde.Rate != nil {
-				return errors.New("pinned cost basis contains a manual rate")
-			}
-			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.PinnedIntent{
-				FiatCurrency:        fiatCurrency,
-				CurrencyCostBasisID: *serde.CurrencyCostBasisID,
-			}))
-		case chargecostbasis.ModeManual:
-			if serde.Rate == nil {
-				return errors.New("manual cost basis rate is required")
-			}
-			if serde.CurrencyCostBasisID != nil {
-				return errors.New("manual cost basis contains a pinned cost basis ID")
-			}
-			decoded = NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
-				FiatCurrency: fiatCurrency,
-				Rate:         *serde.Rate,
-			}))
-		default:
-			return fmt.Errorf("unsupported custom-currency cost basis mode: %s", serde.Mode)
+		intent, err := chargecostbasis.NewIntentFromFields(chargecostbasis.NewIntentFromFieldsInput{
+			Mode:                serde.Mode,
+			FiatCurrency:        fiatCurrency,
+			CurrencyCostBasisID: serde.CurrencyCostBasisID,
+			Rate:                serde.Rate,
+		})
+		if err != nil {
+			return fmt.Errorf("decoding custom-currency cost basis: %w", err)
 		}
+
+		decoded = NewCostBasis(intent)
 	default:
 		return fmt.Errorf("unsupported credit purchase cost basis type: %s", serde.Type)
 	}
@@ -213,11 +215,7 @@ func (c *CostBasis) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *CostBasis) Validate() error {
-	if c == nil {
-		return models.NewGenericValidationError(errors.New("cost basis is required"))
-	}
-
+func (c CostBasis) Validate() error {
 	if err := c.kind.Validate(); err != nil {
 		return err
 	}
@@ -270,88 +268,4 @@ func (c CostBasis) AsCustomCurrency() (chargecostbasis.Intent, error) {
 	}
 
 	return c.customCurrency.Clone(), nil
-}
-
-func (c CostBasis) GetFiatCurrency(purchaseCurrency currencies.Currency) (*currencyx.FiatCurrency, error) {
-	switch c.Type() {
-	case CostBasisTypeFiat:
-		if purchaseCurrency.IsCustom() {
-			return nil, errors.New("fiat cost basis requires a fiat purchase currency")
-		}
-
-		fiatCurrency, err := currencyx.NewFiatCurrency(purchaseCurrency.GetCode())
-		if err != nil {
-			return nil, fmt.Errorf("mapping purchase currency to fiat currency: %w", err)
-		}
-
-		return fiatCurrency, nil
-	case CostBasisTypeCustomCurrency:
-		intent, err := c.AsCustomCurrency()
-		if err != nil {
-			return nil, err
-		}
-
-		fiatCurrency, err := intent.GetFiatCurrency()
-		if err != nil {
-			return nil, fmt.Errorf("getting custom-currency fiat currency: %w", err)
-		}
-
-		return fiatCurrency, nil
-	default:
-		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", c.Type())
-	}
-}
-
-type ResolvedCostBasis struct {
-	FiatCurrency *currencyx.FiatCurrency
-	Rate         alpacadecimal.Decimal
-}
-
-// FiatAmount converts a credit amount to fiat and rounds it at the settlement
-// currency's precision.
-func (c ResolvedCostBasis) FiatAmount(creditAmount alpacadecimal.Decimal) alpacadecimal.Decimal {
-	return c.FiatCurrency.RoundToPrecision(creditAmount.Mul(c.Rate))
-}
-
-func (c ResolvedCostBasis) Validate() error {
-	var errs []error
-
-	if c.FiatCurrency == nil {
-		errs = append(errs, errors.New("fiat currency is required"))
-	} else if err := c.FiatCurrency.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("fiat currency: %w", err))
-	}
-
-	if !c.Rate.IsPositive() {
-		errs = append(errs, errors.New("rate must be positive"))
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
-// GetResolvedCostBasis returns the fiat currency and per-credit rate used by
-// every monetary consumer. It never consults the legacy settlement shadow.
-func (c ChargeBase) GetResolvedCostBasis() (ResolvedCostBasis, error) {
-	if c.Intent.Settlement.Type() == SettlementTypePromotional {
-		return ResolvedCostBasis{}, errors.New("promotional credit purchase does not have a cost basis")
-	}
-
-	if c.Intent.CostBasis == nil {
-		return ResolvedCostBasis{}, errors.New("cost basis is required")
-	}
-	if c.State.ResolvedCostBasis == nil {
-		return ResolvedCostBasis{}, errors.New("cost basis is unresolved")
-	}
-
-	fiatCurrency, err := c.Intent.CostBasis.GetFiatCurrency(c.Intent.Currency)
-	if err != nil {
-		return ResolvedCostBasis{}, fmt.Errorf("getting fiat currency: %w", err)
-	}
-
-	resolved := ResolvedCostBasis{
-		FiatCurrency: fiatCurrency,
-		Rate:         c.State.ResolvedCostBasis.CostBasis,
-	}
-
-	return resolved, resolved.Validate()
 }

--- a/openmeter/billing/charges/creditpurchase/costbasis_test.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis_test.go
@@ -3,20 +3,23 @@ package creditpurchase
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
-	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestCostBasisVariants(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		costBasis := CostBasis{}
+
+		require.True(t, costBasis.IsEmpty())
+		require.Empty(t, costBasis.GetCustomCurrencyModeOrEmpty())
+		require.Error(t, costBasis.Validate())
+	})
+
 	t.Run("fiat", func(t *testing.T) {
 		costBasis := NewCostBasis(FiatCostBasis{
 			Rate: alpacadecimal.NewFromFloat(1.25),
@@ -24,14 +27,11 @@ func TestCostBasisVariants(t *testing.T) {
 
 		require.NoError(t, costBasis.Validate())
 		require.Equal(t, CostBasisTypeFiat, costBasis.Type())
+		require.Empty(t, costBasis.GetCustomCurrencyModeOrEmpty())
 
 		fiat, err := costBasis.AsFiat()
 		require.NoError(t, err)
 		require.Equal(t, 1.25, fiat.Rate.InexactFloat64())
-		fiatCurrency, err := costBasis.GetFiatCurrency(currenciestestutils.NewFiatCurrency(t, "USD"))
-		require.NoError(t, err)
-		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
-
 		_, err = costBasis.AsCustomCurrency()
 		require.Error(t, err)
 	})
@@ -47,14 +47,11 @@ func TestCostBasisVariants(t *testing.T) {
 
 		require.NoError(t, costBasis.Validate())
 		require.Equal(t, CostBasisTypeCustomCurrency, costBasis.Type())
+		require.Equal(t, chargecostbasis.ModeManual, costBasis.GetCustomCurrencyModeOrEmpty())
 
 		intent, err := costBasis.AsCustomCurrency()
 		require.NoError(t, err)
 		require.Equal(t, chargecostbasis.ModeManual, intent.Kind())
-		fiatCurrency, err := costBasis.GetFiatCurrency(currenciestestutils.NewCustomCurrency(t, "TOKENS", 2))
-		require.NoError(t, err)
-		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
-
 		_, err = costBasis.AsFiat()
 		require.Error(t, err)
 	})
@@ -106,102 +103,12 @@ func TestCostBasisJSONRoundTrip(t *testing.T) {
 	}
 }
 
-func TestResolvedCostBasisValidate(t *testing.T) {
-	require.ErrorContains(t, (ResolvedCostBasis{
-		Rate: alpacadecimal.NewFromInt(1),
-	}).Validate(), "fiat currency is required")
-
-	usd, err := currencyx.NewFiatCurrency("USD")
+func TestEmptyCostBasisJSONRoundTrip(t *testing.T) {
+	encoded, err := json.Marshal(CostBasis{})
 	require.NoError(t, err)
-	require.ErrorContains(t, (ResolvedCostBasis{
-		FiatCurrency: usd,
-		Rate:         alpacadecimal.Zero,
-	}).Validate(), "rate must be positive")
-}
+	require.JSONEq(t, "null", string(encoded))
 
-func TestResolvedCostBasisFiatAmount(t *testing.T) {
-	usd, err := currencyx.NewFiatCurrency("USD")
-	require.NoError(t, err)
-
-	amount := (ResolvedCostBasis{
-		FiatCurrency: usd,
-		Rate:         alpacadecimal.NewFromFloat(0.5),
-	}).FiatAmount(alpacadecimal.NewFromFloat(100.1234))
-
-	require.Equal(t, 50.06, amount.InexactFloat64())
-}
-
-func TestChargeBaseValidateCostBasis(t *testing.T) {
-	usd, err := currencyx.NewFiatCurrency("USD")
-	require.NoError(t, err)
-
-	resolved := chargecostbasis.State{
-		CostBasis:  alpacadecimal.NewFromFloat(0.5),
-		ResolvedAt: time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC),
-	}
-	intent := Intent{CostBasis: lo.ToPtr(NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
-		FiatCurrency: usd,
-		Rate:         alpacadecimal.NewFromFloat(0.5),
-	})))}
-	intent.Currency = currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)
-	intent.Settlement = NewInvoiceSettlement()
-
-	require.NoError(t, (ChargeBase{Intent: intent, State: State{
-		ResolvedCostBasis: &resolved,
-	}}).validateCostBasis())
-
-	require.Error(t, (ChargeBase{Intent: intent}).validateCostBasis())
-
-	t.Run("fiat resolved state matches immutable intent", func(t *testing.T) {
-		createdAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
-		fiatIntent := Intent{
-			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
-			IntentMutableFields: IntentMutableFields{
-				Settlement: NewInvoiceSettlement(),
-			},
-			CostBasis: lo.ToPtr(NewCostBasis(FiatCostBasis{Rate: alpacadecimal.NewFromFloat(0.5)})),
-		}
-		validState := State{ResolvedCostBasis: &chargecostbasis.State{
-			CostBasis:  alpacadecimal.NewFromFloat(0.5),
-			ResolvedAt: createdAt,
-		}}
-
-		require.NoError(t, (ChargeBase{
-			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
-			Intent:          fiatIntent,
-			State:           validState,
-		}).validateCostBasis())
-
-		resolvedLater := validState
-		resolvedLater.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
-		resolvedLater.ResolvedCostBasis.ResolvedAt = createdAt.Add(time.Second)
-		require.NoError(t, (ChargeBase{
-			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
-			Intent:          fiatIntent,
-			State:           resolvedLater,
-		}).validateCostBasis())
-
-		mismatchedRate := validState
-		mismatchedRate.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
-		mismatchedRate.ResolvedCostBasis.CostBasis = alpacadecimal.NewFromInt(1)
-		require.ErrorContains(t, (ChargeBase{
-			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
-			Intent:          fiatIntent,
-			State:           mismatchedRate,
-		}).validateCostBasis(), "must match the intent rate")
-
-		withSource := validState
-		withSource.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
-		withSource.ResolvedCostBasis.CostBasisID = lo.ToPtr("currency-cost-basis-id")
-		require.ErrorContains(t, (ChargeBase{
-			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
-			Intent:          fiatIntent,
-			State:           withSource,
-		}).validateCostBasis(), "cannot reference a currency cost basis")
-
-		require.ErrorContains(t, (ChargeBase{
-			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
-			Intent:          fiatIntent,
-		}).validateCostBasis(), "requires resolved cost-basis state")
-	})
+	var decoded CostBasis
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.True(t, decoded.IsEmpty())
 }

--- a/openmeter/billing/charges/creditpurchase/costbasis_test.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestCostBasisVariants(t *testing.T) {
@@ -26,6 +28,9 @@ func TestCostBasisVariants(t *testing.T) {
 		fiat, err := costBasis.AsFiat()
 		require.NoError(t, err)
 		require.Equal(t, 1.25, fiat.Rate.InexactFloat64())
+		fiatCurrency, err := costBasis.GetFiatCurrency(currenciestestutils.NewFiatCurrency(t, "USD"))
+		require.NoError(t, err)
+		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
 
 		_, err = costBasis.AsCustomCurrency()
 		require.Error(t, err)
@@ -46,6 +51,9 @@ func TestCostBasisVariants(t *testing.T) {
 		intent, err := costBasis.AsCustomCurrency()
 		require.NoError(t, err)
 		require.Equal(t, chargecostbasis.ModeManual, intent.Kind())
+		fiatCurrency, err := costBasis.GetFiatCurrency(currenciestestutils.NewCustomCurrency(t, "TOKENS", 2))
+		require.NoError(t, err)
+		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
 
 		_, err = costBasis.AsFiat()
 		require.Error(t, err)
@@ -143,4 +151,48 @@ func TestChargeBaseValidateCostBasis(t *testing.T) {
 	}}).validateCostBasis())
 
 	require.Error(t, (ChargeBase{Intent: intent}).validateCostBasis())
+
+	t.Run("fiat resolved state matches immutable intent", func(t *testing.T) {
+		createdAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+		fiatIntent := Intent{
+			Intent: meta.Intent{Currency: currenciestestutils.NewFiatCurrency(t, "USD")},
+			IntentMutableFields: IntentMutableFields{
+				Settlement: NewInvoiceSettlement(),
+			},
+			CostBasis: lo.ToPtr(NewCostBasis(FiatCostBasis{Rate: alpacadecimal.NewFromFloat(0.5)})),
+		}
+		validState := State{ResolvedCostBasis: &chargecostbasis.State{
+			CostBasis:  alpacadecimal.NewFromFloat(0.5),
+			ResolvedAt: createdAt,
+		}}
+
+		require.NoError(t, (ChargeBase{
+			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
+			Intent:          fiatIntent,
+			State:           validState,
+		}).validateCostBasis())
+
+		mismatchedRate := validState
+		mismatchedRate.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
+		mismatchedRate.ResolvedCostBasis.CostBasis = alpacadecimal.NewFromInt(1)
+		require.ErrorContains(t, (ChargeBase{
+			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
+			Intent:          fiatIntent,
+			State:           mismatchedRate,
+		}).validateCostBasis(), "must match the intent rate")
+
+		withSource := validState
+		withSource.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
+		withSource.ResolvedCostBasis.CostBasisID = lo.ToPtr("currency-cost-basis-id")
+		require.ErrorContains(t, (ChargeBase{
+			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
+			Intent:          fiatIntent,
+			State:           withSource,
+		}).validateCostBasis(), "cannot reference a currency cost basis")
+
+		require.ErrorContains(t, (ChargeBase{
+			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
+			Intent:          fiatIntent,
+		}).validateCostBasis(), "requires resolved cost-basis state")
+	})
 }

--- a/openmeter/billing/charges/creditpurchase/costbasis_test.go
+++ b/openmeter/billing/charges/creditpurchase/costbasis_test.go
@@ -172,6 +172,15 @@ func TestChargeBaseValidateCostBasis(t *testing.T) {
 			State:           validState,
 		}).validateCostBasis())
 
+		resolvedLater := validState
+		resolvedLater.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
+		resolvedLater.ResolvedCostBasis.ResolvedAt = createdAt.Add(time.Second)
+		require.NoError(t, (ChargeBase{
+			ManagedResource: meta.ManagedResource{ManagedModel: models.ManagedModel{CreatedAt: createdAt}},
+			Intent:          fiatIntent,
+			State:           resolvedLater,
+		}).validateCostBasis())
+
 		mismatchedRate := validState
 		mismatchedRate.ResolvedCostBasis = lo.ToPtr(*validState.ResolvedCostBasis)
 		mismatchedRate.ResolvedCostBasis.CostBasis = alpacadecimal.NewFromInt(1)

--- a/openmeter/billing/charges/creditpurchase/service/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/service/costbasis.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
@@ -16,7 +14,7 @@ import (
 
 type resolveInitialCostBasisInput struct {
 	Currency   currencies.Currency
-	CostBasis  *creditpurchase.CostBasis
+	CostBasis  creditpurchase.CostBasis
 	ResolvedAt time.Time
 }
 
@@ -28,7 +26,7 @@ func (i resolveInitialCostBasisInput) Validate() error {
 	if err := i.Currency.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
 	}
-	if i.CostBasis != nil {
+	if !i.CostBasis.IsEmpty() {
 		if err := i.CostBasis.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("cost basis: %w", err))
 		}
@@ -44,29 +42,17 @@ func (s *service) resolveInitialCostBasis(ctx context.Context, input resolveInit
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
-	if input.CostBasis == nil {
+	if input.CostBasis.IsEmpty() {
 		return nil, nil
 	}
 
 	switch input.CostBasis.Type() {
 	case creditpurchase.CostBasisTypeFiat:
-		fiatCostBasis, err := input.CostBasis.AsFiat()
-		if err != nil {
-			return nil, fmt.Errorf("getting fiat cost basis: %w", err)
-		}
-
-		return lo.ToPtr(costbasis.State{
-			CostBasis:  fiatCostBasis.Rate,
-			ResolvedAt: input.ResolvedAt,
-		}), nil
+		return nil, nil
 	case creditpurchase.CostBasisTypeCustomCurrency:
 		customCostBasis, err := input.CostBasis.AsCustomCurrency()
 		if err != nil {
 			return nil, fmt.Errorf("getting custom-currency cost basis: %w", err)
-		}
-
-		if customCostBasis.Kind() == costbasis.ModeDynamic {
-			return nil, errors.New("dynamic cost basis is not supported for credit purchases")
 		}
 
 		resolvedCostBasis, err := s.costbasisResolver.ResolveInitialState(ctx, costbasis.ResolveInitialStateInput{
@@ -82,4 +68,53 @@ func (s *service) resolveInitialCostBasis(ctx context.Context, input resolveInit
 	default:
 		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", input.CostBasis.Type())
 	}
+}
+
+// ResolveDynamicCostBasis pins the cost basis effective at the purchase's
+// service-period start before the first monetary effect.
+func (s *stateMachine) ResolveDynamicCostBasis(ctx context.Context) error {
+	if s.Charge.Intent.CostBasis.Type() != creditpurchase.CostBasisTypeCustomCurrency {
+		return nil
+	}
+
+	intent, err := s.Charge.Intent.CostBasis.AsCustomCurrency()
+	if err != nil {
+		return fmt.Errorf("getting custom-currency cost basis: %w", err)
+	}
+
+	if intent.Kind() != costbasis.ModeDynamic || s.Charge.State.ResolvedCostBasis != nil {
+		return nil
+	}
+
+	if s.Charge.State.ChargeCostBasisID == nil {
+		return models.NewGenericPreConditionFailedError(
+			fmt.Errorf("charge cost basis reference is missing for credit purchase %s", s.Charge.ID),
+		)
+	}
+
+	resolvedState, err := s.CostBasisResolver.ResolveDynamicState(ctx, costbasis.ResolveDynamicStateInput{
+		CurrencyID:        s.Charge.Intent.Currency.NamespacedID,
+		Intent:            intent,
+		ServicePeriodFrom: s.Charge.Intent.ServicePeriod.From,
+	})
+	if err != nil {
+		return fmt.Errorf("resolving dynamic cost basis for credit purchase %s: %w", s.Charge.ID, err)
+	}
+
+	persisted, err := s.Adapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+		ChargeID:          s.Charge.GetChargeID(),
+		ChargeCostBasisID: *s.Charge.State.ChargeCostBasisID,
+		State:             resolvedState,
+	})
+	if err != nil {
+		return fmt.Errorf("persisting dynamic cost basis for credit purchase %s: %w", s.Charge.ID, err)
+	}
+
+	if persisted.State == nil {
+		return fmt.Errorf("persisted dynamic cost basis is unresolved for credit purchase %s", s.Charge.ID)
+	}
+
+	s.Charge.State.ResolvedCostBasis = persisted.State
+
+	return nil
 }

--- a/openmeter/billing/charges/creditpurchase/service/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/service/costbasis.go
@@ -48,6 +48,7 @@ func (s *service) resolveInitialCostBasis(ctx context.Context, input resolveInit
 
 	switch input.CostBasis.Type() {
 	case creditpurchase.CostBasisTypeFiat:
+		// Fiat costbasis is resolved on read from the intent, it doesn't have a credit_purchase_cost_basis row.
 		return nil, nil
 	case creditpurchase.CostBasisTypeCustomCurrency:
 		customCostBasis, err := input.CostBasis.AsCustomCurrency()

--- a/openmeter/billing/charges/creditpurchase/service/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/service/costbasis.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type resolveInitialCostBasisInput struct {
+	Currency   currencies.Currency
+	CostBasis  *creditpurchase.CostBasis
+	ResolvedAt time.Time
+}
+
+var _ models.Validator = (*resolveInitialCostBasisInput)(nil)
+
+func (i resolveInitialCostBasisInput) Validate() error {
+	var errs []error
+
+	if err := i.Currency.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("currency: %w", err))
+	}
+	if i.CostBasis != nil {
+		if err := i.CostBasis.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("cost basis: %w", err))
+		}
+	}
+	if i.ResolvedAt.IsZero() {
+		errs = append(errs, errors.New("resolved at is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (s *service) resolveInitialCostBasis(ctx context.Context, input resolveInitialCostBasisInput) (*costbasis.State, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+	if input.CostBasis == nil {
+		return nil, nil
+	}
+
+	switch input.CostBasis.Type() {
+	case creditpurchase.CostBasisTypeFiat:
+		fiatCostBasis, err := input.CostBasis.AsFiat()
+		if err != nil {
+			return nil, fmt.Errorf("getting fiat cost basis: %w", err)
+		}
+
+		return lo.ToPtr(costbasis.State{
+			CostBasis:  fiatCostBasis.Rate,
+			ResolvedAt: input.ResolvedAt,
+		}), nil
+	case creditpurchase.CostBasisTypeCustomCurrency:
+		customCostBasis, err := input.CostBasis.AsCustomCurrency()
+		if err != nil {
+			return nil, fmt.Errorf("getting custom-currency cost basis: %w", err)
+		}
+
+		if customCostBasis.Kind() == costbasis.ModeDynamic {
+			return nil, errors.New("dynamic cost basis is not supported for credit purchases")
+		}
+
+		resolvedCostBasis, err := s.costbasisResolver.ResolveInitialState(ctx, costbasis.ResolveInitialStateInput{
+			CurrencyID: input.Currency.NamespacedID,
+			Intent:     customCostBasis,
+			ResolvedAt: input.ResolvedAt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("resolving cost basis: %w", err)
+		}
+
+		return resolvedCostBasis, nil
+	default:
+		return nil, fmt.Errorf("unsupported credit purchase cost basis type: %s", input.CostBasis.Type())
+	}
+}

--- a/openmeter/billing/charges/creditpurchase/service/costbasis.go
+++ b/openmeter/billing/charges/creditpurchase/service/costbasis.go
@@ -26,11 +26,13 @@ func (i resolveInitialCostBasisInput) Validate() error {
 	if err := i.Currency.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
 	}
+
 	if !i.CostBasis.IsEmpty() {
 		if err := i.CostBasis.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("cost basis: %w", err))
 		}
 	}
+
 	if i.ResolvedAt.IsZero() {
 		errs = append(errs, errors.New("resolved at is required"))
 	}
@@ -42,13 +44,14 @@ func (s *service) resolveInitialCostBasis(ctx context.Context, input resolveInit
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
+
 	if input.CostBasis.IsEmpty() {
 		return nil, nil
 	}
 
 	switch input.CostBasis.Type() {
 	case creditpurchase.CostBasisTypeFiat:
-		// Fiat costbasis is resolved on read from the intent, it doesn't have a credit_purchase_cost_basis row.
+		// Fiat cost basis is reconstructed from immutable intent on read; it has no credit_purchase_cost_basis row.
 		return nil, nil
 	case creditpurchase.CostBasisTypeCustomCurrency:
 		customCostBasis, err := input.CostBasis.AsCustomCurrency()
@@ -102,7 +105,7 @@ func (s *stateMachine) ResolveDynamicCostBasis(ctx context.Context) error {
 		return fmt.Errorf("resolving dynamic cost basis for credit purchase %s: %w", s.Charge.ID, err)
 	}
 
-	persisted, err := s.Adapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+	persistedState, err := s.Adapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisAdapterInput{
 		ChargeID:          s.Charge.GetChargeID(),
 		ChargeCostBasisID: *s.Charge.State.ChargeCostBasisID,
 		State:             resolvedState,
@@ -111,11 +114,7 @@ func (s *stateMachine) ResolveDynamicCostBasis(ctx context.Context) error {
 		return fmt.Errorf("persisting dynamic cost basis for credit purchase %s: %w", s.Charge.ID, err)
 	}
 
-	if persisted.State == nil {
-		return fmt.Errorf("persisted dynamic cost basis is unresolved for credit purchase %s", s.Charge.ID)
-	}
-
-	s.Charge.State.ResolvedCostBasis = persisted.State
+	s.Charge.State.ResolvedCostBasis = &persistedState
 
 	return nil
 }

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -21,9 +22,22 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditpurchase.ChargeWithGatheringLine, error) {
 		input.Intent = input.Intent.Normalized()
+		resolvedAt := clock.Now().UTC()
+
+		resolvedCostBasis, err := s.resolveInitialCostBasis(ctx, resolveInitialCostBasisInput{
+			Currency:   input.Intent.Currency,
+			CostBasis:  input.Intent.CostBasis,
+			ResolvedAt: resolvedAt,
+		})
+		if err != nil {
+			return creditpurchase.ChargeWithGatheringLine{}, err
+		}
 
 		// Let's create the credit purchase charge
-		charge, err := s.adapter.CreateCharge(ctx, input)
+		charge, err := s.adapter.CreateCharge(ctx, creditpurchase.CreateChargeInput{
+			CreateInput:       input,
+			ResolvedCostBasis: resolvedCostBasis,
+		})
 		if err != nil {
 			return creditpurchase.ChargeWithGatheringLine{}, err
 		}

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -35,7 +35,7 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 		}
 
 		// Let's create the credit purchase charge
-		charge, err := s.adapter.CreateCharge(ctx, creditpurchase.CreateChargeInput{
+		charge, err := s.adapter.CreateCharge(ctx, creditpurchase.CreateChargeAdapterInput{
 			CreateInput:           input,
 			InitialCostBasisState: initialCostBasisState,
 		})

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -24,7 +25,7 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 		input.Intent = input.Intent.Normalized()
 		resolvedAt := clock.Now().UTC()
 
-		resolvedCostBasis, err := s.resolveInitialCostBasis(ctx, resolveInitialCostBasisInput{
+		initialCostBasisState, err := s.resolveInitialCostBasis(ctx, resolveInitialCostBasisInput{
 			Currency:   input.Intent.Currency,
 			CostBasis:  input.Intent.CostBasis,
 			ResolvedAt: resolvedAt,
@@ -35,8 +36,8 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 
 		// Let's create the credit purchase charge
 		charge, err := s.adapter.CreateCharge(ctx, creditpurchase.CreateChargeInput{
-			CreateInput:       input,
-			ResolvedCostBasis: resolvedCostBasis,
+			CreateInput:           input,
+			InitialCostBasisState: initialCostBasisState,
 		})
 		if err != nil {
 			return creditpurchase.ChargeWithGatheringLine{}, err
@@ -46,9 +47,9 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 		switch charge.Intent.Settlement.Type() {
 		case creditpurchase.SettlementTypePromotional:
 			stateMachine, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-				Charge:  charge,
-				Adapter: s.adapter,
-				Service: s,
+				Charge:       charge,
+				Adapter:      s.adapter,
+				Realizations: s.realizations,
 			})
 			if err != nil {
 				return creditpurchase.ChargeWithGatheringLine{}, fmt.Errorf("new promotional state machine: %w", err)
@@ -74,7 +75,7 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 
 		// For invoice settlement, prepare the gathering line (actual invoicing happens after TX commits)
 		if charge.Intent.Settlement.Type() == creditpurchase.SettlementTypeInvoice {
-			gatheringLine, err := s.buildInvoiceCreditPurchaseGatheringLine(charge)
+			gatheringLine, err := buildInvoiceCreditPurchaseGatheringLine(charge)
 			if err != nil {
 				return creditpurchase.ChargeWithGatheringLine{}, fmt.Errorf("building invoice credit purchase gathering line: %w", err)
 			}
@@ -91,20 +92,28 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 	})
 }
 
-func (s *service) buildInvoiceCreditPurchaseGatheringLine(charge creditpurchase.Charge) (billing.GatheringLine, error) {
+func buildInvoiceCreditPurchaseGatheringLine(charge creditpurchase.Charge) (billing.GatheringLine, error) {
 	if charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeInvoice {
 		return billing.GatheringLine{}, errors.New("credit purchase is not invoice settled")
 	}
 
 	intent := charge.Intent
-	resolvedCostBasis, err := charge.GetResolvedCostBasis()
+
+	fiatCurrency, err := intent.GetSettlementFiatCurrency()
 	if err != nil {
-		return billing.GatheringLine{}, fmt.Errorf("getting resolved cost basis: %w", err)
+		return billing.GatheringLine{}, fmt.Errorf("getting settlement fiat currency: %w", err)
 	}
 
-	// Total cost = credit amount * cost basis (e.g., 100 credits * $0.5 = $50)
-	totalCost := resolvedCostBasis.FiatAmount(intent.CreditAmount)
-	invoiceCurrency := resolvedCostBasis.FiatCurrency.GetFiatCode()
+	// Dynamic cost basis can remain unresolved while the gathering line is
+	// pending. Invoice creation replaces this temporary amount after resolution.
+	totalCost := alpacadecimal.Zero
+
+	if charge.State.ResolvedCostBasis != nil {
+		totalCost, err = charge.GetFiatSettlementAmount()
+		if err != nil {
+			return billing.GatheringLine{}, fmt.Errorf("getting fiat settlement amount: %w", err)
+		}
+	}
 
 	// Clone metadata and add credit-purchase specific annotations
 	annotations, err := charge.Intent.Annotations.Clone()
@@ -137,7 +146,7 @@ func (s *service) buildInvoiceCreditPurchaseGatheringLine(charge creditpurchase.
 					},
 				),
 			),
-			Currency:      invoiceCurrency,
+			Currency:      fiatCurrency.GetFiatCode(),
 			ServicePeriod: intent.ServicePeriod,
 			InvoiceAt:     intent.CalculateEffectiveAt(),
 			TaxConfig:     lo.ToPtr(intent.TaxConfig.ToTaxConfig()),

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/statelessx"
 )
 
 func (s *service) onExternalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
@@ -66,8 +67,8 @@ func NewExternalCreditPurchaseStateMachine(config StateMachineConfig) (*External
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Realizations == nil {
-		return nil, fmt.Errorf("realizations service is required")
+	if config.CostBasisResolver == nil {
+		return nil, fmt.Errorf("cost basis resolver is required")
 	}
 
 	if config.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeExternal {
@@ -93,7 +94,10 @@ func (s *ExternalCreditPurchaseStateMachine) configureStates() {
 
 	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
 		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).
-		OnActive(s.GrantCredits)
+		OnActive(statelessx.AllOf(
+			s.ResolveDynamicCostBasis,
+			s.GrantCredits,
+		))
 
 	s.Configure(creditpurchase.StatusActivePaymentPending).
 		Permit(billing.TriggerAuthorized, creditpurchase.StatusActivePaymentAuthorized).
@@ -146,9 +150,10 @@ func (s *ExternalCreditPurchaseStateMachine) SettleExternalPayment(ctx context.C
 
 func (s *service) newExternalCreditPurchaseStateMachine(charge creditpurchase.Charge) (*ExternalCreditPurchaseStateMachine, error) {
 	return NewExternalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:       charge,
-		Adapter:      s.adapter,
-		Realizations: s.realizations,
+		Charge:            charge,
+		Adapter:           s.adapter,
+		Realizations:      s.realizations,
+		CostBasisResolver: s.costbasisResolver,
 	})
 }
 

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -2,11 +2,11 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -55,7 +55,11 @@ func TestExternalCreditPurchaseServiceRoutesAuthorizedInitialStatus(t *testing.T
 		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
 		Once()
 	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
-	svc := &service{adapter: adapter, realizations: realizationsService}
+	svc := &service{
+		adapter:           adapter,
+		realizations:      realizationsService,
+		costbasisResolver: externalStateMachineCostBasisResolver{},
+	}
 
 	got, err := svc.onExternalCreditPurchase(t.Context(), charge)
 
@@ -109,9 +113,10 @@ func TestExternalCreditPurchaseStateMachineAuthorizationUsesRealizationDuplicate
 	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
 
 	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:       charge,
-		Adapter:      adapter,
-		Realizations: realizationsService,
+		Charge:            charge,
+		Adapter:           adapter,
+		Realizations:      realizationsService,
+		CostBasisResolver: externalStateMachineCostBasisResolver{},
 	})
 	require.NoError(t, err)
 
@@ -140,6 +145,16 @@ func newExternalStateMachineRealizations(
 	require.NoError(t, err)
 
 	return realizationsService
+}
+
+type externalStateMachineCostBasisResolver struct{}
+
+func (externalStateMachineCostBasisResolver) ResolveInitialState(context.Context, chargecostbasis.ResolveInitialStateInput) (*chargecostbasis.State, error) {
+	return nil, errors.New("unexpected initial cost-basis resolution")
+}
+
+func (externalStateMachineCostBasisResolver) ResolveDynamicState(context.Context, chargecostbasis.ResolveDynamicStateInput) (chargecostbasis.State, error) {
+	return chargecostbasis.State{}, errors.New("unexpected dynamic cost-basis resolution")
 }
 
 type externalStateMachineTestChargeInput struct {
@@ -185,9 +200,9 @@ func newExternalStateMachineTestChargeWithInput(t *testing.T, input externalStat
 				InitialStatus: input.initialStatus,
 			}),
 		},
-		CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+		CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 			Rate: input.costBasis,
-		})),
+		}),
 	}.Normalized()
 
 	return creditpurchase.Charge{

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -15,6 +15,7 @@ import (
 	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
@@ -203,6 +204,12 @@ func newExternalStateMachineTestChargeWithInput(t *testing.T, input externalStat
 			},
 			Intent: intent,
 			Status: input.status,
+			State: creditpurchase.State{
+				ResolvedCostBasis: &chargecostbasis.State{
+					CostBasis:  input.costBasis,
+					ResolvedAt: period.From,
+				},
+			},
 		},
 	}
 }

--- a/openmeter/billing/charges/creditpurchase/service/invoice.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice.go
@@ -23,8 +23,8 @@ func NewInvoiceCreditPurchaseStateMachine(config StateMachineConfig) (*InvoiceCr
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Realizations == nil {
-		return nil, errors.New("realizations service is required")
+	if config.CostBasisResolver == nil {
+		return nil, errors.New("cost basis resolver is required")
 	}
 
 	if config.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeInvoice {
@@ -50,7 +50,10 @@ func (s *InvoiceCreditPurchaseStateMachine) configureStates() {
 
 	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
 		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).
-		OnActive(s.GrantCredits)
+		OnActive(statelessx.AllOf(
+			s.ResolveDynamicCostBasis,
+			s.GrantCredits,
+		))
 
 	s.Configure(creditpurchase.StatusActivePaymentPending).
 		Permit(billing.TriggerAuthorized, creditpurchase.StatusActivePaymentAuthorized)
@@ -180,9 +183,10 @@ func (s *service) handleInvoiceLifecycleTrigger(ctx context.Context, input Handl
 	}
 
 	stateMachine, err := NewInvoiceCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:       input.Charge,
-		Adapter:      s.adapter,
-		Realizations: s.realizations,
+		Charge:            input.Charge,
+		Adapter:           s.adapter,
+		Realizations:      s.realizations,
+		CostBasisResolver: s.costbasisResolver,
 	})
 	if err != nil {
 		return creditpurchase.Charge{}, err

--- a/openmeter/billing/charges/creditpurchase/service/invoice_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice_test.go
@@ -42,7 +42,7 @@ func TestBuildInvoiceCreditPurchaseGatheringLineUsesZeroForUnresolvedCostBasis(t
 	require.Equal(t, currencyx.FiatCode("USD"), line.Currency)
 	price, err := line.Price.AsFlat()
 	require.NoError(t, err)
-	require.Equal(t, alpacadecimal.Zero, price.Amount)
+	require.Equal(t, float64(0), price.Amount.InexactFloat64())
 }
 
 func TestInvoiceCreditPurchaseStateMachineRejectsMismatchedPaymentLine(t *testing.T) {

--- a/openmeter/billing/charges/creditpurchase/service/invoice_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice_test.go
@@ -10,13 +10,40 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+func TestBuildInvoiceCreditPurchaseGatheringLineUsesZeroForUnresolvedCostBasis(t *testing.T) {
+	// given:
+	// - an invoice credit purchase whose dynamic cost basis is not yet resolved
+	// when:
+	// - its gathering line is built
+	// then:
+	// - the line keeps the settlement currency and uses a temporary zero amount
+	charge := newInvoiceStateMachineTestCharge(t, creditpurchase.StatusCreated)
+	charge.Intent.Currency = currenciestestutils.NewCustomCurrency(t, "TOKENS", 3)
+	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+	charge.Intent.CostBasis = creditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.DynamicIntent{
+		FiatCurrency: fiatCurrency,
+	}))
+	charge.State.ChargeCostBasisID = lo.ToPtr("charge-cost-basis-1")
+	charge.State.ResolvedCostBasis = nil
+
+	line, err := buildInvoiceCreditPurchaseGatheringLine(charge)
+	require.NoError(t, err)
+	require.Equal(t, currencyx.FiatCode("USD"), line.Currency)
+	price, err := line.Price.AsFlat()
+	require.NoError(t, err)
+	require.Equal(t, alpacadecimal.Zero, price.Amount)
+}
 
 func TestInvoiceCreditPurchaseStateMachineRejectsMismatchedPaymentLine(t *testing.T) {
 	charge := newGrantedInvoiceStateMachineTestCharge(t, creditpurchase.StatusActivePaymentAuthorized)
@@ -26,8 +53,9 @@ func TestInvoiceCreditPurchaseStateMachineRejectsMismatchedPaymentLine(t *testin
 	adapter := &externalStateMachineAdapter{}
 	handler := &externalStateMachineHandler{}
 	service := &service{
-		adapter:      adapter,
-		realizations: newExternalStateMachineRealizations(t, adapter, handler, &externalStateMachineLineage{}),
+		adapter:           adapter,
+		realizations:      newExternalStateMachineRealizations(t, adapter, handler, &externalStateMachineLineage{}),
+		costbasisResolver: externalStateMachineCostBasisResolver{},
 	}
 
 	_, err := service.handleInvoiceLifecycleTrigger(t.Context(), HandleInvoiceLifecycleTriggerInput{

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -46,8 +46,9 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 	return e.buildInvoiceCreditPurchaseStandardLines(ctx, input)
 }
 
-// buildInvoiceCreditPurchaseStandardLines preserves the purchased credit
-// quantity and its resolved cost basis instead of rerating the fiat line total.
+// buildInvoiceCreditPurchaseStandardLines preserves unresolved gathering lines
+// as provisional zero-value lines. Resolved charges can be fully represented
+// without lifecycle side effects, including in previews.
 func (e *LineEngine) buildInvoiceCreditPurchaseStandardLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("validating input: %w", err)
@@ -67,8 +68,9 @@ func (e *LineEngine) buildInvoiceCreditPurchaseStandardLines(ctx context.Context
 		return nil, err
 	}
 
-	for idx, stdLine := range stdLines {
+	return lo.MapErr(stdLines, func(stdLine *billing.StandardLine, _ int) (*billing.StandardLine, error) {
 		charge, ok := chargesByID[*stdLine.ChargeID]
+
 		if !ok {
 			return nil, fmt.Errorf("credit purchase charge[%s] not found for line[%s]", *stdLine.ChargeID, stdLine.ID)
 		}
@@ -77,33 +79,17 @@ func (e *LineEngine) buildInvoiceCreditPurchaseStandardLines(ctx context.Context
 			return nil, fmt.Errorf("credit purchase charge[%s] is not invoice settled", charge.ID)
 		}
 
-		resolvedCostBasis, err := charge.GetResolvedCostBasis()
-		if err != nil {
-			return nil, fmt.Errorf("getting resolved cost basis for credit purchase charge[%s]: %w", charge.ID, err)
+		// If costbasis is not yet resolved, we should not try to populate the detailed lines until
+		// we have resolved the costbasis (later in the lifecycle).
+		if charge.State.ResolvedCostBasis == nil {
+			return stdLine, nil
 		}
 
-		fiatAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
-		stdLineWithDetails, err := creditpurchasemodels.WithDetailedLines(creditpurchasemodels.WithDetailedLinesInput{
-			Line:              stdLine,
-			Name:              stdLine.Name,
-			CreditCurrency:    charge.Intent.Currency,
-			CreditAmount:      charge.Intent.CreditAmount,
-			ResolvedCostBasis: resolvedCostBasis.Rate,
-			FiatCurrency:      resolvedCostBasis.FiatCurrency,
-			FiatAmount:        fiatAmount,
+		return populateInvoiceCreditPurchaseStandardLine(populateInvoiceCreditPurchaseStandardLineInput{
+			Line:   stdLine,
+			Charge: charge,
 		})
-		if err != nil {
-			return nil, fmt.Errorf("populating credit purchase standard line[%s]: %w", stdLine.ID, err)
-		}
-
-		if err := stdLineWithDetails.Validate(); err != nil {
-			return nil, fmt.Errorf("validating credit purchase standard line[%s]: %w", stdLine.ID, err)
-		}
-
-		stdLines[idx] = stdLineWithDetails
-	}
-
-	return stdLines, nil
+	})
 }
 
 type getChargesForStandardLinesInput struct {
@@ -158,6 +144,18 @@ func (i getChargesForStandardLinesInput) Validate() error {
 		}
 	}
 
+	chargeIDs := lo.FilterMap(i.Lines, func(stdLine *billing.StandardLine, _ int) (string, bool) {
+		if stdLine == nil || stdLine.ChargeID == nil || *stdLine.ChargeID == "" {
+			return "", false
+		}
+
+		return *stdLine.ChargeID, true
+	})
+
+	for _, chargeID := range lo.FindDuplicates(chargeIDs) {
+		errs = append(errs, fmt.Errorf("credit purchase charge[%s] is referenced by multiple standard lines", chargeID))
+	}
+
 	if err := i.Expands.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("expands: %w", err))
 	}
@@ -170,17 +168,9 @@ func (e *LineEngine) getChargesForStandardLines(ctx context.Context, input getCh
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	chargeIDs := make([]string, 0, len(input.Lines))
-	seenChargeIDs := make(map[string]struct{}, len(input.Lines))
-
-	for _, stdLine := range input.Lines {
-		if _, ok := seenChargeIDs[*stdLine.ChargeID]; ok {
-			continue
-		}
-
-		seenChargeIDs[*stdLine.ChargeID] = struct{}{}
-		chargeIDs = append(chargeIDs, *stdLine.ChargeID)
-	}
+	chargeIDs := lo.Map(input.Lines, func(stdLine *billing.StandardLine, _ int) string {
+		return *stdLine.ChargeID
+	})
 
 	charges, err := e.service.GetByIDs(ctx, creditpurchase.GetByIDsInput{
 		Namespace: input.Invoice.Namespace,
@@ -205,11 +195,17 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	if err := e.fireInvoiceLifecycleTriggerForLines(ctx, meta.TriggerInvoiceCreated, input); err != nil {
+	updatedCharges, err := e.fireInvoiceLifecycleTriggerForLines(ctx, meta.TriggerInvoiceCreated, input)
+	if err != nil {
 		return nil, err
 	}
 
-	return input.Lines, nil
+	return lo.MapErr(input.Lines, func(stdLine *billing.StandardLine, idx int) (*billing.StandardLine, error) {
+		return populateInvoiceCreditPurchaseStandardLine(populateInvoiceCreditPurchaseStandardLineInput{
+			Line:   stdLine,
+			Charge: updatedCharges[idx],
+		})
+	})
 }
 
 func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, _ billing.OnMutableInvoiceUpdateInput) error {
@@ -237,7 +233,8 @@ func (e *LineEngine) OnPaymentAuthorized(ctx context.Context, input billing.OnPa
 		return fmt.Errorf("validating input: %w", err)
 	}
 
-	return e.fireInvoiceLifecycleTriggerForLines(ctx, billing.TriggerAuthorized, input)
+	_, err := e.fireInvoiceLifecycleTriggerForLines(ctx, billing.TriggerAuthorized, input)
+	return err
 }
 
 func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPaymentSettledInput) error {
@@ -245,23 +242,25 @@ func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPayme
 		return fmt.Errorf("validating input: %w", err)
 	}
 
-	return e.fireInvoiceLifecycleTriggerForLines(ctx, billing.TriggerPaid, input)
+	_, err := e.fireInvoiceLifecycleTriggerForLines(ctx, billing.TriggerPaid, input)
+	return err
 }
 
-func (e *LineEngine) fireInvoiceLifecycleTriggerForLines(ctx context.Context, trigger meta.Trigger, input billing.StandardLineEventInput) error {
+func (e *LineEngine) fireInvoiceLifecycleTriggerForLines(ctx context.Context, trigger meta.Trigger, input billing.StandardLineEventInput) ([]creditpurchase.Charge, error) {
 	chargesByID, err := e.getChargesForStandardLines(ctx, getChargesForStandardLinesInput{
 		Invoice: input.Invoice,
 		Lines:   input.Lines,
 		Expands: meta.Expands{meta.ExpandRealizations},
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for _, stdLine := range input.Lines {
+	return lo.MapErr(input.Lines, func(stdLine *billing.StandardLine, _ int) (creditpurchase.Charge, error) {
 		charge, ok := chargesByID[*stdLine.ChargeID]
+
 		if !ok {
-			return fmt.Errorf("credit purchase charge[%s] not found for line[%s]", *stdLine.ChargeID, stdLine.ID)
+			return creditpurchase.Charge{}, fmt.Errorf("credit purchase charge[%s] not found for line[%s]", *stdLine.ChargeID, stdLine.ID)
 		}
 
 		updatedCharge, err := e.service.handleInvoiceLifecycleTrigger(ctx, HandleInvoiceLifecycleTriggerInput{
@@ -273,13 +272,76 @@ func (e *LineEngine) fireInvoiceLifecycleTriggerForLines(ctx context.Context, tr
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("triggering %s for credit purchase charge[%s]: %w", trigger, charge.ID, err)
+			return creditpurchase.Charge{}, fmt.Errorf("triggering %s for credit purchase charge[%s]: %w", trigger, charge.ID, err)
 		}
 
-		// Multiple lines can reference the same charge. Keep its post-transition state
-		// so subsequent triggers do not evaluate stale lifecycle data.
-		chargesByID[updatedCharge.ID] = updatedCharge
+		return updatedCharge, nil
+	})
+}
+
+type populateInvoiceCreditPurchaseStandardLineInput struct {
+	Line   *billing.StandardLine
+	Charge creditpurchase.Charge
+}
+
+var _ models.Validator = populateInvoiceCreditPurchaseStandardLineInput{}
+
+func (i populateInvoiceCreditPurchaseStandardLineInput) Validate() error {
+	var errs []error
+
+	if i.Line == nil {
+		errs = append(errs, errors.New("standard line is required"))
 	}
 
-	return nil
+	if err := i.Charge.GetChargeID().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// populateInvoiceCreditPurchaseStandardLine replaces a provisional line with
+// the purchased quantity, pinned unit cost basis, and resulting fiat totals.
+func populateInvoiceCreditPurchaseStandardLine(input populateInvoiceCreditPurchaseStandardLineInput) (*billing.StandardLine, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
+	charge := input.Charge
+
+	if charge.State.ResolvedCostBasis == nil {
+		return nil, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("credit purchase charge[%s] cost basis is unresolved", charge.ID),
+		)
+	}
+
+	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	if err != nil {
+		return nil, fmt.Errorf("getting settlement fiat currency for credit purchase charge[%s]: %w", charge.ID, err)
+	}
+
+	fiatAmount, err := charge.GetFiatSettlementAmount()
+	if err != nil {
+		return nil, fmt.Errorf("getting fiat settlement amount for credit purchase charge[%s]: %w", charge.ID, err)
+	}
+
+	resolvedCostBasis := charge.State.ResolvedCostBasis.CostBasis
+	stdLineWithDetails, err := creditpurchasemodels.WithDetailedLines(creditpurchasemodels.WithDetailedLinesInput{
+		Line:              input.Line,
+		Name:              input.Line.Name,
+		CreditCurrency:    charge.Intent.Currency,
+		CreditAmount:      charge.Intent.CreditAmount,
+		ResolvedCostBasis: resolvedCostBasis,
+		FiatCurrency:      fiatCurrency,
+		FiatAmount:        fiatAmount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("populating credit purchase standard line[%s]: %w", input.Line.ID, err)
+	}
+
+	if err := stdLineWithDetails.Validate(); err != nil {
+		return nil, fmt.Errorf("validating credit purchase standard line[%s]: %w", input.Line.ID, err)
+	}
+
+	return stdLineWithDetails, nil
 }

--- a/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
@@ -19,6 +19,22 @@ func TestLineEngineDoesNotImplementLineCalculator(t *testing.T) {
 	require.False(t, implementsLineCalculator)
 }
 
+func TestPopulateInvoiceCreditPurchaseStandardLineRejectsUnresolvedCostBasis(t *testing.T) {
+	// given: an invoice credit purchase whose lifecycle left its cost basis unresolved
+	charge := newInvoiceStateMachineTestCharge(t, creditpurchase.StatusActivePaymentPending)
+	charge.State.ResolvedCostBasis = nil
+	line := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.Zero).Line
+
+	// when: the line engine attempts to finalize the provisional standard line
+	_, err := populateInvoiceCreditPurchaseStandardLine(populateInvoiceCreditPurchaseStandardLineInput{
+		Line:   line,
+		Charge: charge,
+	})
+
+	// then: the unresolved lifecycle state is rejected instead of being priced
+	require.ErrorContains(t, err, "cost basis is unresolved")
+}
+
 func TestGetChargesForStandardLinesInputValidate(t *testing.T) {
 	charge := newInvoiceStateMachineTestCharge(t, creditpurchase.StatusCreated)
 	lineWithHeader := newInvoiceStateMachineTestLine(t, charge, alpacadecimal.NewFromInt(50))
@@ -29,6 +45,20 @@ func TestGetChargesForStandardLinesInputValidate(t *testing.T) {
 	}
 
 	require.NoError(t, input.Validate())
+
+	t.Run("rejects multiple lines for the same charge", func(t *testing.T) {
+		// given: two otherwise valid invoice lines referencing one credit purchase
+		duplicateLine := *lineWithHeader.Line
+		duplicateLine.ID = "line-2"
+		duplicateInput := input
+		duplicateInput.Lines = billing.StandardLines{lineWithHeader.Line, &duplicateLine}
+
+		// when: the line event input is validated
+		err := duplicateInput.Validate()
+
+		// then: the charge cannot receive the same lifecycle trigger twice
+		require.ErrorContains(t, err, "is referenced by multiple standard lines")
+	})
 
 	input.Invoice.Namespace = ""
 	input.Lines[0].ChargeID = nil

--- a/openmeter/billing/charges/creditpurchase/service/promotional.go
+++ b/openmeter/billing/charges/creditpurchase/service/promotional.go
@@ -5,47 +5,9 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 )
-
-func (s *service) grantPromotionalCredit(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
-	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {
-		return creditpurchase.Charge{}, fmt.Errorf("promotional credit grant already realized [charge_id=%s, transaction_group_id=%s]", charge.ID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
-	}
-
-	ledgerTransactionGroupReference, err := s.handler.OnPromotionalCreditPurchase(ctx, charge)
-	if err != nil {
-		return creditpurchase.Charge{}, err
-	}
-
-	grantRealization, err := s.adapter.CreateCreditGrant(ctx, charge.GetChargeID(), creditpurchase.CreateCreditGrantInput{
-		TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-		GrantedAt:          clock.Now(),
-	})
-	if err != nil {
-		return creditpurchase.Charge{}, err
-	}
-
-	charge.Realizations.CreditGrantRealization = &grantRealization
-
-	if ledgerTransactionGroupReference.TransactionGroupID != "" {
-		if err := s.lineage.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
-			Namespace:                 charge.Namespace,
-			CustomerID:                charge.Intent.CustomerID,
-			Currency:                  charge.Intent.Currency,
-			Amount:                    charge.Intent.CreditAmount,
-			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-			FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
-		}); err != nil {
-			return creditpurchase.Charge{}, err
-		}
-	}
-
-	return charge, nil
-}
 
 type PromotionalCreditpurchaseStateMachine struct {
 	*stateMachine
@@ -54,10 +16,6 @@ type PromotionalCreditpurchaseStateMachine struct {
 func NewPromotionalCreditPurchaseStateMachine(config StateMachineConfig) (*PromotionalCreditpurchaseStateMachine, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("validate: %w", err)
-	}
-
-	if config.Service == nil {
-		return nil, fmt.Errorf("service is required")
 	}
 
 	if config.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypePromotional {
@@ -89,7 +47,7 @@ func (s *PromotionalCreditpurchaseStateMachine) configureStates() {
 }
 
 func (s *PromotionalCreditpurchaseStateMachine) GrantPromotionalCredit(ctx context.Context) error {
-	charge, err := s.Service.grantPromotionalCredit(ctx, s.Charge)
+	charge, err := s.Realizations.GrantPromotionalCredits(ctx, s.Charge)
 	if err != nil {
 		return err
 	}

--- a/openmeter/billing/charges/creditpurchase/service/promotional_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/promotional_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
@@ -90,16 +91,17 @@ func TestPromotionalCreditPurchaseStateMachineRejectsExistingCreditGrant(t *test
 
 	adapter := &promotionalStateMachineAdapter{}
 	lineageService := &promotionalStateMachineLineage{}
-	svc := &service{
-		adapter: adapter,
-		handler: &promotionalStateMachineHandler{},
-		lineage: lineageService,
-	}
+	realizationsService := newPromotionalStateMachineRealizations(
+		t,
+		adapter,
+		&promotionalStateMachineHandler{},
+		lineageService,
+	)
 
 	stateMachine, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:  charge,
-		Adapter: adapter,
-		Service: svc,
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
 	})
 	require.NoError(t, err)
 
@@ -121,16 +123,17 @@ func TestPromotionalCreditPurchaseStateMachineReturnsNilForFinalCharge(t *testin
 	// then:
 	// - it is already stable and does not call side-effect handlers
 	adapter := &promotionalStateMachineAdapter{}
-	svc := &service{
-		adapter: adapter,
-		handler: &promotionalStateMachineHandler{},
-		lineage: &promotionalStateMachineLineage{},
-	}
+	realizationsService := newPromotionalStateMachineRealizations(
+		t,
+		adapter,
+		&promotionalStateMachineHandler{},
+		&promotionalStateMachineLineage{},
+	)
 
 	stateMachine, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:  newPromotionalStateMachineTestCharge(t, creditpurchase.StatusFinal),
-		Adapter: adapter,
-		Service: svc,
+		Charge:       newPromotionalStateMachineTestCharge(t, creditpurchase.StatusFinal),
+		Adapter:      adapter,
+		Realizations: realizationsService,
 	})
 	require.NoError(t, err)
 
@@ -151,11 +154,18 @@ func TestPromotionalCreditPurchaseStateMachineRejectsNonPromotionalCharge(t *tes
 	// - construction fails before any lifecycle side effect can happen
 	charge := newPromotionalStateMachineTestCharge(t, creditpurchase.StatusCreated)
 	charge.Intent.Settlement = creditpurchase.NewInvoiceSettlement()
+	adapter := &promotionalStateMachineAdapter{}
+	realizationsService := newPromotionalStateMachineRealizations(
+		t,
+		adapter,
+		&promotionalStateMachineHandler{},
+		&promotionalStateMachineLineage{},
+	)
 
 	_, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:  charge,
-		Adapter: &promotionalStateMachineAdapter{},
-		Service: &service{},
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
 	})
 
 	require.Error(t, err)
@@ -169,29 +179,37 @@ func TestPromotionalCreditPurchaseStateMachineRejectsMissingAdapter(t *testing.T
 	// - the promotional state machine is constructed
 	// then:
 	// - construction fails before lifecycle methods can dereference the adapter
+	adapter := &promotionalStateMachineAdapter{}
+	realizationsService := newPromotionalStateMachineRealizations(
+		t,
+		adapter,
+		&promotionalStateMachineHandler{},
+		&promotionalStateMachineLineage{},
+	)
+
 	_, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:  newPromotionalStateMachineTestCharge(t, creditpurchase.StatusCreated),
-		Service: &service{},
+		Charge:       newPromotionalStateMachineTestCharge(t, creditpurchase.StatusCreated),
+		Realizations: realizationsService,
 	})
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "adapter is required")
 }
 
-func TestPromotionalCreditPurchaseStateMachineRejectsMissingService(t *testing.T) {
+func TestStateMachineConfigRejectsMissingRealizationsService(t *testing.T) {
 	// given:
-	// - a promotional credit-purchase charge without runtime service dependencies
+	// - a state-machine config without realization dependencies
 	// when:
-	// - the promotional state machine is constructed
+	// - the shared config is validated
 	// then:
-	// - construction fails before final-state entry can dereference the service
-	_, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
+	// - validation fails before any concrete state machine is constructed
+	err := (StateMachineConfig{
 		Charge:  newPromotionalStateMachineTestCharge(t, creditpurchase.StatusCreated),
 		Adapter: &promotionalStateMachineAdapter{},
-	})
+	}).Validate()
 
 	require.Error(t, err)
-	require.ErrorContains(t, err, "service is required")
+	require.ErrorContains(t, err, "realizations service is required")
 }
 
 func advancePromotionalChargeUntilStable(t *testing.T, stateMachine *PromotionalCreditpurchaseStateMachine) (*creditpurchase.Charge, error) {
@@ -224,11 +242,7 @@ func newPromotionalStateMachineTestMachine(
 			}, nil
 		},
 	}
-	svc := &service{
-		adapter: adapter,
-		handler: handler,
-		lineage: lineageService,
-	}
+	realizationsService := newPromotionalStateMachineRealizations(t, adapter, handler, lineageService)
 
 	lineageService.On("BackfillAdvanceLineageSegments",
 		mock.Anything,
@@ -243,13 +257,31 @@ func newPromotionalStateMachineTestMachine(
 		Once()
 
 	stateMachine, err := NewPromotionalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:  charge,
-		Adapter: adapter,
-		Service: svc,
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
 	})
 	require.NoError(t, err)
 
 	return stateMachine, charge, adapter, lineageService
+}
+
+func newPromotionalStateMachineRealizations(
+	t *testing.T,
+	adapter creditpurchase.Adapter,
+	handler creditpurchase.Handler,
+	lineageService lineage.Service,
+) *creditpurchaserealizations.Service {
+	t.Helper()
+
+	realizationsService, err := creditpurchaserealizations.New(creditpurchaserealizations.Config{
+		Adapter: adapter,
+		Handler: handler,
+		Lineage: lineageService,
+	})
+	require.NoError(t, err)
+
+	return realizationsService
 }
 
 func newPromotionalStateMachineTestCharge(t *testing.T, status creditpurchase.Status) creditpurchase.Charge {

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -58,6 +58,42 @@ func New(config Config) (*Service, error) {
 	}, nil
 }
 
+func (s *Service) GrantPromotionalCredits(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {
+		return creditpurchase.Charge{}, fmt.Errorf("promotional credit grant already realized [charge_id=%s, transaction_group_id=%s]", charge.ID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
+	}
+
+	ledgerTransactionGroupReference, err := s.handler.OnPromotionalCreditPurchase(ctx, charge)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	grantRealization, err := s.adapter.CreateCreditGrant(ctx, charge.GetChargeID(), creditpurchase.CreateCreditGrantInput{
+		TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
+		GrantedAt:          clock.Now(),
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.CreditGrantRealization = &grantRealization
+
+	if ledgerTransactionGroupReference.TransactionGroupID != "" {
+		if err := s.lineage.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
+			Namespace:                 charge.Namespace,
+			CustomerID:                charge.Intent.CustomerID,
+			Currency:                  charge.Intent.Currency,
+			Amount:                    charge.Intent.CreditAmount,
+			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
+			FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
+		}); err != nil {
+			return creditpurchase.Charge{}, err
+		}
+	}
+
+	return charge, nil
+}
+
 func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
 	if err := charge.Intent.Settlement.Validate(); err != nil {
 		return creditpurchase.Charge{}, err
@@ -239,12 +275,10 @@ func (s *Service) AuthorizeExternalPayment(ctx context.Context, charge creditpur
 		return creditpurchase.Charge{}, err
 	}
 
-	resolvedCostBasis, err := charge.GetResolvedCostBasis()
+	fiatAmount, err := charge.GetFiatSettlementAmount()
 	if err != nil {
-		return creditpurchase.Charge{}, err
+		return creditpurchase.Charge{}, fmt.Errorf("getting fiat settlement amount: %w", err)
 	}
-
-	fiatAmount := resolvedCostBasis.FiatAmount(charge.Intent.CreditAmount)
 
 	eventAt := clock.Now()
 	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{

--- a/openmeter/billing/charges/creditpurchase/service/realizations_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -76,10 +75,10 @@ func TestRealizationsAuthorizeExternalPaymentRoundsFiatAmount(t *testing.T) {
 				charge.Intent.Currency = currenciestestutils.NewCustomCurrency(t, "CREDITS", 2)
 				fiatCurrency, err := currencyx.NewFiatCurrency("USD")
 				require.NoError(t, err)
-				charge.Intent.CostBasis = lo.ToPtr(creditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				charge.Intent.CostBasis = creditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
 					FiatCurrency: fiatCurrency,
 					Rate:         alpacadecimal.RequireFromString(tt.costBasis),
-				})))
+				}))
 				charge.State.ResolvedCostBasis = &chargecostbasis.State{
 					CostBasis:  alpacadecimal.RequireFromString(tt.costBasis),
 					ResolvedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/openmeter/billing/charges/creditpurchase/service/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/service.go
@@ -9,6 +9,8 @@ import (
 	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 )
 
 type Config struct {
@@ -16,6 +18,7 @@ type Config struct {
 	Handler     creditpurchase.Handler
 	Lineage     lineage.Service
 	MetaAdapter meta.Adapter
+	Currencies  currencies.Service
 }
 
 func (c Config) Validate() error {
@@ -37,6 +40,10 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("meta adapter cannot be null"))
 	}
 
+	if c.Currencies == nil {
+		errs = append(errs, errors.New("currencies service cannot be null"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -54,12 +61,20 @@ func New(config Config) (creditpurchase.Service, error) {
 		return nil, fmt.Errorf("realizations: %w", err)
 	}
 
+	costbasisResolver, err := costbasis.NewResolver(costbasis.ResolverConfig{
+		Currencies: config.Currencies,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cost basis resolver: %w", err)
+	}
+
 	return &service{
-		adapter:      config.Adapter,
-		handler:      config.Handler,
-		lineage:      config.Lineage,
-		metaAdapter:  config.MetaAdapter,
-		realizations: realizations,
+		adapter:           config.Adapter,
+		handler:           config.Handler,
+		lineage:           config.Lineage,
+		metaAdapter:       config.MetaAdapter,
+		realizations:      realizations,
+		costbasisResolver: costbasisResolver,
 	}, nil
 }
 
@@ -69,6 +84,8 @@ type service struct {
 	handler      creditpurchase.Handler
 	lineage      lineage.Service
 	realizations *creditpurchaserealizations.Service
+
+	costbasisResolver costbasis.Resolver
 }
 
 func (s *service) GetLineEngine() billing.LineEngine {

--- a/openmeter/billing/charges/creditpurchase/service/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/service.go
@@ -70,8 +70,6 @@ func New(config Config) (creditpurchase.Service, error) {
 
 	return &service{
 		adapter:           config.Adapter,
-		handler:           config.Handler,
-		lineage:           config.Lineage,
 		metaAdapter:       config.MetaAdapter,
 		realizations:      realizations,
 		costbasisResolver: costbasisResolver,
@@ -81,8 +79,6 @@ func New(config Config) (creditpurchase.Service, error) {
 type service struct {
 	adapter      creditpurchase.Adapter
 	metaAdapter  meta.Adapter
-	handler      creditpurchase.Handler
-	lineage      lineage.Service
 	realizations *creditpurchaserealizations.Service
 
 	costbasisResolver costbasis.Resolver

--- a/openmeter/billing/charges/creditpurchase/service/statemachine.go
+++ b/openmeter/billing/charges/creditpurchase/service/statemachine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -15,9 +16,9 @@ import (
 type stateMachine struct {
 	*chargestatemachine.Machine[creditpurchase.Charge, creditpurchase.ChargeBase, creditpurchase.Status]
 
-	Adapter      creditpurchase.Adapter
-	Realizations *creditpurchaserealizations.Service
-	Service      *service
+	Adapter           creditpurchase.Adapter
+	Realizations      *creditpurchaserealizations.Service
+	CostBasisResolver costbasis.Resolver
 
 	CreditNotesSupported bool
 }
@@ -27,12 +28,14 @@ type StateMachine = chargestatemachine.StateMachine[creditpurchase.Charge]
 type StateMachineConfig struct {
 	Charge creditpurchase.Charge
 
-	Adapter      creditpurchase.Adapter
-	Realizations *creditpurchaserealizations.Service
-	Service      *service
+	Adapter           creditpurchase.Adapter
+	Realizations      *creditpurchaserealizations.Service
+	CostBasisResolver costbasis.Resolver
 
 	CreditNotesSupported bool
 }
+
+var _ models.Validator = StateMachineConfig{}
 
 func (c StateMachineConfig) Validate() error {
 	var errs []error
@@ -43,6 +46,10 @@ func (c StateMachineConfig) Validate() error {
 
 	if c.Adapter == nil {
 		errs = append(errs, errors.New("adapter is required"))
+	}
+
+	if c.Realizations == nil {
+		errs = append(errs, errors.New("realizations service is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -56,7 +63,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	out := &stateMachine{
 		Adapter:              config.Adapter,
 		Realizations:         config.Realizations,
-		Service:              config.Service,
+		CostBasisResolver:    config.CostBasisResolver,
 		CreditNotesSupported: config.CreditNotesSupported,
 	}
 

--- a/openmeter/billing/charges/meta/customcurrency.go
+++ b/openmeter/billing/charges/meta/customcurrency.go
@@ -26,12 +26,16 @@ type FiatOverage struct {
 // CalculateFiatAmount converts an amount using a resolved cost basis and
 // rounds the result to the settlement currency's precision.
 func CalculateFiatAmount(amount, resolvedCostBasis alpacadecimal.Decimal, fiatCurrency *currencyx.FiatCurrency) (alpacadecimal.Decimal, error) {
+	if fiatCurrency == nil {
+		return alpacadecimal.Zero, fmt.Errorf("fiat currency is required")
+	}
+
 	if amount.IsNegative() {
 		return alpacadecimal.Zero, fmt.Errorf("amount cannot be negative")
 	}
 
-	if resolvedCostBasis.IsZero() {
-		return alpacadecimal.Zero, fmt.Errorf("resolved cost basis cannot be zero")
+	if !resolvedCostBasis.IsPositive() {
+		return alpacadecimal.Zero, fmt.Errorf("resolved cost basis must be positive")
 	}
 
 	return fiatCurrency.RoundToPrecision(amount.Mul(resolvedCostBasis)), nil

--- a/openmeter/billing/charges/meta/customcurrency.go
+++ b/openmeter/billing/charges/meta/customcurrency.go
@@ -23,6 +23,20 @@ type FiatOverage struct {
 	Amount   alpacadecimal.Decimal
 }
 
+// CalculateFiatAmount converts an amount using a resolved cost basis and
+// rounds the result to the settlement currency's precision.
+func CalculateFiatAmount(amount, resolvedCostBasis alpacadecimal.Decimal, fiatCurrency *currencyx.FiatCurrency) (alpacadecimal.Decimal, error) {
+	if amount.IsNegative() {
+		return alpacadecimal.Zero, fmt.Errorf("amount cannot be negative")
+	}
+
+	if resolvedCostBasis.IsZero() {
+		return alpacadecimal.Zero, fmt.Errorf("resolved cost basis cannot be zero")
+	}
+
+	return fiatCurrency.RoundToPrecision(amount.Mul(resolvedCostBasis)), nil
+}
+
 // ConvertCustomCurrencyOverageToFiat converts the post-allocation total of a
 // custom-currency realization into its invoice currency using the persisted
 // cost basis.
@@ -64,10 +78,17 @@ func ConvertCustomCurrencyOverageToFiat(input ConvertCustomCurrencyOverageToFiat
 		return FiatOverage{}, fmt.Errorf("resolved cost basis: %w", err)
 	}
 
+	fiatAmount, err := CalculateFiatAmount(
+		input.Totals.Total,
+		input.ResolvedCostBasis.CostBasis,
+		fiatCurrency,
+	)
+	if err != nil {
+		return FiatOverage{}, fmt.Errorf("calculate fiat amount: %w", err)
+	}
+
 	return FiatOverage{
 		Currency: fiatCurrency,
-		Amount: fiatCurrency.RoundToPrecision(
-			input.Totals.Total.Mul(input.ResolvedCostBasis.CostBasis),
-		),
+		Amount:   fiatAmount,
 	}, nil
 }

--- a/openmeter/billing/charges/meta/customcurrency_test.go
+++ b/openmeter/billing/charges/meta/customcurrency_test.go
@@ -121,12 +121,28 @@ func TestCalculateFiatAmount(t *testing.T) {
 		require.ErrorContains(t, err, "amount cannot be negative")
 	})
 
-	t.Run("rejects zero cost basis", func(t *testing.T) {
+	t.Run("rejects non-positive cost basis", func(t *testing.T) {
 		_, err := CalculateFiatAmount(
 			alpacadecimal.NewFromInt(1),
 			alpacadecimal.Zero,
 			fiatCurrency,
 		)
-		require.ErrorContains(t, err, "resolved cost basis cannot be zero")
+		require.ErrorContains(t, err, "resolved cost basis must be positive")
+
+		_, err = CalculateFiatAmount(
+			alpacadecimal.NewFromInt(1),
+			alpacadecimal.NewFromInt(-1),
+			fiatCurrency,
+		)
+		require.ErrorContains(t, err, "resolved cost basis must be positive")
+	})
+
+	t.Run("rejects missing fiat currency", func(t *testing.T) {
+		_, err := CalculateFiatAmount(
+			alpacadecimal.NewFromInt(1),
+			alpacadecimal.NewFromInt(1),
+			nil,
+		)
+		require.ErrorContains(t, err, "fiat currency is required")
 	})
 }

--- a/openmeter/billing/charges/meta/customcurrency_test.go
+++ b/openmeter/billing/charges/meta/customcurrency_test.go
@@ -97,3 +97,36 @@ func TestConvertCustomCurrencyOverageToFiat(t *testing.T) {
 		require.ErrorContains(t, err, "resolved cost basis is required")
 	})
 }
+
+func TestCalculateFiatAmount(t *testing.T) {
+	fiatCurrency, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+
+	t.Run("converts and rounds to fiat precision", func(t *testing.T) {
+		amount, err := CalculateFiatAmount(
+			alpacadecimal.NewFromFloat(1.23),
+			alpacadecimal.NewFromFloat(1.5),
+			fiatCurrency,
+		)
+		require.NoError(t, err)
+		require.Equal(t, float64(1.85), amount.InexactFloat64())
+	})
+
+	t.Run("rejects negative amount", func(t *testing.T) {
+		_, err := CalculateFiatAmount(
+			alpacadecimal.NewFromInt(-1),
+			alpacadecimal.NewFromInt(1),
+			fiatCurrency,
+		)
+		require.ErrorContains(t, err, "amount cannot be negative")
+	})
+
+	t.Run("rejects zero cost basis", func(t *testing.T) {
+		_, err := CalculateFiatAmount(
+			alpacadecimal.NewFromInt(1),
+			alpacadecimal.Zero,
+			fiatCurrency,
+		)
+		require.ErrorContains(t, err, "resolved cost basis cannot be zero")
+	})
+}

--- a/openmeter/billing/charges/models/costbasis/intent.go
+++ b/openmeter/billing/charges/models/costbasis/intent.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -54,6 +55,58 @@ func NewIntent[T DynamicIntent | PinnedIntent | ManualIntent](in T) Intent {
 	}
 
 	return Intent{}
+}
+
+type NewIntentFromFieldsInput struct {
+	Mode                Mode
+	FiatCurrency        *currencyx.FiatCurrency
+	CurrencyCostBasisID *string
+	Rate                *alpacadecimal.Decimal
+}
+
+// NewIntentFromFields constructs a custom-currency cost-basis intent from its
+// flattened persistence or transport representation.
+func NewIntentFromFields(input NewIntentFromFieldsInput) (Intent, error) {
+	var intent Intent
+
+	switch input.Mode {
+	case ModeDynamic:
+		if input.Rate != nil {
+			return Intent{}, errors.New("dynamic cost basis doesn't support a manual rate")
+		}
+
+		if input.CurrencyCostBasisID != nil {
+			return Intent{}, errors.New("dynamic cost basis doesn't support a currency cost basis ID")
+		}
+
+		intent = NewIntent(DynamicIntent{FiatCurrency: input.FiatCurrency})
+	case ModePinned:
+		if input.Rate != nil {
+			return Intent{}, errors.New("pinned cost basis doesn't support a manual rate")
+		}
+
+		intent = NewIntent(PinnedIntent{
+			FiatCurrency:        input.FiatCurrency,
+			CurrencyCostBasisID: lo.FromPtr(input.CurrencyCostBasisID),
+		})
+	case ModeManual:
+		if input.CurrencyCostBasisID != nil {
+			return Intent{}, errors.New("manual cost basis doesn't support a currency cost basis ID")
+		}
+
+		intent = NewIntent(ManualIntent{
+			FiatCurrency: input.FiatCurrency,
+			Rate:         lo.FromPtr(input.Rate),
+		})
+	default:
+		return Intent{}, fmt.Errorf("unsupported cost basis mode: %s", input.Mode)
+	}
+
+	if err := intent.Validate(); err != nil {
+		return Intent{}, err
+	}
+
+	return intent, nil
 }
 
 func (i Intent) Kind() Mode {

--- a/openmeter/billing/charges/models/costbasis/model.go
+++ b/openmeter/billing/charges/models/costbasis/model.go
@@ -240,32 +240,12 @@ func getIntent(dbEntity Getter) (Intent, error) {
 		return Intent{}, fmt.Errorf("map fiat currency: %w", err)
 	}
 
-	switch dbEntity.GetMode() {
-	case ModeDynamic:
-		return NewIntent(DynamicIntent{FiatCurrency: fiatCurrency}), nil
-	case ModePinned:
-		currencyCostBasisID := dbEntity.GetCurrencyCostBasisID()
-		if currencyCostBasisID == nil {
-			return Intent{}, errors.New("currency cost basis ID is required")
-		}
-
-		return NewIntent(PinnedIntent{
-			FiatCurrency:        fiatCurrency,
-			CurrencyCostBasisID: *currencyCostBasisID,
-		}), nil
-	case ModeManual:
-		manualRate := dbEntity.GetManualRate()
-		if manualRate == nil {
-			return Intent{}, errors.New("manual rate is required")
-		}
-
-		return NewIntent(ManualIntent{
-			FiatCurrency: fiatCurrency,
-			Rate:         *manualRate,
-		}), nil
-	default:
-		return Intent{}, fmt.Errorf("invalid cost basis mode: %s", dbEntity.GetMode())
-	}
+	return NewIntentFromFields(NewIntentFromFieldsInput{
+		Mode:                dbEntity.GetMode(),
+		FiatCurrency:        fiatCurrency,
+		CurrencyCostBasisID: dbEntity.GetCurrencyCostBasisID(),
+		Rate:                dbEntity.GetManualRate(),
+	})
 }
 
 func getState(dbEntity Getter) (*State, error) {

--- a/openmeter/billing/charges/models/creditpurchase/detailedline.go
+++ b/openmeter/billing/charges/models/creditpurchase/detailedline.go
@@ -158,6 +158,8 @@ func (i WithDetailedLinesInput) Validate() error {
 
 	if i.Line == nil {
 		errs = append(errs, errors.New("line is required"))
+	} else if i.Line.UsageBased == nil {
+		errs = append(errs, errors.New("line price is required"))
 	}
 
 	if i.Name == "" {
@@ -200,7 +202,7 @@ func (i WithDetailedLinesInput) Validate() error {
 }
 
 // WithDetailedLines returns a cloned invoice line populated from an
-// already-resolved credit valuation while preserving detailed-line identity.
+// already-resolved credit cost basis while preserving detailed-line identity.
 func WithDetailedLines(input WithDetailedLinesInput) (*billing.StandardLine, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
@@ -228,6 +230,10 @@ func WithDetailedLines(input WithDetailedLinesInput) (*billing.StandardLine, err
 
 	line.DetailedLines = line.DetailedLinesWithIDReuse(billing.DetailedLines{detailedLine})
 	line.Totals = line.DetailedLines.SumTotals().RoundToPrecision(input.FiatCurrency)
+	line.UsageBased.Price = productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+		Amount:      input.FiatAmount,
+		PaymentTerm: productcatalog.InAdvancePaymentTerm,
+	})
 
 	if !line.Totals.Total.Equal(input.FiatAmount) {
 		return nil, fmt.Errorf(

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -178,6 +178,7 @@ func (s *BaseSuite) SetupSuite() {
 		Handler:     s.CreditPurchaseTestHandler,
 		Lineage:     lineageService,
 		MetaAdapter: metaAdapter,
+		Currencies:  currencyService,
 	})
 	s.NoError(err)
 

--- a/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
@@ -66,7 +66,6 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesPinnedCostBas
 	s.Equal(float64(0.25), created.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
 	s.Equal(pinnedCostBasis.ID, lo.FromPtr(created.Charge.State.ResolvedCostBasis.CostBasisID))
 	s.Equal(now.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
-	s.Equal(created.Charge.CreatedAt.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
 
 	s.Require().NotNil(created.GatheringLineToCreate)
 	s.Equal(currencyx.FiatCode(currency.USD), created.GatheringLineToCreate.Currency)

--- a/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
@@ -102,7 +102,10 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesInitialCostBa
 			s.Require().NoError(err)
 			s.Require().NotNil(created.Charge.State.ChargeCostBasisID)
 			s.Require().NotNil(created.Charge.State.ResolvedCostBasis)
-			s.Equal(test.expectedRate, created.Charge.State.ResolvedCostBasis.CostBasis)
+			s.Require().Equal(
+				test.expectedRate.InexactFloat64(),
+				created.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+			)
 			s.Equal(test.expectedCurrencyCostBasis, created.Charge.State.ResolvedCostBasis.CostBasisID)
 			s.Equal(now.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
 
@@ -110,7 +113,7 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesInitialCostBa
 			s.Equal(currencyx.FiatCode(currency.USD), created.GatheringLineToCreate.Currency)
 			price, err := created.GatheringLineToCreate.Price.AsFlat()
 			s.Require().NoError(err)
-			s.Equal(test.expectedFiatAmount, price.Amount)
+			s.Require().Equal(test.expectedFiatAmount.InexactFloat64(), price.Amount.InexactFloat64())
 
 			persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
 				Namespace: namespace,
@@ -120,7 +123,10 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesInitialCostBa
 			s.Require().Len(persisted, 1)
 			s.Equal(created.Charge.State.ChargeCostBasisID, persisted[0].State.ChargeCostBasisID)
 			s.Require().NotNil(persisted[0].State.ResolvedCostBasis)
-			s.Equal(created.Charge.State.ResolvedCostBasis.CostBasis, persisted[0].State.ResolvedCostBasis.CostBasis)
+			s.Require().Equal(
+				created.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+				persisted[0].State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+			)
 			s.Equal(created.Charge.State.ResolvedCostBasis.CostBasisID, persisted[0].State.ResolvedCostBasis.CostBasisID)
 			s.Equal(
 				created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond),
@@ -303,17 +309,19 @@ func (s *CreditPurchaseTestSuite) TestSetResolvedDynamicCostBasisOverwritesExist
 		CostBasisID: lo.ToPtr(currencyCostBasis.ID),
 		ResolvedAt:  servicePeriodFrom.Add(time.Hour),
 	}
-	updated, err := s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+	updated, err := s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisAdapterInput{
 		ChargeID:          created.Charge.GetChargeID(),
 		ChargeCostBasisID: *created.Charge.State.ChargeCostBasisID,
 		State:             replacement,
 	})
 	s.Require().NoError(err)
-	s.Equal(&replacement, updated.State)
+	s.Require().Equal(replacement.CostBasis.InexactFloat64(), updated.CostBasis.InexactFloat64())
+	s.Equal(replacement.CostBasisID, updated.CostBasisID)
+	s.Equal(replacement.ResolvedAt, updated.ResolvedAt)
 
 	wrongChargeID := created.Charge.GetChargeID()
 	wrongChargeID.ID = "another-charge"
-	_, err = s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+	_, err = s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisAdapterInput{
 		ChargeID:          wrongChargeID,
 		ChargeCostBasisID: *created.Charge.State.ChargeCostBasisID,
 		State: costbasis.State{
@@ -330,7 +338,13 @@ func (s *CreditPurchaseTestSuite) TestSetResolvedDynamicCostBasisOverwritesExist
 	})
 	s.Require().NoError(err)
 	s.Require().Len(persisted, 1)
-	s.Equal(&replacement, persisted[0].State.ResolvedCostBasis)
+	s.Require().NotNil(persisted[0].State.ResolvedCostBasis)
+	s.Require().Equal(
+		replacement.CostBasis.InexactFloat64(),
+		persisted[0].State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+	)
+	s.Equal(replacement.CostBasisID, persisted[0].State.ResolvedCostBasis.CostBasisID)
+	s.Equal(replacement.ResolvedAt, persisted[0].State.ResolvedCostBasis.ResolvedAt)
 }
 
 func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseLineEnginePreviewsUnresolvedCostBasisAsZero() {
@@ -395,7 +409,7 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseLineEnginePreviewsUnr
 	s.Require().Len(lines, 1)
 	price, err := lines[0].UsageBased.Price.AsFlat()
 	s.Require().NoError(err)
-	s.Equal(alpacadecimal.Zero, price.Amount)
+	s.Require().Equal(float64(0), price.Amount.InexactFloat64())
 	s.Empty(lines[0].DetailedLines)
 	persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
 		Namespace: namespace,

--- a/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
@@ -18,16 +20,17 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesPinnedCostBasis() {
+func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesInitialCostBasis() {
 	// given:
-	// - a custom-currency credit purchase pinned to a durable USD cost basis
+	// - manual and pinned custom-currency cost-basis intents
 	// when:
-	// - the invoice-settled purchase is created
+	// - invoice-settled purchases are created
 	// then:
-	// - the pinned rate and source are persisted before the gathering line is priced
+	// - each initial resolution, gathering line, and durable charge state agree
 	ctx := s.T().Context()
 	now := time.Date(2026, time.January, 15, 12, 0, 0, 123456789, time.UTC)
 	clock.FreezeTime(now)
@@ -47,45 +50,106 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesPinnedCostBas
 
 	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
 	s.Require().NoError(err)
-	intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
-		customer.ID,
-		customCurrency,
-		defaults.CreditGrantTaxCodeID,
-		costbasis.NewIntent(costbasis.PinnedIntent{
-			FiatCurrency:        fiatCurrency,
-			CurrencyCostBasisID: pinnedCostBasis.ID,
-		}),
+
+	tests := []struct {
+		name                      string
+		intent                    costbasis.Intent
+		expectedRate              alpacadecimal.Decimal
+		expectedCurrencyCostBasis *string
+		expectedFiatAmount        alpacadecimal.Decimal
+	}{
+		{
+			name: "manual",
+			intent: costbasis.NewIntent(costbasis.ManualIntent{
+				FiatCurrency: fiatCurrency,
+				Rate:         alpacadecimal.NewFromFloat(0.5),
+			}),
+			expectedRate:       alpacadecimal.NewFromFloat(0.5),
+			expectedFiatAmount: alpacadecimal.NewFromInt(50),
+		},
+		{
+			name: "pinned",
+			intent: costbasis.NewIntent(costbasis.PinnedIntent{
+				FiatCurrency:        fiatCurrency,
+				CurrencyCostBasisID: pinnedCostBasis.ID,
+			}),
+			expectedRate:              pinnedCostBasis.Rate,
+			expectedCurrencyCostBasis: lo.ToPtr(pinnedCostBasis.ID),
+			expectedFiatAmount:        alpacadecimal.NewFromInt(25),
+		},
+	}
+
+	var (
+		referencedChargeID        string
+		referencedChargeCostBasis string
 	)
 
-	created, err := s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
-		Namespace: namespace,
-		Intent:    intent,
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(created.Charge.State.ResolvedCostBasis)
-	s.Equal(float64(0.25), created.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
-	s.Equal(pinnedCostBasis.ID, lo.FromPtr(created.Charge.State.ResolvedCostBasis.CostBasisID))
-	s.Equal(now.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// This subtest verifies the mode-specific initial resolution while
+			// sharing the invoice-line and persistence contract across both modes.
+			intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
+				customer.ID,
+				customCurrency,
+				defaults.CreditGrantTaxCodeID,
+				test.intent,
+			)
 
-	s.Require().NotNil(created.GatheringLineToCreate)
-	s.Equal(currencyx.FiatCode(currency.USD), created.GatheringLineToCreate.Currency)
-	price, err := created.GatheringLineToCreate.Price.AsFlat()
-	s.Require().NoError(err)
-	s.Equal(float64(25), price.Amount.InexactFloat64())
+			created, err := s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+				Namespace: namespace,
+				Intent:    intent,
+			})
+			s.Require().NoError(err)
+			s.Require().NotNil(created.Charge.State.ChargeCostBasisID)
+			s.Require().NotNil(created.Charge.State.ResolvedCostBasis)
+			s.Equal(test.expectedRate, created.Charge.State.ResolvedCostBasis.CostBasis)
+			s.Equal(test.expectedCurrencyCostBasis, created.Charge.State.ResolvedCostBasis.CostBasisID)
+			s.Equal(now.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
 
-	persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
-		Namespace: namespace,
-		IDs:       []string{created.Charge.ID},
+			s.Require().NotNil(created.GatheringLineToCreate)
+			s.Equal(currencyx.FiatCode(currency.USD), created.GatheringLineToCreate.Currency)
+			price, err := created.GatheringLineToCreate.Price.AsFlat()
+			s.Require().NoError(err)
+			s.Equal(test.expectedFiatAmount, price.Amount)
+
+			persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+				Namespace: namespace,
+				IDs:       []string{created.Charge.ID},
+			})
+			s.Require().NoError(err)
+			s.Require().Len(persisted, 1)
+			s.Equal(created.Charge.State.ChargeCostBasisID, persisted[0].State.ChargeCostBasisID)
+			s.Require().NotNil(persisted[0].State.ResolvedCostBasis)
+			s.Equal(created.Charge.State.ResolvedCostBasis.CostBasis, persisted[0].State.ResolvedCostBasis.CostBasis)
+			s.Equal(created.Charge.State.ResolvedCostBasis.CostBasisID, persisted[0].State.ResolvedCostBasis.CostBasisID)
+			s.Equal(
+				created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond),
+				persisted[0].State.ResolvedCostBasis.ResolvedAt,
+			)
+
+			if test.intent.Kind() == costbasis.ModePinned {
+				referencedChargeID = created.Charge.ID
+				referencedChargeCostBasis = *created.Charge.State.ChargeCostBasisID
+			}
+		})
+	}
+
+	s.Run("referenced charge cost basis cannot be deleted", func() {
+		// This subtest verifies that a charge-owned cost-basis record cannot be
+		// removed while the financial charge still references it.
+		s.Require().NotEmpty(referencedChargeID)
+		s.Require().NotEmpty(referencedChargeCostBasis)
+
+		err := s.DBClient.ChargeCreditPurchaseCostBasis.DeleteOneID(referencedChargeCostBasis).Exec(ctx)
+		s.Require().Error(err)
+
+		persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+			Namespace: namespace,
+			IDs:       []string{referencedChargeID},
+		})
+		s.Require().NoError(err)
+		s.Require().Len(persisted, 1)
 	})
-	s.Require().NoError(err)
-	s.Require().Len(persisted, 1)
-	s.Require().NotNil(persisted[0].State.ResolvedCostBasis)
-	s.Equal(created.Charge.State.ResolvedCostBasis.CostBasis, persisted[0].State.ResolvedCostBasis.CostBasis)
-	s.Equal(created.Charge.State.ResolvedCostBasis.CostBasisID, persisted[0].State.ResolvedCostBasis.CostBasisID)
-	s.Equal(
-		created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond),
-		persisted[0].State.ResolvedCostBasis.ResolvedAt,
-	)
 }
 
 func (s *CreditPurchaseTestSuite) TestPinnedCreditPurchaseCostBasisMustMatchCurrencyAndFiatCurrency() {
@@ -173,18 +237,121 @@ func (s *CreditPurchaseTestSuite) TestPinnedCreditPurchaseCostBasisMustMatchCurr
 	s.requireNoPersistedCreditPurchases(ctx, namespace)
 }
 
-func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsDynamicCostBasisBeforePersistence() {
+func (s *CreditPurchaseTestSuite) TestSetResolvedDynamicCostBasisOverwritesExistingState() {
 	// given:
-	// - a custom-currency credit purchase with dynamic cost-basis intent
+	// - a dynamically resolved credit-purchase cost basis and its owning charge
 	// when:
-	// - the purchase is created before dynamic lifecycle resolution exists
+	// - the service persists a different resolution and another charge attempts an update
 	// then:
-	// - creation is rejected without persisting a charge or cost-basis row
+	// - the latest owner resolution persists and the unrelated charge is rejected
 	ctx := s.T().Context()
-	namespace := s.GetUniqueNamespace("credit-purchase-dynamic-cost-basis")
+	namespace := s.GetUniqueNamespace("credit-purchase-dynamic-cost-basis-retry")
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
-	customer := s.CreateTestCustomer(namespace, "credit-purchase-dynamic-cost-basis")
+	customer := s.CreateTestCustomer(namespace, "credit-purchase-dynamic-cost-basis-retry")
 	customCurrency := s.createTestCustomCurrency(ctx, namespace)
+	servicePeriodFrom := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	clock.FreezeTime(servicePeriodFrom)
+	defer clock.UnFreeze()
+
+	currencyCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  namespace,
+		CurrencyID: customCurrency.ID,
+		FiatCode:   currencyx.Code(currency.USD),
+		Rate:       alpacadecimal.NewFromFloat(0.25),
+	})
+	s.Require().NoError(err)
+
+	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
+	s.Require().NoError(err)
+	intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
+		customer.ID,
+		customCurrency,
+		defaults.CreditGrantTaxCodeID,
+		costbasis.NewIntent(costbasis.DynamicIntent{FiatCurrency: fiatCurrency}),
+	)
+	intent.Settlement = creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+		InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+	})
+
+	defer s.CreditPurchaseTestHandler.Reset()
+	initiatedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
+	s.CreditPurchaseTestHandler.onCreditPurchaseInitiated = initiatedCallback.Handler(s.T())
+	lineageMock := &mockLineageService{Service: s.LineageService}
+	lineageMock.On("BackfillAdvanceLineageSegments", mock.Anything, mock.Anything).
+		Return(nil).
+		Once()
+	creditPurchaseService, err := creditpurchaseservice.New(creditpurchaseservice.Config{
+		Adapter:     s.CreditPurchaseAdapter,
+		Handler:     s.CreditPurchaseTestHandler,
+		Lineage:     lineageMock,
+		MetaAdapter: s.MetaAdapter,
+		Currencies:  s.CurrencyService,
+	})
+	s.Require().NoError(err)
+
+	created, err := creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		Namespace: namespace,
+		Intent:    intent,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created.Charge.State.ChargeCostBasisID)
+	s.Require().NotNil(created.Charge.State.ResolvedCostBasis)
+	lineageMock.AssertExpectations(s.T())
+
+	replacement := costbasis.State{
+		CostBasis:   alpacadecimal.NewFromInt(9),
+		CostBasisID: lo.ToPtr(currencyCostBasis.ID),
+		ResolvedAt:  servicePeriodFrom.Add(time.Hour),
+	}
+	updated, err := s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+		ChargeID:          created.Charge.GetChargeID(),
+		ChargeCostBasisID: *created.Charge.State.ChargeCostBasisID,
+		State:             replacement,
+	})
+	s.Require().NoError(err)
+	s.Equal(&replacement, updated.State)
+
+	wrongChargeID := created.Charge.GetChargeID()
+	wrongChargeID.ID = "another-charge"
+	_, err = s.CreditPurchaseAdapter.SetResolvedCostBasis(ctx, creditpurchase.SetResolvedCostBasisInput{
+		ChargeID:          wrongChargeID,
+		ChargeCostBasisID: *created.Charge.State.ChargeCostBasisID,
+		State: costbasis.State{
+			CostBasis:   alpacadecimal.NewFromInt(10),
+			CostBasisID: lo.ToPtr(currencyCostBasis.ID),
+			ResolvedAt:  servicePeriodFrom.Add(2 * time.Hour),
+		},
+	})
+	s.Require().ErrorContains(err, "not found")
+
+	persisted, err := creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+		Namespace: namespace,
+		IDs:       []string{created.Charge.ID},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(persisted, 1)
+	s.Equal(&replacement, persisted[0].State.ResolvedCostBasis)
+}
+
+func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseLineEnginePreviewsUnresolvedCostBasisAsZero() {
+	// given: a dynamic invoice credit purchase that has not entered its invoice lifecycle
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("invoice-credit-purchase-dynamic-cost-basis")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
+	customer := s.CreateTestCustomer(namespace, "invoice-credit-purchase-dynamic-cost-basis")
+	customCurrency := s.createTestCustomCurrency(ctx, namespace)
+	servicePeriodFrom := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	clock.FreezeTime(servicePeriodFrom)
+	defer clock.UnFreeze()
+
+	_, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  namespace,
+		CurrencyID: customCurrency.ID,
+		FiatCode:   currencyx.Code(currency.USD),
+		Rate:       alpacadecimal.NewFromFloat(0.25),
+	})
+	s.Require().NoError(err)
+
 	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
 	s.Require().NoError(err)
 	intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
@@ -194,13 +361,49 @@ func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsDynamicCostBasisBefor
 		costbasis.NewIntent(costbasis.DynamicIntent{FiatCurrency: fiatCurrency}),
 	)
 
-	_, err = s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+	created, err := s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
 		Namespace: namespace,
 		Intent:    intent,
 	})
-	s.Require().ErrorContains(err, "dynamic cost basis is not supported for credit purchases")
+	s.Require().NoError(err)
+	s.Require().NotNil(created.Charge.State.ChargeCostBasisID)
+	s.Nil(created.Charge.State.ResolvedCostBasis)
+	s.Require().NotNil(created.GatheringLineToCreate)
 
-	s.requireNoPersistedCreditPurchases(ctx, namespace)
+	gatheringLine := *created.GatheringLineToCreate
+	gatheringLine.ManagedResource = models.NewManagedResource(models.ManagedResourceInput{
+		ID:        "gathering-line-1",
+		Namespace: namespace,
+		CreatedAt: servicePeriodFrom,
+		UpdatedAt: servicePeriodFrom,
+		Name:      gatheringLine.Name,
+	})
+	invoice := billing.StandardInvoice{}
+	invoice.ID = "invoice-1"
+	invoice.Namespace = namespace
+	lineInput := billing.BuildStandardInvoiceLinesInput{
+		Invoice:        invoice,
+		GatheringLines: billing.GatheringLines{gatheringLine},
+	}
+	lineEngine := s.Charges.creditPurchaseService.GetLineEngine()
+
+	// when: the side-effect-free line preview materializes the unresolved gathering line
+	lines, err := lineEngine.BuildStandardLinesForGatheringPreview(ctx, lineInput)
+	s.Require().NoError(err)
+
+	// then: it preserves the temporary zero value without resolving the charge
+	s.Require().Len(lines, 1)
+	price, err := lines[0].UsageBased.Price.AsFlat()
+	s.Require().NoError(err)
+	s.Equal(alpacadecimal.Zero, price.Amount)
+	s.Empty(lines[0].DetailedLines)
+	persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+		Namespace: namespace,
+		IDs:       []string{created.Charge.ID},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(persisted, 1)
+	s.Nil(persisted[0].State.ResolvedCostBasis)
 }
 
 func newCustomCurrencyInvoiceCreditPurchaseIntent(
@@ -233,7 +436,7 @@ func newCustomCurrencyInvoiceCreditPurchaseIntent(
 			CreditAmount: alpacadecimal.NewFromInt(100),
 			Settlement:   creditpurchase.NewInvoiceSettlement(),
 		},
-		CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(costBasisIntent)),
+		CostBasis: creditpurchase.NewCostBasis(costBasisIntent),
 	}
 }
 

--- a/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_costbasis_test.go
@@ -1,0 +1,255 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	dbchargecreditpurchase "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchase"
+	dbchargecreditpurchasecostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchasecostbasis"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseResolvesPinnedCostBasis() {
+	// given:
+	// - a custom-currency credit purchase pinned to a durable USD cost basis
+	// when:
+	// - the invoice-settled purchase is created
+	// then:
+	// - the pinned rate and source are persisted before the gathering line is priced
+	ctx := s.T().Context()
+	now := time.Date(2026, time.January, 15, 12, 0, 0, 123456789, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	namespace := s.GetUniqueNamespace("credit-purchase-pinned-cost-basis")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
+	customer := s.CreateTestCustomer(namespace, "credit-purchase-pinned-cost-basis")
+	customCurrency := s.createTestCustomCurrency(ctx, namespace)
+	pinnedCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  namespace,
+		CurrencyID: customCurrency.ID,
+		FiatCode:   currencyx.Code(currency.USD),
+		Rate:       alpacadecimal.NewFromFloat(0.25),
+	})
+	s.Require().NoError(err)
+
+	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
+	s.Require().NoError(err)
+	intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
+		customer.ID,
+		customCurrency,
+		defaults.CreditGrantTaxCodeID,
+		costbasis.NewIntent(costbasis.PinnedIntent{
+			FiatCurrency:        fiatCurrency,
+			CurrencyCostBasisID: pinnedCostBasis.ID,
+		}),
+	)
+
+	created, err := s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		Namespace: namespace,
+		Intent:    intent,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created.Charge.State.ResolvedCostBasis)
+	s.Equal(float64(0.25), created.Charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
+	s.Equal(pinnedCostBasis.ID, lo.FromPtr(created.Charge.State.ResolvedCostBasis.CostBasisID))
+	s.Equal(now.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
+	s.Equal(created.Charge.CreatedAt.Truncate(time.Microsecond), created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond))
+
+	s.Require().NotNil(created.GatheringLineToCreate)
+	s.Equal(currencyx.FiatCode(currency.USD), created.GatheringLineToCreate.Currency)
+	price, err := created.GatheringLineToCreate.Price.AsFlat()
+	s.Require().NoError(err)
+	s.Equal(float64(25), price.Amount.InexactFloat64())
+
+	persisted, err := s.Charges.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
+		Namespace: namespace,
+		IDs:       []string{created.Charge.ID},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(persisted, 1)
+	s.Require().NotNil(persisted[0].State.ResolvedCostBasis)
+	s.Equal(created.Charge.State.ResolvedCostBasis.CostBasis, persisted[0].State.ResolvedCostBasis.CostBasis)
+	s.Equal(created.Charge.State.ResolvedCostBasis.CostBasisID, persisted[0].State.ResolvedCostBasis.CostBasisID)
+	s.Equal(
+		created.Charge.State.ResolvedCostBasis.ResolvedAt.Truncate(time.Microsecond),
+		persisted[0].State.ResolvedCostBasis.ResolvedAt,
+	)
+}
+
+func (s *CreditPurchaseTestSuite) TestPinnedCreditPurchaseCostBasisMustMatchCurrencyAndFiatCurrency() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("credit-purchase-pinned-cost-basis-mismatch")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
+	customer := s.CreateTestCustomer(namespace, "credit-purchase-pinned-cost-basis-mismatch")
+	customCurrency := s.createTestCustomCurrency(ctx, namespace)
+	otherCurrency, err := s.CurrencyService.CreateCurrency(ctx, currencies.CreateCurrencyInput{
+		Namespace: namespace,
+		CurrencyDetails: currencyx.CurrencyDetails{
+			Code:               "OTHER",
+			Name:               "Other",
+			Symbol:             "O",
+			Precision:          3,
+			DecimalMark:        ".",
+			ThousandsSeparator: ",",
+		},
+	})
+	s.Require().NoError(err)
+
+	otherCurrencyCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  namespace,
+		CurrencyID: otherCurrency.ID,
+		FiatCode:   currencyx.Code(currency.USD),
+		Rate:       alpacadecimal.NewFromInt(1),
+	})
+	s.Require().NoError(err)
+	eurCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  namespace,
+		CurrencyID: customCurrency.ID,
+		FiatCode:   currencyx.Code(currency.EUR),
+		Rate:       alpacadecimal.NewFromInt(1),
+	})
+	s.Require().NoError(err)
+
+	usd, err := currencyx.NewFiatCurrency(currency.USD)
+	s.Require().NoError(err)
+	tests := []struct {
+		name          string
+		fiatCurrency  *currencyx.FiatCurrency
+		costBasisID   string
+		expectedError string
+	}{
+		{
+			name:          "custom currency mismatch",
+			fiatCurrency:  usd,
+			costBasisID:   otherCurrencyCostBasis.ID,
+			expectedError: "currency cost basis currency mismatch",
+		},
+		{
+			name:          "fiat currency mismatch",
+			fiatCurrency:  usd,
+			costBasisID:   eurCostBasis.ID,
+			expectedError: "currency cost basis fiat currency mismatch",
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			// given:
+			// - a pinned source that disagrees with the purchased or settlement currency
+			// when:
+			// - the credit purchase is created
+			// then:
+			// - resolution fails before either charge row is persisted
+			intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
+				customer.ID,
+				customCurrency,
+				defaults.CreditGrantTaxCodeID,
+				costbasis.NewIntent(costbasis.PinnedIntent{
+					FiatCurrency:        test.fiatCurrency,
+					CurrencyCostBasisID: test.costBasisID,
+				}),
+			)
+
+			_, err := s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+				Namespace: namespace,
+				Intent:    intent,
+			})
+			s.Require().ErrorContains(err, test.expectedError)
+		})
+	}
+
+	s.requireNoPersistedCreditPurchases(ctx, namespace)
+}
+
+func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsDynamicCostBasisBeforePersistence() {
+	// given:
+	// - a custom-currency credit purchase with dynamic cost-basis intent
+	// when:
+	// - the purchase is created before dynamic lifecycle resolution exists
+	// then:
+	// - creation is rejected without persisting a charge or cost-basis row
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("credit-purchase-dynamic-cost-basis")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
+	customer := s.CreateTestCustomer(namespace, "credit-purchase-dynamic-cost-basis")
+	customCurrency := s.createTestCustomCurrency(ctx, namespace)
+	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
+	s.Require().NoError(err)
+	intent := newCustomCurrencyInvoiceCreditPurchaseIntent(
+		customer.ID,
+		customCurrency,
+		defaults.CreditGrantTaxCodeID,
+		costbasis.NewIntent(costbasis.DynamicIntent{FiatCurrency: fiatCurrency}),
+	)
+
+	_, err = s.Charges.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		Namespace: namespace,
+		Intent:    intent,
+	})
+	s.Require().ErrorContains(err, "dynamic cost basis is not supported for credit purchases")
+
+	s.requireNoPersistedCreditPurchases(ctx, namespace)
+}
+
+func newCustomCurrencyInvoiceCreditPurchaseIntent(
+	customerID string,
+	currency currencies.Currency,
+	taxCodeID string,
+	costBasisIntent costbasis.Intent,
+) creditpurchase.Intent {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return creditpurchase.Intent{
+		Intent: meta.Intent{
+			ManagedBy:  billing.ManuallyManagedLine,
+			CustomerID: customerID,
+			Currency:   currency,
+			TaxConfig: productcatalog.TaxCodeConfig{
+				TaxCodeID: taxCodeID,
+			},
+		},
+		IntentMutableFields: creditpurchase.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              "Custom Currency Credit Purchase",
+				ServicePeriod:     servicePeriod,
+				BillingPeriod:     servicePeriod,
+				FullServicePeriod: servicePeriod,
+			},
+			CreditAmount: alpacadecimal.NewFromInt(100),
+			Settlement:   creditpurchase.NewInvoiceSettlement(),
+		},
+		CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(costBasisIntent)),
+	}
+}
+
+func (s *CreditPurchaseTestSuite) requireNoPersistedCreditPurchases(ctx context.Context, namespace string) {
+	s.T().Helper()
+
+	chargeCount, err := s.DBClient.ChargeCreditPurchase.Query().
+		Where(dbchargecreditpurchase.NamespaceEQ(namespace)).
+		Count(ctx)
+	s.Require().NoError(err)
+	s.Zero(chargeCount)
+
+	costBasisCount, err := s.DBClient.ChargeCreditPurchaseCostBasis.Query().
+		Where(dbchargecreditpurchasecostbasis.NamespaceEQ(namespace)).
+		Count(ctx)
+	s.Require().NoError(err)
+	s.Zero(costBasisCount)
+}

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -627,7 +627,6 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchaseDeferred() {
 		s.Equal(*line.ChargeID, chargeID.ID)
 	})
 
-	// The TestStandardInvoiceCreditPurchase test covers the full non-deferred invoicing path.
-	// This path only covers parts up to the point where the gathering line is created, as for
-	// invoice based triggers the lifecycle is governed by the invoicing line engine.
+	// Dynamic invoice lifecycle coverage exercises materialization and payment transitions.
+	// This test remains focused on the deferred path up to gathering-line creation.
 }

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -855,7 +855,6 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 		s.Require().NotNil(creditPurchaseCharge.State.ResolvedCostBasis)
 		s.Nil(creditPurchaseCharge.State.ResolvedCostBasis.CostBasisID)
 		s.Equal(float64(0.5), creditPurchaseCharge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
-		s.Equal(creditPurchaseCharge.CreatedAt, creditPurchaseCharge.State.ResolvedCostBasis.ResolvedAt)
 		s.Nil(creditPurchaseCharge.Realizations.CreditGrantRealization)
 		s.Nil(creditPurchaseCharge.Realizations.InvoiceSettlement)
 	})

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -177,6 +177,7 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchaseWithCustomCurrenc
 			Handler:     s.CreditPurchaseTestHandler,
 			Lineage:     lineageMock,
 			MetaAdapter: s.MetaAdapter,
+			Currencies:  s.CurrencyService,
 		})
 		s.Require().NoError(err)
 
@@ -265,6 +266,7 @@ func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() 
 		Handler:     s.CreditPurchaseTestHandler,
 		Lineage:     s.LineageService,
 		MetaAdapter: s.MetaAdapter,
+		Currencies:  s.CurrencyService,
 	})
 	s.Require().NoError(err)
 
@@ -850,6 +852,10 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
 		s.NoError(err)
 		s.Equal(creditpurchase.StatusCreated, creditPurchaseCharge.Status)
+		s.Require().NotNil(creditPurchaseCharge.State.ResolvedCostBasis)
+		s.Nil(creditPurchaseCharge.State.ResolvedCostBasis.CostBasisID)
+		s.Equal(float64(0.5), creditPurchaseCharge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
+		s.Equal(creditPurchaseCharge.CreatedAt, creditPurchaseCharge.State.ResolvedCostBasis.ResolvedAt)
 		s.Nil(creditPurchaseCharge.Realizations.CreditGrantRealization)
 		s.Nil(creditPurchaseCharge.Realizations.InvoiceSettlement)
 	})

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -8,20 +8,17 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
@@ -221,124 +218,6 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchaseWithCustomCurrenc
 	})
 }
 
-func (s *CreditPurchaseTestSuite) TestInvoiceCreditPurchaseWithCustomCurrency() {
-	ctx := s.T().Context()
-	ns := s.GetUniqueNamespace("charges-service-invoice-credit-purchase-custom-currency")
-	defaultTaxCodes := s.ProvisionDefaultTaxCodes(ctx, ns)
-
-	cust := s.CreateTestCustomer(ns, "test-subject")
-	s.NotEmpty(cust.ID)
-	customCurrency := s.createTestCustomCurrency(ctx, ns)
-
-	servicePeriod := timeutil.ClosedPeriod{
-		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
-		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
-	}
-	fiatCurrency, err := currencyx.NewFiatCurrency(currency.USD)
-	s.Require().NoError(err)
-	intent := creditpurchase.Intent{
-		Intent: meta.Intent{
-			ManagedBy:  billing.ManuallyManagedLine,
-			CustomerID: cust.ID,
-			Currency:   customCurrency,
-			TaxConfig: productcatalog.TaxCodeConfig{
-				TaxCodeID: defaultTaxCodes.CreditGrantTaxCodeID,
-			},
-		},
-		IntentMutableFields: creditpurchase.IntentMutableFields{
-			IntentMutableFields: meta.IntentMutableFields{
-				Name:              "Custom Currency Credit Purchase",
-				ServicePeriod:     servicePeriod,
-				BillingPeriod:     servicePeriod,
-				FullServicePeriod: servicePeriod,
-			},
-			CreditAmount: alpacadecimal.NewFromFloat(100.1234),
-			Settlement:   creditpurchase.NewInvoiceSettlement(),
-		},
-		CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
-			FiatCurrency: fiatCurrency,
-			Rate:         alpacadecimal.NewFromFloat(0.5),
-		}))),
-	}
-
-	creditPurchaseService, err := creditpurchaseservice.New(creditpurchaseservice.Config{
-		Adapter:     s.CreditPurchaseAdapter,
-		Handler:     s.CreditPurchaseTestHandler,
-		Lineage:     s.LineageService,
-		MetaAdapter: s.MetaAdapter,
-		Currencies:  s.CurrencyService,
-	})
-	s.Require().NoError(err)
-
-	var createdCharge creditpurchase.Charge
-
-	s.Run("create", func() {
-		// given:
-		// - a custom-currency invoice credit purchase
-		// when:
-		// - the invoice credit purchase is created
-		// then:
-		// - the charge keeps the purchased currency while the gathering line uses fiat settlement
-		created, err := creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
-			Namespace: ns,
-			Intent:    intent,
-		})
-		s.Require().NoError(err)
-		createdCharge = created.Charge
-
-		s.True(createdCharge.Intent.Currency.IsCustom())
-		s.Equal(customCurrency.ID, createdCharge.Intent.Currency.ID)
-		s.Equal(float64(100.123), createdCharge.Intent.CreditAmount.InexactFloat64())
-		s.NotNil(createdCharge.Intent.CostBasis)
-		s.NotNil(createdCharge.State.ResolvedCostBasis)
-
-		s.Require().NotNil(created.GatheringLineToCreate)
-		gatheringLine := *created.GatheringLineToCreate
-		s.Equal(currencyx.FiatCode(currency.USD), gatheringLine.Currency)
-		s.Equal("Custom Currency Credit Purchase (100.123 TOKENS credits)", gatheringLine.Name)
-
-		flatPrice, err := gatheringLine.Price.AsFlat()
-		s.Require().NoError(err)
-		s.Equal(float64(50.06), flatPrice.Amount.InexactFloat64())
-
-		persisted, err := creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
-			Namespace: ns,
-			IDs:       []string{createdCharge.ID},
-		})
-		s.Require().NoError(err)
-		s.Require().Len(persisted, 1)
-		s.True(persisted[0].Intent.Currency.IsCustom())
-		s.Equal(customCurrency.ID, persisted[0].Intent.Currency.ID)
-
-		s.Equal(creditpurchase.SettlementTypeInvoice, persisted[0].Intent.Settlement.Type())
-		resolvedCostBasis, err := persisted[0].GetResolvedCostBasis()
-		s.Require().NoError(err)
-		s.Equal(currencyx.FiatCode(currency.USD), resolvedCostBasis.FiatCurrency.GetFiatCode())
-	})
-
-	s.Run("referenced cost basis cannot be deleted", func() {
-		// given:
-		// - a persisted custom-currency purchase referencing its cost basis
-		persistedEntity, err := s.DBClient.ChargeCreditPurchase.Get(ctx, createdCharge.ID)
-		s.Require().NoError(err)
-		s.Require().NotNil(persistedEntity.CostBasisID, "create subtest must have persisted a cost basis")
-
-		// when:
-		// - the referenced cost-basis row is deleted directly
-		err = s.DBClient.ChargeCreditPurchaseCostBasis.DeleteOneID(*persistedEntity.CostBasisID).Exec(ctx)
-
-		// then:
-		// - the foreign key rejects the delete and preserves the financial charge
-		s.Require().Error(err)
-		persisted, err := creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
-			Namespace: ns,
-			IDs:       []string{createdCharge.ID},
-		})
-		s.Require().NoError(err)
-		s.Require().Len(persisted, 1)
-	})
-}
-
 func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsFiatCostBasisForCustomCurrency() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-credit-purchase-fiat-cost-basis-custom-currency")
@@ -388,9 +267,9 @@ func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsFiatCostBasisForCusto
 					CreditAmount: alpacadecimal.NewFromFloat(100),
 					Settlement:   tc.settlement,
 				},
-				CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+				CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 					Rate: alpacadecimal.NewFromFloat(0.5),
-				})),
+				}),
 			})
 
 			res, err := s.Charges.Create(ctx, charges.CreateInput{
@@ -455,7 +334,7 @@ func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsNonPositiveCostBasisB
 			// - charge creation validates the intent
 			// then:
 			// - it fails before lifecycle callbacks or charge persistence can run
-			costBasis := lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: tc.costBasis}))
+			costBasis := creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: tc.costBasis})
 			intent := charges.NewChargeIntent(creditpurchase.Intent{
 				Intent: meta.Intent{
 					ManagedBy:  billing.ManuallyManagedLine,
@@ -504,7 +383,7 @@ type createCreditPurchaseIntentInput struct {
 	amount        alpacadecimal.Decimal
 	servicePeriod timeutil.ClosedPeriod
 	settlement    creditpurchase.Settlement
-	costBasis     *creditpurchase.CostBasis
+	costBasis     creditpurchase.CostBasis
 }
 
 func (i createCreditPurchaseIntentInput) Validate() error {
@@ -555,8 +434,8 @@ func CreateCreditPurchaseIntent(t *testing.T, input createCreditPurchaseIntentIn
 	})
 }
 
-func newFiatCreditPurchaseCostBasis(rate alpacadecimal.Decimal) *creditpurchase.CostBasis {
-	return lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: rate}))
+func newFiatCreditPurchaseCostBasis(rate alpacadecimal.Decimal) creditpurchase.CostBasis {
+	return creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{Rate: rate})
 }
 
 func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettled() {
@@ -650,7 +529,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 			// The charge should have both a grant and a payment settlement.
 			creditPurchaseCharge, err := tc.charge.AsCreditPurchaseCharge()
 			s.NoError(err)
-			s.Require().NotNil(creditPurchaseCharge.Intent.CostBasis)
+			s.Require().False(creditPurchaseCharge.Intent.CostBasis.IsEmpty())
 			fiatCostBasis, err := creditPurchaseCharge.Intent.CostBasis.AsFiat()
 			s.NoError(err)
 			s.Equal(float64(0.5), fiatCostBasis.Rate.InexactFloat64())
@@ -667,362 +546,6 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 			s.Equal(creditpurchase.StatusFinal, creditPurchaseCharge.Status)
 		})
 	}
-}
-
-func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySettled() {
-	ctx := context.Background()
-	ns := s.GetUniqueNamespace("charges-service-external-authorized-credit-purchase-manually-settled")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
-
-	cust := s.CreateTestCustomer(ns, "test-subject")
-	s.NotEmpty(cust.ID)
-
-	// Let's buy 100 USD credits for $0.50 each (total cost is $50)
-	intent := CreateCreditPurchaseIntent(s.T(),
-		createCreditPurchaseIntentInput{
-			customer: cust.GetID(),
-			currency: USD,
-			amount:   alpacadecimal.NewFromFloat(100),
-			servicePeriod: timeutil.ClosedPeriod{
-				From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
-				To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
-			},
-			settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
-				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
-			}),
-			costBasis: newFiatCreditPurchaseCostBasis(alpacadecimal.NewFromFloat(0.5)),
-		},
-	)
-
-	var chargeID meta.ChargeID
-	var initatedTrnsID string
-	var authorizedTrnsID string
-
-	s.Run("initiated", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		// The initiated callback creates the credit grant before payment is authorized.
-		initatedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchaseInitiated = initatedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
-			assert.Nil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should not be set")
-			assert.Nil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should not be set")
-			assert.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status, "charge status should be initial credit grant")
-		})
-
-		res, err := s.Charges.Create(ctx, charges.CreateInput{
-			Namespace: ns,
-			Intents: charges.ChargeIntents{
-				intent,
-			},
-		})
-		s.NoError(err)
-		s.Len(res, 1)
-		s.Equal(meta.ChargeTypeCreditPurchase, res[0].Type())
-
-		creditPurchaseCharge, err := res[0].AsCreditPurchaseCharge()
-		s.NoError(err)
-		s.Equal(1, initatedCallback.nrInvocations)
-		s.NotNil(creditPurchaseCharge.Realizations.CreditGrantRealization)
-		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.TransactionGroupID)
-		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status)
-
-		chargeID = creditPurchaseCharge.GetChargeID()
-		initatedTrnsID = initatedCallback.id
-	})
-
-	s.Run("authorized", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		// Then the authorized callback should be called, with a grant realization and no payment settlement.
-		// The handler receives the charge after the authorized transition has entered its destination state.
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
-			charge := input.Charge
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
-			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
-			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
-			assert.Nil(t, charge.Realizations.ExternalPaymentSettlement)
-			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
-		})
-
-		res, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
-			ChargeID:           chargeID,
-			TargetPaymentState: payment.StatusAuthorized,
-		})
-		s.NoError(err)
-
-		s.Equal(1, authorizedCallback.nrInvocations)
-		s.Equal(authorizedCallback.id, res.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
-		s.Equal(payment.StatusAuthorized, res.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(creditpurchase.StatusActivePaymentAuthorized, res.Status)
-
-		authorizedTrnsID = authorizedCallback.id
-	})
-
-	s.Run("settled", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		// Then the settled callback should be called in the settlement state with a payment settlement.
-		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
-			charge := input.Charge
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
-			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
-			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
-			assert.NotNil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
-
-			// Authorized transaction group ID should be set
-			assert.Equal(t, authorizedTrnsID, charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
-			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-			assert.Equal(t, creditpurchase.StatusActivePaymentSettled, charge.Status, "charge status should be payment settled")
-		})
-		res, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
-			ChargeID:           chargeID,
-			TargetPaymentState: payment.StatusSettled,
-		})
-		s.NoError(err)
-
-		s.Equal(1, settledCallback.nrInvocations)
-		s.Equal(settledCallback.id, res.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID)
-		s.Equal(payment.StatusSettled, res.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(creditpurchase.StatusFinal, res.Status)
-	})
-}
-
-func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
-	defer clock.UnFreeze()
-	ctx := context.Background()
-	ns := s.GetUniqueNamespace("charges-service-standard-invoice-credit-purchase")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
-
-	cust := s.CreateTestCustomer(ns, "test-subject")
-	s.NotEmpty(cust.ID)
-
-	customInvoicing := s.SetupCustomInvoicing(ns)
-
-	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
-		billingtest.WithProgressiveBilling(),
-		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
-		billingtest.WithManualApproval(),
-	)
-
-	servicePeriod := timeutil.ClosedPeriod{
-		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
-		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
-	}
-
-	clock.SetTime(datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime())
-
-	// Let's buy 100 USD credits for $0.50 each (total cost is $50)
-	intent := CreateCreditPurchaseIntent(s.T(),
-		createCreditPurchaseIntentInput{
-			customer:      cust.GetID(),
-			currency:      USD,
-			amount:        alpacadecimal.NewFromFloat(100),
-			servicePeriod: servicePeriod,
-			settlement:    creditpurchase.NewInvoiceSettlement(),
-			costBasis:     newFiatCreditPurchaseCostBasis(alpacadecimal.NewFromFloat(0.5)),
-		},
-	)
-
-	var chargeID meta.ChargeID
-	var initatedTrnsID string
-
-	var invoiceID billing.InvoiceID
-
-	s.Run("initiated", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		// First the initiated callback should be called, without any grant realizations or payment settlements
-
-		res, err := s.Charges.Create(ctx, charges.CreateInput{
-			Namespace: ns,
-			Intents: charges.ChargeIntents{
-				intent,
-			},
-		})
-		s.NoError(err)
-		s.Len(res, 1)
-		s.Equal(meta.ChargeTypeCreditPurchase, res[0].Type())
-		chargeID, err = res[0].GetChargeID()
-		s.NoError(err)
-
-		charge := s.mustGetChargeByID(chargeID)
-		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
-		s.NoError(err)
-		s.Equal(creditpurchase.StatusCreated, creditPurchaseCharge.Status)
-		s.Require().NotNil(creditPurchaseCharge.State.ResolvedCostBasis)
-		s.Nil(creditPurchaseCharge.State.ResolvedCostBasis.CostBasisID)
-		s.Equal(float64(0.5), creditPurchaseCharge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
-		s.Nil(creditPurchaseCharge.Realizations.CreditGrantRealization)
-		s.Nil(creditPurchaseCharge.Realizations.InvoiceSettlement)
-	})
-
-	s.Run("invoice pending lines", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		initatedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchaseInitiated = initatedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeInvoice)
-			assert.Nil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should not be set")
-			assert.Nil(t, charge.Realizations.InvoiceSettlement, "invoice settlement should not be set")
-		})
-
-		clock.FreezeTime(datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime())
-		now := clock.Now()
-		createdInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-			Customer: cust.GetID(),
-			AsOf:     &now,
-		})
-
-		s.NoError(err)
-		s.Len(createdInvoices, 1)
-		s.Len(createdInvoices[0].Lines.OrEmpty(), 1)
-		invoiceID = createdInvoices[0].GetInvoiceID()
-		s.NotEmpty(invoiceID)
-		s.NoError(invoiceID.Validate())
-
-		invoicesResult, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
-			Namespace: ns,
-		})
-
-		s.NoError(err)
-		s.Len(invoicesResult.Items, 1)
-
-		updatedCharge := s.mustGetChargeByID(chargeID)
-
-		creditPurchaseCharge, err := updatedCharge.AsCreditPurchaseCharge()
-		s.NoError(err)
-
-		s.Equal(1, initatedCallback.nrInvocations)
-		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
-		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status)
-
-		chargeID = creditPurchaseCharge.GetChargeID()
-		initatedTrnsID = initatedCallback.id
-
-		s.NotEmpty(invoiceID)
-	})
-
-	s.Run("authorized", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-
-		// Then the authorized callback should be called, with a grant realization and no payment settlement
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
-			charge := input.Charge
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeInvoice)
-			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
-			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
-			assert.Nil(t, charge.Realizations.InvoiceSettlement)
-			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
-		})
-
-		invoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
-			Invoice: invoiceID,
-			Expand:  billing.StandardInvoiceExpandAll,
-		})
-		s.NoError(err)
-		s.Equal(invoiceID, invoice.GetInvoiceID())
-
-		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
-
-		res, err := s.BillingService.ApproveInvoice(ctx, invoiceID)
-		s.NoError(err)
-
-		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, res.Status)
-
-		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
-			Invoice: invoiceID,
-			Expand:  billing.StandardInvoiceExpandAll,
-		})
-		s.NoError(err)
-		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
-
-		charge := s.mustGetChargeByID(chargeID)
-		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
-		s.NoError(err)
-
-		// Payment authorization is no longer persisted at pending.
-		s.Equal(0, authorizedCallback.nrInvocations)
-		s.Nil(creditPurchaseCharge.Realizations.InvoiceSettlement)
-		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status, "charge status should be payment pending")
-
-		// validate the standard line
-		lines := invoice.Lines.OrEmpty()
-		s.Require().Len(lines, 1)
-
-		line := lines[0]
-		s.Equal(currencyx.FiatCode(USD), line.Currency)
-		s.Equal(timeutil.ClosedPeriod{
-			From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
-			To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
-		}, line.Period)
-		s.Equal(alpacadecimal.NewFromFloat(50), line.Totals.Amount)
-		s.Equal(alpacadecimal.NewFromFloat(50), line.Totals.Total)
-
-		// validate the detailed line
-		s.Require().Len(line.DetailedLines, 1)
-
-		detailedLine := line.DetailedLines[0]
-
-		s.Equal(float64(0.5), detailedLine.PerUnitAmount.InexactFloat64())
-		s.Equal(float64(100), detailedLine.Quantity.InexactFloat64())
-		s.Equal(alpacadecimal.NewFromFloat(50), detailedLine.Totals.Amount)
-		s.Equal(alpacadecimal.NewFromFloat(50), detailedLine.Totals.Total)
-
-		// validate invoice totals
-		s.Equal(alpacadecimal.NewFromFloat(50), invoice.Totals.Amount)
-		s.Equal(alpacadecimal.NewFromFloat(50), invoice.Totals.Total)
-	})
-
-	s.Run("settled", func() {
-		defer s.CreditPurchaseTestHandler.Reset()
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T())
-
-		// Then the settled callback should be called, with a grant realization and a payment settlement
-		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
-			charge := input.Charge
-			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeInvoice)
-			assert.NotNil(t, charge.Realizations.InvoiceSettlement, "invoice settlement should be set")
-
-			// Authorized transaction group ID should still be set from the authorized phase
-			assert.Equal(t, authorizedCallback.id, charge.Realizations.InvoiceSettlement.Authorized.TransactionGroupID)
-			assert.Equal(t, creditpurchase.StatusActivePaymentSettled, charge.Status, "charge status should be payment settled")
-		})
-
-		// First verify the invoice is in the expected state
-		invoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
-			Invoice: invoiceID,
-		})
-
-		s.NoError(err)
-		s.Equal(invoiceID, invoice.GetInvoiceID())
-		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
-
-		res, err := s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
-			InvoiceID: invoiceID,
-			Trigger:   billing.TriggerPaid,
-		})
-
-		s.NoError(err)
-		s.Equal(billing.StandardInvoiceStatusPaid, res.Status)
-
-		s.Equal(1, settledCallback.nrInvocations)
-
-		charge := s.mustGetChargeByID(chargeID)
-		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
-		s.NoError(err)
-
-		s.Equal(1, authorizedCallback.nrInvocations)
-		s.Equal(settledCallback.id, creditPurchaseCharge.Realizations.InvoiceSettlement.Settled.TransactionGroupID)
-		s.Equal(float64(50), creditPurchaseCharge.Realizations.InvoiceSettlement.FiatAmount.InexactFloat64())
-		s.Equal(payment.StatusSettled, creditPurchaseCharge.Realizations.InvoiceSettlement.Status)
-		s.Equal(creditpurchase.StatusFinal, creditPurchaseCharge.Status)
-	})
 }
 
 func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchaseDeferred() {

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -396,9 +396,9 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropaga
 					CreditAmount: alpacadecimal.NewFromFloat(100),
 					Settlement:   creditpurchase.NewInvoiceSettlement(),
 				},
-				CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+				CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 					Rate: alpacadecimal.NewFromFloat(0.5),
-				})),
+				}),
 			}),
 		},
 	})
@@ -513,9 +513,9 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxC
 					CreditAmount: alpacadecimal.NewFromFloat(100),
 					Settlement:   creditpurchase.NewInvoiceSettlement(),
 				},
-				CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+				CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 					Rate: alpacadecimal.NewFromFloat(0.5),
-				})),
+				}),
 			}),
 		},
 	})

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -233,6 +233,7 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 		Handler:     config.CreditPurchaseHandler,
 		Lineage:     lineageService,
 		MetaAdapter: metaAdapter,
+		Currencies:  currencyService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating credit purchase service: %w", err)

--- a/openmeter/billing/creditgrant/service/service.go
+++ b/openmeter/billing/creditgrant/service/service.go
@@ -369,12 +369,12 @@ func toIntent(input creditgrant.CreateInput) (creditpurchase.Intent, error) {
 		return creditpurchase.Intent{}, fmt.Errorf("build fiat currency: %w", err)
 	}
 
-	var costBasis *creditpurchase.CostBasis
+	var costBasis creditpurchase.CostBasis
 	if input.FundingMethod != creditgrant.FundingMethodNone {
 		// TODO: map custom-currency grants to the shared custom-currency cost-basis intent.
-		costBasis = lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+		costBasis = creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 			Rate: lo.FromPtrOr(input.Purchase.PerUnitCostBasis, alpacadecimal.NewFromInt(1)),
-		}))
+		})
 	}
 
 	intent := creditpurchase.Intent{

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -77,11 +77,18 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 	}
 	charge := input.Charge
 
-	resolvedCostBasis, err := charge.GetResolvedCostBasis()
-	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get resolved cost basis: %w", err)
+	if charge.State.ResolvedCostBasis == nil {
+		return ledgertransaction.GroupReference{}, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("credit purchase charge[%s] cost basis is unresolved", charge.ID),
+		)
 	}
-	costBasis := resolvedCostBasis.Rate
+
+	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+	}
+
+	costBasis := charge.State.ResolvedCostBasis.CostBasis
 
 	customerID := customer.CustomerID{
 		Namespace: charge.Namespace,
@@ -90,7 +97,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 	featureFilters := charge.Intent.FeatureFilters.Normalize()
 
-	settlementCurrency := currencyx.Code(resolvedCostBasis.FiatCurrency.GetFiatCode())
+	settlementCurrency := currencyx.Code(fiatCurrency.GetFiatCode())
 
 	var templates []transactions.TransactionTemplate
 	if charge.Intent.Currency.IsCustom() || !input.FiatAmount.Equal(charge.Intent.CreditAmount) {
@@ -156,11 +163,18 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 	}
 	charge := input.Charge
 
-	resolvedCostBasis, err := charge.GetResolvedCostBasis()
-	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get resolved cost basis: %w", err)
+	if charge.State.ResolvedCostBasis == nil {
+		return ledgertransaction.GroupReference{}, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("credit purchase charge[%s] cost basis is unresolved", charge.ID),
+		)
 	}
-	costBasis := resolvedCostBasis.Rate
+
+	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+	}
+
+	costBasis := charge.State.ResolvedCostBasis.CostBasis
 
 	customerID := customer.CustomerID{
 		Namespace: charge.Namespace,
@@ -169,7 +183,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 	featureFilters := charge.Intent.FeatureFilters.Normalize()
 
-	settlementCurrency := currencyx.Code(resolvedCostBasis.FiatCurrency.GetFiatCode())
+	settlementCurrency := currencyx.Code(fiatCurrency.GetFiatCode())
 
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
@@ -237,14 +251,20 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			costBasisPtr = lo.ToPtr(alpacadecimal.Zero)
 		}
 	} else {
-		resolvedCostBasis, err := charge.GetResolvedCostBasis()
-		if err != nil {
-			return ledgertransaction.GroupReference{}, fmt.Errorf("get resolved cost basis: %w", err)
+		if charge.State.ResolvedCostBasis == nil {
+			return ledgertransaction.GroupReference{}, models.NewGenericPreConditionFailedError(
+				fmt.Errorf("credit purchase charge[%s] cost basis is unresolved", charge.ID),
+			)
 		}
 
-		costBasisPtr = &resolvedCostBasis.Rate
+		costBasisPtr = &charge.State.ResolvedCostBasis.CostBasis
 		if charge.Intent.Currency.IsCustom() {
-			costBasisCurrency = lo.ToPtr(currencyx.Code(resolvedCostBasis.FiatCurrency.GetFiatCode()))
+			fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+			if err != nil {
+				return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+			}
+
+			costBasisCurrency = lo.ToPtr(currencyx.Code(fiatCurrency.GetFiatCode()))
 		}
 	}
 	customerID := customer.CustomerID{

--- a/openmeter/ledger/chargeadapter/creditpurchase_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_customcurrency_test.go
@@ -306,7 +306,8 @@ func (e *creditPurchaseHandlerTestEnv) newPromotionalChargeCustomCurrency(
 	charge.ID = "credit-purchase-cc-promo"
 	charge.Intent.Name = "Promotional Credit Purchase (custom currency)"
 	charge.Intent.Settlement = chargecreditpurchase.NewSettlement(chargecreditpurchase.PromotionalSettlement{})
-	charge.Intent.CostBasis = nil
+	charge.Intent.CostBasis = chargecreditpurchase.CostBasis{}
+	charge.State.ChargeCostBasisID = nil
 	charge.State.ResolvedCostBasis = nil
 
 	return charge
@@ -534,13 +535,14 @@ func (e *creditPurchaseHandlerTestEnv) newExternalChargeCustomCurrency(
 						InitialStatus: chargecreditpurchase.CreatedInitialPaymentSettlementStatus,
 					}),
 				},
-				CostBasis: lo.ToPtr(chargecreditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
+				CostBasis: chargecreditpurchase.NewCostBasis(chargecostbasis.NewIntent(chargecostbasis.ManualIntent{
 					FiatCurrency: fiatCurrency,
 					Rate:         costBasis,
-				}))),
+				})),
 			},
 			Status: chargecreditpurchase.StatusCreated,
 			State: chargecreditpurchase.State{
+				ChargeCostBasisID: lo.ToPtr("credit-purchase-cost-basis-cc"),
 				ResolvedCostBasis: &chargecostbasis.State{
 					CostBasis:  costBasis,
 					ResolvedAt: now,

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -795,9 +794,9 @@ func (e *creditPurchaseHandlerTestEnv) newExternalCharge(amount, costBasis alpac
 						InitialStatus: chargecreditpurchase.CreatedInitialPaymentSettlementStatus,
 					}),
 				},
-				CostBasis: lo.ToPtr(chargecreditpurchase.NewCostBasis(chargecreditpurchase.FiatCostBasis{
+				CostBasis: chargecreditpurchase.NewCostBasis(chargecreditpurchase.FiatCostBasis{
 					Rate: costBasis,
-				})),
+				}),
 			},
 			Status: chargecreditpurchase.StatusCreated,
 			State: chargecreditpurchase.State{

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	chargecreditpurchase "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
@@ -799,6 +800,12 @@ func (e *creditPurchaseHandlerTestEnv) newExternalCharge(amount, costBasis alpac
 				})),
 			},
 			Status: chargecreditpurchase.StatusCreated,
+			State: chargecreditpurchase.State{
+				ResolvedCostBasis: &chargecostbasis.State{
+					CostBasis:  costBasis,
+					ResolvedAt: now,
+				},
+			},
 		},
 	}
 }

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	chargemeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
@@ -836,6 +837,12 @@ func TestIsPendingCreditGrantAt(t *testing.T) {
 					CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 						Rate: alpacadecimal.NewFromInt(1),
 					})),
+				},
+				State: creditpurchase.State{
+					ResolvedCostBasis: &costbasis.State{
+						CostBasis:  alpacadecimal.NewFromInt(1),
+						ResolvedAt: now,
+					},
 				},
 			},
 		}

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
@@ -834,9 +833,9 @@ func TestIsPendingCreditGrantAt(t *testing.T) {
 						CreditAmount: alpacadecimal.NewFromInt(10),
 						Settlement:   creditpurchase.NewInvoiceSettlement(),
 					},
-					CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+					CostBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 						Rate: alpacadecimal.NewFromInt(1),
-					})),
+					}),
 				},
 				State: creditpurchase.State{
 					ResolvedCostBasis: &costbasis.State{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -637,11 +637,11 @@ func (e *testEnv) createCreditPurchase(
 		From: periodAt,
 		To:   periodAt,
 	}
-	var costBasis *creditpurchase.CostBasis
+	var costBasis creditpurchase.CostBasis
 	if settlement.Type() != creditpurchase.SettlementTypePromotional {
-		costBasis = lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+		costBasis = creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 			Rate: alpacadecimal.NewFromInt(1),
-		}))
+		})
 	}
 
 	result, err := e.creditPurchase.Create(t.Context(), creditpurchase.CreateInput{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -326,6 +326,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		Handler:     creditPurchaseHandler,
 		Lineage:     lineageService,
 		MetaAdapter: metaAdapter,
+		Currencies:  currencyService,
 	})
 	require.NoError(t, err)
 

--- a/test/app/stripe/invoice_credits_test.go
+++ b/test/app/stripe/invoice_credits_test.go
@@ -125,9 +125,9 @@ func (s *StripeInvoiceTestSuite) TestUsageBasedCreditThenInvoiceProgressiveBilli
 					settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
 						InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
 					}),
-					costBasis: lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+					costBasis: creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 						Rate: costBasis,
-					})),
+					}),
 				}),
 			},
 		})
@@ -406,7 +406,7 @@ type createCreditPurchaseIntentInput struct {
 	amount        alpacadecimal.Decimal
 	servicePeriod timeutil.ClosedPeriod
 	settlement    creditpurchase.Settlement
-	costBasis     *creditpurchase.CostBasis
+	costBasis     creditpurchase.CostBasis
 }
 
 func (s *StripeInvoiceTestSuite) createCreditPurchaseIntent(input createCreditPurchaseIntentInput) charges.ChargeIntent {

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -779,15 +779,15 @@ type CreateCreditPurchaseIntentInput struct {
 	Priority       *int
 	ServicePeriod  timeutil.ClosedPeriod
 	Settlement     creditpurchase.Settlement
-	CostBasis      *creditpurchase.CostBasis
+	CostBasis      creditpurchase.CostBasis
 	FeatureFilters creditpurchase.FeatureFilters
 	TaxConfig      productcatalog.TaxCodeConfig
 }
 
-func newFiatCreditPurchaseCostBasis(rate alpacadecimal.Decimal) *creditpurchase.CostBasis {
-	return lo.ToPtr(creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
+func newFiatCreditPurchaseCostBasis(rate alpacadecimal.Decimal) creditpurchase.CostBasis {
+	return creditpurchase.NewCostBasis(creditpurchase.FiatCostBasis{
 		Rate: rate,
-	}))
+	})
 }
 
 func (i CreateCreditPurchaseIntentInput) Validate() error {

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -64,6 +64,7 @@ type BaseSuite struct {
 	FlatFeeHandler       flatfee.Handler
 	LineageService       lineage.Service
 	RevenueRecognizer    recognizer.Service
+	CurrencyService      currencies.Service
 }
 
 func (s *BaseSuite) SetupSuite() {
@@ -178,6 +179,7 @@ func (s *BaseSuite) SetupSuite() {
 	s.Charges = stack.ChargesService
 	s.CreditPurchaseSvc = stack.CreditPurchaseService
 	s.UsageBasedSvc = stack.UsageBasedService
+	s.CurrencyService = stack.CurrencyService
 
 	customerBalanceSvc, err := customerbalance.New(customerbalance.Config{
 		AccountResolver:   deps.ResolversService,

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -82,6 +82,7 @@ func (s *CreditGrantTestSuite) SetupSuite() {
 		Handler:     creditPurchaseHandler,
 		Lineage:     lineageService,
 		MetaAdapter: metaAdapter,
+		Currencies:  s.CurrencyService,
 	})
 	s.Require().NoError(err)
 

--- a/test/credits/creditpurchase_costbasis_test.go
+++ b/test/credits/creditpurchase_costbasis_test.go
@@ -134,7 +134,7 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		s.Require().NotNil(created.GatheringLineToCreate)
 		gatheringPrice, err := created.GatheringLineToCreate.Price.AsFlat()
 		s.Require().NoError(err)
-		s.Equal(alpacadecimal.Zero, gatheringPrice.Amount)
+		s.Require().Equal(float64(0), gatheringPrice.Amount.InexactFloat64())
 
 		_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: fixture.customerID,
@@ -146,12 +146,12 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		persisted, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
 		s.Require().NoError(err)
 		s.Nil(persisted.State.ResolvedCostBasis)
-		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
 			Currency:          fixture.customCurrency.Reference(),
 			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
 			CostBasis:         mo.Some(&fixture.resolvedRate),
 			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-		}))
+		}).InexactFloat64())
 	})
 
 	s.Run("when billing materializes the invoice line", func() {
@@ -171,18 +171,18 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		s.Require().Len(lines, 1)
 		line := lines[0]
 		s.Equal(currencyx.FiatCode(fixture.settlementCurrency), line.Currency)
-		s.Equal(fixture.fiatAmount, line.Totals.Amount)
-		s.Equal(fixture.fiatAmount, line.Totals.Total)
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), line.Totals.Amount.InexactFloat64())
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), line.Totals.Total.InexactFloat64())
 		s.Require().Len(line.DetailedLines, 1)
-		s.Equal(fixture.creditAmount, line.DetailedLines[0].Quantity)
-		s.Equal(fixture.resolvedRate, line.DetailedLines[0].PerUnitAmount)
+		s.Require().Equal(fixture.creditAmount.InexactFloat64(), line.DetailedLines[0].Quantity.InexactFloat64())
+		s.Require().Equal(fixture.resolvedRate.InexactFloat64(), line.DetailedLines[0].PerUnitAmount.InexactFloat64())
 
 		charge, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
 		s.Require().NoError(err)
 		s.Equal(creditpurchase.StatusActivePaymentPending, charge.Status)
 		s.Require().NotNil(charge.Realizations.CreditGrantRealization)
 		s.Require().NotNil(charge.State.ResolvedCostBasis)
-		s.Equal(fixture.resolvedRate, charge.State.ResolvedCostBasis.CostBasis)
+		s.Require().Equal(fixture.resolvedRate.InexactFloat64(), charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
 		s.Equal(fixture.resolvedCurrencyCostBasisID, lo.FromPtr(charge.State.ResolvedCostBasis.CostBasisID))
 		s.Equal(fixture.servicePeriod.From, charge.State.ResolvedCostBasis.ResolvedAt)
 
@@ -191,18 +191,18 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
 			CostBasis:         mo.Some(&fixture.resolvedRate),
 		}
-		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		s.Require().Equal(fixture.creditAmount.InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
 			Currency:          customRoute.Currency,
 			CostBasisCurrency: customRoute.CostBasisCurrency,
 			CostBasis:         customRoute.CostBasis,
 			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-		}))
-		s.Equal(fixture.creditAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(fixture.creditAmount.Neg().InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       customRoute.Currency,
 			CostBasisCurrency:              customRoute.CostBasisCurrency,
 			CostBasis:                      customRoute.CostBasis,
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
-		}))
+		}).InexactFloat64())
 	})
 
 	s.Run("when the invoice payment is authorized", func() {
@@ -222,19 +222,19 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		s.Equal(creditpurchase.StatusActivePaymentAuthorized, charge.Status)
 		s.Require().NotNil(charge.Realizations.InvoiceSettlement)
 		s.Equal(payment.StatusAuthorized, charge.Realizations.InvoiceSettlement.Status)
-		s.Equal(fixture.fiatAmount, charge.Realizations.InvoiceSettlement.FiatAmount)
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), charge.Realizations.InvoiceSettlement.FiatAmount.InexactFloat64())
 
-		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       fixture.customCurrency.Reference(),
 			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
-		}))
-		s.Equal(fixture.fiatAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(fixture.fiatAmount.Neg().InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
-		}))
+		}).InexactFloat64())
 	})
 
 	s.Run("when the invoice payment is settled", func() {
@@ -253,23 +253,78 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		s.Equal(creditpurchase.StatusFinal, charge.Status)
 		s.Require().NotNil(charge.Realizations.InvoiceSettlement)
 		s.Equal(payment.StatusSettled, charge.Realizations.InvoiceSettlement.Status)
-		s.Equal(fixture.fiatAmount, charge.Realizations.InvoiceSettlement.FiatAmount)
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), charge.Realizations.InvoiceSettlement.FiatAmount.InexactFloat64())
 		s.Require().NotNil(charge.Realizations.InvoiceSettlement.Authorized)
 		s.Require().NotNil(charge.Realizations.InvoiceSettlement.Settled)
 
-		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
-		}))
-		s.Equal(fixture.fiatAmount.Neg(), s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)))
-		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(
+			fixture.fiatAmount.Neg().InexactFloat64(),
+			s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)).InexactFloat64(),
+		)
+		s.Require().Equal(fixture.creditAmount.InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
 			Currency:          fixture.customCurrency.Reference(),
 			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
 			CostBasis:         mo.Some(&fixture.resolvedRate),
 			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-		}))
+		}).InexactFloat64())
 	})
+}
+
+func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementResolutionFailureIsAtomic() {
+	// given:
+	// - an unresolved dynamic invoice credit purchase without a cost basis at its service-period start
+	// when:
+	// - billing attempts to materialize the invoice
+	// then:
+	// - invoice creation fails without resolving the cost basis or granting credits
+	t := s.T()
+	ctx := t.Context()
+	namespace := s.GetUniqueNamespace("dynamic-invoice-credit-purchase-resolution-failure")
+
+	customInvoicing := s.SetupCustomInvoicing(namespace)
+	_ = s.ProvisionBillingProfile(ctx, namespace, customInvoicing.App.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	fixture := s.provisionDynamicCreditPurchaseFixtureWithoutThresholdCostBasis(namespace)
+	created, err := s.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		Namespace: namespace,
+		Intent:    fixture.newIntent(creditpurchase.NewInvoiceSettlement()),
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created.GatheringLineToCreate)
+
+	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: fixture.customerID,
+		Currency: currencyx.FiatCode(fixture.settlementCurrency),
+		Lines:    []billing.GatheringLine{*created.GatheringLineToCreate},
+	})
+	s.Require().NoError(err)
+
+	asOf := clock.Now()
+	_, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: fixture.customerID,
+		AsOf:     &asOf,
+	})
+	s.Require().ErrorContains(err, "cost basis not found")
+
+	charge, err := s.MustGetChargeByID(created.Charge.GetChargeID()).AsCreditPurchaseCharge()
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.StatusCreated, charge.Status)
+	s.Nil(charge.State.ResolvedCostBasis)
+	s.Nil(charge.Realizations.CreditGrantRealization)
+	s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		Currency:       fixture.customCurrency.Reference(),
+		CostBasis:      mo.None[*alpacadecimal.Decimal](),
+		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+	}).InexactFloat64())
 }
 
 func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() {
@@ -309,7 +364,7 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() 
 		chargeID = charge.GetChargeID()
 		s.Equal(creditpurchase.StatusActivePaymentPending, charge.Status)
 		s.Require().NotNil(charge.State.ResolvedCostBasis)
-		s.Equal(fixture.resolvedRate, charge.State.ResolvedCostBasis.CostBasis)
+		s.Require().Equal(fixture.resolvedRate.InexactFloat64(), charge.State.ResolvedCostBasis.CostBasis.InexactFloat64())
 		s.Equal(fixture.resolvedCurrencyCostBasisID, lo.FromPtr(charge.State.ResolvedCostBasis.CostBasisID))
 		s.Equal(fixture.servicePeriod.From, charge.State.ResolvedCostBasis.ResolvedAt)
 		s.Require().NotNil(charge.Realizations.CreditGrantRealization)
@@ -318,19 +373,25 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() 
 
 		persisted, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
 		s.Require().NoError(err)
-		s.Equal(charge.State.ResolvedCostBasis, persisted.State.ResolvedCostBasis)
-		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		s.Require().NotNil(persisted.State.ResolvedCostBasis)
+		s.Require().Equal(
+			charge.State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+			persisted.State.ResolvedCostBasis.CostBasis.InexactFloat64(),
+		)
+		s.Equal(charge.State.ResolvedCostBasis.CostBasisID, persisted.State.ResolvedCostBasis.CostBasisID)
+		s.Equal(charge.State.ResolvedCostBasis.ResolvedAt, persisted.State.ResolvedCostBasis.ResolvedAt)
+		s.Require().Equal(fixture.creditAmount.InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
 			Currency:          fixture.customCurrency.Reference(),
 			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
 			CostBasis:         mo.Some(&fixture.resolvedRate),
 			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-		}))
-		s.Equal(fixture.creditAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(fixture.creditAmount.Neg().InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       fixture.customCurrency.Reference(),
 			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
-		}))
+		}).InexactFloat64())
 	})
 
 	s.Run("when the external payment is authorized", func() {
@@ -345,19 +406,19 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() 
 		s.Equal(creditpurchase.StatusActivePaymentAuthorized, charge.Status)
 		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement)
 		s.Equal(payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(fixture.fiatAmount, charge.Realizations.ExternalPaymentSettlement.FiatAmount)
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), charge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 
-		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       fixture.customCurrency.Reference(),
 			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
-		}))
-		s.Equal(fixture.fiatAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(fixture.fiatAmount.Neg().InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
-		}))
+		}).InexactFloat64())
 	})
 
 	s.Run("when the external payment is settled", func() {
@@ -371,22 +432,25 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() 
 		s.Equal(creditpurchase.StatusFinal, charge.Status)
 		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement)
 		s.Equal(payment.StatusSettled, charge.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(fixture.fiatAmount, charge.Realizations.ExternalPaymentSettlement.FiatAmount)
+		s.Require().Equal(fixture.fiatAmount.InexactFloat64(), charge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement.Authorized)
 		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement.Settled)
 
-		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		s.Require().Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
 			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
 			CostBasis:                      mo.Some(&fixture.resolvedRate),
 			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
-		}))
-		s.Equal(fixture.fiatAmount.Neg(), s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)))
-		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		}).InexactFloat64())
+		s.Require().Equal(
+			fixture.fiatAmount.Neg().InexactFloat64(),
+			s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)).InexactFloat64(),
+		)
+		s.Require().Equal(fixture.creditAmount.InexactFloat64(), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
 			Currency:          fixture.customCurrency.Reference(),
 			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
 			CostBasis:         mo.Some(&fixture.resolvedRate),
 			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-		}))
+		}).InexactFloat64())
 	})
 }
 
@@ -405,6 +469,34 @@ type dynamicCreditPurchaseFixture struct {
 }
 
 func (s *CreditPurchaseCostBasisSuite) provisionDynamicCreditPurchaseFixture(namespace string) dynamicCreditPurchaseFixture {
+	s.T().Helper()
+
+	fixture := s.provisionDynamicCreditPurchaseFixtureWithoutThresholdCostBasis(namespace)
+	ctx := s.T().Context()
+
+	thresholdCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:     namespace,
+		CurrencyID:    fixture.customCurrency.ID,
+		FiatCode:      fixture.settlementCurrency,
+		Rate:          fixture.resolvedRate,
+		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From),
+	})
+	s.Require().NoError(err)
+	fixture.resolvedCurrencyCostBasisID = thresholdCostBasis.ID
+
+	_, err = s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:     namespace,
+		CurrencyID:    fixture.customCurrency.ID,
+		FiatCode:      fixture.settlementCurrency,
+		Rate:          alpacadecimal.NewFromFloat(0.5),
+		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From.Add(10 * 24 * time.Hour)),
+	})
+	s.Require().NoError(err)
+
+	return fixture
+}
+
+func (s *CreditPurchaseCostBasisSuite) provisionDynamicCreditPurchaseFixtureWithoutThresholdCostBasis(namespace string) dynamicCreditPurchaseFixture {
 	s.T().Helper()
 
 	ctx := s.T().Context()
@@ -432,25 +524,6 @@ func (s *CreditPurchaseCostBasisSuite) provisionDynamicCreditPurchaseFixture(nam
 			DecimalMark:        ".",
 			ThousandsSeparator: ",",
 		},
-	})
-	s.Require().NoError(err)
-
-	thresholdCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
-		Namespace:     namespace,
-		CurrencyID:    fixture.customCurrency.ID,
-		FiatCode:      fixture.settlementCurrency,
-		Rate:          fixture.resolvedRate,
-		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From),
-	})
-	s.Require().NoError(err)
-	fixture.resolvedCurrencyCostBasisID = thresholdCostBasis.ID
-
-	_, err = s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
-		Namespace:     namespace,
-		CurrencyID:    fixture.customCurrency.ID,
-		FiatCode:      fixture.settlementCurrency,
-		Rate:          alpacadecimal.NewFromFloat(0.5),
-		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From.Add(10 * 24 * time.Hour)),
 	})
 	s.Require().NoError(err)
 
@@ -499,6 +572,8 @@ func (s *CreditPurchaseCostBasisSuite) mustAccountBalance(account ledger.Account
 	return balance
 }
 
+// TODO: Use the production lineage service once advance lineage supports the
+// full identity of custom currencies instead of rejecting them.
 type creditPurchaseCostBasisLineage struct {
 	lineage.Service
 }

--- a/test/credits/creditpurchase_costbasis_test.go
+++ b/test/credits/creditpurchase_costbasis_test.go
@@ -1,0 +1,508 @@
+package credits
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/suite"
+
+	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaseadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/adapter"
+	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	ledgerchargeadapter "github.com/openmeterio/openmeter/openmeter/ledger/chargeadapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	omtestutils "github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+func TestCreditPurchaseCostBasisSuite(t *testing.T) {
+	suite.Run(t, new(CreditPurchaseCostBasisSuite))
+}
+
+type CreditPurchaseCostBasisSuite struct {
+	BaseSuite
+
+	creditPurchaseService creditpurchase.Service
+}
+
+func (s *CreditPurchaseCostBasisSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+
+	logger := omtestutils.NewLogger(s.T())
+	metaAdapter, err := metaadapter.New(metaadapter.Config{
+		Client: s.DBClient,
+		Logger: logger,
+	})
+	s.Require().NoError(err)
+
+	adapter, err := creditpurchaseadapter.New(creditpurchaseadapter.Config{
+		Client:      s.DBClient,
+		Logger:      logger,
+		MetaAdapter: metaAdapter,
+	})
+	s.Require().NoError(err)
+
+	handler, err := ledgerchargeadapter.NewCreditPurchaseHandler(
+		s.Ledger,
+		s.BalanceQuerier,
+		s.LedgerResolver,
+		s.LedgerAccountService,
+		s.BreakageService,
+		enttx.NewCreator(s.DBClient),
+	)
+	s.Require().NoError(err)
+
+	s.creditPurchaseService, err = creditpurchaseservice.New(creditpurchaseservice.Config{
+		Adapter:     adapter,
+		Handler:     handler,
+		Lineage:     creditPurchaseCostBasisLineage{},
+		MetaAdapter: metaAdapter,
+		Currencies:  s.CurrencyService,
+	})
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.BillingService.DeregisterLineEngine(billing.LineEngineTypeChargeCreditPurchase))
+	s.Require().NoError(s.BillingService.RegisterLineEngine(s.creditPurchaseService.GetLineEngine()))
+}
+
+func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
+	// given:
+	// - a dynamic invoice-settled custom-currency credit purchase
+	// - a cost basis effective at the service-period start and a newer cost basis
+	// when:
+	// - billing materializes, authorizes, and settles the invoice
+	// then:
+	// - the state machine pins the threshold cost basis before granting credits
+	// - invoicing and every ledger realization use that resolved cost basis
+	t := s.T()
+	ctx := t.Context()
+	namespace := s.GetUniqueNamespace("dynamic-invoice-credit-purchase")
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+
+	var (
+		fixture  dynamicCreditPurchaseFixture
+		chargeID meta.ChargeID
+		invoice  billing.StandardInvoice
+	)
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	s.Run("given a dynamic invoice credit purchase with historical cost bases", func() {
+		// This phase verifies that creation persists the dynamic intent without
+		// resolving it or booking the credit grant.
+		customInvoicing := s.SetupCustomInvoicing(namespace)
+		_ = s.ProvisionBillingProfile(ctx, namespace, customInvoicing.App.GetID(),
+			billingtest.WithProgressiveBilling(),
+			billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "PT1H")),
+			billingtest.WithManualApproval(),
+		)
+
+		fixture = s.provisionDynamicCreditPurchaseFixture(namespace)
+		created, err := s.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+			Namespace: namespace,
+			Intent:    fixture.newIntent(creditpurchase.NewInvoiceSettlement()),
+		})
+		s.Require().NoError(err)
+		charge := created.Charge
+		chargeID = charge.GetChargeID()
+		s.Equal(creditpurchase.StatusCreated, charge.Status)
+		s.Require().NotNil(charge.State.ChargeCostBasisID)
+		s.Nil(charge.State.ResolvedCostBasis)
+		s.Nil(charge.Realizations.CreditGrantRealization)
+		s.Require().NotNil(created.GatheringLineToCreate)
+		gatheringPrice, err := created.GatheringLineToCreate.Price.AsFlat()
+		s.Require().NoError(err)
+		s.Equal(alpacadecimal.Zero, gatheringPrice.Amount)
+
+		_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+			Customer: fixture.customerID,
+			Currency: currencyx.FiatCode(fixture.settlementCurrency),
+			Lines:    []billing.GatheringLine{*created.GatheringLineToCreate},
+		})
+		s.Require().NoError(err)
+
+		persisted, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
+		s.Require().NoError(err)
+		s.Nil(persisted.State.ResolvedCostBasis)
+		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+			Currency:          fixture.customCurrency.Reference(),
+			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+			CostBasis:         mo.Some(&fixture.resolvedRate),
+			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+		}))
+	})
+
+	s.Run("when billing materializes the invoice line", func() {
+		// This phase verifies that invoice creation resolves the threshold cost
+		// basis before the line and granted-credit ledger route are finalized.
+		clock.FreezeTime(fixture.servicePeriod.From)
+		now := clock.Now()
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: fixture.customerID,
+			AsOf:     &now,
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+
+		lines := invoice.Lines.OrEmpty()
+		s.Require().Len(lines, 1)
+		line := lines[0]
+		s.Equal(currencyx.FiatCode(fixture.settlementCurrency), line.Currency)
+		s.Equal(fixture.fiatAmount, line.Totals.Amount)
+		s.Equal(fixture.fiatAmount, line.Totals.Total)
+		s.Require().Len(line.DetailedLines, 1)
+		s.Equal(fixture.creditAmount, line.DetailedLines[0].Quantity)
+		s.Equal(fixture.resolvedRate, line.DetailedLines[0].PerUnitAmount)
+
+		charge, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
+		s.Require().NoError(err)
+		s.Equal(creditpurchase.StatusActivePaymentPending, charge.Status)
+		s.Require().NotNil(charge.Realizations.CreditGrantRealization)
+		s.Require().NotNil(charge.State.ResolvedCostBasis)
+		s.Equal(fixture.resolvedRate, charge.State.ResolvedCostBasis.CostBasis)
+		s.Equal(fixture.resolvedCurrencyCostBasisID, lo.FromPtr(charge.State.ResolvedCostBasis.CostBasisID))
+		s.Equal(fixture.servicePeriod.From, charge.State.ResolvedCostBasis.ResolvedAt)
+
+		customRoute := ledger.RouteFilter{
+			Currency:          fixture.customCurrency.Reference(),
+			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+			CostBasis:         mo.Some(&fixture.resolvedRate),
+		}
+		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+			Currency:          customRoute.Currency,
+			CostBasisCurrency: customRoute.CostBasisCurrency,
+			CostBasis:         customRoute.CostBasis,
+			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+		}))
+		s.Equal(fixture.creditAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       customRoute.Currency,
+			CostBasisCurrency:              customRoute.CostBasisCurrency,
+			CostBasis:                      customRoute.CostBasis,
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
+		}))
+	})
+
+	s.Run("when the invoice payment is authorized", func() {
+		// This phase verifies that authorization translates the custom-currency
+		// receivable into the correctly valued fiat receivable.
+		var err error
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+		invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+		charge, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
+		s.Require().NoError(err)
+		s.Equal(creditpurchase.StatusActivePaymentAuthorized, charge.Status)
+		s.Require().NotNil(charge.Realizations.InvoiceSettlement)
+		s.Equal(payment.StatusAuthorized, charge.Realizations.InvoiceSettlement.Status)
+		s.Equal(fixture.fiatAmount, charge.Realizations.InvoiceSettlement.FiatAmount)
+
+		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       fixture.customCurrency.Reference(),
+			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
+		}))
+		s.Equal(fixture.fiatAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
+		}))
+	})
+
+	s.Run("when the invoice payment is settled", func() {
+		// This phase verifies that settlement clears the fiat authorization while
+		// preserving the granted custom credits at their pinned ledger route.
+		var err error
+		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+		charge, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
+		s.Require().NoError(err)
+		s.Equal(creditpurchase.StatusFinal, charge.Status)
+		s.Require().NotNil(charge.Realizations.InvoiceSettlement)
+		s.Equal(payment.StatusSettled, charge.Realizations.InvoiceSettlement.Status)
+		s.Equal(fixture.fiatAmount, charge.Realizations.InvoiceSettlement.FiatAmount)
+		s.Require().NotNil(charge.Realizations.InvoiceSettlement.Authorized)
+		s.Require().NotNil(charge.Realizations.InvoiceSettlement.Settled)
+
+		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
+		}))
+		s.Equal(fixture.fiatAmount.Neg(), s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)))
+		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+			Currency:          fixture.customCurrency.Reference(),
+			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+			CostBasis:         mo.Some(&fixture.resolvedRate),
+			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+		}))
+	})
+}
+
+func (s *CreditPurchaseCostBasisSuite) TestDynamicExternalSettlementLifecycle() {
+	// given:
+	// - a dynamic externally settled custom-currency credit purchase
+	// - a cost basis effective at the service-period start and a newer cost basis
+	// when:
+	// - the external payment is authorized and settled
+	// then:
+	// - the state machine pins the threshold cost basis before granting credits
+	// - every ledger realization uses that resolved cost basis
+	t := s.T()
+	ctx := t.Context()
+	namespace := s.GetUniqueNamespace("dynamic-external-credit-purchase")
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+
+	var (
+		fixture  dynamicCreditPurchaseFixture
+		chargeID meta.ChargeID
+	)
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	s.Run("given a dynamic external credit purchase with historical cost bases", func() {
+		// This phase verifies that creation pins the cost basis effective at the
+		// service-period threshold before booking the external credit grant.
+		fixture = s.provisionDynamicCreditPurchaseFixture(namespace)
+		created, err := s.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+			Namespace: namespace,
+			Intent: fixture.newIntent(creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+			})),
+		})
+		s.Require().NoError(err)
+		charge := created.Charge
+		chargeID = charge.GetChargeID()
+		s.Equal(creditpurchase.StatusActivePaymentPending, charge.Status)
+		s.Require().NotNil(charge.State.ResolvedCostBasis)
+		s.Equal(fixture.resolvedRate, charge.State.ResolvedCostBasis.CostBasis)
+		s.Equal(fixture.resolvedCurrencyCostBasisID, lo.FromPtr(charge.State.ResolvedCostBasis.CostBasisID))
+		s.Equal(fixture.servicePeriod.From, charge.State.ResolvedCostBasis.ResolvedAt)
+		s.Require().NotNil(charge.Realizations.CreditGrantRealization)
+		s.Nil(charge.Realizations.ExternalPaymentSettlement)
+		s.Nil(created.GatheringLineToCreate)
+
+		persisted, err := s.MustGetChargeByID(chargeID).AsCreditPurchaseCharge()
+		s.Require().NoError(err)
+		s.Equal(charge.State.ResolvedCostBasis, persisted.State.ResolvedCostBasis)
+		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+			Currency:          fixture.customCurrency.Reference(),
+			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+			CostBasis:         mo.Some(&fixture.resolvedRate),
+			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+		}))
+		s.Equal(fixture.creditAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       fixture.customCurrency.Reference(),
+			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
+		}))
+	})
+
+	s.Run("when the external payment is authorized", func() {
+		// This phase verifies that authorization translates the custom-currency
+		// receivable into the correctly valued fiat receivable.
+		clock.FreezeTime(fixture.servicePeriod.From)
+		charge, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
+			ChargeID:           chargeID,
+			TargetPaymentState: payment.StatusAuthorized,
+		})
+		s.Require().NoError(err)
+		s.Equal(creditpurchase.StatusActivePaymentAuthorized, charge.Status)
+		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement)
+		s.Equal(payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(fixture.fiatAmount, charge.Realizations.ExternalPaymentSettlement.FiatAmount)
+
+		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       fixture.customCurrency.Reference(),
+			CostBasisCurrency:              mo.Some(&fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusOpen),
+		}))
+		s.Equal(fixture.fiatAmount.Neg(), s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
+		}))
+	})
+
+	s.Run("when the external payment is settled", func() {
+		// This phase verifies that settlement clears the fiat authorization while
+		// preserving the externally funded custom credits at their pinned route.
+		charge, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
+			ChargeID:           chargeID,
+			TargetPaymentState: payment.StatusSettled,
+		})
+		s.Require().NoError(err)
+		s.Equal(creditpurchase.StatusFinal, charge.Status)
+		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement)
+		s.Equal(payment.StatusSettled, charge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(fixture.fiatAmount, charge.Realizations.ExternalPaymentSettlement.FiatAmount)
+		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement.Authorized)
+		s.Require().NotNil(charge.Realizations.ExternalPaymentSettlement.Settled)
+
+		s.Equal(alpacadecimal.Zero, s.mustAccountBalance(fixture.customerAccounts.ReceivableAccount, ledger.RouteFilter{
+			Currency:                       currencies.NewCurrencyReference(fixture.settlementCurrency),
+			CostBasis:                      mo.Some(&fixture.resolvedRate),
+			TransactionAuthorizationStatus: lo.ToPtr(ledger.TransactionAuthorizationStatusAuthorized),
+		}))
+		s.Equal(fixture.fiatAmount.Neg(), s.MustWashBalance(namespace, fixture.settlementCurrency, mo.Some(&fixture.resolvedRate)))
+		s.Equal(fixture.creditAmount, s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+			Currency:          fixture.customCurrency.Reference(),
+			CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+			CostBasis:         mo.Some(&fixture.resolvedRate),
+			CreditPriority:    lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+		}))
+	})
+}
+
+type dynamicCreditPurchaseFixture struct {
+	taxCodeID                   string
+	servicePeriod               timeutil.ClosedPeriod
+	settlementCurrency          currencyx.Code
+	fiatCurrency                *currencyx.FiatCurrency
+	resolvedRate                alpacadecimal.Decimal
+	creditAmount                alpacadecimal.Decimal
+	fiatAmount                  alpacadecimal.Decimal
+	resolvedCurrencyCostBasisID string
+	customerID                  customer.CustomerID
+	customCurrency              currencies.Currency
+	customerAccounts            ledger.CustomerAccounts
+}
+
+func (s *CreditPurchaseCostBasisSuite) provisionDynamicCreditPurchaseFixture(namespace string) dynamicCreditPurchaseFixture {
+	s.T().Helper()
+
+	ctx := s.T().Context()
+	fixture := dynamicCreditPurchaseFixture{
+		servicePeriod: timeutil.ClosedPeriod{
+			From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+			To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+		},
+		settlementCurrency: currencyx.Code(currency.USD),
+		resolvedRate:       alpacadecimal.NewFromFloat(0.25),
+		creditAmount:       alpacadecimal.NewFromInt(100),
+		fiatAmount:         alpacadecimal.NewFromInt(25),
+	}
+	fixture.taxCodeID = s.ProvisionDefaultTaxCodes(ctx, namespace).CreditGrantTaxCodeID
+	fixture.customerID = s.CreateLedgerBackedCustomer(namespace, namespace).GetID()
+
+	var err error
+	fixture.customCurrency, err = s.CurrencyService.CreateCurrency(ctx, currencies.CreateCurrencyInput{
+		Namespace: namespace,
+		CurrencyDetails: currencyx.CurrencyDetails{
+			Code:               "TOKENS",
+			Name:               "Tokens",
+			Symbol:             "T",
+			Precision:          3,
+			DecimalMark:        ".",
+			ThousandsSeparator: ",",
+		},
+	})
+	s.Require().NoError(err)
+
+	thresholdCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:     namespace,
+		CurrencyID:    fixture.customCurrency.ID,
+		FiatCode:      fixture.settlementCurrency,
+		Rate:          fixture.resolvedRate,
+		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From),
+	})
+	s.Require().NoError(err)
+	fixture.resolvedCurrencyCostBasisID = thresholdCostBasis.ID
+
+	_, err = s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:     namespace,
+		CurrencyID:    fixture.customCurrency.ID,
+		FiatCode:      fixture.settlementCurrency,
+		Rate:          alpacadecimal.NewFromFloat(0.5),
+		EffectiveFrom: lo.ToPtr(fixture.servicePeriod.From.Add(10 * 24 * time.Hour)),
+	})
+	s.Require().NoError(err)
+
+	fixture.customerAccounts, err = s.LedgerResolver.GetCustomerAccounts(ctx, fixture.customerID)
+	s.Require().NoError(err)
+	fixture.fiatCurrency, err = currencyx.NewFiatCurrency(fixture.settlementCurrency)
+	s.Require().NoError(err)
+
+	return fixture
+}
+
+// newIntent keeps the cost-basis scenario identical while allowing each test
+// to exercise its settlement-specific state machine.
+func (f dynamicCreditPurchaseFixture) newIntent(settlement creditpurchase.Settlement) creditpurchase.Intent {
+	return creditpurchase.Intent{
+		Intent: meta.Intent{
+			ManagedBy:  billing.ManuallyManagedLine,
+			CustomerID: f.customerID.ID,
+			Currency:   f.customCurrency,
+			TaxConfig: productcatalog.TaxCodeConfig{
+				TaxCodeID: f.taxCodeID,
+			},
+		},
+		IntentMutableFields: creditpurchase.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              "Dynamic Cost Basis Credit Purchase",
+				ServicePeriod:     f.servicePeriod,
+				BillingPeriod:     f.servicePeriod,
+				FullServicePeriod: f.servicePeriod,
+			},
+			CreditAmount: f.creditAmount,
+			Settlement:   settlement,
+		},
+		CostBasis: creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.DynamicIntent{
+			FiatCurrency: f.fiatCurrency,
+		})),
+	}
+}
+
+func (s *CreditPurchaseCostBasisSuite) mustAccountBalance(account ledger.Account, route ledger.RouteFilter) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), account, route, ledger.BalanceQuery{})
+	s.Require().NoError(err)
+
+	return balance
+}
+
+type creditPurchaseCostBasisLineage struct {
+	lineage.Service
+}
+
+func (creditPurchaseCostBasisLineage) BackfillAdvanceLineageSegments(context.Context, lineage.BackfillAdvanceLineageSegmentsInput) error {
+	return nil
+}


### PR DESCRIPTION
## Business context

A credit purchase grants credits now and settles their monetary value through either an invoice or an external payment. When those credits use a custom currency, OpenMeter must pin the exchange rate used for the purchase so the granted credits, the customer-facing settlement amount, and later ledger activity all refer to the same value.

This change completes that cost-basis flow for credit purchases and aligns it with the behavior already used by usage-based and flat-fee charges.

## Flow

1. A fiat credit purchase starts with its fixed fiat cost basis. A custom-currency purchase starts with a manual, pinned, or dynamic cost-basis intent.
2. Manual and pinned purchases have their cost basis available immediately. Dynamic purchases remain unresolved while they are only being previewed; their provisional invoice amount is therefore zero.
3. When the purchase becomes active and OpenMeter is about to grant credits, the dynamic cost basis is resolved using the beginning of the purchase service period.
4. The resolved cost basis is pinned to the purchase before any credits are granted.
5. Invoice and externally settled purchases then use that same pinned value for the fiat settlement amount, payment lifecycle, and ledger entries.

If resolution fails, the purchase does not grant credits or advance into its active payment lifecycle. This prevents a purchase from being realized with an unknown or inconsistent monetary value.

## What this enables

- consistent cost-basis pinning across credit purchases, usage-based charges, and flat-fee charges
- dynamic custom-currency credit purchases through both invoice and external settlement flows
- a single pinned value for credit grants, customer-facing settlement amounts, and ledger activity
- safe invoice previews before a dynamic rate is known

Ticket: OM-436

## Validation

- `make test-nocache`
- `make lint-go-fast`
- focused credit-purchase domain, adapter, service, and end-to-end tests after the review fixes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds durable cost-basis resolution for credit purchases before their first monetary realization.
- Represents purchase cost basis as either a fiat scalar or shared custom-currency intent and state.
- Resolves dynamic cost basis at invoice or external-settlement lifecycle boundaries.
- Updates invoice lines, ledger operations, API conversion, and lifecycle tests to consume resolved fiat amounts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/creditpurchase/service/costbasis.go | Resolves initial and dynamic custom-currency cost basis and persists the resulting pinned state. |
| openmeter/billing/charges/creditpurchase/service/lineengine.go | Supports provisional gathering lines and populates standard invoice lines after lifecycle resolution. |
| openmeter/billing/charges/creditpurchase/adapter/costbasis.go | Adds namespace- and ownership-scoped persistence for resolved credit-purchase cost basis. |
| openmeter/billing/charges/creditpurchase/charge.go | Defines resolved charge-state validation and fiat settlement amount calculation. |
| openmeter/ledger/chargeadapter/creditpurchase.go | Updates ledger realization to consume the charge's resolved monetary state. |
| api/v3/handlers/customers/credits/convert.go | Maps resolved settlement currency, amount, and per-unit cost basis into credit-grant API responses. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant CreditPurchase
  participant CostBasisResolver
  participant InvoiceEngine
  participant Ledger
  Client->>CreditPurchase: Create funded credit purchase
  alt Fiat, manual, or pinned
    CreditPurchase->>CreditPurchase: Materialize resolved state
  else Dynamic custom currency
    CreditPurchase->>CreditPurchase: Persist unresolved intent
  end
  CreditPurchase->>InvoiceEngine: Create provisional gathering line
  InvoiceEngine->>CreditPurchase: Standard invoice created
  CreditPurchase->>CostBasisResolver: Resolve at service-period start
  CostBasisResolver-->>CreditPurchase: Pinned fiat conversion rate
  CreditPurchase->>Ledger: Grant purchased credits
  CreditPurchase-->>InvoiceEngine: Replace line with resolved amount
  InvoiceEngine->>CreditPurchase: Authorization and settlement events
```
</details>

<sub>Reviews (5): Last reviewed commit: ["feat(creditpurchase): resolve dynamic co..."](https://github.com/openmeterio/openmeter/commit/7d0ed342215e678afddcacc406f24eaa47fa0b00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52203263)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic, manual, pinned, and fiat cost-basis support for credit purchases.
  - Dynamic cost bases resolve at service-period start and retain resolved values.
  - Invoice lines support provisional zero-value amounts until resolution.
  - Added fiat settlement amount calculation with currency conversion and rounding.

- **Bug Fixes**
  - Improved validation for currencies, cost bases, settlement amounts, and charge references.
  - Restricted cost-basis updates to the owning charge.
  - Promotional credit grants now process independently of payment settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->