### PR TITLE
feat(flatfee): prepare fiat overage credit allocation

### DIFF
--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -21,7 +22,10 @@ import (
 type OnAllocateCreditsInput struct {
 	Charge        Charge                `json:"charge"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
-	BookedAt      time.Time             `json:"bookedAt"`
+	// BookedAt is the economic timestamp of the resulting ledger transaction.
+	BookedAt time.Time `json:"bookedAt"`
+	// SourceBalanceAsOf is the cutoff for balances eligible to fund the allocation.
+	SourceBalanceAsOf time.Time `json:"sourceBalanceAsOf"`
 	// PreTaxAmountToAllocate is the pre-tax amount to allocate from credits.
 	// The input charge's settlement mode governs whether this may create a negative balance.
 	PreTaxAmountToAllocate alpacadecimal.Decimal `json:"preTaxAmountToAllocate"`
@@ -40,6 +44,10 @@ func (i OnAllocateCreditsInput) Validate() error {
 
 	if i.BookedAt.IsZero() {
 		errs = append(errs, fmt.Errorf("booked at is required"))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, fmt.Errorf("source balance as of is required"))
 	}
 
 	if i.PreTaxAmountToAllocate.IsNegative() {
@@ -193,6 +201,115 @@ func (i CorrectCreditAllocationsInput) ValidateWith(currencyCalculator currencyx
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+type AllocateFiatOverageCreditsInput struct {
+	Charge Charge         `json:"charge"`
+	Run    RealizationRun `json:"run"`
+
+	BookedAt          time.Time `json:"bookedAt"`
+	SourceBalanceAsOf time.Time `json:"sourceBalanceAsOf"`
+
+	// AmountToAllocate is denominated in the settlement fiat currency.
+	AmountToAllocate alpacadecimal.Decimal `json:"amountToAllocate"`
+}
+
+func (i AllocateFiatOverageCreditsInput) GetFiatCurrency() (*currencyx.FiatCurrency, error) {
+	costBasisIntent := i.Charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return nil, errors.New("cost basis intent is required")
+	}
+
+	return costBasisIntent.GetFiatCurrency()
+}
+
+func (i AllocateFiatOverageCreditsInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if !i.Charge.Intent.GetCurrency().IsCustom() {
+		errs = append(errs, errors.New("charge currency must be custom"))
+	}
+
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, errors.New("settlement mode must be credit_then_invoice"))
+	}
+
+	if _, err := i.GetFiatCurrency(); err != nil {
+		errs = append(errs, fmt.Errorf("fiat currency: %w", err))
+	}
+
+	if i.BookedAt.IsZero() {
+		errs = append(errs, errors.New("booked at is required"))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, errors.New("source balance as of is required"))
+	}
+
+	if !i.AmountToAllocate.IsPositive() {
+		errs = append(errs, errors.New("amount to allocate must be positive"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type CorrectFiatOverageCreditAllocationsInput struct {
+	Charge   Charge         `json:"charge"`
+	Run      RealizationRun `json:"run"`
+	BookedAt time.Time      `json:"bookedAt"`
+
+	Corrections                  creditrealization.CorrectionRequest   `json:"corrections"`
+	LineageSegmentsByRealization lineage.ActiveSegmentsByRealizationID `json:"-"`
+}
+
+func (i CorrectFiatOverageCreditAllocationsInput) GetFiatCurrency() (*currencyx.FiatCurrency, error) {
+	costBasisIntent := i.Charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return nil, errors.New("cost basis intent is required")
+	}
+
+	return costBasisIntent.GetFiatCurrency()
+}
+
+func (i CorrectFiatOverageCreditAllocationsInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if !i.Charge.Intent.GetCurrency().IsCustom() {
+		errs = append(errs, errors.New("charge currency must be custom"))
+	}
+
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, errors.New("settlement mode must be credit_then_invoice"))
+	}
+
+	fiatCurrency, err := i.GetFiatCurrency()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("fiat currency: %w", err))
+	} else if err := i.Corrections.ValidateWith(fiatCurrency); err != nil {
+		errs = append(errs, fmt.Errorf("corrections: %w", err))
+	}
+
+	if i.BookedAt.IsZero() {
+		errs = append(errs, errors.New("booked at is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 type PaymentEventInput struct {
 	Charge     Charge                `json:"charge"`
 	Run        RealizationRun        `json:"run"`
@@ -240,6 +357,12 @@ type Handler interface {
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
 	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+
+	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against a custom-currency overage.
+	OnAllocateFiatOverageCredits(ctx context.Context, input AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+
+	// OnCorrectFiatOverageCreditAllocations corrects settlement-fiat allocations for a custom-currency overage.
+	OnCorrectFiatOverageCreditAllocations(ctx context.Context, input CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 
 	// OnFlatFeePaymentAuthorized is called when a flat fee payment is authorized.
 	OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -608,9 +608,10 @@ func (s *CreditThenInvoiceStateMachine) StartRealization(ctx context.Context, in
 	}
 
 	result, err := s.Realizations.StartCreditThenInvoiceRun(ctx, flatfeerealizations.StartCreditThenInvoiceRunInput{
-		Charge:    s.Charge,
-		LineID:    input.Line.ID,
-		InvoiceID: input.Invoice.ID,
+		Charge:            s.Charge,
+		SourceBalanceAsOf: clock.Now(),
+		LineID:            input.Line.ID,
+		InvoiceID:         input.Invoice.ID,
 	})
 	if err != nil {
 		return fmt.Errorf("start credit-then-invoice run: %w", err)
@@ -662,9 +663,10 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	line.ID = input.Line.ID
 
 	result, err := s.Realizations.StartCreditThenInvoiceRun(ctx, flatfeerealizations.StartCreditThenInvoiceRunInput{
-		Charge:    s.Charge,
-		LineID:    line.ID,
-		InvoiceID: input.Invoice.ID,
+		Charge:            s.Charge,
+		SourceBalanceAsOf: clock.Now(),
+		LineID:            line.ID,
+		InvoiceID:         input.Invoice.ID,
 	})
 	if err != nil {
 		return fmt.Errorf("start attached credit-then-invoice run: %w", err)
@@ -919,9 +921,10 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		// Rerate and reconcile it first, then project the resulting charge state
 		// onto the billing-owned line identity.
 		result, err := s.Realizations.ReconcileRunToIntent(ctx, flatfeerealizations.ReconcileRunToIntentInput{
-			Charge:     s.Charge,
-			Run:        *currentRun,
-			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), s.Charge.Intent.GetEffectiveServicePeriod()),
+			Charge:            s.Charge,
+			Run:               *currentRun,
+			AllocateAt:        flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), s.Charge.Intent.GetEffectiveServicePeriod()),
+			SourceBalanceAsOf: clock.Now(),
 		})
 		if err != nil {
 			return fmt.Errorf("reconcile run to intent for %s flat-fee charge[%s]: %w", input.Op, s.Charge.ID, err)

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -224,6 +224,7 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 
 	result, err := s.Realizations.AllocateCreditsOnly(ctx, flatfeerealizations.AllocateCreditsOnlyInput{
 		Charge:             s.Charge,
+		SourceBalanceAsOf:  clock.Now(),
 		Totals:             ratingResult.Totals,
 		CurrencyCalculator: currency,
 	})
@@ -320,6 +321,7 @@ func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context
 		Charge:             s.Charge,
 		Run:                run,
 		AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
+		SourceBalanceAsOf:  clock.Now(),
 		TargetAmount:       creditAllocationTarget,
 		CurrencyCalculator: currency,
 	})

--- a/openmeter/billing/charges/flatfee/service/realizations/correct.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/correct.go
@@ -22,6 +22,7 @@ type ReconcileCreditRealizationsInput struct {
 	Charge             flatfee.Charge
 	Run                flatfee.RealizationRun
 	AllocateAt         time.Time
+	SourceBalanceAsOf  time.Time
 	TargetAmount       alpacadecimal.Decimal
 	CurrencyCalculator currencyx.Currency
 }
@@ -39,6 +40,10 @@ func (i ReconcileCreditRealizationsInput) Validate() error {
 
 	if i.AllocateAt.IsZero() {
 		errs = append(errs, errors.New("allocate at is required"))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, errors.New("source balance as of is required"))
 	}
 
 	if i.TargetAmount.IsNegative() {
@@ -94,6 +99,7 @@ func (s *Service) ReconcileCredits(ctx context.Context, in ReconcileCreditRealiz
 			Charge:                 in.Charge,
 			ServicePeriod:          in.Run.ServicePeriod,
 			BookedAt:               in.AllocateAt,
+			SourceBalanceAsOf:      in.SourceBalanceAsOf,
 			PreTaxAmountToAllocate: delta,
 		}
 		if err := handlerInput.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/mo"
@@ -18,6 +19,7 @@ import (
 
 type AllocateCreditsOnlyInput struct {
 	Charge             flatfee.Charge
+	SourceBalanceAsOf  time.Time
 	Totals             totals.Totals
 	CurrencyCalculator currencyx.Currency
 }
@@ -31,6 +33,10 @@ func (i AllocateCreditsOnlyInput) Validate() error {
 
 	if err := i.Totals.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("totals: %w", err))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, errors.New("source balance as of is required"))
 	}
 
 	if i.CurrencyCalculator == nil {
@@ -62,6 +68,7 @@ func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnl
 			Charge:                 in.Charge,
 			ServicePeriod:          servicePeriod,
 			BookedAt:               flatfee.UsageBookedAt(in.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
+			SourceBalanceAsOf:      in.SourceBalanceAsOf,
 			PreTaxAmountToAllocate: amountToAllocate,
 		}
 		if err := input.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -17,9 +17,10 @@ import (
 )
 
 type StartCreditThenInvoiceRunInput struct {
-	Charge    flatfee.Charge
-	LineID    string
-	InvoiceID string
+	Charge            flatfee.Charge
+	SourceBalanceAsOf time.Time
+	LineID            string
+	InvoiceID         string
 }
 
 func (i StartCreditThenInvoiceRunInput) Validate() error {
@@ -27,6 +28,10 @@ func (i StartCreditThenInvoiceRunInput) Validate() error {
 
 	if err := i.Charge.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, errors.New("source balance as of is required"))
 	}
 
 	if i.LineID == "" {
@@ -93,6 +98,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 				Charge:                 charge,
 				ServicePeriod:          rateableIntent.ServicePeriod,
 				BookedAt:               flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), rateableIntent.ServicePeriod),
+				SourceBalanceAsOf:      in.SourceBalanceAsOf,
 				PreTaxAmountToAllocate: creditAllocationTarget,
 			}
 			if err := handlerInput.Validate(); err != nil {
@@ -171,6 +177,8 @@ type ReconcileRunToIntentInput struct {
 	// AllocateAt is used as the ledger timestamp when reconciliation needs to
 	// allocate or correct credit rows.
 	AllocateAt time.Time
+	// SourceBalanceAsOf is the cutoff used when selecting credit balances for new allocations.
+	SourceBalanceAsOf time.Time
 }
 
 func (i ReconcileRunToIntentInput) Validate() error {
@@ -186,6 +194,10 @@ func (i ReconcileRunToIntentInput) Validate() error {
 
 	if i.AllocateAt.IsZero() {
 		errs = append(errs, errors.New("allocate at is required"))
+	}
+
+	if i.SourceBalanceAsOf.IsZero() {
+		errs = append(errs, errors.New("source balance as of is required"))
 	}
 
 	if i.Run.LineID == nil || *i.Run.LineID == "" {
@@ -231,6 +243,7 @@ func (s *Service) ReconcileRunToIntent(ctx context.Context, in ReconcileRunToInt
 			Charge:             in.Charge,
 			Run:                run,
 			AllocateAt:         in.AllocateAt,
+			SourceBalanceAsOf:  in.SourceBalanceAsOf,
 			TargetAmount:       creditAllocationTarget,
 			CurrencyCalculator: currency,
 		})

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -37,13 +37,15 @@ func (m *mockLineageService) BackfillAdvanceLineageSegments(ctx context.Context,
 var _ flatfee.Handler = (*flatFeeTestHandler)(nil)
 
 type flatFeeTestHandler struct {
-	onAllocateCredits              func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onInvoiceUsageAccrued          func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
-	onCorrectCreditAllocations     func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onPaymentAuthorized            func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled               func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onPaymentUncollectible         func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
+	onAllocateCredits                     func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onInvoiceUsageAccrued                 func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued        func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
+	onCorrectCreditAllocations            func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits          func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onPaymentAuthorized                   func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                      func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onPaymentUncollectible                func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
 }
 
 func newFlatFeeTestHandler() *flatFeeTestHandler {
@@ -80,6 +82,22 @@ func (h *flatFeeTestHandler) OnCorrectCreditAllocations(ctx context.Context, inp
 	}
 
 	return h.onCorrectCreditAllocations(ctx, input)
+}
+
+func (h *flatFeeTestHandler) OnAllocateFiatOverageCredits(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	if h.onAllocateFiatOverageCredits == nil {
+		return nil, errors.New("onAllocateFiatOverageCredits is not set")
+	}
+
+	return h.onAllocateFiatOverageCredits(ctx, input)
+}
+
+func (h *flatFeeTestHandler) OnCorrectFiatOverageCreditAllocations(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
+	if h.onCorrectFiatOverageCreditAllocations == nil {
+		return nil, errors.New("onCorrectFiatOverageCreditAllocations is not set")
+	}
+
+	return h.onCorrectFiatOverageCreditAllocations(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -76,6 +76,26 @@ func (mockFlatFeeHandler) OnCorrectCreditAllocations(_ context.Context, input fl
 	}), nil
 }
 
+func (mockFlatFeeHandler) OnAllocateFiatOverageCredits(_ context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	return creditrealization.CreateAllocationInputs{
+		{
+			ServicePeriod:     input.Run.ServicePeriod,
+			LedgerTransaction: newMockLedgerTransactionGroupReference(),
+			Amount:            input.AmountToAllocate,
+		},
+	}, nil
+}
+
+func (mockFlatFeeHandler) OnCorrectFiatOverageCreditAllocations(_ context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
+	return lo.Map(input.Corrections, func(correction creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
+		return creditrealization.CreateCorrectionInput{
+			LedgerTransaction:     newMockLedgerTransactionGroupReference(),
+			Amount:                correction.Amount,
+			CorrectsRealizationID: correction.Allocation.ID,
+		}
+	}), nil
+}
+
 func (mockFlatFeeHandler) OnPaymentAuthorized(context.Context, flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
 	return newMockLedgerTransactionGroupReference(), nil
 }

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -67,7 +67,7 @@ func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.On
 		CustomerID:        intent.GetCustomerID(),
 		Annotations:       chargeAnnotationsForFlatFeeCharge(input.Charge),
 		BookedAt:          input.BookedAt,
-		SourceBalanceAsOf: intent.GetEffectiveInvoiceAt(),
+		SourceBalanceAsOf: input.SourceBalanceAsOf,
 		Currency:          intent.GetCurrency().Reference(),
 		TaxCode:           lo.ToPtr(taxConfig.TaxCodeID),
 		TaxBehavior:       (*ledger.TaxBehavior)(taxConfig.Behavior),
@@ -163,6 +163,24 @@ func (h *flatFeeHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, inp
 
 	// TODO[implement]: Book the fiat overage in the customer's outstanding account.
 	return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
+func (h *flatFeeHandler) OnAllocateFiatOverageCredits(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	// TODO[implement]: Allocate settlement-fiat credits against the custom-currency overage.
+	return nil, fmt.Errorf("implement OnAllocateFiatOverageCredits: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
+func (h *flatFeeHandler) OnCorrectFiatOverageCreditAllocations(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	// TODO[implement]: Correct settlement-fiat allocations for the custom-currency overage.
+	return nil, fmt.Errorf("implement OnCorrectFiatOverageCreditAllocations: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
 func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -133,6 +133,17 @@ func TestOnAllocateCredits(t *testing.T) {
 		require.Nil(t, realizations)
 	})
 
+	t.Run("source balance as of is required", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newAssignmentInput(alpacadecimal.NewFromInt(30))
+		input.SourceBalanceAsOf = time.Time{}
+
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), input)
+		require.ErrorContains(t, err, "source balance as of is required")
+		require.Nil(t, realizations)
+	})
+
 	t.Run("in arrears books credit allocation at service period end", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
@@ -739,6 +750,7 @@ func (e *flatFeeHandlerTestEnv) newAllocateCreditsInputForCharge(charge chargefl
 		Charge:                 charge,
 		ServicePeriod:          charge.Intent.GetEffectiveServicePeriod(),
 		BookedAt:               chargeflatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), charge.Intent.GetEffectiveServicePeriod()),
+		SourceBalanceAsOf:      e.Now(),
 		PreTaxAmountToAllocate: amount,
 	}
 }
@@ -794,6 +806,7 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 		},
 		ServicePeriod:          servicePeriod,
 		BookedAt:               chargeflatfee.UsageBookedAt(productcatalog.InAdvancePaymentTerm, servicePeriod),
+		SourceBalanceAsOf:      now,
 		PreTaxAmountToAllocate: amount,
 	}
 }


### PR DESCRIPTION
## Summary

- introduce flat-fee lifecycle contracts for allocating and correcting settlement-fiat credits against custom-currency overages
- carry the source-balance cutoff independently from the ledger booking timestamp through flat-fee allocation and reconciliation
- wire the shared test handlers and add explicit production ledger stubs for the new operations

## Behavior

This draft does not enable production custom-currency settlement. The ledger methods continue to return the existing unsupported error until the flat-fee implementation is resumed. It isolates the flat-fee preparation so usage-based settlement can proceed independently.

## Jira

OM-435

## Validation

- affected packages compile
- focused flat-fee ledger allocation tests pass
- full lint intentionally deferred for this draft split

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds flat-fee contracts and stubs for future settlement-fiat overage allocation while separating ledger booking time from source-balance eligibility time.
- Propagates `SourceBalanceAsOf` through flat-fee allocation and reconciliation services.
- Adds fiat-overage allocation and correction handler contracts with intentionally unsupported production implementations.
- Extends shared handlers and adapter tests for the new inputs and methods.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until flat-fee balance eligibility is anchored to a stable economic timestamp so delayed processing cannot consume later-funded credits.

The new clock-based cutoff widens the eligible ledger balance window whenever flat-fee allocation occurs after the charge's booking boundary, producing incorrect credit consumption and invoice overage.

**Files Needing Attention:** openmeter/billing/charges/flatfee/service/creditheninvoice.go, openmeter/billing/charges/flatfee/service/creditsonly.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/handler.go | Adds required source-balance cutoffs and future fiat-overage allocation/correction contracts with validation. |
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Propagates a wall-clock balance cutoff into initial and reconciled allocations, allowing late-funded credits to cover historical charges. |
| openmeter/billing/charges/flatfee/service/creditsonly.go | Uses the current processing time for both initial and reconciled credit-only allocation eligibility. |
| openmeter/billing/charges/flatfee/service/realizations/correct.go | Carries the independently supplied cutoff into positive reconciliation allocations while leaving correction behavior unchanged. |
| openmeter/billing/charges/flatfee/service/realizations/creditsonly.go | Validates and forwards the new cutoff through credits-only realization. |
| openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go | Validates and forwards the new cutoff through run creation and mutable-run reconciliation. |
| openmeter/ledger/chargeadapter/flatfee.go | Replaces the fixed invoice-time cutoff with the caller-provided cutoff and adds intentionally unsupported fiat-overage stubs. |
| openmeter/ledger/chargeadapter/flatfee_test.go | Adds validation coverage requiring the independently supplied source-balance cutoff. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SM as Flat-fee state machine
  participant R as Realization service
  participant H as Ledger charge adapter
  participant C as Collector
  participant B as Historical balance query
  SM->>R: "Allocate/Reconcile(BookedAt, SourceBalanceAsOf=clock.Now)"
  R->>H: OnAllocateCredits
  H->>C: CollectToAccrued(BookedAt, SourceBalanceAsOf)
  C->>B: GetBalanceBuckets(AsOf)
  B-->>C: Credits booked at or before cutoff
  C-->>SM: Credit realizations
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fflatfee%2Fservice%2Fcreditheninvoice.go%3A612%0A**Wall-clock%20cutoff%20consumes%20later%20credits**%0A%0AWhen%20a%20flat-fee%20realization%20runs%20after%20its%20economic%20booking%20boundary%2C%20using%20%60clock.Now%28%29%60%20for%20%60SourceBalanceAsOf%60%20makes%20credits%20funded%20between%20that%20boundary%20and%20processing%20time%20eligible%20for%20the%20historical%20charge%2C%20reducing%20its%20invoice%20overage%20and%20leaving%20less%20credit%20for%20later%20charges.%20The%20same%20wall-clock%20cutoff%20is%20also%20used%20by%20attachment%20and%20reconciliation%20paths.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4920&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fflatfee-fiat-overage-credit-handlers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fflatfee-fiat-overage-credit-handlers%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fflatfee%2Fservice%2Fcreditheninvoice.go%3A612%0A**Wall-clock%20cutoff%20consumes%20later%20credits**%0A%0AWhen%20a%20flat-fee%20realization%20runs%20after%20its%20economic%20booking%20boundary%2C%20using%20%60clock.Now%28%29%60%20for%20%60SourceBalanceAsOf%60%20makes%20credits%20funded%20between%20that%20boundary%20and%20processing%20time%20eligible%20for%20the%20historical%20charge%2C%20reducing%20its%20invoice%20overage%20and%20leaving%20less%20credit%20for%20later%20charges.%20The%20same%20wall-clock%20cutoff%20is%20also%20used%20by%20attachment%20and%20reconciliation%20paths.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4920&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/billing/charges/flatfee/service/creditheninvoice.go:612
**Wall-clock cutoff consumes later credits**

When a flat-fee realization runs after its economic booking boundary, using `clock.Now()` for `SourceBalanceAsOf` makes credits funded between that boundary and processing time eligible for the historical charge, reducing its invoice overage and leaving less credit for later charges. The same wall-clock cutoff is also used by attachment and reconciliation paths.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(flatfee): add fiat overage credit h..."](https://github.com/openmeterio/openmeter/commit/90f15401c232cb32c0639cb4c6b30c6e391e085d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52579734)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Credit Grants, Balances, and Entitlements](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-entitlement.md)

<!-- /greptile_comment -->