### PR TITLE
fix(app): preserve deleted workflow apps

### DIFF
--- a/openmeter/app/app.go
+++ b/openmeter/app/app.go
@@ -34,6 +34,15 @@ type App interface {
 	DeleteCustomerData(ctx context.Context, input DeleteAppInstanceCustomerDataInput) error
 }
 
+// AppOperations contains behavior that must be implemented by all apps.
+type AppOperations interface {
+	UpdateAppConfig(ctx context.Context, input AppConfigUpdate) error
+	ValidateCapabilities(capabilities ...CapabilityType) error
+	GetCustomerData(ctx context.Context, input GetAppInstanceCustomerDataInput) (CustomerData, error)
+	UpsertCustomerData(ctx context.Context, input UpsertAppInstanceCustomerDataInput) error
+	DeleteCustomerData(ctx context.Context, input DeleteAppInstanceCustomerDataInput) error
+}
+
 type GetAppInstanceCustomerDataInput struct {
 	CustomerID customer.CustomerID
 }

--- a/openmeter/app/custominvoicing/adapter/appconfig.go
+++ b/openmeter/app/custominvoicing/adapter/appconfig.go
@@ -19,7 +19,6 @@ func (a *adapter) GetAppConfiguration(ctx context.Context, input app.AppID) (cus
 			Where(
 				appcustominvoicing.ID(input.ID),
 				appcustominvoicing.Namespace(input.Namespace),
-				appcustominvoicing.DeletedAtIsNil(),
 			).
 			First(ctx)
 		if err != nil {

--- a/openmeter/app/custominvoicing/app.go
+++ b/openmeter/app/custominvoicing/app.go
@@ -57,16 +57,34 @@ func (m *Meta) FromEventAppData(event app.EventApp) error {
 
 type App struct {
 	Meta
+	Operations
+}
+
+type Operations interface {
+	app.AppOperations
+	customerapp.App
+	billing.InvoicingApp
+	billing.InvoicingAppAsyncSyncer
+}
+
+type appOperations struct {
+	Meta
 
 	customInvoicingService Service
 	sequenceService        sequence.Service
 }
 
-func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
+var _ Operations = (*appOperations)(nil)
+
+func (a appOperations) ValidateCapabilities(capabilities ...app.CapabilityType) error {
+	return a.AppBase.ValidateCapabilities(capabilities...)
+}
+
+func (a appOperations) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
 	return nil
 }
 
-func (a App) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
+func (a appOperations) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
 	cfg, ok := input.(Configuration)
 	if !ok {
 		return fmt.Errorf("invalid configuration")
@@ -91,15 +109,15 @@ func (a App) GetEventAppData() (app.EventAppData, error) {
 
 // ValidateStandardInvoice is a no-op as any validation issues are published via the draft.syncing and finalizations syncing
 // flow.
-func (a App) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	return nil
 }
 
-func (a App) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
+func (a appOperations) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
 	return nil, nil
 }
 
-func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
+func (a appOperations) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
 	canAdvance, err := a.CanIssuingSyncAdvance(invoice)
 	if err != nil {
 		return nil, err
@@ -131,13 +149,13 @@ func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.Standa
 }
 
 // DeleteStandardInvoice is a no-op as this should happen via the notifications webhook
-func (a App) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	return nil
 }
 
 // InvoicingAppAsyncSyncer
 
-func (a App) CanDraftSyncAdvance(invoice billing.StandardInvoice) (bool, error) {
+func (a appOperations) CanDraftSyncAdvance(invoice billing.StandardInvoice) (bool, error) {
 	if !a.Configuration.EnableDraftSyncHook {
 		return true, nil
 	}
@@ -153,7 +171,7 @@ func (a App) CanDraftSyncAdvance(invoice billing.StandardInvoice) (bool, error) 
 	return false, nil
 }
 
-func (a App) CanIssuingSyncAdvance(invoice billing.StandardInvoice) (bool, error) {
+func (a appOperations) CanIssuingSyncAdvance(invoice billing.StandardInvoice) (bool, error) {
 	if !a.Configuration.EnableIssuingSyncHook {
 		return true, nil
 	}
@@ -167,4 +185,19 @@ func (a App) CanIssuingSyncAdvance(invoice billing.StandardInvoice) (bool, error
 	}
 
 	return false, nil
+}
+
+type deletedApp struct {
+	app.DeletedApp
+	billing.DeletedInvoicingApp
+}
+
+var _ Operations = (*deletedApp)(nil)
+
+func (a deletedApp) CanDraftSyncAdvance(billing.StandardInvoice) (bool, error) {
+	return false, fmt.Errorf("app %s: %w", a.GetID().ID, billing.ErrInvoiceWorkflowAppDeleted)
+}
+
+func (a deletedApp) CanIssuingSyncAdvance(billing.StandardInvoice) (bool, error) {
+	return false, fmt.Errorf("app %s: %w", a.GetID().ID, billing.ErrInvoiceWorkflowAppDeleted)
 }

--- a/openmeter/app/custominvoicing/customerdata.go
+++ b/openmeter/app/custominvoicing/customerdata.go
@@ -21,7 +21,7 @@ func (c CustomerData) Validate() error {
 
 // Customer Specific App Data Handling
 
-func (a App) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
+func (a appOperations) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
 	return a.customInvoicingService.GetCustomerData(ctx, GetAppCustomerDataInput{
 		Namespace:  a.Namespace,
 		AppID:      a.ID,
@@ -29,7 +29,7 @@ func (a App) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustom
 	})
 }
 
-func (a App) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
+func (a appOperations) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
 	data, ok := input.Data.(CustomerData)
 	if !ok {
 		return fmt.Errorf("invalid customer data: %v", input.Data)
@@ -45,7 +45,7 @@ func (a App) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstance
 	})
 }
 
-func (a App) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
+func (a appOperations) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
 	return a.customInvoicingService.DeleteCustomerData(ctx, DeleteAppCustomerDataInput{
 		Namespace:  a.Namespace,
 		AppID:      a.ID,

--- a/openmeter/app/custominvoicing/factory.go
+++ b/openmeter/app/custominvoicing/factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 )
 
@@ -102,13 +103,28 @@ func (f *Factory) NewApp(ctx context.Context, appBase app.AppBase) (app.App, err
 		return nil, fmt.Errorf("failed to get app config: %w", err)
 	}
 
+	meta := Meta{
+		AppBase:       appBase,
+		Configuration: cfg,
+	}
+
+	if appBase.DeletedAt != nil {
+		return App{
+			Meta: meta,
+			Operations: &deletedApp{
+				DeletedApp:          app.NewDeletedApp(appBase.GetID()),
+				DeletedInvoicingApp: billing.NewDeletedInvoicingApp(appBase.GetID()),
+			},
+		}, nil
+	}
+
 	return App{
-		Meta: Meta{
-			AppBase:       appBase,
-			Configuration: cfg,
+		Meta: meta,
+		Operations: &appOperations{
+			Meta:                   meta,
+			customInvoicingService: f.customInvoicingService,
+			sequenceService:        f.sequenceService,
 		},
-		customInvoicingService: f.customInvoicingService,
-		sequenceService:        f.sequenceService,
 	}, nil
 }
 

--- a/openmeter/app/deleted.go
+++ b/openmeter/app/deleted.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+)
+
+// DeletedApp provides the common operations for an app whose provider data is no longer available.
+type DeletedApp struct {
+	appID AppID
+}
+
+var _ AppOperations = DeletedApp{}
+
+func NewDeletedApp(appID AppID) DeletedApp {
+	return DeletedApp{appID: appID}
+}
+
+func (a DeletedApp) GetID() AppID {
+	return a.appID
+}
+
+func (a DeletedApp) UpdateAppConfig(context.Context, AppConfigUpdate) error {
+	return NewAppDeletedError(a.appID)
+}
+
+func (a DeletedApp) ValidateCapabilities(...CapabilityType) error {
+	return NewAppDeletedError(a.appID)
+}
+
+func (a DeletedApp) ValidateCustomer(context.Context, *customer.Customer, []CapabilityType) error {
+	return NewAppDeletedError(a.appID)
+}
+
+func (a DeletedApp) GetCustomerData(context.Context, GetAppInstanceCustomerDataInput) (CustomerData, error) {
+	return nil, NewAppDeletedError(a.appID)
+}
+
+func (a DeletedApp) UpsertCustomerData(context.Context, UpsertAppInstanceCustomerDataInput) error {
+	return NewAppDeletedError(a.appID)
+}
+
+func (a DeletedApp) DeleteCustomerData(context.Context, DeleteAppInstanceCustomerDataInput) error {
+	return NewAppDeletedError(a.appID)
+}

--- a/openmeter/app/errors.go
+++ b/openmeter/app/errors.go
@@ -8,6 +8,12 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
+var ErrAppDeleted = models.NewGenericValidationError(errors.New("app is deleted"))
+
+func NewAppDeletedError(appID AppID) error {
+	return fmt.Errorf("app %s: %w", appID.ID, ErrAppDeleted)
+}
+
 // AppNotFoundError
 func NewAppNotFoundError(appID AppID) *AppNotFoundError {
 	return &AppNotFoundError{

--- a/openmeter/app/sandbox/app.go
+++ b/openmeter/app/sandbox/app.go
@@ -52,11 +52,29 @@ func (m *Meta) FromEventAppData(event app.EventApp) error {
 
 type App struct {
 	Meta
+	Operations
+}
+
+type Operations interface {
+	app.AppOperations
+	customerapp.App
+	billing.InvoicingApp
+	billing.InvoicingAppPostAdvanceHook
+}
+
+type appOperations struct {
+	appBase app.AppBase
 
 	sequenceService sequence.Service
 }
 
-func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
+var _ Operations = (*appOperations)(nil)
+
+func (a appOperations) ValidateCapabilities(capabilities ...app.CapabilityType) error {
+	return a.appBase.ValidateCapabilities(capabilities...)
+}
+
+func (a appOperations) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
 	if err := a.ValidateCapabilities(capabilities...); err != nil {
 		return fmt.Errorf("error validating capabilities: %w", err)
 	}
@@ -64,31 +82,31 @@ func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, 
 	return nil
 }
 
-func (a App) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
+func (a appOperations) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
 	return CustomerData{}, nil
 }
 
-func (a App) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
+func (a appOperations) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
 	return nil
 }
 
-func (a App) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
+func (a appOperations) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
 	return nil
 }
 
