### PR TITLE
chore(devenv): share Go module cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@
   pre-commit hook.
 - Never run multiple `nix develop` commands concurrently in one worktree; they
   mutate shared `.devenv/` state.
+- Dev shells share downloaded Go modules through `$HOME/go/pkg/mod`. `GOPATH`,
+  `GOCACHE`, and installed tools remain per-worktree under `.devenv/state/go`.
+  Existing worktree module caches are not migrated or removed automatically;
+  clean them up separately after confirming no active shell uses them.
 - `.nvmrc` is the GitHub Actions source of truth for Node. Keep it aligned with
   `node -v` in the Nix `.#ci` shell.
 

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
             ];
 
             env = {
+              GOCACHE = "${config.devenv.shells.default.env.DEVENV_STATE}/go/build-cache";
               KUBECONFIG = "${config.devenv.shells.default.env.DEVENV_STATE}/kube/config";
               KIND_CLUSTER_NAME = "openmeter";
 
@@ -151,6 +152,9 @@
             };
 
             enterShell = ''
+              # Share downloaded modules across worktrees; keep GOPATH and build artifacts local.
+              export GOMODCACHE="$HOME/go/pkg/mod"
+
               ${lib.optionalString pkgs.stdenv.isDarwin ''
                 # Workaround for XCBUILD.XCRUN cosmetic issue due to incompatible plists (see https://github.com/NixOS/nixpkgs/issues/376958)
                 # 1) Filter out the buggy Nix version of xcbuild/xcrun from PATH


### PR DESCRIPTION
## Summary

- use the standard per-user `$HOME/go/pkg/mod` as `GOMODCACHE`
- keep `GOPATH`, installed tools, and `GOCACHE` under each worktree's `.devenv/state/go`
- document that legacy caches are not migrated or removed automatically

Go's module cache is safe for concurrent Go commands and stores source/download artifacts, while version-sensitive compiled build artifacts remain isolated.

## Disk impact

Measured on 2026-08-13 from the OpenMeter git worktree registry, counting canonical `.devenv/state/go/pkg/mod` directories once by device/inode:

- 16 existing module caches
- 43.547 GiB total allocated size
- existing shared `$HOME/go/pkg/mod`: 3.402 GiB after validation

Immediate savings are **0 GiB** because this change deliberately does not delete or migrate existing caches. After a separate, explicit cleanup, reclaimable space is the size of removed legacy caches (currently up to **43.547 GiB**) minus any legacy-only modules that are later downloaded into the shared cache. New worktrees avoid another full module-cache working set; their build cache and installed tools still consume per-worktree space.

## Validation

- `nixpkgs-fmt --check flake.nix`
- started two distinct dev-shell roots concurrently
- ran `go mod download` concurrently in both roots
- ran `go test ./pkg/errorsx` concurrently in both roots
- confirmed both roots used `$HOME/go/pkg/mod`
- confirmed distinct `DEVENV_STATE`, `GOPATH`, and `GOCACHE` paths and distinct build-cache directories

## Caveats

- cleanup of old `.devenv/state/go/pkg/mod` directories is a separate manual follow-up and must only happen after their shells are inactive
- private module authentication is unchanged; private source follows normal Go module-cache behavior inside the user's home
- CI runners use their own ephemeral `HOME`; this does not share caches across runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Updated development environment guidance for shared Go caches.
  * Go build and module caches now use consistent locations within the development shell.
  * Existing worktree caches are not migrated or removed automatically; they can be cleaned up separately after confirming they are no longer in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shares downloaded Go modules across worktrees while retaining worktree-local build caches and tools.
- Sets `GOMODCACHE` to the standard per-user `$HOME/go/pkg/mod`.
- Places `GOCACHE` under each worktree’s devenv state.
- Documents cache ownership and manual cleanup of legacy module caches.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The environment changes preserve worktree-local build artifacts while moving only concurrency-safe downloaded module content to the standard user cache, and the documentation accurately describes that behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flake.nix | Configures a shared module-download cache while keeping compiled Go artifacts scoped to each worktree; no actionable defect was found. |
| AGENTS.md | Documents the cache layout and safe manual cleanup expectations consistently with the configuration. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Shell[Dev shell] --> Modules[Shared HOME/go/pkg/mod]
  Shell --> State[Per-worktree .devenv/state/go]
  State --> BuildCache[GOCACHE build-cache]
  State --> Tools[GOPATH and installed tools]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%234931%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=4931&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["chore(devenv): share Go module cache"](https://github.com/openmeterio/openmeter/commit/e675a26085192d0a018056b417a5ec3f3759be91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53003049)</sub>

<!-- /greptile_comment -->