### PR TITLE
fix(app): prevent uninstall of apps required by billing

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -280,7 +280,7 @@ func NewBillingRegistry(
 		return BillingRegistry{}, err
 	}
 
-	if err := appService.RegisterUninstallHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
+	if err := appService.RegisterHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
 		return BillingRegistry{}, fmt.Errorf("registering billing app uninstall validator: %w", err)
 	}
 

--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/google/wire"
@@ -23,6 +24,7 @@ import (
 	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
 	billingsequenceservice "github.com/openmeterio/openmeter/openmeter/billing/sequence/service"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
+	billingappuninstall "github.com/openmeterio/openmeter/openmeter/billing/validators/appuninstall"
 	billingcustomer "github.com/openmeterio/openmeter/openmeter/billing/validators/customer"
 	billingsubscription "github.com/openmeterio/openmeter/openmeter/billing/validators/subscription"
 	billingworkerautoadvance "github.com/openmeterio/openmeter/openmeter/billing/worker/advance"
@@ -273,6 +275,14 @@ func NewBillingRegistry(
 	}
 
 	// Hook registration
+	appUninstallValidator, err := billingappuninstall.NewValidator(billingRegistry.Billing)
+	if err != nil {
+		return BillingRegistry{}, err
+	}
+
+	if err := appService.RegisterUninstallHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
+		return BillingRegistry{}, fmt.Errorf("registering billing app uninstall validator: %w", err)
+	}
 
 	// Customer validate (and sync subscription on delete)
 	// To prevent circular dependencies, we create the validator here

