### PR TITLE
fix(billing): return minimal invoice advancement targets

### DIFF
--- a/cmd/jobs/billing/advance/advance.go
+++ b/cmd/jobs/billing/advance/advance.go
@@ -39,8 +39,8 @@ var ListCmd = func() *cobra.Command {
 				return err
 			}
 
-			for _, invoice := range invoices {
-				fmt.Printf("Namespace: %s ID: %s\n", invoice.Namespace, invoice.ID)
+			for _, candidate := range invoices {
+				fmt.Printf("Namespace: %s ID: %s\n", candidate.InvoiceID.Namespace, candidate.InvoiceID.ID)
 			}
 
 			return nil

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -76,7 +76,7 @@ type StandardInvoiceAdapter interface {
 	GetStandardLinesForSubscription(ctx context.Context, input GetLinesForSubscriptionInput) (StandardLines, error)
 	GetStandardInvoiceById(ctx context.Context, input GetStandardInvoiceByIdInput) (StandardInvoice, error)
 	UpdateStandardInvoice(ctx context.Context, input UpdateStandardInvoiceAdapterInput) (StandardInvoice, error)
-	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]InvoiceID, error)
+	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]InvoiceAdvancementCandidate, error)
 	CountStandardInvoicesPendingAdvancement(ctx context.Context, input CountStandardInvoicesPendingAdvancementInput) (int64, error)
 }
 

--- a/openmeter/billing/adapter/invoice_advancement.go
+++ b/openmeter/billing/adapter/invoice_advancement.go
@@ -50,12 +50,12 @@ func invoicePendingAdvancementPredicate(filter billing.InvoicePendingAdvancement
 	)
 }
 
