### PR TITLE
fix(entitlements): honor query params when listing customer entitlement grants

### DIFF
--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -756,9 +756,6 @@ func TestEntitlementWithLatestAggregation(t *testing.T) {
 	})
 }
 
-// TestCustomerEntitlementGrantsPagination pins that the list endpoint honors the caller supplied
-// pagination. The handler used to drop every query parameter, capping callers at the first 100
-// grants with no way to reach the rest.
 func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 	client := initClient(t)
 
@@ -812,7 +809,39 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
 	}
 
-	t.Run("Should honor pageSize", func(t *testing.T) {
+	t.Run("Should default to the first page", func(t *testing.T) {
+		// when no pagination parameters are sent at all
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		// then the documented page defaults apply, rather than the limit/offset mode that
+		// reports no page metadata
+		require.Len(t, resp.JSON200.Items, grantCount)
+		require.Equal(t, 1, resp.JSON200.Page)
+		require.Equal(t, 100, resp.JSON200.PageSize)
+		require.Equal(t, grantCount, resp.JSON200.TotalCount)
+	})
+
+	t.Run("Should default the offset when only a limit is sent", func(t *testing.T) {
+		// when only the deprecated limit is sent, the offset defaults to zero
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			Limit:   lo.ToPtr(2),
+			OrderBy: lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:   lo.ToPtr(api.SortOrderASC),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		// then the window starts at the first grant
+		require.Len(t, resp.JSON200.Items, 2)
+		require.Equal(t, 1.0, resp.JSON200.Items[0].Amount)
+		require.Equal(t, 2.0, resp.JSON200.Items[1].Amount)
+	})
+
+	t.Run("Should default the page when only a pageSize is sent", func(t *testing.T) {
 		// when a page smaller than the grant count is requested
 		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
 			PageSize: lo.ToPtr(2),

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -916,12 +916,13 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
 		require.NotNil(t, resp.JSON200)
 
-		// then the remaining grants are returned in order; this mode runs no count query, so
-		// the page metadata stays zeroed, matching /api/v2/grants
+		// then the remaining grants are returned in order. The page fields stay zeroed because
+		// this mode has no page, but the count is real, so a caller walking the offset can
+		// still tell when it has seen every grant.
 		require.Equal(t, []float64{10, 20}, amounts(resp.JSON200.Items))
 		require.Zero(t, resp.JSON200.Page)
 		require.Zero(t, resp.JSON200.PageSize)
-		require.Zero(t, resp.JSON200.TotalCount)
+		require.Equal(t, grantCount, resp.JSON200.TotalCount)
 	})
 
 	t.Run("Should honor a descending order", func(t *testing.T) {

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -795,18 +795,25 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
 	}
 
-	// given three grants created in ascending amount order, so that ordering by createdAt makes
-	// the returned window identifiable by amount
-	grantCount := 3
-	firstEffectiveAt := time.Now().Truncate(time.Minute)
+	// given three grants whose amounts identify them, and whose amounts and effective dates both
+	// run counter to their creation order. Ordering by createdAt therefore yields a sequence that
+	// ordering by amount or by effectiveAt could not produce, so the assertions below fail if
+	// orderBy is ignored or resolved to the wrong column.
+	amountsInCreationOrder := []float64{30, 10, 20}
+	grantCount := len(amountsInCreationOrder)
+	lastEffectiveAt := time.Now().Truncate(time.Minute).Add(time.Duration(grantCount) * time.Minute)
 
-	for i := 0; i < grantCount; i++ {
+	for i, amount := range amountsInCreationOrder {
 		resp, err := client.CreateCustomerEntitlementGrantV2WithResponse(ctx, cust.Id, featureKey, api.CreateCustomerEntitlementGrantV2JSONRequestBody{
-			Amount:      float64(i + 1),
-			EffectiveAt: firstEffectiveAt.Add(time.Duration(i) * time.Minute),
+			Amount:      amount,
+			EffectiveAt: lastEffectiveAt.Add(-time.Duration(i) * time.Minute),
 		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
+	}
+
+	amounts := func(items []api.EntitlementGrantV2) []float64 {
+		return lo.Map(items, func(item api.EntitlementGrantV2, _ int) float64 { return item.Amount })
 	}
 
 	t.Run("Should default to the first page", func(t *testing.T) {
@@ -817,8 +824,8 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.NotNil(t, resp.JSON200)
 
 		// then the documented page defaults apply, rather than the limit/offset mode that
-		// reports no page metadata
-		require.Len(t, resp.JSON200.Items, grantCount)
+		// reports no page metadata, and the grants come back in the default createdAt order
+		require.Equal(t, amountsInCreationOrder, amounts(resp.JSON200.Items))
 		require.Equal(t, 1, resp.JSON200.Page)
 		require.Equal(t, 100, resp.JSON200.PageSize)
 		require.Equal(t, grantCount, resp.JSON200.TotalCount)
@@ -835,10 +842,8 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
 		require.NotNil(t, resp.JSON200)
 
-		// then the window starts at the first grant
-		require.Len(t, resp.JSON200.Items, 2)
-		require.Equal(t, 1.0, resp.JSON200.Items[0].Amount)
-		require.Equal(t, 2.0, resp.JSON200.Items[1].Amount)
+		// then the window starts at the first created grant
+		require.Equal(t, []float64{30, 10}, amounts(resp.JSON200.Items))
 	})
 
 	t.Run("Should default the page when only a pageSize is sent", func(t *testing.T) {
@@ -853,9 +858,7 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.NotNil(t, resp.JSON200)
 
 		// then the page is capped at the requested size while the count covers every grant
-		require.Len(t, resp.JSON200.Items, 2)
-		require.Equal(t, 1.0, resp.JSON200.Items[0].Amount)
-		require.Equal(t, 2.0, resp.JSON200.Items[1].Amount)
+		require.Equal(t, []float64{30, 10}, amounts(resp.JSON200.Items))
 		require.Equal(t, 1, resp.JSON200.Page)
 		require.Equal(t, 2, resp.JSON200.PageSize)
 		require.Equal(t, grantCount, resp.JSON200.TotalCount)
@@ -874,9 +877,30 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.NotNil(t, resp.JSON200)
 
 		// then only the grant left over from the first page is returned
-		require.Len(t, resp.JSON200.Items, 1)
-		require.Equal(t, 3.0, resp.JSON200.Items[0].Amount)
+		require.Equal(t, []float64{20}, amounts(resp.JSON200.Items))
 		require.Equal(t, 2, resp.JSON200.Page)
+		require.Equal(t, grantCount, resp.JSON200.TotalCount)
+	})
+
+	t.Run("Should prefer page over the deprecated limit and offset", func(t *testing.T) {
+		// when both modes are sent, with legacy values that would select a different window
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			Page:     lo.ToPtr(2),
+			PageSize: lo.ToPtr(2),
+			Limit:    lo.ToPtr(1),
+			Offset:   lo.ToPtr(0),
+			OrderBy:  lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:    lo.ToPtr(api.SortOrderASC),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		// then the page window wins and the response still carries page metadata, which the
+		// limit/offset mode would have zeroed
+		require.Equal(t, []float64{20}, amounts(resp.JSON200.Items))
+		require.Equal(t, 2, resp.JSON200.Page)
+		require.Equal(t, 2, resp.JSON200.PageSize)
 		require.Equal(t, grantCount, resp.JSON200.TotalCount)
 	})
 
@@ -894,12 +918,24 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 
 		// then the remaining grants are returned in order; this mode runs no count query, so
 		// the page metadata stays zeroed, matching /api/v2/grants
-		require.Len(t, resp.JSON200.Items, 2)
-		require.Equal(t, 2.0, resp.JSON200.Items[0].Amount)
-		require.Equal(t, 3.0, resp.JSON200.Items[1].Amount)
+		require.Equal(t, []float64{10, 20}, amounts(resp.JSON200.Items))
 		require.Zero(t, resp.JSON200.Page)
 		require.Zero(t, resp.JSON200.PageSize)
 		require.Zero(t, resp.JSON200.TotalCount)
+	})
+
+	t.Run("Should honor a descending order", func(t *testing.T) {
+		// when the same ordering column is requested in the opposite direction
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			OrderBy: lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:   lo.ToPtr(api.SortOrderDESC),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		// then the creation order is reversed
+		require.Equal(t, []float64{20, 10, 30}, amounts(resp.JSON200.Items))
 	})
 
 	t.Run("Should reject an invalid page", func(t *testing.T) {

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -755,3 +755,113 @@ func TestEntitlementWithLatestAggregation(t *testing.T) {
 		}, 2*time.Minute, time.Second)
 	})
 }
+
+// TestCustomerEntitlementGrantsPagination pins that the list endpoint honors the caller supplied
+// pagination. The handler used to drop every query parameter, capping callers at the first 100
+// grants with no way to reach the rest.
+func TestCustomerEntitlementGrantsPagination(t *testing.T) {
+	client := initClient(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	customerKey := fmt.Sprintf("grant_paging_customer_%d", time.Now().UnixNano())
+	cust := CreateCustomerWithSubject(t, client, customerKey, customerKey+"-subject")
+
+	apiMONTH := &api.RecurringPeriodInterval{}
+	require.NoError(t, apiMONTH.FromRecurringPeriodIntervalEnum(api.RecurringPeriodIntervalEnumMONTH))
+
+	featureKey := fmt.Sprintf("grant_paging_feature_%d", time.Now().UnixNano())
+	{
+		resp, err := client.CreateFeatureWithResponse(ctx, api.CreateFeatureJSONRequestBody{
+			Name:      "Grant Paging Test Feature",
+			MeterSlug: convert.ToPointer("entitlement_uc_meter"),
+			Key:       featureKey,
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
+	}
+
+	{
+		metered := api.EntitlementMeteredV2CreateInputs{
+			Type:       "metered",
+			FeatureKey: &featureKey,
+			UsagePeriod: api.RecurringPeriodCreateInput{
+				Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+				Interval: *apiMONTH,
+			},
+		}
+		body := api.CreateCustomerEntitlementV2JSONRequestBody{}
+		require.NoError(t, body.FromEntitlementMeteredV2CreateInputs(metered))
+
+		resp, err := client.CreateCustomerEntitlementV2WithResponse(ctx, cust.Id, body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
+	}
+
+	// given three grants, each effective a minute apart so that ordering by effectiveAt is
+	// deterministic
+	grantCount := 3
+	firstEffectiveAt := time.Now().Truncate(time.Minute)
+
+	for i := 0; i < grantCount; i++ {
+		resp, err := client.CreateCustomerEntitlementGrantV2WithResponse(ctx, cust.Id, featureKey, api.CreateCustomerEntitlementGrantV2JSONRequestBody{
+			Amount:      float64(i + 1),
+			EffectiveAt: firstEffectiveAt.Add(time.Duration(i) * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
+	}
+
+	t.Run("Should honor pageSize", func(t *testing.T) {
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			PageSize: lo.ToPtr(2),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		require.Len(t, resp.JSON200.Items, 2)
+		require.Equal(t, 1, resp.JSON200.Page)
+		require.Equal(t, 2, resp.JSON200.PageSize)
+		require.Equal(t, grantCount, resp.JSON200.TotalCount)
+	})
+
+	t.Run("Should honor page", func(t *testing.T) {
+		// when the last page of size two is requested, only the remaining grant is returned
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			Page:     lo.ToPtr(2),
+			PageSize: lo.ToPtr(2),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		require.Len(t, resp.JSON200.Items, 1)
+		require.Equal(t, 2, resp.JSON200.Page)
+		require.Equal(t, grantCount, resp.JSON200.TotalCount)
+	})
+
+	t.Run("Should honor limit and offset", func(t *testing.T) {
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			Limit:   lo.ToPtr(2),
+			Offset:  lo.ToPtr(1),
+			OrderBy: lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:   lo.ToPtr(api.SortOrderASC),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
+		require.NotNil(t, resp.JSON200)
+
+		require.Len(t, resp.JSON200.Items, 2)
+	})
+
+	t.Run("Should reject an invalid page", func(t *testing.T) {
+		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
+			Page:     lo.ToPtr(0),
+			PageSize: lo.ToPtr(2),
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode(), "body: %s", resp.Body)
+	})
+}

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -762,8 +762,7 @@ func TestEntitlementWithLatestAggregation(t *testing.T) {
 func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 	client := initClient(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	customerKey := fmt.Sprintf("grant_paging_customer_%d", time.Now().UnixNano())
 	cust := CreateCustomerWithSubject(t, client, customerKey, customerKey+"-subject")
@@ -799,8 +798,8 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusCreated, resp.StatusCode(), "body: %s", resp.Body)
 	}
 
-	// given three grants, each effective a minute apart so that ordering by effectiveAt is
-	// deterministic
+	// given three grants created in ascending amount order, so that ordering by createdAt makes
+	// the returned window identifiable by amount
 	grantCount := 3
 	firstEffectiveAt := time.Now().Truncate(time.Minute)
 
@@ -814,35 +813,46 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 	}
 
 	t.Run("Should honor pageSize", func(t *testing.T) {
+		// when a page smaller than the grant count is requested
 		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
 			PageSize: lo.ToPtr(2),
+			OrderBy:  lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:    lo.ToPtr(api.SortOrderASC),
 		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
 		require.NotNil(t, resp.JSON200)
 
+		// then the page is capped at the requested size while the count covers every grant
 		require.Len(t, resp.JSON200.Items, 2)
+		require.Equal(t, 1.0, resp.JSON200.Items[0].Amount)
+		require.Equal(t, 2.0, resp.JSON200.Items[1].Amount)
 		require.Equal(t, 1, resp.JSON200.Page)
 		require.Equal(t, 2, resp.JSON200.PageSize)
 		require.Equal(t, grantCount, resp.JSON200.TotalCount)
 	})
 
 	t.Run("Should honor page", func(t *testing.T) {
-		// when the last page of size two is requested, only the remaining grant is returned
+		// when the last page of size two is requested
 		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
 			Page:     lo.ToPtr(2),
 			PageSize: lo.ToPtr(2),
+			OrderBy:  lo.ToPtr(api.GrantOrderByCreatedAt),
+			Order:    lo.ToPtr(api.SortOrderASC),
 		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
 		require.NotNil(t, resp.JSON200)
 
+		// then only the grant left over from the first page is returned
 		require.Len(t, resp.JSON200.Items, 1)
+		require.Equal(t, 3.0, resp.JSON200.Items[0].Amount)
 		require.Equal(t, 2, resp.JSON200.Page)
 		require.Equal(t, grantCount, resp.JSON200.TotalCount)
 	})
 
 	t.Run("Should honor limit and offset", func(t *testing.T) {
+		// when the deprecated limit/offset mode skips the first grant
 		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
 			Limit:   lo.ToPtr(2),
 			Offset:  lo.ToPtr(1),
@@ -853,15 +863,25 @@ func TestCustomerEntitlementGrantsPagination(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode(), "body: %s", resp.Body)
 		require.NotNil(t, resp.JSON200)
 
+		// then the remaining grants are returned in order; this mode runs no count query, so
+		// the page metadata stays zeroed, matching /api/v2/grants
 		require.Len(t, resp.JSON200.Items, 2)
+		require.Equal(t, 2.0, resp.JSON200.Items[0].Amount)
+		require.Equal(t, 3.0, resp.JSON200.Items[1].Amount)
+		require.Zero(t, resp.JSON200.Page)
+		require.Zero(t, resp.JSON200.PageSize)
+		require.Zero(t, resp.JSON200.TotalCount)
 	})
 
 	t.Run("Should reject an invalid page", func(t *testing.T) {
+		// when a page index below the documented minimum is requested
 		resp, err := client.ListCustomerEntitlementGrantsV2WithResponse(ctx, cust.Id, featureKey, &api.ListCustomerEntitlementGrantsV2Params{
 			Page:     lo.ToPtr(0),
 			PageSize: lo.ToPtr(2),
 		})
 		require.NoError(t, err)
+
+		// then the request is rejected rather than silently falling back to the first page
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode(), "body: %s", resp.Body)
 	})
 }

--- a/openmeter/credit/adapter/grant.go
+++ b/openmeter/credit/adapter/grant.go
@@ -152,6 +152,8 @@ func (g *grantDBADapter) ListGrants(ctx context.Context, params grant.ListParams
 			order = entutils.GetOrdering(params.Order)
 		}
 		switch params.OrderBy {
+		case grant.OrderByID:
+			query = query.Order(db_grant.ByID(order...))
 		case grant.OrderByCreatedAt:
 			query = query.Order(db_grant.ByCreatedAt(order...))
 		case grant.OrderByUpdatedAt:
@@ -171,6 +173,13 @@ func (g *grantDBADapter) ListGrants(ctx context.Context, params grant.ListParams
 
 	// we're using limit and offset
 	if params.Page.IsZero() {
+		// Counted before the window is applied, so callers walking the offset still learn how
+		// many grants match. Page.Paginate below reports the same figure for the other mode.
+		totalCount, err := query.Clone().Count(ctx)
+		if err != nil {
+			return response, err
+		}
+
 		if params.Limit > 0 {
 			query = query.Limit(params.Limit)
 		}
@@ -189,6 +198,8 @@ func (g *grantDBADapter) ListGrants(ctx context.Context, params grant.ListParams
 		}
 
 		response.Items = grants
+		response.TotalCount = totalCount
+
 		return response, nil
 	}
 

--- a/openmeter/credit/grant/repo.go
+++ b/openmeter/credit/grant/repo.go
@@ -15,6 +15,7 @@ import (
 type OrderBy string
 
 const (
+	OrderByID          OrderBy = "id"
 	OrderByCreatedAt   OrderBy = "created_at"
 	OrderByUpdatedAt   OrderBy = "updated_at"
 	OrderByExpiresAt   OrderBy = "expires_at"
@@ -25,6 +26,7 @@ const (
 
 func (f OrderBy) Values() []OrderBy {
 	return []OrderBy{
+		OrderByID,
 		OrderByCreatedAt,
 		OrderByUpdatedAt,
 		OrderByExpiresAt,

--- a/openmeter/entitlement/driver/v2/customer_metered.go
+++ b/openmeter/entitlement/driver/v2/customer_metered.go
@@ -22,6 +22,16 @@ import (
 	"github.com/openmeterio/openmeter/pkg/strcase"
 )
 
+// Defaults for the pagination query parameters of listCustomerEntitlementGrantsV2. The OpenAPI
+// spec declares them, but the generated server does not apply them, so they are restated here
+// rather than borrowed from a shared constant that is free to drift from the published contract.
+const (
+	defaultPage     = 1
+	defaultPageSize = 100
+	defaultLimit    = 100
+	defaultOffset   = 0
+)
+
 type (
 	ListCustomerEntitlementGrantsHandlerParams struct {
 		CustomerIDOrKey           string
@@ -78,15 +88,18 @@ func (h *entitlementHandler) ListCustomerEntitlementGrants() ListCustomerEntitle
 				Order:                     sortx.Order(lo.CoalesceOrEmpty(string(lo.FromPtr(request.Params.Order)), string(sortx.OrderDefault))),
 			}
 
-			// page/pageSize takes precedence over the deprecated limit/offset mode.
-			if request.Params.Page != nil || request.Params.PageSize != nil {
-				listParams.Page = pagination.NewPage(
-					lo.FromPtrOr(request.Params.Page, commonhttp.DefaultPage),
-					lo.FromPtrOr(request.Params.PageSize, commonhttp.DefaultPageSize),
-				)
+			// The deprecated limit/offset mode is only entered when the caller asks for it, and
+			// page/pageSize wins when both are given. A request carrying neither keeps the
+			// paginated default response, which is what this endpoint has always returned.
+			if request.Params.Page == nil && request.Params.PageSize == nil &&
+				(request.Params.Limit != nil || request.Params.Offset != nil) {
+				listParams.Limit = lo.FromPtrOr(request.Params.Limit, defaultLimit)
+				listParams.Offset = lo.FromPtrOr(request.Params.Offset, defaultOffset)
 			} else {
-				listParams.Limit = lo.FromPtrOr(request.Params.Limit, commonhttp.DefaultPageSize)
-				listParams.Offset = lo.FromPtrOr(request.Params.Offset, 0)
+				listParams.Page = pagination.NewPage(
+					lo.FromPtrOr(request.Params.Page, defaultPage),
+					lo.FromPtrOr(request.Params.PageSize, defaultPageSize),
+				)
 			}
 
 			grants, err := h.balanceConnector.ListEntitlementGrants(ctx, request.Namespace, listParams)

--- a/openmeter/entitlement/driver/v2/customer_metered.go
+++ b/openmeter/entitlement/driver/v2/customer_metered.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/sortx"
+	"github.com/openmeterio/openmeter/pkg/strcase"
 )
 
 type (
@@ -49,6 +50,7 @@ func (h *entitlementHandler) ListCustomerEntitlementGrants() ListCustomerEntitle
 				CustomerIDOrKey:           params.CustomerIDOrKey,
 				EntitlementIdOrFeatureKey: params.EntitlementIdOrFeatureKey,
 				Namespace:                 ns,
+				Params:                    params.Params,
 			}, nil
 		},
 		func(ctx context.Context, request ListCustomerEntitlementGrantsHandlerRequest) (ListCustomerEntitlementGrantsHandlerResponse, error) {
@@ -68,16 +70,26 @@ func (h *entitlementHandler) ListCustomerEntitlementGrants() ListCustomerEntitle
 				)
 			}
 
-			grants, err := h.balanceConnector.ListEntitlementGrants(ctx, request.Namespace, meteredentitlement.ListEntitlementGrantsParams{
+			listParams := meteredentitlement.ListEntitlementGrantsParams{
 				CustomerID:                cus.ID,
 				EntitlementIDOrFeatureKey: request.EntitlementIdOrFeatureKey,
-				OrderBy:                   grant.OrderBy(lo.CoalesceOrEmpty(string(lo.FromPtr(request.Params.OrderBy)), string(grant.OrderByDefault))),
+				IncludeDeleted:            lo.FromPtr(request.Params.IncludeDeleted),
+				OrderBy:                   grant.OrderBy(strcase.CamelToSnake(lo.CoalesceOrEmpty(string(lo.FromPtr(request.Params.OrderBy)), string(grant.OrderByDefault)))),
 				Order:                     sortx.Order(lo.CoalesceOrEmpty(string(lo.FromPtr(request.Params.Order)), string(sortx.OrderDefault))),
-				Page: pagination.NewPage(
-					lo.FromPtrOr(request.Params.Page, 1),
-					lo.FromPtrOr(request.Params.PageSize, 100),
-				),
-			})
+			}
+
+			// page/pageSize takes precedence over the deprecated limit/offset mode.
+			if request.Params.Page != nil || request.Params.PageSize != nil {
+				listParams.Page = pagination.NewPage(
+					lo.FromPtrOr(request.Params.Page, commonhttp.DefaultPage),
+					lo.FromPtrOr(request.Params.PageSize, commonhttp.DefaultPageSize),
+				)
+			} else {
+				listParams.Limit = lo.FromPtrOr(request.Params.Limit, commonhttp.DefaultPageSize)
+				listParams.Offset = lo.FromPtrOr(request.Params.Offset, 0)
+			}
+
+			grants, err := h.balanceConnector.ListEntitlementGrants(ctx, request.Namespace, listParams)
 			if err != nil {
 				return ListCustomerEntitlementGrantsHandlerResponse{}, err
 			}

--- a/openmeter/entitlement/metered/entitlement_grant.go
+++ b/openmeter/entitlement/metered/entitlement_grant.go
@@ -2,6 +2,7 @@ package meteredentitlement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,30 +36,32 @@ type ListEntitlementGrantsParams struct {
 }
 
 func (p ListEntitlementGrantsParams) Validate() error {
+	var errs []error
+
 	// A zero Page selects the deprecated limit/offset mode, where the page fields carry no
 	// meaning. Exactly one of the two modes has to bound the result set, otherwise the
 	// query would be unbounded.
 	if p.Page.IsZero() {
 		if p.Limit < 1 {
-			return fmt.Errorf("either Page or Limit is required")
+			errs = append(errs, errors.New("either page or limit is required"))
 		}
 
 		if p.Offset < 0 {
-			return fmt.Errorf("offset cannot be negative")
+			errs = append(errs, fmt.Errorf("offset cannot be negative: %d", p.Offset))
 		}
 	} else if err := p.Page.Validate(); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
 	if p.CustomerID == "" {
-		return fmt.Errorf("customerID is required")
+		errs = append(errs, errors.New("customerID is required"))
 	}
 
 	if p.EntitlementIDOrFeatureKey == "" {
-		return fmt.Errorf("entitlementIDOrFeatureKey is required")
+		errs = append(errs, errors.New("entitlementIDOrFeatureKey is required"))
 	}
 
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 // CreateGrant creates a grant for a given entitlement

--- a/openmeter/entitlement/metered/entitlement_grant.go
+++ b/openmeter/entitlement/metered/entitlement_grant.go
@@ -25,11 +25,28 @@ type ListEntitlementGrantsParams struct {
 	EntitlementIDOrFeatureKey string
 	OrderBy                   grant.OrderBy
 	Order                     sortx.Order
+	IncludeDeleted            bool
 	Page                      pagination.Page
+
+	// Limit and Offset are only honored when Page is not set. They serve the deprecated
+	// limit/offset pagination mode of the HTTP APIs and, unlike Page, yield no total count.
+	Limit  int
+	Offset int
 }
 
 func (p ListEntitlementGrantsParams) Validate() error {
-	if err := p.Page.Validate(); err != nil {
+	// A zero Page selects the deprecated limit/offset mode, where the page fields carry no
+	// meaning. Exactly one of the two modes has to bound the result set, otherwise the
+	// query would be unbounded.
+	if p.Page.IsZero() {
+		if p.Limit < 1 {
+			return fmt.Errorf("either Page or Limit is required")
+		}
+
+		if p.Offset < 0 {
+			return fmt.Errorf("offset cannot be negative")
+		}
+	} else if err := p.Page.Validate(); err != nil {
 		return err
 	}
 
@@ -111,10 +128,12 @@ func (e *connector) ListEntitlementGrants(ctx context.Context, namespace string,
 	grants, err := e.grantRepo.ListGrants(ctx, grant.ListParams{
 		Namespace:      ent.Namespace,
 		OwnerID:        convert.ToPointer(ent.ID),
-		IncludeDeleted: false,
+		IncludeDeleted: params.IncludeDeleted,
 		OrderBy:        params.OrderBy,
 		Order:          params.Order,
 		Page:           params.Page,
+		Limit:          params.Limit,
+		Offset:         params.Offset,
 	})
 	if err != nil {
 		return def, err

--- a/openmeter/entitlement/metered/entitlement_grant.go
+++ b/openmeter/entitlement/metered/entitlement_grant.go
@@ -30,7 +30,7 @@ type ListEntitlementGrantsParams struct {
 	Page                      pagination.Page
 
 	// Limit and Offset are only honored when Page is not set. They serve the deprecated
-	// limit/offset pagination mode of the HTTP APIs and, unlike Page, yield no total count.
+	// limit/offset pagination mode of the HTTP APIs.
 	Limit  int
 	Offset int
 }

--- a/openmeter/entitlement/service/grants_test.go
+++ b/openmeter/entitlement/service/grants_test.go
@@ -117,8 +117,23 @@ func TestListEntitlementGrantsPagination(t *testing.T) {
 	})
 
 	t.Run("Should reject an unbounded query", func(t *testing.T) {
-		// when neither pagination mode is provided the result set would be unbounded
+		// given neither pagination mode, when the grants are listed
 		_, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, listParams())
-		require.EqualError(t, err, "either Page or Limit is required")
+
+		// then the request is rejected instead of returning every grant
+		require.EqualError(t, err, "validation error: either page or limit is required")
+	})
+
+	t.Run("Should reject a negative offset", func(t *testing.T) {
+		// given a bounded limit paired with a negative offset
+		params := listParams()
+		params.Limit = 1
+		params.Offset = -1
+
+		// when the grants are listed
+		_, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, params)
+
+		// then the offset is rejected rather than silently ignored by the repository
+		require.EqualError(t, err, "validation error: offset cannot be negative: -1")
 	})
 }

--- a/openmeter/entitlement/service/grants_test.go
+++ b/openmeter/entitlement/service/grants_test.go
@@ -1,0 +1,124 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/credit"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/sortx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestListEntitlementGrantsPagination pins that the caller controlled window is honored in both
+// pagination modes. The HTTP layer picks one of the two, so silently falling back to the defaults
+// makes large grant sets unreachable.
+func TestListEntitlementGrantsPagination(t *testing.T) {
+	namespace := "ns1"
+
+	conn, deps := setupDependecies(t)
+	defer deps.Teardown()
+
+	mtr, err := deps.meterService.CreateMeter(t.Context(), meter.CreateMeterInput{
+		Namespace:     namespace,
+		Name:          "Meter 1",
+		Key:           "meter1",
+		Aggregation:   meter.MeterAggregationSum,
+		EventType:     "test",
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	require.NoError(t, err)
+	createMeterInPG(t, deps.dbClient, mtr)
+
+	feat, err := deps.featureRepo.CreateFeature(t.Context(), feature.CreateFeatureInputs{
+		Name:      "feature1",
+		Key:       "feature1",
+		Namespace: namespace,
+		MeterID:   lo.ToPtr(mtr.ID),
+	})
+	require.NoError(t, err)
+
+	cust := createCustomerAndSubject(t, deps.subjectService, deps.customerService, namespace, "cust1", "Customer 1")
+
+	// given a metered entitlement with three grants, each effective a minute apart so that
+	// ordering by effectiveAt is deterministic
+	firstEffectiveAt := time.Now().Truncate(time.Minute).Add(time.Minute)
+
+	ent, err := conn.CreateEntitlement(t.Context(), entitlement.CreateEntitlementInputs{
+		Namespace:        namespace,
+		FeatureKey:       lo.ToPtr(feat.Key),
+		UsageAttribution: cust.GetUsageAttribution(),
+		EntitlementType:  entitlement.EntitlementTypeMetered,
+		UsagePeriod: lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
+			Interval: timeutil.RecurrencePeriodDaily,
+			Anchor:   time.Now(),
+		})),
+	}, []entitlement.CreateEntitlementGrantInputs{
+		{CreateGrantInput: credit.CreateGrantInput{Amount: 1, EffectiveAt: firstEffectiveAt}},
+	})
+	require.NoError(t, err)
+
+	for i := 2; i <= 3; i++ {
+		_, err := deps.registry.MeteredEntitlement.CreateGrant(t.Context(), namespace, cust.ID, ent.ID, meteredentitlement.CreateEntitlementGrantInputs{
+			CreateGrantInput: credit.CreateGrantInput{
+				Amount:      float64(i),
+				EffectiveAt: firstEffectiveAt.Add(time.Duration(i) * time.Minute),
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	listParams := func() meteredentitlement.ListEntitlementGrantsParams {
+		return meteredentitlement.ListEntitlementGrantsParams{
+			CustomerID:                cust.ID,
+			EntitlementIDOrFeatureKey: ent.ID,
+			OrderBy:                   grant.OrderByEffectiveAt,
+			Order:                     sortx.OrderAsc,
+		}
+	}
+
+	t.Run("Should return the requested page and the total count", func(t *testing.T) {
+		// when the second page of size one is requested
+		params := listParams()
+		params.Page = pagination.NewPage(2, 1)
+
+		grants, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, params)
+		require.NoError(t, err)
+
+		// then only the second grant is returned, while the count still covers every grant
+		require.Len(t, grants.Items, 1)
+		require.Equal(t, 2.0, grants.Items[0].Amount)
+		require.Equal(t, 3, grants.TotalCount)
+		require.Equal(t, 2, grants.Page.PageNumber)
+		require.Equal(t, 1, grants.Page.PageSize)
+	})
+
+	t.Run("Should return the requested limit and offset window", func(t *testing.T) {
+		// when the deprecated limit/offset mode skips the first grant
+		params := listParams()
+		params.Limit = 2
+		params.Offset = 1
+
+		grants, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, params)
+		require.NoError(t, err)
+
+		// then the remaining two grants are returned; this mode carries no total count
+		require.Len(t, grants.Items, 2)
+		require.Equal(t, 2.0, grants.Items[0].Amount)
+		require.Equal(t, 3.0, grants.Items[1].Amount)
+	})
+
+	t.Run("Should reject an unbounded query", func(t *testing.T) {
+		// when neither pagination mode is provided the result set would be unbounded
+		_, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, listParams())
+		require.EqualError(t, err, "either Page or Limit is required")
+	})
+}

--- a/openmeter/entitlement/service/grants_test.go
+++ b/openmeter/entitlement/service/grants_test.go
@@ -110,10 +110,32 @@ func TestListEntitlementGrantsPagination(t *testing.T) {
 		grants, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, params)
 		require.NoError(t, err)
 
-		// then the remaining two grants are returned; this mode carries no total count
+		// then the remaining two grants are returned, and the count covers every match rather
+		// than the window, so a caller walking the offset can tell when it is done
 		require.Len(t, grants.Items, 2)
 		require.Equal(t, 2.0, grants.Items[0].Amount)
 		require.Equal(t, 3.0, grants.Items[1].Amount)
+		require.Equal(t, 3, grants.TotalCount)
+	})
+
+	t.Run("Should order by id", func(t *testing.T) {
+		// given ULIDs, which sort by creation time, ordering by id descending reverses the
+		// order the grants were issued in
+		params := listParams()
+		params.OrderBy = grant.OrderByID
+		params.Order = sortx.OrderDesc
+		params.Page = pagination.NewPage(1, 100)
+
+		// when the grants are listed
+		grants, err := deps.registry.MeteredEntitlement.ListEntitlementGrants(t.Context(), namespace, params)
+		require.NoError(t, err)
+
+		// then the ordering is applied, rather than the query going out unordered because the
+		// column has no mapping
+		require.Len(t, grants.Items, 3)
+		require.Equal(t, 3.0, grants.Items[0].Amount)
+		require.Equal(t, 2.0, grants.Items[1].Amount)
+		require.Equal(t, 1.0, grants.Items[2].Amount)
 	})
 
 	t.Run("Should reject an unbounded query", func(t *testing.T) {


### PR DESCRIPTION
## Problem

A customer reported that `GET /api/v2/customers/{customerIdOrKey}/entitlements/{entitlementIdOrFeatureKey}/grants` always returns 100 items regardless of `page`, `pageSize`, `limit`, or `offset`.

Confirmed: the handler's request decoder never copied the parsed query parameters into its request struct, so `request.Params` stayed a zero value and **every** documented query parameter was silently dropped:

- `page` → always 1
- `pageSize` → always 100
- `limit` / `offset` → ignored
- `order` / `orderBy` → ignored
- `includeDeleted` → always false

`totalCount` still reported the real total, so the response looked like paging should work while the rest of the grants were unreachable.

## Change

- Wire `params.Params` through the decoder.
- Select the pagination mode so the existing contract is preserved: `page`/`pageSize` wins when supplied, the deprecated `limit`/`offset` mode is entered only when one of those is actually sent, and a request carrying neither keeps the paginated default response (`page=1`, `pageSize=100`, real `totalCount`) this endpoint has always returned.
- `meteredentitlement.ListEntitlementGrantsParams` gains `IncludeDeleted`, `Limit`, and `Offset`, forwarded to the grant repository. `Validate()` aggregates field errors and rejects a request that bounds the result set with neither mode.
- `orderBy` now goes through `strcase.CamelToSnake` before becoming a `grant.OrderBy`. The raw API value (`createdAt`) matched no branch in the repository's ordering switch, so ordering was dropped even when the parameter was read.

### Two latent bugs this diff made reachable

Both were harmless while every request collapsed to page 1 with ordering forced to the default, and both bite once pagination and ordering actually work:

- **`orderBy=id` emitted no `ORDER BY`.** `GrantOrderBy` documents `id`, but `grant.OrderBy` had no such member, so the ordering switch fell through. Two `LIMIT/OFFSET` queries with no ordering can return the same grant on both pages or on neither. Added `grant.OrderByID` and the matching `db_grant.ByID` ordering. This also means `/api/v1/grants` stops rejecting `orderBy=id`, which its own enum documents.
- **The limit/offset branch never set `TotalCount`.** Clients that had been sending the previously-ignored `limit` would start receiving `totalCount: 0` beside a non-empty `items` array. The branch now counts matches before applying the window, which also settles `/api/v2/grants` — its response schema requires `totalCount` but it reported `0` in its default mode.

Note: `/api/v1/grants` returns a plain array when no page is given, so it now pays for a `COUNT` it discards. Happy to thread an `IncludeTotalCount` flag through `grant.ListParams` instead if reviewers prefer.

## Tests

- `openmeter/entitlement/service/grants_test.go` (new, Postgres-backed): page window with total count, limit/offset window with total count, `orderBy=id` ordering, unbounded query rejected, negative offset rejected.
- `e2e/entitlement_test.go`: `TestCustomerEntitlementGrantsPagination` drives the endpoint over HTTP for the empty-parameter default, `pageSize`-only, `limit`-only, explicit `page`, `page` winning over conflicting `limit`/`offset`, `limit`+`offset`, descending order, and a `page=0` rejection. The grants are created with amounts and effective dates running counter to their creation order, so an assertion on `createdAt` ordering cannot be satisfied by ordering on another column.

Verified locally: `go build ./...`, `go vet ./...`, `go vet -C e2e ./...`, `golangci-lint` on the changed packages, and `go test ./openmeter/entitlement/... ./openmeter/credit/...` against Postgres — all green. The e2e case has not been executed anywhere; it needs the live stack and no test workflow has triggered on this fork PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR wires customer-entitlement grant query parameters through the HTTP and service layers and completes pagination metadata and ID ordering support.
- Preserves page-based defaults while enabling deprecated limit/offset requests.
- Forwards deletion, ordering, and pagination options to the grant repository.
- Counts all matching grants before applying limit/offset and adds deterministic ID ordering.
- Adds service and E2E coverage for pagination modes, validation, counts, and ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/entitlement/driver/v2/customer_metered.go | Propagates parsed query parameters and selects page or legacy limit/offset pagination while normalizing ordering fields. |
| openmeter/entitlement/metered/entitlement_grant.go | Extends and validates entitlement grant list parameters before forwarding them to the repository. |
| openmeter/credit/adapter/grant.go | Adds ID ordering and populates total counts for limit/offset queries. |
| openmeter/credit/grant/repo.go | Adds ID to the supported grant ordering contract. |
| e2e/entitlement_test.go | Adds HTTP coverage for default, page-based, legacy, conflicting, ordered, and invalid pagination requests. |
| openmeter/entitlement/service/grants_test.go | Adds PostgreSQL-backed coverage for grant windows, total counts, ordering, and validation. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%234921%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=4921&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (7): Last reviewed commit: ["fix(credit): order grants by id and coun..."](https://github.com/openmeterio/openmeter/commit/2dce89e5917f9749f11baaa5ee31d6d283d5e0b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52612454)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/openmeterio/openmeter/blob/main/AGENTS.md))

<!-- /greptile_comment -->