--- a/openmeter/app/httpdriver/app.go
+++ b/openmeter/app/httpdriver/app.go
@@ -238,12 +238,6 @@ func (h *handler) UninstallApp() UninstallAppHandler {
 			}, nil
 		},
 		func(ctx context.Context, request UninstallAppRequest) (UninstallAppResponse, error) {
-			// Check if the app is not used by any billing profile
-
-			if err := h.billingService.IsAppUsed(ctx, request); err != nil {
-				return nil, err
-			}
-
 			// Uninstall app
 			err := h.service.UninstallApp(ctx, request)
 			if err != nil {

--- a/openmeter/app/service.go
+++ b/openmeter/app/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/servicehooks"
 )
 
 type Service interface {
@@ -25,10 +26,17 @@ type AppService interface {
 	UpdateAppStatus(ctx context.Context, input UpdateAppStatusInput) error
 	UpdateApp(ctx context.Context, input UpdateAppInput) (App, error)
 	ListApps(ctx context.Context, input ListAppInput) (pagination.Result[App], error)
+	RegisterUninstallHook(name string, hook servicehooks.Hook[AppUninstallEvent]) error
 	UninstallApp(ctx context.Context, input UninstallAppInput) error
 
 	// Customer data
 	ListCustomerData(ctx context.Context, input ListCustomerInput) (pagination.Result[CustomerApp], error)
 	EnsureCustomer(ctx context.Context, input EnsureCustomerInput) error
 	DeleteCustomer(ctx context.Context, input DeleteCustomerInput) error
+}
+
+// AppUninstallEvent contains the installed app state available to synchronous
+// validators before provider-specific resources are removed.
+type AppUninstallEvent struct {
+	App AppBase
 }

--- a/openmeter/app/service.go
+++ b/openmeter/app/service.go
@@ -26,7 +26,7 @@ type AppService interface {
 	UpdateAppStatus(ctx context.Context, input UpdateAppStatusInput) error
 	UpdateApp(ctx context.Context, input UpdateAppInput) (App, error)
 	ListApps(ctx context.Context, input ListAppInput) (pagination.Result[App], error)
-	RegisterUninstallHook(name string, hook servicehooks.Hook[AppUninstallEvent]) error
+	RegisterHook(name string, hook servicehooks.Hook[LifecycleEvent]) error
 	UninstallApp(ctx context.Context, input UninstallAppInput) error
 
 	// Customer data
@@ -35,8 +35,16 @@ type AppService interface {
 	DeleteCustomer(ctx context.Context, input DeleteCustomerInput) error
 }
 
-// AppUninstallEvent contains the installed app state available to synchronous
-// validators before provider-specific resources are removed.
-type AppUninstallEvent struct {
-	App AppBase
+type OperationKind string
+
+const (
+	OperationKindUninstall OperationKind = "uninstall"
+)
+
+// LifecycleEvent contains the app state available to synchronous hooks for an
+// operation. Before and After are populated according to the operation kind.
+type LifecycleEvent struct {
+	Operation OperationKind
+	Before    *AppBase
+	After     *AppBase
 }

--- a/openmeter/app/service/app.go
+++ b/openmeter/app/service/app.go
@@ -13,8 +13,8 @@ import (
 
 var _ app.AppService = (*Service)(nil)
 
-func (s *Service) RegisterUninstallHook(name string, hook servicehooks.Hook[app.AppUninstallEvent]) error {
-	return s.uninstallHooks.Register(name, hook)
+func (s *Service) RegisterHook(name string, hook servicehooks.Hook[app.LifecycleEvent]) error {
+	return s.hooks.Register(name, hook)
 }
 
 func (s *Service) CreateApp(ctx context.Context, input app.CreateAppInput) (app.AppBase, error) {
@@ -112,10 +112,12 @@ func (s *Service) UninstallApp(ctx context.Context, input app.UninstallAppInput)
 			return uninstallResult{}, err
 		}
 
-		if err := s.uninstallHooks.Invoke(ctx, app.AppUninstallEvent{
-			App: existingApp.GetAppBase(),
+		before := existingApp.GetAppBase()
+		if err := s.hooks.Invoke(ctx, app.LifecycleEvent{
+			Operation: app.OperationKindUninstall,
+			Before:    &before,
 		}); err != nil {
-			return uninstallResult{}, fmt.Errorf("invoking app uninstall hooks: %w", err)
+			return uninstallResult{}, fmt.Errorf("invoking app lifecycle hooks: %w", err)
 		}
 
 		// Delete the app

--- a/openmeter/app/service/app.go
+++ b/openmeter/app/service/app.go
@@ -2,14 +2,20 @@ package appservice
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/servicehooks"
 )
 
 var _ app.AppService = (*Service)(nil)
+
+func (s *Service) RegisterUninstallHook(name string, hook servicehooks.Hook[app.AppUninstallEvent]) error {
+	return s.uninstallHooks.Register(name, hook)
+}
 
 func (s *Service) CreateApp(ctx context.Context, input app.CreateAppInput) (app.AppBase, error) {
 	// Validate the input
@@ -94,25 +100,47 @@ func (s *Service) UninstallApp(ctx context.Context, input app.UninstallAppInput)
 		return models.NewGenericValidationError(err)
 	}
 
-	// Existing app
-	existingApp, err := s.adapter.GetApp(ctx, input)
+	type uninstallResult struct {
+		appBase      app.AppBase
+		eventAppData app.EventAppData
+	}
+
+	result, err := transaction.Run(ctx, s.adapter, func(ctx context.Context) (uninstallResult, error) {
+		// Existing app
+		existingApp, err := s.adapter.GetApp(ctx, input)
+		if err != nil {
+			return uninstallResult{}, err
+		}
+
+		if err := s.uninstallHooks.Invoke(ctx, app.AppUninstallEvent{
+			App: existingApp.GetAppBase(),
+		}); err != nil {
+			return uninstallResult{}, fmt.Errorf("invoking app uninstall hooks: %w", err)
+		}
+
+		// Delete the app
+		appBase, err := s.adapter.UninstallApp(ctx, input)
+		if err != nil {
+			return uninstallResult{}, err
+		}
+
+		// Capture event data while the concrete app still exists.
+		eventAppData, err := existingApp.GetEventAppData()
+		if err != nil {
+			return uninstallResult{}, err
+		}
+
+		return uninstallResult{
+			appBase:      *appBase,
+			eventAppData: eventAppData,
+		}, nil
+	})
 	if err != nil {
 		return err
 	}
 
-	// Delete the app
-	appBase, err := s.adapter.UninstallApp(ctx, input)
-	if err != nil {
-		return err
-	}
-
-	// Emit the app deleted event
-	eventAppData, err := existingApp.GetEventAppData()
-	if err != nil {
-		return err
-	}
-
-	event := app.NewAppDeleteEvent(ctx, *appBase, eventAppData)
+	// Emit the app deleted event after the uninstall transaction has committed.
+	event := app.NewAppDeleteEvent(ctx, result.appBase, result.eventAppData)
 	if err := s.publisher.Publish(ctx, event); err != nil {
 		return err
 	}

--- a/openmeter/app/service/service.go
+++ b/openmeter/app/service/service.go
@@ -11,9 +11,9 @@ import (
 var _ app.Service = (*Service)(nil)
 
 type Service struct {
-	adapter        app.Adapter
-	publisher      eventbus.Publisher
-	uninstallHooks servicehooks.Registry[app.AppUninstallEvent]
+	adapter   app.Adapter
+	publisher eventbus.Publisher
+	hooks     servicehooks.Registry[app.LifecycleEvent]
 }
 
 type Config struct {

--- a/openmeter/app/service/service.go
+++ b/openmeter/app/service/service.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/servicehooks"
 )
 
 var _ app.Service = (*Service)(nil)
 
 type Service struct {
-	adapter   app.Adapter
-	publisher eventbus.Publisher
+	adapter        app.Adapter
+	publisher      eventbus.Publisher
+	uninstallHooks servicehooks.Registry[app.AppUninstallEvent]
 }
 
 type Config struct {

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -130,3 +130,6 @@ asynchronously; webhook delivery is not part of the invoice lifecycle.
 - line engines cannot silently change the identity or count of callback output
 - immutable invoice drift is recorded as validation issues rather than
   rewriting customer-visible history
+- an app referenced by a non-final invoice cannot be uninstalled, because its
+  provider-specific resources are required to complete that invoice's
+  snapshotted workflow

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -817,61 +817,59 @@ func (a *adapter) IsAppUsed(ctx context.Context, appID app.AppID) error {
 		}
 	}
 
-	// Check if the app is used in any billing profile
-	err := a.isBillingProfileUsed(ctx, appID)
-	if err != nil {
-		return err
-	}
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		// Check if the app is used in any billing profile
+		if err := tx.isBillingProfileUsed(ctx, appID); err != nil {
+			return err
+		}
 
-	// Check if the app is used in any invoice in gathering or issued states
-	usedInInvoices, err := a.db.BillingInvoice.
-		Query().
-		Where(billinginvoice.Namespace(appID.Namespace)).
-		Where(
-			// The non-final states are listed here, so that we can make sure that all
-			// invoices can reach a final state before the app is removed.
-			billinginvoice.StatusIn(
-				billing.StandardInvoiceStatusGathering,
-				billing.StandardInvoiceStatusIssuingLineFinalization,
-				billing.StandardInvoiceStatusIssuingLineFinalizationFailed,
-				billing.StandardInvoiceStatusIssuingSyncing,
-				billing.StandardInvoiceStatusIssuingSyncFailed,
-				billing.StandardInvoiceStatusIssuingChargeBooking,
-				billing.StandardInvoiceStatusIssuingChargeBookingFailed,
-				billing.StandardInvoiceStatusIssued,
-				billing.StandardInvoiceStatusPaymentProcessingPending,
-				billing.StandardInvoiceStatusPaymentProcessingBookingAuthorized,
-				billing.StandardInvoiceStatusPaymentProcessingBookingAuthorizedFailed,
-				billing.StandardInvoiceStatusPaymentProcessingBookingAuthorizedAndSettled,
-				billing.StandardInvoiceStatusPaymentProcessingBookingAuthorizedAndSettledFailed,
-				billing.StandardInvoiceStatusPaymentProcessingAuthorized,
-				billing.StandardInvoiceStatusPaymentProcessingFailed,
-				billing.StandardInvoiceStatusPaymentProcessingActionRequired,
-				billing.StandardInvoiceStatusPaymentProcessingBookingSettled,
-				billing.StandardInvoiceStatusPaymentProcessingBookingSettledFailed,
-				billing.StandardInvoiceStatusOverdue,
-			),
-			billinginvoice.DeletedAtIsNil(),
-		).
-		Where(
-			billinginvoice.Or(
-				billinginvoice.InvoicingAppID(appID.ID),
-				billinginvoice.PaymentAppID(appID.ID),
-				billinginvoice.TaxAppID(appID.ID),
-			),
-		).
-		All(ctx)
-	if err != nil {
-		return err
-	}
+		// Invoice app references are immutable history. Every non-final standard
+		// invoice that references an app must be able to complete its lifecycle
+		// before the app's provider-specific resources are removed.
+		query := tx.db.BillingInvoice.
+			Query().
+			Where(
+				billinginvoice.Namespace(appID.Namespace),
+				billinginvoice.TypeEQ(billing.InvoiceTypeStandard),
+				billinginvoice.StatusNotIn(
+					billing.StandardInvoiceStatusDeleted,
+					billing.StandardInvoiceStatusPaid,
+					billing.StandardInvoiceStatusUncollectible,
+					billing.StandardInvoiceStatusVoided,
+				),
+				billinginvoice.DeletedAtIsNil(),
+				billinginvoice.Or(
+					billinginvoice.InvoicingAppID(appID.ID),
+					billinginvoice.PaymentAppID(appID.ID),
+					billinginvoice.TaxAppID(appID.ID),
+				),
+			)
 
-	if len(usedInInvoices) > 0 {
-		return models.NewGenericConflictError(fmt.Errorf("app is used in %d non-finalized invoices: %s", len(usedInInvoices), strings.Join(lo.Map(usedInInvoices, func(invoice *db.BillingInvoice, _ int) string {
-			return fmt.Sprintf("%s[%s]", invoice.Number, invoice.ID)
-		}), ",")))
-	}
+		count, err := query.Clone().Count(ctx)
+		if err != nil {
+			return err
+		}
 
-	return nil
+		usedInInvoices, err := query.
+			Limit(appUsageReferenceLimit).
+			All(ctx)
+		if err != nil {
+			return err
+		}
+
+		if count > 0 {
+			references := strings.Join(lo.Map(usedInInvoices, func(invoice *db.BillingInvoice, _ int) string {
+				return fmt.Sprintf("%s[%s]", invoice.Number, invoice.ID)
+			}), ",")
+			if count > len(usedInInvoices) {
+				references += fmt.Sprintf(", and %d more", count-len(usedInInvoices))
+			}
+
+			return models.NewGenericConflictError(fmt.Errorf("app is used in %d non-finalized invoices: %s", count, references))
+		}
+
+		return nil
+	})
 }
 
 func (a *adapter) GetInvoiceType(ctx context.Context, input billing.GetInvoiceTypeAdapterInput) (billing.InvoiceType, error) {

--- a/openmeter/billing/adapter/profile.go
+++ b/openmeter/billing/adapter/profile.go
@@ -33,6 +33,8 @@ import (
 
 var _ billing.ProfileAdapter = (*adapter)(nil)
 
+const appUsageReferenceLimit = 10
+
 func workflowConfigWithTaxCode(namespace string) func(*db.BillingWorkflowConfigQuery) {
 	return func(q *db.BillingWorkflowConfigQuery) {
 		q.Where(billingworkflowconfig.Namespace(namespace)).
@@ -383,9 +385,8 @@ func (a *adapter) isBillingProfileUsed(ctx context.Context, appID app.AppID) err
 		return fmt.Errorf("invalid app id: %w", err)
 	}
 
-	profiles, err := a.db.BillingProfile.Query().
+	query := a.db.BillingProfile.Query().
 		Where(
-
 			billingprofile.Namespace(appID.Namespace),
 			billingprofile.Or(
 				billingprofile.InvoicingAppID(appID.ID),
@@ -393,16 +394,29 @@ func (a *adapter) isBillingProfileUsed(ctx context.Context, appID app.AppID) err
 				billingprofile.TaxAppID(appID.ID),
 			),
 			billingprofile.DeletedAtIsNil(),
-		).
+		)
+
+	count, err := query.Clone().Count(ctx)
+	if err != nil {
+		return err
+	}
+
+	profiles, err := query.
+		Limit(appUsageReferenceLimit).
 		All(ctx)
 	if err != nil {
 		return err
 	}
 
-	if len(profiles) > 0 {
-		return models.NewGenericConflictError(fmt.Errorf("app is used in %d billing profiles: %s", len(profiles), strings.Join(lo.Map(profiles, func(profile *db.BillingProfile, _ int) string {
+	if count > 0 {
+		references := strings.Join(lo.Map(profiles, func(profile *db.BillingProfile, _ int) string {
 			return fmt.Sprintf("%s[%s]", profile.Name, profile.ID)
-		}), ",")))
+		}), ",")
+		if count > len(profiles) {
+			references += fmt.Sprintf(", and %d more", count-len(profiles))
+		}
+
+		return models.NewGenericConflictError(fmt.Errorf("app is used in %d billing profiles: %s", count, references))
 	}
 
 	return nil

--- a/openmeter/billing/validators/appuninstall/validator.go
+++ b/openmeter/billing/validators/appuninstall/validator.go
@@ -1,0 +1,41 @@
+package appuninstall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/pkg/servicehooks"
+)
+
+// HookName identifies the billing app-usage validator in the app uninstall registry.
+const HookName = "billing.app-usage"
+
+type appUsageChecker interface {
+	IsAppUsed(ctx context.Context, appID app.AppID) error
+}
+
+var _ servicehooks.Hook[app.AppUninstallEvent] = (*Validator)(nil)
+
+type Validator struct {
+	appUsageChecker appUsageChecker
+}
+
+func NewValidator(appUsageChecker appUsageChecker) (*Validator, error) {
+	if appUsageChecker == nil {
+		return nil, errors.New("app usage checker is required")
+	}
+
+	return &Validator{
+		appUsageChecker: appUsageChecker,
+	}, nil
+}
+
+func (v *Validator) Handle(ctx context.Context, event app.AppUninstallEvent) error {
+	if err := v.appUsageChecker.IsAppUsed(ctx, event.App.GetID()); err != nil {
+		return fmt.Errorf("validating billing app usage: %w", err)
+	}
+
+	return nil
+}

--- a/openmeter/billing/validators/appuninstall/validator.go
+++ b/openmeter/billing/validators/appuninstall/validator.go
@@ -9,14 +9,14 @@ import (
 	"github.com/openmeterio/openmeter/pkg/servicehooks"
 )
 
-// HookName identifies the billing app-usage validator in the app uninstall registry.
+// HookName identifies the billing app-usage validator in the app lifecycle registry.
 const HookName = "billing.app-usage"
 
 type appUsageChecker interface {
 	IsAppUsed(ctx context.Context, appID app.AppID) error
 }
 
-var _ servicehooks.Hook[app.AppUninstallEvent] = (*Validator)(nil)
+var _ servicehooks.Hook[app.LifecycleEvent] = (*Validator)(nil)
 
 type Validator struct {
 	appUsageChecker appUsageChecker
@@ -32,8 +32,16 @@ func NewValidator(appUsageChecker appUsageChecker) (*Validator, error) {
 	}, nil
 }
 
-func (v *Validator) Handle(ctx context.Context, event app.AppUninstallEvent) error {
-	if err := v.appUsageChecker.IsAppUsed(ctx, event.App.GetID()); err != nil {
+func (v *Validator) Handle(ctx context.Context, event app.LifecycleEvent) error {
+	if event.Operation != app.OperationKindUninstall {
+		return nil
+	}
+
+	if event.Before == nil {
+		return errors.New("app state before uninstall is required")
+	}
+
+	if err := v.appUsageChecker.IsAppUsed(ctx, event.Before.GetID()); err != nil {
 		return fmt.Errorf("validating billing app usage: %w", err)
 	}
 

--- a/openmeter/billing/validators/appuninstall/validator_test.go
+++ b/openmeter/billing/validators/appuninstall/validator_test.go
@@ -1,0 +1,74 @@
+package appuninstall
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type appUsageCheckerStub struct {
+	appID app.AppID
+	err   error
+	calls int
+}
+
+func (s *appUsageCheckerStub) IsAppUsed(_ context.Context, appID app.AppID) error {
+	s.appID = appID
+	s.calls++
+
+	return s.err
+}
+
+func TestValidatorHandlesUninstallOperation(t *testing.T) {
+	rejected := errors.New("app is in use")
+	checker := &appUsageCheckerStub{err: rejected}
+	validator, err := NewValidator(checker)
+	require.NoError(t, err)
+
+	before := app.AppBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "test"},
+			ID:              "app-1",
+		},
+	}
+
+	err = validator.Handle(t.Context(), app.LifecycleEvent{
+		Operation: app.OperationKindUninstall,
+		Before:    &before,
+	})
+
+	require.ErrorIs(t, err, rejected)
+	require.Equal(t, 1, checker.calls)
+	require.Equal(t, before.GetID(), checker.appID)
+}
+
+func TestValidatorIgnoresOtherOperations(t *testing.T) {
+	checker := &appUsageCheckerStub{}
+	validator, err := NewValidator(checker)
+	require.NoError(t, err)
+
+	err = validator.Handle(t.Context(), app.LifecycleEvent{
+		Operation: app.OperationKind("create"),
+	})
+
+	require.NoError(t, err)
+	require.Zero(t, checker.calls)
+}
+
+func TestValidatorRequiresStateBeforeUninstall(t *testing.T) {
+	checker := &appUsageCheckerStub{}
+	validator, err := NewValidator(checker)
+	require.NoError(t, err)
+
+	err = validator.Handle(t.Context(), app.LifecycleEvent{
+		Operation: app.OperationKindUninstall,
+	})
+
+	require.EqualError(t, err, "app state before uninstall is required")
+	require.Zero(t, checker.calls)
+}

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1333,7 +1333,7 @@ func (n NoopAppService) ListApps(ctx context.Context, input app.ListAppInput) (p
 	return pagination.Result[app.App]{}, nil
 }
 
-func (n NoopAppService) RegisterUninstallHook(name string, hook servicehooks.Hook[app.AppUninstallEvent]) error {
+func (n NoopAppService) RegisterHook(name string, hook servicehooks.Hook[app.LifecycleEvent]) error {
 	return nil
 }
 

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/ref"
+	"github.com/openmeterio/openmeter/pkg/servicehooks"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -1330,6 +1331,10 @@ func (n NoopAppService) UpdateApp(ctx context.Context, input app.UpdateAppInput)
 
 func (n NoopAppService) ListApps(ctx context.Context, input app.ListAppInput) (pagination.Result[app.App], error) {
 	return pagination.Result[app.App]{}, nil
+}
+
+func (n NoopAppService) RegisterUninstallHook(name string, hook servicehooks.Hook[app.AppUninstallEvent]) error {
+	return nil
 }
 
 func (n NoopAppService) UninstallApp(ctx context.Context, input app.UninstallAppInput) error {

--- a/test/app/stripe/app_test.go
+++ b/test/app/stripe/app_test.go
@@ -48,6 +48,10 @@ func TestAppStripe(t *testing.T) {
 			testSuite.TestUninstall(ctx, t)
 		})
 
+		t.Run("UninstallInUse", func(t *testing.T) {
+			testSuite.TestUninstallInUse(ctx, t)
+		})
+
 		t.Run("CustomerData", func(t *testing.T) {
 			testSuite.TestCustomerData(ctx, t)
 		})

--- a/test/app/stripe/appstripe.go
+++ b/test/app/stripe/appstripe.go
@@ -182,6 +182,32 @@ func (s *AppHandlerTestSuite) TestUninstall(ctx context.Context, t *testing.T) {
 	require.True(t, app.IsAppNotFoundError(err), "get after uninstall must return app not found error")
 }
 
+// TestUninstallInUse verifies that billing usage prevents provider cleanup.
+func (s *AppHandlerTestSuite) TestUninstallInUse(ctx context.Context, t *testing.T) {
+	s.setupNamespace(t)
+
+	// Given an installed Stripe app referenced by a billing profile.
+	testApp, err := s.Env.Fixture().setupApp(ctx, s.namespace)
+	require.NoError(t, err, "setup fixture must not return error")
+
+	_, err = s.Env.Billing().CreateProfile(ctx, stripeBillingProfileInput(t, s.namespace, testApp.GetID()))
+	require.NoError(t, err, "create billing profile must not return error")
+
+	// Isolate provider-cleanup calls made by this test from the shared test environment.
+	s.Env.StripeAppClient().Restore()
+	s.Env.StripeAppClient().Calls = nil
+
+	// When uninstalling through the app service, billing vetoes the operation.
+	err = s.Env.App().UninstallApp(ctx, testApp.GetID())
+	require.True(t, models.IsGenericConflictError(err), "uninstalling an app in use must return conflict error")
+
+	// Then no provider resource is removed and the app remains installed.
+	s.Env.StripeAppClient().AssertNotCalled(t, "DeleteWebhook", mock.Anything)
+	installedApp, err := s.Env.App().GetApp(ctx, testApp.GetID())
+	require.NoError(t, err, "get after rejected uninstall must not return error")
+	require.Equal(t, testApp.GetID(), installedApp.GetID())
+}
+
 // TestCustomerData tests stripe app behavior when adding customer data
 func (s *AppHandlerTestSuite) TestCustomerData(ctx context.Context, t *testing.T) {
 	s.setupNamespace(t)
@@ -397,22 +423,16 @@ func (s *AppHandlerTestSuite) TestCustomerData(ctx context.Context, t *testing.T
 	require.Equal(t, testApp.GetID(), listCustomerData.Items[0].App.GetID(), "App ID must match")
 }
 
-// TestCustomerValidate tests stripe app behavior when validating a customer
-func (s *AppHandlerTestSuite) TestCustomerValidate(ctx context.Context, t *testing.T) {
-	// Create test app
-	testApp, testCustomer, _, err := s.Env.Fixture().setupAppWithCustomer(ctx, s.namespace)
-	require.NoError(t, err, "setup fixture must not return error")
+func stripeBillingProfileInput(t *testing.T, namespace string, appID app.AppID) billing.CreateProfileInput {
+	t.Helper()
 
-	// Create default billing profile
-	billingProfile, err := s.Env.Billing().CreateProfile(ctx, billing.CreateProfileInput{
-		Namespace: s.namespace,
+	return billing.CreateProfileInput{
+		Namespace: namespace,
 		Default:   true,
 		Name:      "Awesome Default Profile",
-
 		Metadata: map[string]string{
 			"key": "value",
 		},
-
 		WorkflowConfig: billing.WorkflowConfig{
 			Collection: billing.CollectionConfig{
 				Alignment: billing.AlignmentKindSubscription,
@@ -432,7 +452,6 @@ func (s *AppHandlerTestSuite) TestCustomerValidate(ctx context.Context, t *testi
 				Enforced: false,
 			},
 		},
-
 		Supplier: billing.SupplierContact{
 			Name: "Awesome Supplier",
 			Address: models.Address{
@@ -445,13 +464,22 @@ func (s *AppHandlerTestSuite) TestCustomerValidate(ctx context.Context, t *testi
 				PhoneNumber: lo.ToPtr("1234567890"),
 			},
 		},
-
 		Apps: billing.CreateProfileAppsInput{
-			Invoicing: testApp.GetID(),
-			Payment:   testApp.GetID(),
-			Tax:       testApp.GetID(),
+			Invoicing: appID,
+			Payment:   appID,
+			Tax:       appID,
 		},
-	})
+	}
+}
+
+// TestCustomerValidate tests stripe app behavior when validating a customer
+func (s *AppHandlerTestSuite) TestCustomerValidate(ctx context.Context, t *testing.T) {
+	// Create test app
+	testApp, testCustomer, _, err := s.Env.Fixture().setupAppWithCustomer(ctx, s.namespace)
+	require.NoError(t, err, "setup fixture must not return error")
+
+	// Create default billing profile
+	billingProfile, err := s.Env.Billing().CreateProfile(ctx, stripeBillingProfileInput(t, s.namespace, testApp.GetID()))
 	require.NoError(t, err, "Create billing profile must not return error")
 
 	// Create customer without stripe data

--- a/test/app/stripe/testenv.go
+++ b/test/app/stripe/testenv.go
@@ -15,6 +15,7 @@ import (
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 	appstripeservice "github.com/openmeterio/openmeter/openmeter/app/stripe/service"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingappuninstall "github.com/openmeterio/openmeter/openmeter/billing/validators/appuninstall"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
@@ -159,6 +160,15 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create billing service: %w", err)
+	}
+
+	appUninstallValidator, err := billingappuninstall.NewValidator(billingService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create billing app uninstall validator: %w", err)
+	}
+
+	if err := appService.RegisterUninstallHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
+		return nil, fmt.Errorf("failed to register billing app uninstall validator: %w", err)
 	}
 
 	// Stripe Client

--- a/test/app/stripe/testenv.go
+++ b/test/app/stripe/testenv.go
@@ -167,7 +167,7 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		return nil, fmt.Errorf("failed to create billing app uninstall validator: %w", err)
 	}
 
-	if err := appService.RegisterUninstallHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
+	if err := appService.RegisterHook(billingappuninstall.HookName, appUninstallValidator); err != nil {
 		return nil, fmt.Errorf("failed to register billing app uninstall validator: %w", err)
 	}
 

--- a/test/billing/profile_test.go
+++ b/test/billing/profile_test.go
@@ -280,6 +280,44 @@ func (s *ProfileTestSuite) TestProfileLifecycle() {
 	})
 }
 
+func (s *ProfileTestSuite) TestDeletedProfileAppUsageFollowsNonFinalInvoices() {
+	t := s.T()
+	ctx := t.Context()
+	namespace := s.GetUniqueNamespace("deleted-profile-app-usage")
+
+	// Given a draft invoice that snapshots the apps from the current default profile.
+	referencedApp := s.InstallSandboxApp(t, namespace)
+	referencedProfile := s.ProvisionBillingProfile(ctx, namespace, referencedApp.GetID())
+	customerEntity := s.CreateTestCustomer(namespace, ulid.Make().String())
+	invoice := s.CreateDraftInvoice(t, ctx, DraftInvoiceInput{
+		Namespace: namespace,
+		Customer:  customerEntity,
+	})
+
+	// And the profile is superseded and deleted, leaving the invoice as the only reference.
+	replacementApp := s.InstallSandboxApp(t, namespace)
+	s.ProvisionBillingProfile(ctx, namespace, replacementApp.GetID())
+	require.NoError(t, s.BillingService.DeleteProfile(ctx, billing.DeleteProfileInput{
+		Namespace: namespace,
+		ID:        referencedProfile.ID,
+	}))
+
+	// Then the non-final invoice keeps the referenced app in use.
+	err := s.BillingService.IsAppUsed(ctx, referencedApp.GetID())
+	var conflictErr *models.GenericConflictError
+	require.ErrorAs(t, err, &conflictErr)
+	require.ErrorContains(t, err, invoice.ID)
+
+	// When the invoice reaches a final state, it no longer prevents uninstall.
+	invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        invoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceAPIRequest,
+	})
+	require.NoError(t, err)
+	require.Equal(t, billing.StandardInvoiceStatusDeleted, invoice.Status)
+	require.NoError(t, s.BillingService.IsAppUsed(ctx, referencedApp.GetID()))
+}
+
 func (s *ProfileTestSuite) TestProfileFieldSetting() {
 	ctx := context.Background()
 	t := s.T()


### PR DESCRIPTION
## Summary

- add synchronous typed app-uninstall hooks and invoke them inside the uninstall transaction before provider-specific cleanup
- register a billing validator that prevents uninstall while an app is referenced by an active billing profile or a non-final standard invoice
- treat invoice app references as immutable lifecycle history and bound conflict diagnostics
- add PostgreSQL-backed billing and Stripe regressions for deleted-profile invoice references, final invoice release, and provider cleanup veto

## Root cause

App usage validation lived at the HTTP boundary, so service-level uninstall callers could bypass it. The invoice usage query also enumerated selected active statuses and omitted draft states. After a billing profile was replaced or deleted, its draft invoices still owned snapshotted app references, but those references did not prevent the Stripe app from being uninstalled. Later invoice advancement then failed while resolving the missing app.

The guard now runs at the app service boundary before provider resources are removed, and billing blocks on every non-final standard invoice instead of maintaining an incomplete active-state allowlist.

## Impact

Apps required to complete non-final invoices cannot be uninstalled. Once the referencing invoices reach a final state, uninstall is allowed again.

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/billing ./test/app/stripe -count=1`
- `make lint-go-fast` for affected packages
- `make lint-go-style` for affected packages
- full configured `make lint-go`

## Context

Maintenance follow-up to #4923. No Jira ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle validation for app uninstall operations.
  * Apps cannot be uninstalled while referenced by active billing profiles or non-final invoices.
  * Uninstall checks now run before removal, with changes finalized transactionally.

* **Bug Fixes**
  * Improved conflict messages by listing affected billing references and additional items.

* **Tests**
  * Added coverage for protected app uninstall scenarios and invoice/profile usage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves billing app-usage enforcement into the app service’s transactional uninstall lifecycle and protects apps referenced by active profiles or non-final standard invoices.
- Adds typed synchronous lifecycle hooks and registers the billing uninstall validator during application wiring.
- Checks immutable invoice app references against final invoice states and bounds conflict diagnostics.
- Adds PostgreSQL-backed regression coverage for deleted profiles, invoice finalization, and provider-cleanup vetoes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/app/service/app.go | Runs uninstall hooks, provider cleanup, and app deletion within the uninstall transaction, then publishes the delete event. |
| openmeter/billing/adapter/invoice.go | Blocks uninstall for app references held by every non-final standard invoice and limits diagnostic reference enumeration. |
| openmeter/billing/adapter/profile.go | Preserves active-profile usage checks while bounding the profile references included in conflict errors. |
| openmeter/billing/validators/appuninstall/validator.go | Implements the typed billing lifecycle hook that validates app usage before uninstall. |
| app/common/billing.go | Registers the billing uninstall validator with the app service during dependency construction. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant AppService
    participant Hooks
    participant Billing
    participant Provider
    participant Database
    Caller->>AppService: UninstallApp(app ID)
    AppService->>Database: Begin transaction and load app
    AppService->>Hooks: Invoke uninstall lifecycle event
    Hooks->>Billing: IsAppUsed(app ID)
    Billing->>Database: Check active profiles and non-final invoices
    alt App is referenced
        Billing-->>Hooks: Conflict
        Hooks-->>AppService: Veto uninstall
        AppService->>Database: Roll back
        AppService-->>Caller: Conflict
    else App is unused
        Billing-->>Hooks: Allowed
        AppService->>Provider: Remove provider resources
        AppService->>Database: Soft-delete app and commit
        AppService-->>Caller: Success
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(app): generalize lifecycle hook"](https://github.com/openmeterio/openmeter/commit/8ec918af685c371d30c536ebfdea06acaeb22e02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52901741)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [App Framework (Marketplace Integrations)](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/app.md)
- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Typed service hooks](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/service-hooks.md)
</details>

<!-- /greptile_comment -->