-func (a *adapter) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceID, error) {
+func (a *adapter) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceAdvancementCandidate, error) {
 	if err := input.Validate(); err != nil {
 		return nil, billing.ValidationError{Err: err}
 	}
 
-	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) ([]billing.InvoiceID, error) {
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) ([]billing.InvoiceAdvancementCandidate, error) {
 		query := tx.db.BillingInvoice.Query().
 			Where(
 				billinginvoice.DeletedAtIsNil(),
@@ -74,7 +74,7 @@ func (a *adapter) ListStandardInvoicesPendingAdvancement(ctx context.Context, in
 		}
 
 		query.
-			Select(billinginvoice.FieldNamespace, billinginvoice.FieldID).
+			Select(billinginvoice.FieldNamespace, billinginvoice.FieldID, billinginvoice.FieldCustomerID).
 			Order(billinginvoice.ByCreatedAt(entutils.GetOrdering(sortx.OrderDefault)...))
 
 		entities, err := query.All(ctx)
@@ -82,11 +82,14 @@ func (a *adapter) ListStandardInvoicesPendingAdvancement(ctx context.Context, in
 			return nil, fmt.Errorf("failed to list standard invoices pending advancement: %w", err)
 		}
 
-		invoices := make([]billing.InvoiceID, 0, len(entities))
+		invoices := make([]billing.InvoiceAdvancementCandidate, 0, len(entities))
 		for _, entity := range entities {
-			invoices = append(invoices, billing.InvoiceID{
-				Namespace: entity.Namespace,
-				ID:        entity.ID,
+			invoices = append(invoices, billing.InvoiceAdvancementCandidate{
+				InvoiceID: billing.InvoiceID{
+					Namespace: entity.Namespace,
+					ID:        entity.ID,
+				},
+				CustomerID: entity.CustomerID,
 			})
 		}
 

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -103,8 +103,8 @@ type StandardInvoiceService interface {
 	GetStandardInvoiceById(ctx context.Context, input GetStandardInvoiceByIdInput) (StandardInvoice, error)
 	// ListStandardInvoices lists standard invoices
 	ListStandardInvoices(ctx context.Context, input ListStandardInvoicesInput) (ListStandardInvoicesResponse, error)
-	// ListStandardInvoicesPendingAdvancement lists standard invoice IDs due for automatic advancement.
-	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]InvoiceID, error)
+	// ListStandardInvoicesPendingAdvancement lists the identifiers required to dispatch automatic advancement.
+	ListStandardInvoicesPendingAdvancement(ctx context.Context, input ListStandardInvoicesPendingAdvancementInput) ([]InvoiceAdvancementCandidate, error)
 	// CreateStandardInvoiceFromGatheringLines creates a standard invoice from the gathering invoice lines.
 	CreateStandardInvoiceFromGatheringLines(ctx context.Context, input CreateStandardInvoiceFromGatheringLinesInput) (*StandardInvoice, error)
 	// RegisterStandardInvoiceHooks registers hooks for standard invoice lifecycle events

--- a/openmeter/billing/service/stdinvoice.go
+++ b/openmeter/billing/service/stdinvoice.go
@@ -161,7 +161,7 @@ func (s *Service) ListStandardInvoices(ctx context.Context, input billing.ListSt
 	}, nil
 }
 
-func (s *Service) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceID, error) {
+func (s *Service) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceAdvancementCandidate, error) {
 	if err := input.Validate(); err != nil {
 		return nil, billing.ValidationError{Err: err}
 	}

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -1124,6 +1124,13 @@ type ListStandardInvoicesPendingAdvancementInput struct {
 	MinimumAge time.Duration
 }
 
+// InvoiceAdvancementCandidate contains the identifiers required to dispatch an
+// invoice advancement without resolving the invoice's workflow dependencies.
+type InvoiceAdvancementCandidate struct {
+	InvoiceID  InvoiceID
+	CustomerID string
+}
+
 var _ models.Validator = (*ListStandardInvoicesPendingAdvancementInput)(nil)
 
 func (i ListStandardInvoicesPendingAdvancementInput) Validate() error {

--- a/openmeter/billing/worker/advance/advance.go
+++ b/openmeter/billing/worker/advance/advance.go
@@ -31,7 +31,7 @@ func (a *AutoAdvancer) All(ctx context.Context, namespaces []string, batchSize i
 		return fmt.Errorf("failed to list invoices to advance: %w", err)
 	}
 
-	batches := [][]billing.InvoiceID{
+	batches := [][]billing.InvoiceAdvancementCandidate{
 		invoices,
 	}
 	if batchSize > 0 {
@@ -48,15 +48,15 @@ func (a *AutoAdvancer) All(ctx context.Context, namespaces []string, batchSize i
 
 	for _, batch := range batches {
 		var wg sync.WaitGroup
-		for _, invoice := range batch {
+		for _, candidate := range batch {
 			wg.Add(1)
 
 			go func() {
 				defer wg.Done()
 
-				_, err = a.AdvanceInvoice(ctx, invoice)
+				_, err := a.AdvanceInvoice(ctx, candidate.InvoiceID)
 				if err != nil {
-					err = fmt.Errorf("failed to auto-advance invoice [namespace=%s id=%s]: %w", invoice.Namespace, invoice.ID, err)
+					err = fmt.Errorf("failed to auto-advance invoice [namespace=%s id=%s]: %w", candidate.InvoiceID.Namespace, candidate.InvoiceID.ID, err)
 				}
 
 				errChan <- err
@@ -75,7 +75,7 @@ func (a *AutoAdvancer) All(ctx context.Context, namespaces []string, batchSize i
 	return errors.Join(errs...)
 }
 
-func (a *AutoAdvancer) ListInvoicesToAdvance(ctx context.Context, namespaces []string, ids []string) ([]billing.InvoiceID, error) {
+func (a *AutoAdvancer) ListInvoicesToAdvance(ctx context.Context, namespaces []string, ids []string) ([]billing.InvoiceAdvancementCandidate, error) {
 	invoices, err := a.invoice.ListStandardInvoicesPendingAdvancement(ctx, billing.ListStandardInvoicesPendingAdvancementInput{
 		Namespaces: namespaces,
 		IDs:        ids,

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1915,7 +1915,7 @@ func (n NoopBillingService) ListStandardInvoices(ctx context.Context, input bill
 	return billing.ListStandardInvoicesResponse{}, nil
 }
 
-func (n NoopBillingService) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceID, error) {
+func (n NoopBillingService) ListStandardInvoicesPendingAdvancement(ctx context.Context, input billing.ListStandardInvoicesPendingAdvancementInput) ([]billing.InvoiceAdvancementCandidate, error) {
 	return nil, nil
 }
 

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -643,10 +643,11 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 	// given:
 	// - gathering invoices for the same customer in two currencies, including a legacy nil collection time
 	// - another collectable customer in a second namespace
+	// - an invoice workflow reference that cannot be resolved in its namespace
 	// when:
 	// - customers pending collection are listed across both namespaces
 	// then:
-	// - each namespaced customer ID is returned exactly once
+	// - each namespaced customer ID is returned exactly once without resolving invoice dependencies
 	namespace := s.GetUniqueNamespace("gathering-pending-collection")
 	ctx := s.T().Context()
 
@@ -718,6 +719,20 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 		Namespace: secondNamespace,
 		Customer:  secondCustomer,
 	})
+
+	_, err = s.TestDB.PGDriver.DB().ExecContext(ctx,
+		`UPDATE billing_workflow_configs
+		 SET namespace = $1
+		 WHERE id = (
+			 SELECT workflow_config_id
+			 FROM billing_invoices
+			 WHERE namespace = $2 AND id = $3
+		 )`,
+		s.GetUniqueNamespace("gathering-pending-collection-foreign"),
+		namespace,
+		res.Invoice.ID,
+	)
+	require.NoError(s.T(), err)
 
 	customers, err := s.BillingService.ListCustomerIDsPendingCollection(ctx, billing.ListCustomerIDsPendingCollectionInput{
 		Namespaces: []string{namespace, secondNamespace},
@@ -3948,7 +3963,7 @@ func (s *InvoicingTestSuite) TestListPendingAdvancementDoesNotResolveWorkflowRef
 	// when:
 	// - pending advancement candidates are listed
 	// then:
-	// - the invoice identity is returned without resolving its workflow or tax code
+	// - the invoice and customer identities are returned without resolving its workflow or tax code
 	ctx := s.T().Context()
 	namespace := s.GetUniqueNamespace("pending-advancement")
 	s.ProvisionBillingProfile(ctx, namespace, s.InstallSandboxApp(s.T(), namespace).GetID())
@@ -3986,7 +4001,8 @@ func (s *InvoicingTestSuite) TestListPendingAdvancementDoesNotResolveWorkflowRef
 	})
 	s.Require().NoError(err)
 	s.Require().Len(candidates, 1)
-	s.Equal(invoices[0].GetInvoiceID(), candidates[0])
+	s.Equal(invoices[0].GetInvoiceID(), candidates[0].InvoiceID)
+	s.Equal(customerEntity.ID, candidates[0].CustomerID)
 }
 
 func (s *InvoicingTestSuite) TestProgressiveBillLate() {


### PR DESCRIPTION
## Summary

- return lightweight invoice advancement candidates containing only invoice and customer identifiers
- select only `namespace`, `id`, and `customer_id` during candidate discovery
- keep actual invoice advancement ID-only and avoid sharing error state between worker goroutines
- lock collection and advancement discovery against unresolvable invoice workflow references

This lets event dispatchers publish advancement work without hydrating a full invoice and resolving its workflow apps.

## Follow-up

Cloud should consume `InvoiceAdvancementCandidate` directly and remove the per-candidate `GetStandardInvoiceById` call from `SendInvoiceAdvanceEvents`.

Jira: no ticket yet; follow-up tickets are pending for the broader incident work.

## Verification

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/billing -run 'TestInvoicing/(TestListCustomerIDsPendingCollectionReturnsUniqueCustomersAcrossNamespaces|TestListPendingAdvancementDoesNotResolveWorkflowReferences)$' -count=1`
- `go test -tags=dynamic ./openmeter/billing/... ./cmd/jobs/billing/advance ./openmeter/server`
- `nix develop --impure .#ci -c make lint-go-fast`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces lightweight invoice-advancement candidates so discovery can return invoice and customer identifiers without hydrating workflow dependencies.
- Selects only namespace, invoice ID, and customer ID during pending-advancement discovery.
- Updates service, adapter, worker, CLI, and test interfaces to use the candidate type.
- Keeps advancement keyed by the namespaced invoice ID and removes shared goroutine error state.
- Adds integration coverage for unresolved cross-namespace workflow references.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or compatibility defects identified.

The changed interfaces and callers remain aligned, the partial projection includes every mapped non-nullable field, and concurrent advancement uses each candidate’s namespaced invoice ID with goroutine-local error state.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/adapter/invoice_advancement.go | Projects the three required identifier columns and maps them into lightweight advancement candidates without loading invoice relationships. |
| openmeter/billing/stdinvoice.go | Adds the candidate contract containing a namespaced invoice ID and its customer ID. |
| openmeter/billing/worker/advance/advance.go | Adapts batching to the candidate type while preserving ID-only advancement and making goroutine errors local. |
| cmd/jobs/billing/advance/advance.go | Updates candidate listing output to read the nested namespaced invoice identifier. |
| test/billing/invoice_test.go | Verifies lightweight discovery returns both identifiers and does not resolve invalid workflow references. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Job as Billing advance job
  participant Worker as AutoAdvancer
  participant Service as Billing service
  participant Adapter as Billing adapter
  participant DB as PostgreSQL
  Job->>Worker: ListInvoicesToAdvance(filters)
  Worker->>Service: ListStandardInvoicesPendingAdvancement
  Service->>Adapter: List pending candidates
  Adapter->>DB: SELECT namespace, id, customer_id
  DB-->>Adapter: Lightweight rows
  Adapter-->>Worker: InvoiceAdvancementCandidate[]
  loop Candidate batches
    Worker->>Service: AdvanceInvoice(candidate.InvoiceID)
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): return minimal invoice adv..."](https://github.com/openmeterio/openmeter/commit/9980563f6935f5937153aaad62c058a1bff67f78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52640757)</sub>

**Context used:**

- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Scheduled and Background Jobs (cmd/jobs)](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/jobs.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved automatic invoice advancement by including the customer identity with each eligible invoice.
  - Invoice processing now continues reliably when workflow configuration resides in a different namespace.
  - Pending invoice listings provide complete, uniquely identified invoice and customer information.

- **Bug Fixes**
  - Corrected invoice identification when displaying and processing invoices eligible for advancement.
  - Reduced reliance on workflow and tax-code configuration during pending invoice collection and advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->