### PR TITLE
fix(ci): support fork pull requests

### DIFF
--- a/.github/workflows/aip-npm-release.yaml
+++ b/.github/workflows/aip-npm-release.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/analysis-scorecard.yaml
+++ b/.github/workflows/analysis-scorecard.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -162,7 +162,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -67,7 +67,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -148,7 +148,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -219,7 +219,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -267,7 +267,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -335,7 +335,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -373,7 +373,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -458,7 +458,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -508,7 +508,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -646,7 +646,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -667,7 +667,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -692,7 +692,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -828,7 +828,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/release-go-sdk.yaml
+++ b/.github/workflows/release-go-sdk.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -124,7 +124,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -207,7 +207,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -306,7 +306,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/sdk-python-dev-release.yaml
+++ b/.github/workflows/sdk-python-dev-release.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -72,7 +72,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/untrusted-artifacts.yaml
+++ b/.github/workflows/untrusted-artifacts.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository
@@ -69,7 +69,7 @@ jobs:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
-          use-policy-store: true
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- enable the StepSecurity policy store only when its API key is available
- keep Harden Runner in audit mode when fork PRs do not receive repository secrets

## Root cause

GitHub does not pass repository secrets to workflows triggered by fork pull requests. The Harden Runner pre-step rejected `use-policy-store: true` without `STEP_SECURITY_API_KEY`, causing jobs to fail before checkout.

This unblocks CI for fork PRs such as #4921 while preserving policy-store behavior for trusted runs.

## Validation

- `nix shell nixpkgs#actionlint -c actionlint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated automated workflows to use the security policy store only when the required security API key is configured.
  - Prevented policy-store access from being enabled unconditionally across build, release, testing, and analysis workflows.
- **Reliability**
  - Improved workflow compatibility for environments where the security API key is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR conditionally enables StepSecurity’s policy store only when its API key is available, allowing workflows without repository secrets—particularly fork pull requests—to continue in audit mode.
- Applies the secret-availability check consistently to all Harden Runner invocations across 13 workflows.
- Preserves policy-store behavior for trusted runs where `STEP_SECURITY_API_KEY` is available.
- Leaves each workflow’s existing triggers, jobs, and egress audit policy unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the conditional policy-store configuration.

The expression passes Harden Runner the expected true or false value based on API-key availability, and every repository invocation was updated consistently while retaining audit mode.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Conditionally enables the policy store across CI jobs, including fork-aware artifact and pull-request paths, without changing job selection. |
| .github/workflows/untrusted-artifacts.yaml | Allows fork-oriented reusable artifact jobs to initialize Harden Runner without access to repository secrets. |
| .github/workflows/pr-checks.yaml | Prevents pull-request checks from requiring the StepSecurity API key when it is unavailable. |
| .github/workflows/codeql.yml | Applies the same API-key availability guard to the CodeQL workflow while retaining audit egress behavior. |
| .github/workflows/release.yaml | Preserves policy-store use on trusted release runs while safely disabling it if the secret is absent. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%234927%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=4927&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): support fork pull requests"](https://github.com/openmeterio/openmeter/commit/e440712876ca0f94739966ae49eb0653f616dfb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52932544)</sub>

<!-- /greptile_comment -->