-func (a App) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	return nil
 }
 
-func (a App) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
+func (a appOperations) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
 	return nil
 }
 
-func (a App) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
+func (a appOperations) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
 	return billing.NewUpsertStandardInvoiceResult(), nil
 }
 
-func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
+func (a appOperations) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
 	invoiceNumber, err := a.sequenceService.GenerateInvoiceSequenceNumber(
 		ctx,
 		sequence.GenerationInput{
@@ -107,11 +125,11 @@ func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.Standa
 		SetSentToCustomerAt(clock.Now()), nil
 }
 
-func (a App) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	return nil
 }
 
-func (a App) PostAdvanceStandardInvoiceHook(ctx context.Context, invoice billing.StandardInvoice) (*billing.PostAdvanceHookResult, error) {
+func (a appOperations) PostAdvanceStandardInvoiceHook(ctx context.Context, invoice billing.StandardInvoice) (*billing.PostAdvanceHookResult, error) {
 	if invoice.Status != billing.StandardInvoiceStatusPaymentProcessingPending {
 		return nil, nil
 	}
@@ -158,6 +176,21 @@ func (a App) PostAdvanceStandardInvoiceHook(ctx context.Context, invoice billing
 
 func (a App) GetEventAppData() (app.EventAppData, error) {
 	return app.EventAppData{}, nil
+}
+
+type deletedApp struct {
+	app.DeletedApp
+	billing.DeletedInvoicingApp
+}
+
+var _ Operations = (*deletedApp)(nil)
+
+func (a deletedApp) PostAdvanceStandardInvoiceHook(_ context.Context, invoice billing.StandardInvoice) (*billing.PostAdvanceHookResult, error) {
+	if invoice.Status == billing.StandardInvoiceStatusDeleted {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("app %s: %w", a.GetID().ID, billing.ErrInvoiceWorkflowAppDeleted)
 }
 
 type CustomerData struct{}
@@ -211,11 +244,26 @@ func NewFactory(config Config) (*Factory, error) {
 
 // Factory
 func (a *Factory) NewApp(_ context.Context, appBase app.AppBase) (app.App, error) {
+	if appBase.DeletedAt != nil {
+		return App{
+			Meta: Meta{
+				AppBase: appBase,
+			},
+			Operations: &deletedApp{
+				DeletedApp:          app.NewDeletedApp(appBase.GetID()),
+				DeletedInvoicingApp: billing.NewDeletedInvoicingApp(appBase.GetID()),
+			},
+		}, nil
+	}
+
 	return App{
 		Meta: Meta{
 			AppBase: appBase,
 		},
-		sequenceService: a.sequenceService,
+		Operations: &appOperations{
+			appBase:         appBase,
+			sequenceService: a.sequenceService,
+		},
 	}, nil
 }
 

--- a/openmeter/app/sandbox/mock.go
+++ b/openmeter/app/sandbox/mock.go
@@ -272,6 +272,12 @@ func NewMockableFactory(_ *testing.T, config Config, opts ...mockConfigOption) (
 }
 
 func (m *MockableFactory) NewApp(ctx context.Context, appBase app.AppBase) (app.App, error) {
+	// Mock overrides represent an available Sandbox app. Deleted apps must retain
+	// the unavailable operations provided by the real factory.
+	if appBase.DeletedAt != nil {
+		return m.Factory.NewApp(ctx, appBase)
+	}
+
 	if m.overrideFactory != nil {
 		return m.overrideFactory.NewApp(ctx, appBase)
 	}

--- a/openmeter/app/stripe/README.md
+++ b/openmeter/app/stripe/README.md
@@ -5,6 +5,16 @@ references whose app ID, namespace, and semantic key match the app being created
 updates preserve that ownership rather than allowing callers to combine the namespace, app ID, or
 key from different references.
 
+App persistence permits only two credential states: active rows retain both the API-key and
+webhook-secret references, while soft-deleted rows retain neither. A deletion transition must set
+`deleted_at` and clear both references atomically; partial credential removal is invalid.
+
+This lifecycle makes the nullable-secret migration conditionally irreversible. After a
+soft-deleted row exists, its migration cannot be rolled back to `NOT NULL` columns until that row is
+purged or both valid secret references are reconstructed. Purging soft-deleted Stripe subtype rows
+is the expected rollback preparation because uninstallation intentionally removes the underlying
+secrets.
+
 ## Webhook namespace bootstrap
 
 Stripe webhook routes receive a globally unique app ID but no trusted namespace. Resolving the

--- a/openmeter/app/stripe/adapter/customer.go
+++ b/openmeter/app/stripe/adapter/customer.go
@@ -117,6 +117,7 @@ func (a *adapter) UpsertStripeCustomerData(ctx context.Context, input appstripe.
 		stripeAppExists, err := repo.db.AppStripe.Query().
 			Where(appstripedb.Namespace(input.AppID.Namespace)).
 			Where(appstripedb.ID(input.AppID.ID)).
+			Where(appstripedb.DeletedAtIsNil()).
 			Exist(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve stripe app: %w", err)

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stripe/stripe-go/v80"
@@ -200,10 +201,16 @@ func (a *adapter) GetStripeAppData(ctx context.Context, input appstripe.GetStrip
 			return appstripe.AppData{}, fmt.Errorf("error getting stripe customer data: %w", err)
 		}
 
+		if dbApp.DeletedAt != nil && !input.IncludeDeleted {
+			return appstripe.AppData{}, app.NewAppDeletedError(input.AppID)
+		}
+
 		// Map the database stripe app to an app entity
 		appData := mapAppStripeData(input.AppID, dbApp)
-		if err := appData.Validate(); err != nil {
-			return appstripe.AppData{}, models.NewGenericValidationError(fmt.Errorf("error validating stripe app data: %w", err))
+		if dbApp.DeletedAt == nil {
+			if err := appData.Validate(); err != nil {
+				return appstripe.AppData{}, models.NewGenericValidationError(fmt.Errorf("error validating stripe app data: %w", err))
+			}
 		}
 
 		return appData, nil
@@ -219,18 +226,22 @@ func (a *adapter) DeleteStripeAppData(ctx context.Context, input appstripe.Delet
 	}
 
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, repo *adapter) error {
-		// Delete the stripe app data
-		_, err := repo.db.AppStripe.
-			Delete().
+		// Preserve provider metadata for historical reads while removing access to credentials.
+		updated, err := repo.db.AppStripe.
+			Update().
 			Where(appstripedb.Namespace(input.AppID.Namespace)).
 			Where(appstripedb.ID(input.AppID.ID)).
-			Exec(ctx)
+			Where(appstripedb.DeletedAtIsNil()).
+			SetDeletedAt(time.Now()).
+			ClearAPIKey().
+			ClearWebhookSecret().
+			Save(ctx)
 		if err != nil {
-			if entdb.IsNotFound(err) {
-				return app.NewAppNotFoundError(input.AppID)
-			}
-
 			return fmt.Errorf("failed to delete stripe app: %w", err)
+		}
+
+		if updated == 0 {
+			return app.NewAppNotFoundError(input.AppID)
 		}
 
 		return nil
@@ -253,6 +264,7 @@ func (a *adapter) GetWebhookSecret(ctx context.Context, input appstripe.GetWebho
 			// The app row supplies the namespace needed to resolve the signing secret;
 			// callers must verify the signature before trusting it for namespaced work.
 			Where(appstripedb.ID(input.AppID)).
+			Where(appstripedb.DeletedAtIsNil()).
 			Only(ctx)
 		if err != nil {
 			if entdb.IsNotFound(err) {
@@ -271,8 +283,11 @@ func (a *adapter) GetWebhookSecret(ctx context.Context, input appstripe.GetWebho
 			Namespace: stripeApp.Namespace,
 			ID:        stripeApp.ID,
 		}
+		if stripeApp.WebhookSecret == nil {
+			return secretentity.Secret{}, errors.New("stripe app webhook secret reference is missing")
+		}
 
-		secret, err := a.webhookSecretService.GetAppSecret(ctx, secretentity.NewSecretID(appID, stripeApp.WebhookSecret, appstripe.WebhookSecretKey))
+		secret, err := a.webhookSecretService.GetAppSecret(ctx, secretentity.NewSecretID(appID, *stripeApp.WebhookSecret, appstripe.WebhookSecretKey))
 		if err != nil {
 			return secretentity.Secret{}, fmt.Errorf("failed to get webhook secret: %w", err)
 		}
@@ -360,6 +375,7 @@ func (a *adapter) CreateCheckoutSession(ctx context.Context, input appstripe.Cre
 			Query().
 			Where(appstripedb.ID(input.AppID.ID)).
 			Where(appstripedb.Namespace(input.AppID.Namespace)).
+			Where(appstripedb.DeletedAtIsNil()).
 			Only(ctx)
 		if err != nil {
 			if entdb.IsNotFound(err) {
@@ -456,7 +472,11 @@ func (a *adapter) CreateCheckoutSession(ctx context.Context, input appstripe.Cre
 		input.StripeCustomerID = &stripeCustomerId
 
 		// Get Stripe API Key
-		apiKeySecret, err := repo.secretService.GetAppSecret(ctx, secretentity.NewSecretID(input.AppID, stripeApp.APIKey, appstripe.APIKeySecretKey))
+		if stripeApp.APIKey == nil {
+			return appstripe.CreateCheckoutSessionOutput{}, errors.New("stripe app API key reference is missing")
+		}
+
+		apiKeySecret, err := repo.secretService.GetAppSecret(ctx, secretentity.NewSecretID(input.AppID, *stripeApp.APIKey, appstripe.APIKeySecretKey))
 		if err != nil {
 			return appstripe.CreateCheckoutSessionOutput{}, fmt.Errorf("failed to get stripe api key secret: %w", err)
 		}
@@ -511,7 +531,7 @@ func (a adapter) GetSupplierContact(ctx context.Context, input appstripe.GetSupp
 	}
 
 	// Get stripe app data
-	stripeAppData, err := a.GetStripeAppData(ctx, appstripe.GetStripeAppDataInput(input))
+	stripeAppData, err := a.GetStripeAppData(ctx, appstripe.GetStripeAppDataInput{AppID: input.AppID})
 	if err != nil {
 		return billing.SupplierContact{}, fmt.Errorf("failed to get stripe app data: %w", err)
 	}
@@ -675,12 +695,20 @@ func (a adapter) getStripeAppClient(ctx context.Context, appID app.AppID, logOpe
 
 // mapAppStripeData maps stripe app data from the database
 func mapAppStripeData(appID app.AppID, dbApp *entdb.AppStripe) appstripe.AppData {
-	return appstripe.AppData{
+	appData := appstripe.AppData{
 		StripeAccountID: dbApp.StripeAccountID,
 		Livemode:        dbApp.StripeLivemode,
-		APIKey:          secretentity.NewSecretID(appID, dbApp.APIKey, appstripe.APIKeySecretKey),
 		MaskedAPIKey:    dbApp.MaskedAPIKey,
 		StripeWebhookID: dbApp.StripeWebhookID,
-		WebhookSecret:   secretentity.NewSecretID(appID, dbApp.WebhookSecret, appstripe.WebhookSecretKey),
 	}
+
+	if dbApp.APIKey != nil {
+		appData.APIKey = secretentity.NewSecretID(appID, *dbApp.APIKey, appstripe.APIKeySecretKey)
+	}
+
+	if dbApp.WebhookSecret != nil {
+		appData.WebhookSecret = secretentity.NewSecretID(appID, *dbApp.WebhookSecret, appstripe.WebhookSecretKey)
+	}
+
+	return appData
 }

--- a/openmeter/app/stripe/adapter/stripe_test.go
+++ b/openmeter/app/stripe/adapter/stripe_test.go
@@ -1,0 +1,78 @@
+package appstripeadapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
+)
+
+func TestDeleteStripeAppDataSoftDeletesAndSanitizesSecrets(t *testing.T) {
+	// Given an active Stripe subtype containing provider metadata and both secret references.
+	// When the subtype is deleted.
+	// Then the row and its metadata remain while its credentials become inaccessible.
+	env := newStripeCustomerTestEnv(t)
+	appID := env.createStripeApp(t, ulid.Make().String())
+
+	before, err := env.db.AppStripe.Get(t.Context(), appID.ID)
+	require.NoError(t, err)
+	require.NotNil(t, before.APIKey)
+	require.NotNil(t, before.WebhookSecret)
+
+	err = env.adapter.DeleteStripeAppData(t.Context(), appstripe.DeleteStripeAppDataInput{AppID: appID})
+	require.NoError(t, err)
+
+	after, err := env.db.AppStripe.Get(t.Context(), appID.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after.DeletedAt)
+	require.Nil(t, after.APIKey)
+	require.Nil(t, after.WebhookSecret)
+	require.Equal(t, before.StripeAccountID, after.StripeAccountID)
+	require.Equal(t, before.StripeLivemode, after.StripeLivemode)
+	require.Equal(t, before.MaskedAPIKey, after.MaskedAPIKey)
+	require.Equal(t, before.StripeWebhookID, after.StripeWebhookID)
+
+	_, err = env.adapter.GetStripeAppData(t.Context(), appstripe.GetStripeAppDataInput{AppID: appID})
+	require.ErrorIs(t, err, app.ErrAppDeleted)
+
+	deletedData, err := env.adapter.GetStripeAppData(t.Context(), appstripe.GetStripeAppDataInput{
+		AppID:          appID,
+		IncludeDeleted: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, before.StripeAccountID, deletedData.StripeAccountID)
+	require.Equal(t, before.StripeLivemode, deletedData.Livemode)
+	require.Equal(t, before.MaskedAPIKey, deletedData.MaskedAPIKey)
+	require.Equal(t, before.StripeWebhookID, deletedData.StripeWebhookID)
+	require.Empty(t, deletedData.APIKey.ID)
+	require.Empty(t, deletedData.WebhookSecret.ID)
+
+	_, err = env.adapter.GetWebhookSecret(t.Context(), appstripe.GetWebhookSecretInput{AppID: appID.ID})
+	require.True(t, app.IsAppNotFoundError(err))
+}
+
+func TestStripeAppSecretLifecycleConstraint(t *testing.T) {
+	// Given an active Stripe subtype with both required secret references.
+	// When only part of the credential lifecycle transition is persisted.
+	// Then the database rejects the inconsistent state.
+	env := newStripeCustomerTestEnv(t)
+	appID := env.createStripeApp(t, ulid.Make().String())
+
+	t.Run("active row cannot lose only the API key", func(t *testing.T) {
+		_, err := env.db.AppStripe.UpdateOneID(appID.ID).
+			ClearAPIKey().
+			Save(t.Context())
+		require.Error(t, err)
+	})
+
+	t.Run("row cannot be marked deleted while retaining secrets", func(t *testing.T) {
+		_, err := env.db.AppStripe.UpdateOneID(appID.ID).
+			SetDeletedAt(time.Now()).
+			Save(t.Context())
+		require.Error(t, err)
+	})
+}

--- a/openmeter/app/stripe/app.go
+++ b/openmeter/app/stripe/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/app"
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
 	"github.com/openmeterio/openmeter/openmeter/secret"
 )
 
@@ -31,6 +32,17 @@ func (m *Meta) FromEventAppData(event app.EventApp) error {
 // App represents an installed Stripe app
 type App struct {
 	Meta
+	Operations
+}
+
+type Operations interface {
+	app.AppOperations
+	customerapp.App
+	billing.InvoicingApp
+}
+
+type appOperations struct {
+	Meta
 
 	Logger *slog.Logger `json:"-"`
 
@@ -41,7 +53,9 @@ type App struct {
 	SecretService          secret.Service                      `json:"-"`
 }
 
-func (a App) Validate() error {
+var _ Operations = (*appOperations)(nil)
+
+func (a appOperations) Validate() error {
 	if err := a.AppBase.Validate(); err != nil {
 		return fmt.Errorf("error validating app: %w", err)
 	}
@@ -85,6 +99,57 @@ func (a App) Validate() error {
 	return nil
 }
 
+func (a appOperations) ValidateCapabilities(capabilities ...app.CapabilityType) error {
+	return a.AppBase.ValidateCapabilities(capabilities...)
+}
+
 func (a App) GetEventAppData() (app.EventAppData, error) {
 	return app.NewEventAppData(a.AppData)
 }
+
+type AppConfig struct {
+	Logger                 *slog.Logger
+	AppService             app.Service
+	BillingService         billing.Service
+	StripeAppClientFactory stripeclient.StripeAppClientFactory
+	StripeAppService       Service
+	SecretService          secret.Service
+}
+
+func New(meta Meta, config AppConfig) (App, error) {
+	implementation := &appOperations{
+		Meta:                   meta,
+		Logger:                 config.Logger,
+		AppService:             config.AppService,
+		BillingService:         config.BillingService,
+		StripeAppClientFactory: config.StripeAppClientFactory,
+		StripeAppService:       config.StripeAppService,
+		SecretService:          config.SecretService,
+	}
+
+	if err := implementation.Validate(); err != nil {
+		return App{}, err
+	}
+
+	return App{
+		Meta:       meta,
+		Operations: implementation,
+	}, nil
+}
+
+func NewDeleted(meta Meta) App {
+	return App{
+		Meta: meta,
+		Operations: &deletedApp{
+			DeletedApp:          app.NewDeletedApp(meta.GetID()),
+			DeletedInvoicingApp: billing.NewDeletedInvoicingApp(meta.GetID()),
+		},
+	}
+}
+
+type deletedApp struct {
+	app.DeletedApp
+	billing.DeletedInvoicingApp
+}
+
+var _ Operations = (*deletedApp)(nil)

--- a/openmeter/app/stripe/app_test.go
+++ b/openmeter/app/stripe/app_test.go
@@ -1,0 +1,28 @@
+package appstripe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestDeletedAppPreservesIdentityAndRejectsOperations(t *testing.T) {
+	appBase := app.AppBase{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			ID:        "app-id",
+			Namespace: "namespace",
+			Name:      "Stripe",
+		}),
+		Type: app.AppTypeStripe,
+	}
+
+	deleted := NewDeleted(Meta{AppBase: appBase})
+	require.Equal(t, appBase.GetID(), deleted.GetID())
+	require.Equal(t, app.AppTypeStripe, deleted.GetType())
+	require.ErrorIs(t, deleted.ValidateCapabilities(app.CapabilityTypeInvoiceCustomers), app.ErrAppDeleted)
+	require.ErrorIs(t, deleted.DeleteStandardInvoice(t.Context(), billing.StandardInvoice{}), billing.WarnInvoiceWorkflowAppDeleteSkipped)
+}

--- a/openmeter/app/stripe/appcustomer.go
+++ b/openmeter/app/stripe/appcustomer.go
@@ -16,12 +16,12 @@ import (
 var _ customerapp.App = (*App)(nil)
 
 // ValidateCustomer validates if the app can run for the given customer
-func (a App) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
+func (a appOperations) ValidateCustomer(ctx context.Context, customer *customer.Customer, capabilities []app.CapabilityType) error {
 	return a.ValidateCustomerByID(ctx, customer.GetID(), capabilities)
 }
 
 // ValidateCustomerByID validates if the app can run for the given customer ID
-func (a App) ValidateCustomerByID(ctx context.Context, customerID customer.CustomerID, capabilities []app.CapabilityType) error {
+func (a appOperations) ValidateCustomerByID(ctx context.Context, customerID customer.CustomerID, capabilities []app.CapabilityType) error {
 	// Validate if the app supports the given capabilities
 	if err := a.ValidateCapabilities(capabilities...); err != nil {
 		return fmt.Errorf("error validating capabilities: %w", err)
@@ -171,7 +171,7 @@ func (a App) ValidateCustomerByID(ctx context.Context, customerID customer.Custo
 }
 
 // GetCustomerData gets the customer data for the app
-func (a App) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
+func (a appOperations) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustomerDataInput) (app.CustomerData, error) {
 	if err := input.Validate(); err != nil {
 		return nil, models.NewGenericValidationError(
 			err,
@@ -190,7 +190,7 @@ func (a App) GetCustomerData(ctx context.Context, input app.GetAppInstanceCustom
 }
 
 // UpsertCustomerData upserts the customer data for the app
-func (a App) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
+func (a appOperations) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstanceCustomerDataInput) error {
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
 			err,
@@ -216,7 +216,7 @@ func (a App) UpsertCustomerData(ctx context.Context, input app.UpsertAppInstance
 }
 
 // DeleteCustomerData deletes the customer data for the app
-func (a App) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
+func (a appOperations) DeleteCustomerData(ctx context.Context, input app.DeleteAppInstanceCustomerDataInput) error {
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
 			err,

--- a/openmeter/app/stripe/appinvoice.go
+++ b/openmeter/app/stripe/appinvoice.go
@@ -29,7 +29,7 @@ const (
 var _ billing.InvoicingApp = (*App)(nil)
 
 // ValidateStandardInvoice validates the invoice for the app
-func (a App) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) ValidateStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	customerID := customer.CustomerID{
 		Namespace: invoice.Namespace,
 		ID:        invoice.Customer.CustomerID,
@@ -61,7 +61,7 @@ func (a App) ValidateStandardInvoice(ctx context.Context, invoice billing.Standa
 // TODO: should we split invoice create and lines adds to make retries more robust?
 // Currently if the create fails between the create and add lines we can end up with
 // an invoice without lines.
-func (a App) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
+func (a appOperations) UpsertStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
 	// Create the invoice in Stripe.
 	if invoice.ExternalIDs.Invoicing == "" {
 		return a.createInvoice(ctx, invoice)
@@ -72,7 +72,7 @@ func (a App) UpsertStandardInvoice(ctx context.Context, invoice billing.Standard
 }
 
 // DeleteStandardInvoice deletes the invoice for the app
-func (a App) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
+func (a appOperations) DeleteStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) error {
 	// Get the Stripe client
 	_, stripeClient, err := a.getStripeClient(ctx, "deleteInvoice", "invoice_id", invoice.ID, "stripe_invoice_id", invoice.ExternalIDs.GetInvoicingOrEmpty())
 	if err != nil {
@@ -86,7 +86,7 @@ func (a App) DeleteStandardInvoice(ctx context.Context, invoice billing.Standard
 }
 
 // FinalizeStandardInvoice finalizes the invoice for the app
-func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
+func (a appOperations) FinalizeStandardInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.FinalizeStandardInvoiceResult, error) {
 	// Get the Stripe client
 	_, stripeClient, err := a.getStripeClient(ctx, "finalizeInvoice", "invoice_id", invoice.ID, "stripe_invoice_id", invoice.ExternalIDs.GetInvoicingOrEmpty())
 	if err != nil {
@@ -145,7 +145,7 @@ func (a App) FinalizeStandardInvoice(ctx context.Context, invoice billing.Standa
 }
 
 // createInvoice creates the invoice for the app
-func (a App) createInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
+func (a appOperations) createInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
 	// Get the currency calculator
 	calculator, err := NewStripeCalculator(invoice.Currency)
 	if err != nil {
@@ -269,7 +269,7 @@ func (a App) createInvoice(ctx context.Context, invoice billing.StandardInvoice)
 }
 
 // updateInvoice update the invoice for the app
-func (a App) updateInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
+func (a appOperations) updateInvoice(ctx context.Context, invoice billing.StandardInvoice) (*billing.UpsertStandardInvoiceResult, error) {
 	// Get the currency calculator
 	calculator, err := NewStripeCalculator(invoice.Currency)
 	if err != nil {

--- a/openmeter/app/stripe/clientapp.go
+++ b/openmeter/app/stripe/clientapp.go
@@ -9,7 +9,7 @@ import (
 )
 
 // getStripeClient gets the Stripe client for the app
-func (a App) getStripeClient(ctx context.Context, logOperation string, logFields ...any) (AppData, stripeclient.StripeAppClient, error) {
+func (a appOperations) getStripeClient(ctx context.Context, logOperation string, logFields ...any) (AppData, stripeclient.StripeAppClient, error) {
 	// Get Stripe App
 	stripeAppData, err := a.StripeAppService.GetStripeAppData(ctx, GetStripeAppDataInput{
 		AppID: a.GetID(),

--- a/openmeter/app/stripe/config.go
+++ b/openmeter/app/stripe/config.go
@@ -19,7 +19,7 @@ func (c Configuration) Validate() error {
 	return nil
 }
 
-func (a App) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
+func (a appOperations) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) error {
 	configUpdate, ok := input.(Configuration)
 	if !ok {
 		return errors.New("invalid config update")

--- a/openmeter/app/stripe/service/factory.go
+++ b/openmeter/app/stripe/service/factory.go
@@ -18,9 +18,23 @@ var _ app.AppFactory = (*Service)(nil)
 
 // NewApp implement the app.AppFactory interface and returns a Stripe App by extending the AppBase
 func (s *Service) NewApp(ctx context.Context, appBase app.AppBase) (app.App, error) {
-	stripeApp, err := s.adapter.GetStripeAppData(ctx, appstripe.GetStripeAppDataInput{AppID: appBase.GetID()})
+	stripeApp, err := s.adapter.GetStripeAppData(ctx, appstripe.GetStripeAppDataInput{
+		AppID:          appBase.GetID(),
+		IncludeDeleted: appBase.DeletedAt != nil,
+	})
 	if err != nil {
+		if appBase.DeletedAt != nil && app.IsAppNotFoundError(err) {
+			return appstripe.NewDeleted(appstripe.Meta{AppBase: appBase}), nil
+		}
+
 		return nil, fmt.Errorf("failed to get stripe app data: %w", err)
+	}
+
+	if appBase.DeletedAt != nil {
+		return appstripe.NewDeleted(appstripe.Meta{
+			AppBase: appBase,
+			AppData: stripeApp,
+		}), nil
 	}
 
 	app, err := s.newApp(appBase, stripeApp)
@@ -217,22 +231,23 @@ func (s *Service) UninstallApp(ctx context.Context, input app.UninstallAppInput)
 
 // newApp combines the app base and stripe app data to create a new app
 func (s *Service) newApp(appBase app.AppBase, stripeApp appstripe.AppData) (appstripe.App, error) {
-	app := appstripe.App{
-		Meta: appstripe.Meta{
+	application, err := appstripe.New(
+		appstripe.Meta{
 			AppBase: appBase,
 			AppData: stripeApp,
 		},
-		AppService:             s.appService,
-		BillingService:         s.billingService,
-		StripeAppService:       s,
-		SecretService:          s.secretService,
-		StripeAppClientFactory: s.adapter.GetStripeAppClientFactory(),
-		Logger:                 s.logger,
-	}
-
-	if err := app.Validate(); err != nil {
+		appstripe.AppConfig{
+			AppService:             s.appService,
+			BillingService:         s.billingService,
+			StripeAppService:       s,
+			SecretService:          s.secretService,
+			StripeAppClientFactory: s.adapter.GetStripeAppClientFactory(),
+			Logger:                 s.logger,
+		},
+	)
+	if err != nil {
 		return appstripe.App{}, fmt.Errorf("failed to map stripe app from db: %w", err)
 	}
 
-	return app, nil
+	return application, nil
 }

--- a/openmeter/app/stripe/types.go
+++ b/openmeter/app/stripe/types.go
@@ -95,7 +95,8 @@ func (i CreateAppStripeInput) Validate() error {
 }
 
 type GetStripeAppDataInput struct {
-	AppID app.AppID
+	AppID          app.AppID
+	IncludeDeleted bool
 }
 
 func (i GetStripeAppDataInput) Validate() error {

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -109,6 +109,12 @@ invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
 engine-owned effects.
 
+A deleted app keeps its historical identity and can still be expanded on
+invoices. Its generic app operations return `app.ErrAppDeleted`, while its
+invoicing operations return billing-owned validation issues. Critical issues
+move the invoice into the failed state for that step. Invoice deletion remains
+available and returns a warning when provider cleanup has to be skipped.
+
 Retrying and deleting are separate domain actions. Use the billing service's
 retry operation for a retryable failure and its delete operation for the
 delete lifecycle; firing a generic state-machine trigger bypasses preparation
@@ -117,7 +123,11 @@ and audit semantics owned by those operations.
 Billing publishes created and updated standard-invoice snapshots for
 downstream consumers. [Notifications](../notification/README.md) maps those
 snapshots into its own API-shaped historical payloads and delivers them
-asynchronously; webhook delivery is not part of the invoice lifecycle.
+asynchronously; webhook delivery is not part of the invoice lifecycle. Every
+snapshot contains the base identity of all three workflow apps. Building that
+identity does not instantiate provider implementations; provider-specific
+event data is included only when the implementation is already available to
+the lifecycle operation.
 
 ## Consistency invariants
 

--- a/openmeter/billing/app.go
+++ b/openmeter/billing/app.go
@@ -182,6 +182,33 @@ type InvoicingApp interface {
 	DeleteStandardInvoice(ctx context.Context, invoice StandardInvoice) error
 }
 
+// DeletedInvoicingApp provides standard invoicing operations for a deleted app.
+type DeletedInvoicingApp struct {
+	appID app.AppID
+}
+
+var _ InvoicingApp = DeletedInvoicingApp{}
+
+func NewDeletedInvoicingApp(appID app.AppID) DeletedInvoicingApp {
+	return DeletedInvoicingApp{appID: appID}
+}
+
+func (a DeletedInvoicingApp) ValidateStandardInvoice(context.Context, StandardInvoice) error {
+	return fmt.Errorf("app %s: %w", a.appID.ID, ErrInvoiceWorkflowAppDeleted)
+}
+
+func (a DeletedInvoicingApp) UpsertStandardInvoice(context.Context, StandardInvoice) (*UpsertStandardInvoiceResult, error) {
+	return nil, fmt.Errorf("app %s: %w", a.appID.ID, ErrInvoiceWorkflowAppDeleted)
+}
+
+func (a DeletedInvoicingApp) FinalizeStandardInvoice(context.Context, StandardInvoice) (*FinalizeStandardInvoiceResult, error) {
+	return nil, fmt.Errorf("app %s: %w", a.appID.ID, ErrInvoiceWorkflowAppDeleted)
+}
+
+func (a DeletedInvoicingApp) DeleteStandardInvoice(context.Context, StandardInvoice) error {
+	return fmt.Errorf("app %s: %w", a.appID.ID, WarnInvoiceWorkflowAppDeleteSkipped)
+}
+
 type InvoicingAppPostAdvanceHook interface {
 	// PostAdvanceInvoiceHook is called after the invoice has been advanced to the next stable state
 	// (e.g. no next trigger is available)

--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -41,6 +41,8 @@ var (
 	ErrInvoiceNotFound                       = NewValidationError("invoice_not_found", "invoice not found")
 	ErrInvoiceDeleteFailed                   = NewValidationError("invoice_delete_failed", "invoice delete failed")
 	ErrInvoiceCannotDeleteGathering          = NewValidationError("invoice_cannot_delete_gathering", "gathering invoices cannot be deleted, please delete the upcoming lines instead")
+	ErrInvoiceWorkflowAppDeleted             = NewValidationError("invoice_workflow_app_deleted", "invoicing workflow app has been deleted")
+	WarnInvoiceWorkflowAppDeleteSkipped      = NewValidationWarning("invoice_workflow_app_delete_skipped", "external invoice deletion was skipped because the invoicing workflow app has been deleted")
 
 	ErrInvoiceLineFeatureHasNoMeters                             = NewValidationError("invoice_line_feature_has_no_meters", "usage based invoice line: feature has no meters")
 	ErrInvoiceLineVolumeSplitNotSupported                        = NewValidationError("invoice_line_graduated_split_not_supported", "graduated tiered pricing is not supported for split periods")

--- a/openmeter/ent/db/appstripe.go
+++ b/openmeter/ent/db/appstripe.go
@@ -31,13 +31,13 @@ type AppStripe struct {
 	// StripeLivemode holds the value of the "stripe_livemode" field.
 	StripeLivemode bool `json:"stripe_livemode,omitempty"`
 	// APIKey holds the value of the "api_key" field.
-	APIKey string `json:"-"`
+	APIKey *string `json:"-"`
 	// MaskedAPIKey holds the value of the "masked_api_key" field.
 	MaskedAPIKey string `json:"masked_api_key,omitempty"`
 	// StripeWebhookID holds the value of the "stripe_webhook_id" field.
 	StripeWebhookID string `json:"stripe_webhook_id,omitempty"`
 	// WebhookSecret holds the value of the "webhook_secret" field.
-	WebhookSecret string `json:"-"`
+	WebhookSecret *string `json:"-"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AppStripeQuery when eager-loading is set.
 	Edges        AppStripeEdges `json:"edges"`
@@ -148,7 +148,8 @@ func (_m *AppStripe) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field api_key", values[i])
 			} else if value.Valid {
-				_m.APIKey = value.String
+				_m.APIKey = new(string)
+				*_m.APIKey = value.String
 			}
 		case appstripe.FieldMaskedAPIKey:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -166,7 +167,8 @@ func (_m *AppStripe) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field webhook_secret", values[i])
 			} else if value.Valid {
-				_m.WebhookSecret = value.String
+				_m.WebhookSecret = new(string)
+				*_m.WebhookSecret = value.String
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])

--- a/openmeter/ent/db/appstripe/where.go
+++ b/openmeter/ent/db/appstripe/where.go
@@ -440,6 +440,16 @@ func APIKeyHasSuffix(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldHasSuffix(FieldAPIKey, v))
 }
 
+// APIKeyIsNil applies the IsNil predicate on the "api_key" field.
+func APIKeyIsNil() predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldIsNull(FieldAPIKey))
+}
+
+// APIKeyNotNil applies the NotNil predicate on the "api_key" field.
+func APIKeyNotNil() predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNotNull(FieldAPIKey))
+}
+
 // APIKeyEqualFold applies the EqualFold predicate on the "api_key" field.
 func APIKeyEqualFold(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldEqualFold(FieldAPIKey, v))
@@ -633,6 +643,16 @@ func WebhookSecretHasPrefix(v string) predicate.AppStripe {
 // WebhookSecretHasSuffix applies the HasSuffix predicate on the "webhook_secret" field.
 func WebhookSecretHasSuffix(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldHasSuffix(FieldWebhookSecret, v))
+}
+
+// WebhookSecretIsNil applies the IsNil predicate on the "webhook_secret" field.
+func WebhookSecretIsNil() predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldIsNull(FieldWebhookSecret))
+}
+
+// WebhookSecretNotNil applies the NotNil predicate on the "webhook_secret" field.
+func WebhookSecretNotNil() predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNotNull(FieldWebhookSecret))
 }
 
 // WebhookSecretEqualFold applies the EqualFold predicate on the "webhook_secret" field.

--- a/openmeter/ent/db/appstripe_create.go
+++ b/openmeter/ent/db/appstripe_create.go
@@ -91,6 +91,14 @@ func (_c *AppStripeCreate) SetAPIKey(v string) *AppStripeCreate {
 	return _c
 }
 
+// SetNillableAPIKey sets the "api_key" field if the given value is not nil.
+func (_c *AppStripeCreate) SetNillableAPIKey(v *string) *AppStripeCreate {
+	if v != nil {
+		_c.SetAPIKey(*v)
+	}
+	return _c
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (_c *AppStripeCreate) SetMaskedAPIKey(v string) *AppStripeCreate {
 	_c.mutation.SetMaskedAPIKey(v)
@@ -106,6 +114,14 @@ func (_c *AppStripeCreate) SetStripeWebhookID(v string) *AppStripeCreate {
 // SetWebhookSecret sets the "webhook_secret" field.
 func (_c *AppStripeCreate) SetWebhookSecret(v string) *AppStripeCreate {
 	_c.mutation.SetWebhookSecret(v)
+	return _c
+}
+
+// SetNillableWebhookSecret sets the "webhook_secret" field if the given value is not nil.
+func (_c *AppStripeCreate) SetNillableWebhookSecret(v *string) *AppStripeCreate {
+	if v != nil {
+		_c.SetWebhookSecret(*v)
+	}
 	return _c
 }
 
@@ -228,9 +244,6 @@ func (_c *AppStripeCreate) check() error {
 	if _, ok := _c.mutation.StripeLivemode(); !ok {
 		return &ValidationError{Name: "stripe_livemode", err: errors.New(`db: missing required field "AppStripe.stripe_livemode"`)}
 	}
-	if _, ok := _c.mutation.APIKey(); !ok {
-		return &ValidationError{Name: "api_key", err: errors.New(`db: missing required field "AppStripe.api_key"`)}
-	}
 	if v, ok := _c.mutation.APIKey(); ok {
 		if err := appstripe.APIKeyValidator(v); err != nil {
 			return &ValidationError{Name: "api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.api_key": %w`, err)}
@@ -251,9 +264,6 @@ func (_c *AppStripeCreate) check() error {
 		if err := appstripe.StripeWebhookIDValidator(v); err != nil {
 			return &ValidationError{Name: "stripe_webhook_id", err: fmt.Errorf(`db: validator failed for field "AppStripe.stripe_webhook_id": %w`, err)}
 		}
-	}
-	if _, ok := _c.mutation.WebhookSecret(); !ok {
-		return &ValidationError{Name: "webhook_secret", err: errors.New(`db: missing required field "AppStripe.webhook_secret"`)}
 	}
 	if v, ok := _c.mutation.WebhookSecret(); ok {
 		if err := appstripe.WebhookSecretValidator(v); err != nil {
@@ -322,7 +332,7 @@ func (_c *AppStripeCreate) createSpec() (*AppStripe, *sqlgraph.CreateSpec) {
 	}
 	if value, ok := _c.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
-		_node.APIKey = value
+		_node.APIKey = &value
 	}
 	if value, ok := _c.mutation.MaskedAPIKey(); ok {
 		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
@@ -334,7 +344,7 @@ func (_c *AppStripeCreate) createSpec() (*AppStripe, *sqlgraph.CreateSpec) {
 	}
 	if value, ok := _c.mutation.WebhookSecret(); ok {
 		_spec.SetField(appstripe.FieldWebhookSecret, field.TypeString, value)
-		_node.WebhookSecret = value
+		_node.WebhookSecret = &value
 	}
 	if nodes := _c.mutation.CustomerAppsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -463,6 +473,12 @@ func (u *AppStripeUpsert) UpdateAPIKey() *AppStripeUpsert {
 	return u
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (u *AppStripeUpsert) ClearAPIKey() *AppStripeUpsert {
+	u.SetNull(appstripe.FieldAPIKey)
+	return u
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (u *AppStripeUpsert) SetMaskedAPIKey(v string) *AppStripeUpsert {
 	u.Set(appstripe.FieldMaskedAPIKey, v)
@@ -496,6 +512,12 @@ func (u *AppStripeUpsert) SetWebhookSecret(v string) *AppStripeUpsert {
 // UpdateWebhookSecret sets the "webhook_secret" field to the value that was provided on create.
 func (u *AppStripeUpsert) UpdateWebhookSecret() *AppStripeUpsert {
 	u.SetExcluded(appstripe.FieldWebhookSecret)
+	return u
+}
+
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (u *AppStripeUpsert) ClearWebhookSecret() *AppStripeUpsert {
+	u.SetNull(appstripe.FieldWebhookSecret)
 	return u
 }
 
@@ -608,6 +630,13 @@ func (u *AppStripeUpsertOne) UpdateAPIKey() *AppStripeUpsertOne {
 	})
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (u *AppStripeUpsertOne) ClearAPIKey() *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.ClearAPIKey()
+	})
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (u *AppStripeUpsertOne) SetMaskedAPIKey(v string) *AppStripeUpsertOne {
 	return u.Update(func(s *AppStripeUpsert) {
@@ -647,6 +676,13 @@ func (u *AppStripeUpsertOne) SetWebhookSecret(v string) *AppStripeUpsertOne {
 func (u *AppStripeUpsertOne) UpdateWebhookSecret() *AppStripeUpsertOne {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.UpdateWebhookSecret()
+	})
+}
+
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (u *AppStripeUpsertOne) ClearWebhookSecret() *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.ClearWebhookSecret()
 	})
 }
 
@@ -926,6 +962,13 @@ func (u *AppStripeUpsertBulk) UpdateAPIKey() *AppStripeUpsertBulk {
 	})
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (u *AppStripeUpsertBulk) ClearAPIKey() *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.ClearAPIKey()
+	})
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (u *AppStripeUpsertBulk) SetMaskedAPIKey(v string) *AppStripeUpsertBulk {
 	return u.Update(func(s *AppStripeUpsert) {
@@ -965,6 +1008,13 @@ func (u *AppStripeUpsertBulk) SetWebhookSecret(v string) *AppStripeUpsertBulk {
 func (u *AppStripeUpsertBulk) UpdateWebhookSecret() *AppStripeUpsertBulk {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.UpdateWebhookSecret()
+	})
+}
+
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (u *AppStripeUpsertBulk) ClearWebhookSecret() *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.ClearWebhookSecret()
 	})
 }
 

--- a/openmeter/ent/db/appstripe_update.go
+++ b/openmeter/ent/db/appstripe_update.go
@@ -69,6 +69,12 @@ func (_u *AppStripeUpdate) SetNillableAPIKey(v *string) *AppStripeUpdate {
 	return _u
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (_u *AppStripeUpdate) ClearAPIKey() *AppStripeUpdate {
+	_u.mutation.ClearAPIKey()
+	return _u
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (_u *AppStripeUpdate) SetMaskedAPIKey(v string) *AppStripeUpdate {
 	_u.mutation.SetMaskedAPIKey(v)
@@ -108,6 +114,12 @@ func (_u *AppStripeUpdate) SetNillableWebhookSecret(v *string) *AppStripeUpdate 
 	if v != nil {
 		_u.SetWebhookSecret(*v)
 	}
+	return _u
+}
+
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (_u *AppStripeUpdate) ClearWebhookSecret() *AppStripeUpdate {
+	_u.mutation.ClearWebhookSecret()
 	return _u
 }
 
@@ -237,6 +249,9 @@ func (_u *AppStripeUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
 	}
+	if _u.mutation.APIKeyCleared() {
+		_spec.ClearField(appstripe.FieldAPIKey, field.TypeString)
+	}
 	if value, ok := _u.mutation.MaskedAPIKey(); ok {
 		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
 	}
@@ -245,6 +260,9 @@ func (_u *AppStripeUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.WebhookSecret(); ok {
 		_spec.SetField(appstripe.FieldWebhookSecret, field.TypeString, value)
+	}
+	if _u.mutation.WebhookSecretCleared() {
+		_spec.ClearField(appstripe.FieldWebhookSecret, field.TypeString)
 	}
 	if _u.mutation.CustomerAppsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -351,6 +369,12 @@ func (_u *AppStripeUpdateOne) SetNillableAPIKey(v *string) *AppStripeUpdateOne {
 	return _u
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (_u *AppStripeUpdateOne) ClearAPIKey() *AppStripeUpdateOne {
+	_u.mutation.ClearAPIKey()
+	return _u
+}
+
 // SetMaskedAPIKey sets the "masked_api_key" field.
 func (_u *AppStripeUpdateOne) SetMaskedAPIKey(v string) *AppStripeUpdateOne {
 	_u.mutation.SetMaskedAPIKey(v)
@@ -390,6 +414,12 @@ func (_u *AppStripeUpdateOne) SetNillableWebhookSecret(v *string) *AppStripeUpda
 	if v != nil {
 		_u.SetWebhookSecret(*v)
 	}
+	return _u
+}
+
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (_u *AppStripeUpdateOne) ClearWebhookSecret() *AppStripeUpdateOne {
+	_u.mutation.ClearWebhookSecret()
 	return _u
 }
 
@@ -549,6 +579,9 @@ func (_u *AppStripeUpdateOne) sqlSave(ctx context.Context) (_node *AppStripe, er
 	if value, ok := _u.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
 	}
+	if _u.mutation.APIKeyCleared() {
+		_spec.ClearField(appstripe.FieldAPIKey, field.TypeString)
+	}
 	if value, ok := _u.mutation.MaskedAPIKey(); ok {
 		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
 	}
@@ -557,6 +590,9 @@ func (_u *AppStripeUpdateOne) sqlSave(ctx context.Context) (_node *AppStripe, er
 	}
 	if value, ok := _u.mutation.WebhookSecret(); ok {
 		_spec.SetField(appstripe.FieldWebhookSecret, field.TypeString, value)
+	}
+	if _u.mutation.WebhookSecretCleared() {
+		_spec.ClearField(appstripe.FieldWebhookSecret, field.TypeString)
 	}
 	if _u.mutation.CustomerAppsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -375,10 +375,10 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "stripe_account_id", Type: field.TypeString},
 		{Name: "stripe_livemode", Type: field.TypeBool},
-		{Name: "api_key", Type: field.TypeString},
+		{Name: "api_key", Type: field.TypeString, Nullable: true},
 		{Name: "masked_api_key", Type: field.TypeString},
 		{Name: "stripe_webhook_id", Type: field.TypeString},
-		{Name: "webhook_secret", Type: field.TypeString},
+		{Name: "webhook_secret", Type: field.TypeString, Nullable: true},
 	}
 	// AppStripesTable holds the schema information for the "app_stripes" table.
 	AppStripesTable = &schema.Table{
@@ -6233,6 +6233,10 @@ func init() {
 	AppCustomersTable.ForeignKeys[0].RefTable = AppsTable
 	AppCustomersTable.ForeignKeys[1].RefTable = CustomersTable
 	AppStripesTable.ForeignKeys[0].RefTable = AppsTable
+	AppStripesTable.Annotation = &entsql.Annotation{}
+	AppStripesTable.Annotation.Checks = map[string]string{
+		"app_stripe_secret_lifecycle": "(deleted_at IS NULL AND api_key IS NOT NULL AND webhook_secret IS NOT NULL) OR (deleted_at IS NOT NULL AND api_key IS NULL AND webhook_secret IS NULL)",
+	}
 	AppStripeCustomersTable.ForeignKeys[0].RefTable = AppStripesTable
 	AppStripeCustomersTable.ForeignKeys[1].RefTable = CustomersTable
 	BalanceSnapshotsTable.ForeignKeys[0].RefTable = EntitlementsTable

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -7845,7 +7845,7 @@ func (m *AppStripeMutation) APIKey() (r string, exists bool) {
 // OldAPIKey returns the old "api_key" field's value of the AppStripe entity.
 // If the AppStripe object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AppStripeMutation) OldAPIKey(ctx context.Context) (v string, err error) {
+func (m *AppStripeMutation) OldAPIKey(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAPIKey is only allowed on UpdateOne operations")
 	}
@@ -7859,9 +7859,22 @@ func (m *AppStripeMutation) OldAPIKey(ctx context.Context) (v string, err error)
 	return oldValue.APIKey, nil
 }
 
+// ClearAPIKey clears the value of the "api_key" field.
+func (m *AppStripeMutation) ClearAPIKey() {
+	m.api_key = nil
+	m.clearedFields[appstripe.FieldAPIKey] = struct{}{}
+}
+
+// APIKeyCleared returns if the "api_key" field was cleared in this mutation.
+func (m *AppStripeMutation) APIKeyCleared() bool {
+	_, ok := m.clearedFields[appstripe.FieldAPIKey]
+	return ok
+}
+
 // ResetAPIKey resets all changes to the "api_key" field.
 func (m *AppStripeMutation) ResetAPIKey() {
 	m.api_key = nil
+	delete(m.clearedFields, appstripe.FieldAPIKey)
 }
 
 // SetMaskedAPIKey sets the "masked_api_key" field.
@@ -7953,7 +7966,7 @@ func (m *AppStripeMutation) WebhookSecret() (r string, exists bool) {
 // OldWebhookSecret returns the old "webhook_secret" field's value of the AppStripe entity.
 // If the AppStripe object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AppStripeMutation) OldWebhookSecret(ctx context.Context) (v string, err error) {
+func (m *AppStripeMutation) OldWebhookSecret(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldWebhookSecret is only allowed on UpdateOne operations")
 	}
@@ -7967,9 +7980,22 @@ func (m *AppStripeMutation) OldWebhookSecret(ctx context.Context) (v string, err
 	return oldValue.WebhookSecret, nil
 }
 
+// ClearWebhookSecret clears the value of the "webhook_secret" field.
+func (m *AppStripeMutation) ClearWebhookSecret() {
+	m.webhook_secret = nil
+	m.clearedFields[appstripe.FieldWebhookSecret] = struct{}{}
+}
+
+// WebhookSecretCleared returns if the "webhook_secret" field was cleared in this mutation.
+func (m *AppStripeMutation) WebhookSecretCleared() bool {
+	_, ok := m.clearedFields[appstripe.FieldWebhookSecret]
+	return ok
+}
+
 // ResetWebhookSecret resets all changes to the "webhook_secret" field.
 func (m *AppStripeMutation) ResetWebhookSecret() {
 	m.webhook_secret = nil
+	delete(m.clearedFields, appstripe.FieldWebhookSecret)
 }
 
 // AddCustomerAppIDs adds the "customer_apps" edge to the AppStripeCustomer entity by ids.
@@ -8299,6 +8325,12 @@ func (m *AppStripeMutation) ClearedFields() []string {
 	if m.FieldCleared(appstripe.FieldDeletedAt) {
 		fields = append(fields, appstripe.FieldDeletedAt)
 	}
+	if m.FieldCleared(appstripe.FieldAPIKey) {
+		fields = append(fields, appstripe.FieldAPIKey)
+	}
+	if m.FieldCleared(appstripe.FieldWebhookSecret) {
+		fields = append(fields, appstripe.FieldWebhookSecret)
+	}
 	return fields
 }
 
@@ -8315,6 +8347,12 @@ func (m *AppStripeMutation) ClearField(name string) error {
 	switch name {
 	case appstripe.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case appstripe.FieldAPIKey:
+		m.ClearAPIKey()
+		return nil
+	case appstripe.FieldWebhookSecret:
+		m.ClearWebhookSecret()
 		return nil
 	}
 	return fmt.Errorf("unknown AppStripe nullable field %s", name)

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -428,6 +428,34 @@ func (u *AppStripeUpdateOne) SetOrClearDeletedAt(value *time.Time) *AppStripeUpd
 	return u.SetDeletedAt(*value)
 }
 
+func (u *AppStripeUpdate) SetOrClearAPIKey(value *string) *AppStripeUpdate {
+	if value == nil {
+		return u.ClearAPIKey()
+	}
+	return u.SetAPIKey(*value)
+}
+
+func (u *AppStripeUpdateOne) SetOrClearAPIKey(value *string) *AppStripeUpdateOne {
+	if value == nil {
+		return u.ClearAPIKey()
+	}
+	return u.SetAPIKey(*value)
+}
+
+func (u *AppStripeUpdate) SetOrClearWebhookSecret(value *string) *AppStripeUpdate {
+	if value == nil {
+		return u.ClearWebhookSecret()
+	}
+	return u.SetWebhookSecret(*value)
+}
+
+func (u *AppStripeUpdateOne) SetOrClearWebhookSecret(value *string) *AppStripeUpdateOne {
+	if value == nil {
+		return u.ClearWebhookSecret()
+	}
+	return u.SetWebhookSecret(*value)
+}
+
 func (u *AppStripeCustomerUpdate) SetOrClearDeletedAt(value *time.Time) *AppStripeCustomerUpdate {
 	if value == nil {
 		return u.ClearDeletedAt()

--- a/openmeter/ent/schema/app_stripe.go
+++ b/openmeter/ent/schema/app_stripe.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/entsql"
+	entschema "entgo.io/ent/schema"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -28,10 +29,18 @@ func (AppStripe) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("stripe_account_id").Immutable(),
 		field.Bool("stripe_livemode").Immutable(),
-		field.String("api_key").NotEmpty().Sensitive(),
+		field.String("api_key").Optional().Nillable().NotEmpty().Sensitive(),
 		field.String("masked_api_key").NotEmpty(),
 		field.String("stripe_webhook_id").NotEmpty(),
-		field.String("webhook_secret").NotEmpty().Sensitive(),
+		field.String("webhook_secret").Optional().Nillable().NotEmpty().Sensitive(),
+	}
+}
+
+func (AppStripe) Annotations() []entschema.Annotation {
+	return []entschema.Annotation{
+		entsql.Checks(map[string]string{
+			"app_stripe_secret_lifecycle": `(deleted_at IS NULL AND api_key IS NOT NULL AND webhook_secret IS NOT NULL) OR (deleted_at IS NOT NULL AND api_key IS NULL AND webhook_secret IS NULL)`,
+		}),
 	}
 }
 

--- a/test/app/stripe/appstripe.go
+++ b/test/app/stripe/appstripe.go
@@ -155,6 +155,9 @@ func (s *AppHandlerTestSuite) TestUpdate(ctx context.Context, t *testing.T) {
 
 // TestUninstall tests uninstalling a stripe app
 func (s *AppHandlerTestSuite) TestUninstall(ctx context.Context, t *testing.T) {
+	// Given an active Stripe app with provider metadata and credentials.
+	// When the app is uninstalled.
+	// Then it remains resolvable as a deleted Stripe app without usable credentials.
 	s.setupNamespace(t)
 
 	// Create a stripe app first
@@ -163,6 +166,19 @@ func (s *AppHandlerTestSuite) TestUninstall(ctx context.Context, t *testing.T) {
 
 	require.NoError(t, err, "Create stripe app must not return error")
 	require.NotNil(t, createApp, "Create stripe app must return app")
+	createdStripeApp, ok := createApp.(appstripe.App)
+	require.True(t, ok)
+	s.Env.Secret().EnableMock()
+	defer s.Env.Secret().DisableMock()
+	s.Env.Secret().
+		On("GetAppSecret", createdStripeApp.APIKey).
+		Return(secretentity.Secret{
+			SecretID: createdStripeApp.APIKey,
+			Value:    createdStripeApp.APIKey.ID,
+		}, nil).
+		Once()
+	s.Env.Secret().On("DeleteAppSecret", createdStripeApp.APIKey).Return(nil).Once()
+	s.Env.Secret().On("DeleteAppSecret", createdStripeApp.WebhookSecret).Return(nil).Once()
 
 	// Mocks
 	s.Env.StripeAppClient().
@@ -177,9 +193,19 @@ func (s *AppHandlerTestSuite) TestUninstall(ctx context.Context, t *testing.T) {
 
 	require.NoError(t, err, "Uninstall stripe app must not return error")
 
-	// Get should return 404
-	_, err = s.Env.App().GetApp(ctx, createApp.GetID())
-	require.True(t, app.IsAppNotFoundError(err), "get after uninstall must return app not found error")
+	deleted, err := s.Env.App().GetApp(ctx, createApp.GetID())
+	require.NoError(t, err)
+	deletedStripeApp, ok := deleted.(appstripe.App)
+	require.True(t, ok)
+	require.NotNil(t, deleted.GetAppBase().DeletedAt)
+	require.Equal(t, createdStripeApp.StripeAccountID, deletedStripeApp.StripeAccountID)
+	require.Equal(t, createdStripeApp.Livemode, deletedStripeApp.Livemode)
+	require.Equal(t, createdStripeApp.MaskedAPIKey, deletedStripeApp.MaskedAPIKey)
+	require.Equal(t, createdStripeApp.StripeWebhookID, deletedStripeApp.StripeWebhookID)
+	require.Empty(t, deletedStripeApp.APIKey.ID)
+	require.Empty(t, deletedStripeApp.WebhookSecret.ID)
+	require.ErrorIs(t, deleted.ValidateCapabilities(app.CapabilityTypeInvoiceCustomers), app.ErrAppDeleted)
+	s.Env.Secret().AssertExpectations(t)
 }
 
 // TestCustomerData tests stripe app behavior when adding customer data

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -26,6 +26,7 @@ import (
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
 	creditgrant "github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
 	creditgrantservice "github.com/openmeterio/openmeter/openmeter/billing/creditgrant/service"
+	billinghttpdriver "github.com/openmeterio/openmeter/openmeter/billing/httpdriver"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	ledgerbreakage "github.com/openmeterio/openmeter/openmeter/ledger/breakage"
@@ -1343,6 +1344,165 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 
 	s.Equal("ACME Inc. (updated)", invoice.Supplier.Name)
 	s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+}
+
+func (s *StripeInvoiceTestSuite) TestDeletedAppFailsAdvancementButAllowsInvoiceDeletion() {
+	ctx := s.T().Context()
+	namespace := "ns-deleted-stripe-app"
+	now := time.Date(2026, 8, 13, 9, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	// Given an invoice whose draft was synchronized with Stripe.
+	// When the Stripe subtype is missing and its app identity is soft-deleted.
+	// Then reads keep working, advancement fails validation, and invoice deletion remains available.
+	var stripeApp app.App
+	var customerEntity *customer.Customer
+	var customerData appstripe.CustomerData
+	var invoice billing.StandardInvoice
+
+	s.Run("given a synchronized Stripe invoice", func() {
+		var err error
+		stripeApp, customerEntity, customerData, err = s.Fixture.setupAppWithCustomer(ctx, namespace)
+		s.Require().NoError(err)
+
+		s.ProvisionBillingProfile(ctx, namespace, stripeApp.GetID(), billingtest.WithManualApproval())
+		s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+
+		s.StripeAppClient.
+			On("GetCustomer", customerData.StripeCustomerID).
+			Return(stripeclient.StripeCustomer{
+				StripeCustomerID: customerData.StripeCustomerID,
+				DefaultPaymentMethod: &stripeclient.StripePaymentMethod{
+					ID: "pm_deleted_app",
+					BillingAddress: &models.Address{
+						Country: lo.ToPtr(models.CountryCode("US")),
+					},
+				},
+			}, nil)
+		s.StripeAppClient.
+			On("CreateInvoice", mock.Anything).
+			Return(&stripe.Invoice{
+				ID:       "in_deleted_app",
+				Customer: &stripe.Customer{ID: customerData.StripeCustomerID},
+				Currency: "USD",
+				Lines:    &stripe.InvoiceLineItemList{},
+			}, nil)
+		s.StripeAppClient.
+			On("AddInvoiceLines", mock.Anything).
+			Return([]stripeclient.StripeInvoiceItemWithLineID{}, nil)
+
+		_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+			Customer: customerEntity.GetID(),
+			Currency: currencyx.FiatCode(currency.USD),
+			Lines: []billing.GatheringLine{
+				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+					Namespace:     namespace,
+					Period:        timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now.Add(-time.Hour)},
+					InvoiceAt:     now.Add(-time.Second),
+					ManagedBy:     billing.ManuallyManagedLine,
+					Name:          "Test item",
+					PerUnitAmount: alpacadecimal.NewFromInt(100),
+					Currency:      currencyx.FiatCode(currency.USD),
+					PaymentTerm:   productcatalog.InArrearsPaymentTerm,
+				}),
+			},
+		})
+		s.Require().NoError(err)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: customerEntity.GetID(),
+			AsOf:     lo.ToPtr(now),
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+	})
+
+	s.Run("when the Stripe subtype is missing and the app is soft-deleted", func() {
+		// Simulate the legacy partial uninstall that caused the production failure.
+		s.Require().NoError(s.DBClient.AppStripe.DeleteOneID(stripeApp.GetID().ID).Exec(ctx))
+		_, err := s.DBClient.App.UpdateOneID(stripeApp.GetID().ID).
+			SetDeletedAt(clock.Now()).
+			Save(ctx)
+		s.Require().NoError(err)
+	})
+
+	s.Run("then app and invoice reads retain the Stripe identity", func() {
+		resolvedApp, err := s.AppService.GetApp(ctx, stripeApp.GetID())
+		s.Require().NoError(err)
+		_, ok := resolvedApp.(appstripe.App)
+		s.True(ok)
+		s.Equal(stripeApp.GetID(), resolvedApp.GetID())
+		s.Equal(stripeApp.GetType(), resolvedApp.GetType())
+		s.Require().NotNil(resolvedApp.GetAppBase().DeletedAt)
+		s.ErrorIs(resolvedApp.ValidateCapabilities(app.CapabilityTypeInvoiceCustomers), app.ErrAppDeleted)
+
+		refetched, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(refetched.Workflow.Apps)
+		_, ok = refetched.Workflow.Apps.Tax.(appstripe.App)
+		s.True(ok)
+		_, ok = refetched.Workflow.Apps.Invoicing.(appstripe.App)
+		s.True(ok)
+		_, ok = refetched.Workflow.Apps.Payment.(appstripe.App)
+		s.True(ok)
+		s.Equal(stripeApp.GetID(), refetched.Workflow.Apps.Tax.GetID())
+		s.Equal(stripeApp.GetID(), refetched.Workflow.Apps.Invoicing.GetID())
+		s.Equal(stripeApp.GetID(), refetched.Workflow.Apps.Payment.GetID())
+		_, err = billinghttpdriver.MapStandardInvoiceToAPI(refetched)
+		s.Require().NoError(err)
+	})
+
+	s.Run("then advancement records a critical validation issue", func() {
+		var err error
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
+
+		deletedIssue, found := lo.Find(invoice.ValidationIssues, func(issue billing.ValidationIssue) bool {
+			return issue.Code == billing.ErrInvoiceWorkflowAppDeleted.Code
+		})
+		s.Require().True(found)
+		s.Equal(billing.ValidationIssueSeverityCritical, deletedIssue.Severity)
+
+		refetched, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, refetched.Status)
+		_, ok := refetched.Workflow.Apps.Invoicing.(appstripe.App)
+		s.True(ok)
+
+		candidates, err := s.BillingService.ListStandardInvoicesPendingAdvancement(ctx, billing.ListStandardInvoicesPendingAdvancementInput{
+			Namespaces: []string{namespace},
+			IDs:        []string{invoice.ID},
+			AsOf:       now.Add(time.Hour),
+		})
+		s.Require().NoError(err)
+		s.Empty(candidates)
+	})
+
+	s.Run("then invoice deletion skips provider cleanup with a warning", func() {
+		var err error
+		invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceAPIRequest,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+
+		deleteSkippedIssue, found := lo.Find(invoice.ValidationIssues, func(issue billing.ValidationIssue) bool {
+			return issue.Code == billing.WarnInvoiceWorkflowAppDeleteSkipped.Code
+		})
+		s.Require().True(found)
+		s.Equal(billing.ValidationIssueSeverityWarning, deleteSkippedIssue.Severity)
+	})
 }
 
 func (s *StripeInvoiceTestSuite) TestSendInvoice() {

--- a/tools/migrate/migrations/20260814064718_make_stripe_app_secrets_nullable.down.sql
+++ b/tools/migrate/migrations/20260814064718_make_stripe_app_secrets_nullable.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "app_stripes" table
+ALTER TABLE "app_stripes" ALTER COLUMN "webhook_secret" SET NOT NULL, ALTER COLUMN "api_key" SET NOT NULL, DROP CONSTRAINT "app_stripe_secret_lifecycle";

--- a/tools/migrate/migrations/20260814064718_make_stripe_app_secrets_nullable.up.sql
+++ b/tools/migrate/migrations/20260814064718_make_stripe_app_secrets_nullable.up.sql
@@ -1,0 +1,2 @@
+-- modify "app_stripes" table
+ALTER TABLE "app_stripes" ADD CONSTRAINT "app_stripe_secret_lifecycle" CHECK (((deleted_at IS NULL) AND (api_key IS NOT NULL) AND (webhook_secret IS NOT NULL)) OR ((deleted_at IS NOT NULL) AND (api_key IS NULL) AND (webhook_secret IS NULL))), ALTER COLUMN "api_key" DROP NOT NULL, ALTER COLUMN "webhook_secret" DROP NOT NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:AxFosLDftkgQaBEIS8tPEoLcxeaTQASkfb+z8xY+CYk=
+h1:nSRJ0al22pbnOmFndF//0+6xErV5djgIXQJlFdXpQco=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -263,3 +263,4 @@ h1:AxFosLDftkgQaBEIS8tPEoLcxeaTQASkfb+z8xY+CYk=
 20260809172658_backfill_persisted_charge_discount_correlation_ids.up.sql h1:Ybb0TjDQ+u/OYhFRtPHIau+NK1PS/DO+sMdTLn5XJHY=
 20260810064730_backfill_subscription_item_currencies.up.sql h1:e2UeY1pD0Icov44B3IRkjQlx8Xn3DIS1httVx36CYI8=
 20260810084018_custom_currency_subscription_semantics.up.sql h1:ENlniMbQWePP3Lsu2ECok9tppZqusd7wGqOuO1VMNPA=
+20260814064718_make_stripe_app_secrets_nullable.up.sql h1:QyRP7+0X/pUyhAEzD7wxBWPiFTS63r/Dor3FJO3NPns=


### PR DESCRIPTION
## Summary

- preserve deleted app identity while replacing provider behavior with deterministic unavailable operations
- return billing-owned validation errors for deleted invoicing apps, while allowing invoice deletion with a warning
- soft-delete Stripe subtype rows, clear secret references atomically, and retain non-secret provider metadata
- keep deleted and legacy missing-subtype apps resolvable for invoice and public API reads
- add PostgreSQL-backed adapter, uninstall, and billing lifecycle regressions

## Root cause

Invoice reads and advancement resolved the workflow app by instantiating its provider implementation. Stripe uninstallation hard-deleted the provider subtype row, so invoices retaining that historical app reference failed during app construction before billing could record a validation issue or enter the appropriate failed state.

## Behavior

Deleted apps retain their ID, type, and public metadata. Generic operations return `app.ErrAppDeleted`; invoicing operations return critical billing validation issues. External invoice deletion remains available and records a warning when provider cleanup must be skipped.

Stripe uninstallation now preserves the subtype row, sets `deleted_at`, and clears both secret references in one database update. Active rows require both references and deleted rows disallow them through a database check constraint.

The migration down path requires purging soft-deleted Stripe subtype rows or reconstructing both valid secret references before restoring `NOT NULL`.

## Validation

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/app/... ./openmeter/billing/... ./test/app/stripe`
- `nix develop --impure .#ci -c make migrate-check`
- `nix develop --impure .#ci -c make lint-go-fast`

Maintenance task; no Jira ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely uninstalling Stripe apps while preserving app identity and historical metadata.
  * Historical invoices remain readable and expandable after an app is deleted.
  * Deleted apps now provide clear status handling across customer, configuration, and invoicing operations.
* **Bug Fixes**
  * Prevented deleted apps from being used for new Stripe operations.
  * Added clearer warnings when external invoice cleanup is skipped.
* **Documentation**
  * Documented credential lifecycle and deleted-app invoice behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves deleted workflow-app identities while replacing provider behavior with deterministic unavailable operations.
- Introduces shared deleted-app implementations and billing-owned validation errors or warnings.
- Soft-deletes Stripe subtype rows, atomically clears credential references, and enforces the active/deleted credential lifecycle with a database constraint.
- Keeps deleted and legacy missing-subtype apps resolvable for invoice and public API reads.
- Adds adapter, uninstall, migration, and billing lifecycle regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

Production factories consistently install active or deleted operation implementations, Stripe credential removal is atomic and database-constrained, and the added lifecycle regressions cover historical reads, failed advancement, and invoice deletion.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/app/deleted.go | Adds deterministic unavailable behavior for generic operations on deleted apps while retaining their identity. |
| openmeter/app/stripe/service/factory.go | Rehydrates deleted and legacy missing-subtype Stripe apps without requiring active provider credentials. |
| openmeter/app/stripe/adapter/stripe.go | Soft-deletes Stripe subtype data, clears both credential references atomically, and excludes deleted rows from active provider operations. |
| openmeter/billing/app.go | Adds deleted invoicing behavior that produces critical validation errors for advancement and a warning for skipped external deletion. |
| openmeter/ent/schema/app_stripe.go | Makes credential references nullable and enforces mutually consistent active and deleted credential states. |
| tools/migrate/migrations/20260814064718_make_stripe_app_secrets_nullable.up.sql | Applies the Stripe credential lifecycle constraint and permits NULL references for deleted subtype rows. |
| test/app/stripe/invoice_test.go | Covers historical app resolution, failed invoice advancement, and warning-backed invoice deletion after provider removal. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as App/Billing caller
  participant Apps as App service
  participant Factory as Provider factory
  participant DB as PostgreSQL
  participant Billing as Invoice lifecycle

  API->>Apps: Resolve historical app ID
  Apps->>DB: Load soft-deleted AppBase
  Apps->>Factory: NewApp(deleted AppBase)
  Factory->>DB: Load retained provider metadata
  Factory-->>Apps: App identity + unavailable operations
  Apps-->>API: Resolvable deleted app
  Billing->>Apps: Resolve invoice workflow app
  Billing->>Factory: Invoke invoicing operation
  Factory-->>Billing: Deleted-app validation issue
  alt Invoice advancement
    Billing->>Billing: Enter failed lifecycle state
  else Invoice deletion
    Billing->>Billing: Delete invoice and record warning
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(app): preserve deleted workflow apps"](https://github.com/openmeterio/openmeter/commit/72c8a36ab1e2851d730a090a2085d017d9b7680b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53268555)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [App Framework (Marketplace Integrations)](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/app.md)
- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)
- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)
</details>

<!-- /greptile_comment -->