### PR TITLE
refactor: make subscription sync invoice line updates explicit

### DIFF
--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
@@ -201,7 +201,7 @@ func isDryRunLoggablePatch(patch Patch, invoicesByID map[string]billing.Invoice)
 			return true
 		}
 
-		return isMutableInvoice(updatePatch.TargetState.GetInvoiceID(), invoicesByID)
+		return isMutableInvoice(updatePatch.InvoiceID, invoicesByID)
 	default:
 		return true
 	}
@@ -246,7 +246,7 @@ type patchesParsed struct {
 }
 
 type invoicePatches struct {
-	updatedLines []billing.GenericInvoiceLine
+	updatedLines []PatchLineUpdate
 	deletedLines []billing.LineID
 }
 
@@ -284,9 +284,13 @@ func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
 				return patchesParsed{}, fmt.Errorf("getting line: %w", err)
 			}
 
-			lineUpdates := parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()]
-			lineUpdates.updatedLines = append(lineUpdates.updatedLines, update.TargetState)
-			parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()] = lineUpdates
+			if err := update.Validate(); err != nil {
+				return patchesParsed{}, fmt.Errorf("validating line[%s] update: %w", update.Line.ID, err)
+			}
+
+			lineUpdates := parsed.updatedLinesByInvoiceID[update.InvoiceID]
+			lineUpdates.updatedLines = append(lineUpdates.updatedLines, update)
+			parsed.updatedLinesByInvoiceID[update.InvoiceID] = lineUpdates
 		case PatchOpSplitLineGroupDelete:
 			deletePatch, err := patch.AsDeleteSplitLineGroupPatch()
 			if err != nil {
@@ -347,15 +351,20 @@ func (u *Updater) updateMutableStandardInvoice(ctx context.Context, invoice bill
 				line.DeletedAt = lo.ToPtr(clock.Now())
 			}
 
-			for _, targetState := range linePatches.updatedLines {
-				targetStandardLine, err := targetState.AsInvoiceLine().AsStandardLine()
-				if err != nil {
-					return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", targetState.GetID(), err)
+			for _, update := range linePatches.updatedLines {
+				line := invoice.Lines.GetByID(update.Line.ID)
+				if line == nil {
+					return fmt.Errorf("line[%s] not found in the invoice, cannot update", update.Line.ID)
 				}
 
-				line := invoice.Lines.GetByID(targetStandardLine.ID)
-				if line == nil {
-					return fmt.Errorf("line[%s] not found in the invoice, cannot update", targetStandardLine.ID)
+				targetState, err := update.Apply(line.AsGenericLine())
+				if err != nil {
+					return fmt.Errorf("applying update to line[%s]: %w", update.Line.ID, err)
+				}
+
+				targetStandardLine, err := targetState.AsInvoiceLine().AsStandardLine()
+				if err != nil {
+					return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", update.Line.ID, err)
 				}
 
 				updatedQtyLine, err := u.quantitySnapshotter.SnapshotLineQuantity(ctx, billinglineengine.SnapshotLineQuantityInput{
@@ -427,10 +436,20 @@ func (u *Updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.
 				}
 			}
 
-			for _, targetStateGeneric := range linePatches.updatedLines {
-				targetGatheringLine, err := targetStateGeneric.AsInvoiceLine().AsGatheringLine()
+			for _, update := range linePatches.updatedLines {
+				line, ok := invoice.Lines.GetByID(update.Line.ID)
+				if !ok {
+					return fmt.Errorf("line[%s] not found in the invoice, cannot update", update.Line.ID)
+				}
+
+				targetState, err := update.Apply(line.AsGenericLine())
 				if err != nil {
-					return fmt.Errorf("line[%s] is not a gathering line, cannot update: %w", targetStateGeneric.GetID(), err)
+					return fmt.Errorf("applying update to line[%s]: %w", update.Line.ID, err)
+				}
+
+				targetGatheringLine, err := targetState.AsInvoiceLine().AsGatheringLine()
+				if err != nil {
+					return fmt.Errorf("line[%s] is not a gathering line, cannot update: %w", update.Line.ID, err)
 				}
 
 				if err := invoice.Lines.ReplaceByID(targetGatheringLine); err != nil {
@@ -462,33 +481,36 @@ func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.St
 		)
 	}
 
-	for _, targetState := range linePatches.updatedLines {
-		existingLine := invoice.Lines.GetByID(targetState.GetID())
+	for _, update := range linePatches.updatedLines {
+		existingLine := invoice.Lines.GetByID(update.Line.ID)
 		if existingLine == nil {
-			return fmt.Errorf("line[%s] not found in the invoice, cannot update", targetState.GetID())
+			return fmt.Errorf("line[%s] not found in the invoice, cannot update", update.Line.ID)
+		}
+
+		targetState, err := update.Apply(existingLine.AsGenericLine())
+		if err != nil {
+			return fmt.Errorf("applying update to line[%s]: %w", update.Line.ID, err)
 		}
 
 		if IsFlatFee(targetState) {
-			existingPerUnitAmount, err := GetFlatFeePerUnitAmount(existingLine)
-			if err != nil {
-				return fmt.Errorf("getting flat fee per unit amount: %w", err)
+			if targetPerUnitAmount, ok := update.FlatFeePerUnitAmount.Get(); ok {
+				existingPerUnitAmount, err := GetFlatFeePerUnitAmount(existingLine)
+				if err != nil {
+					return fmt.Errorf("getting flat fee per unit amount: %w", err)
+				}
+
+				if !existingPerUnitAmount.Equal(targetPerUnitAmount) {
+					validationIssues = append(validationIssues,
+						newValidationIssueOnLine(existingLine, "flat fee line's per unit amount cannot be changed on immutable invoice (new per unit amount: %s)",
+							targetPerUnitAmount.String()),
+					)
+
+					continue
+				}
 			}
 
-			targetPerUnitAmount, err := GetFlatFeePerUnitAmount(targetState)
-			if err != nil {
-				return fmt.Errorf("getting flat fee per unit amount: %w", err)
-			}
-
-			if !existingPerUnitAmount.Equal(targetPerUnitAmount) {
-				validationIssues = append(validationIssues,
-					newValidationIssueOnLine(existingLine, "flat fee line's per unit amount cannot be changed on immutable invoice (new per unit amount: %s)",
-						targetPerUnitAmount.String()),
-				)
-
-				continue
-			}
-
-			if !targetState.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
+			if targetPeriod, ok := update.ServicePeriod.Get(); ok &&
+				!targetPeriod.Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
 				validationIssues = append(validationIssues,
 					newValidationIssueOnLine(existingLine, "flat fee line's service period cannot be changed on immutable invoice"),
 				)
@@ -497,10 +519,11 @@ func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.St
 			continue
 		}
 
-		if !targetState.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
+		if targetPeriod, ok := update.ServicePeriod.Get(); ok &&
+			!targetPeriod.Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
 			targetStandardLine, err := targetState.AsInvoiceLine().AsStandardLine()
 			if err != nil {
-				return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", targetState.GetID(), err)
+				return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", update.Line.ID, err)
 			}
 
 			targetStateWithUpdatedQty, err := u.quantitySnapshotter.SnapshotLineQuantity(ctx, billinglineengine.SnapshotLineQuantityInput{
@@ -508,7 +531,7 @@ func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.St
 				Line:    &targetStandardLine,
 			})
 			if err != nil {
-				return fmt.Errorf("snapshotting quantity for line[%s]: %w", targetState.GetID(), err)
+				return fmt.Errorf("snapshotting quantity for line[%s]: %w", update.Line.ID, err)
 			}
 
 			if !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(lo.FromPtr(existingLine.UsageBased.Quantity)) {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate_test.go
@@ -1,0 +1,106 @@
+package invoiceupdater
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+)
+
+func TestUpdateImmutableInvoiceChecksOnlyPresentFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flat fee amount takes precedence over service period drift", func(t *testing.T) {
+		t.Parallel()
+
+		line := newUpdateLinePatchTestStandardLine()
+		line.UsageBased.Price = productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount:      alpacadecimal.NewFromInt(10),
+			PaymentTerm: productcatalog.InAdvancePaymentTerm,
+		})
+		invoice := newUpdateLinePatchTestImmutableInvoice(line)
+		service := &immutableInvoiceBillingServiceStub{invoice: invoice}
+		updater := &Updater{billingService: service}
+		updatedPeriod := line.Period
+		updatedPeriod.To = updatedPeriod.To.AddDate(0, 0, 1)
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:                 line.GetLineID(),
+			InvoiceID:            line.InvoiceID,
+			ServicePeriod:        mo.Some(updatedPeriod),
+			FlatFeePerUnitAmount: mo.Some(alpacadecimal.NewFromInt(25)),
+		})
+		require.NoError(t, err)
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+
+		err = updater.updateImmutableInvoice(t.Context(), invoice, invoicePatches{
+			updatedLines: []PatchLineUpdate{update},
+		})
+		require.NoError(t, err)
+		require.Len(t, service.upsertedIssues, 1)
+		require.Contains(t, service.upsertedIssues[0].Message, "new per unit amount: 25")
+		require.NotContains(t, service.upsertedIssues[0].Message, "service period")
+	})
+
+	t.Run("deleted at clear preserves existing immutable policy", func(t *testing.T) {
+		t.Parallel()
+
+		line := newUpdateLinePatchTestStandardLine()
+		line.UsageBased.Price = productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount:      alpacadecimal.NewFromInt(10),
+			PaymentTerm: productcatalog.InAdvancePaymentTerm,
+		})
+		deletedAt := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+		line.DeletedAt = &deletedAt
+		invoice := newUpdateLinePatchTestImmutableInvoice(line)
+		service := &immutableInvoiceBillingServiceStub{invoice: invoice}
+		updater := &Updater{billingService: service}
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:      line.GetLineID(),
+			InvoiceID: line.InvoiceID,
+			DeletedAt: mo.Some[*time.Time](nil),
+		})
+		require.NoError(t, err)
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+
+		err = updater.updateImmutableInvoice(t.Context(), invoice, invoicePatches{
+			updatedLines: []PatchLineUpdate{update},
+		})
+		require.NoError(t, err)
+		require.Empty(t, service.upsertedIssues)
+	})
+}
+
+type immutableInvoiceBillingServiceStub struct {
+	billing.Service
+
+	invoice        billing.StandardInvoice
+	upsertedIssues billing.ValidationIssues
+}
+
+func (s *immutableInvoiceBillingServiceStub) GetStandardInvoiceById(_ context.Context, _ billing.GetStandardInvoiceByIdInput) (billing.StandardInvoice, error) {
+	return s.invoice, nil
+}
+
+func (s *immutableInvoiceBillingServiceStub) UpsertValidationIssues(_ context.Context, input billing.UpsertValidationIssuesInput) error {
+	s.upsertedIssues = input.Issues
+
+	return nil
+}
+
+func newUpdateLinePatchTestImmutableInvoice(line *billing.StandardLine) billing.StandardInvoice {
+	return billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			Namespace: "ns",
+			ID:        "invoice-1",
+		},
+		Lines: billing.NewStandardInvoiceLines([]*billing.StandardLine{line}),
+	}
+}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch.go
@@ -1,11 +1,17 @@
 package invoiceupdater
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type PatchOperation string
@@ -27,8 +33,131 @@ type PatchLineDelete struct {
 	InvoiceID string
 }
 
+// NewUpdateLinePatchInput describes only the line fields subscription sync intends to change.
+// An absent option preserves persisted state; DeletedAt containing nil explicitly restores a line.
+type NewUpdateLinePatchInput struct {
+	Line      billing.LineID
+	InvoiceID string
+
+	ServicePeriod        mo.Option[timeutil.ClosedPeriod]
+	InvoiceAt            mo.Option[time.Time]
+	DeletedAt            mo.Option[*time.Time]
+	FlatFeePerUnitAmount mo.Option[alpacadecimal.Decimal]
+}
+
+func (i NewUpdateLinePatchInput) IsNoop() bool {
+	return !i.ServicePeriod.IsPresent() &&
+		!i.InvoiceAt.IsPresent() &&
+		!i.DeletedAt.IsPresent() &&
+		!i.FlatFeePerUnitAmount.IsPresent()
+}
+
+func (i NewUpdateLinePatchInput) Validate() error {
+	var errs []error
+
+	if err := i.Line.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("line: %w", err))
+	}
+
+	if i.InvoiceID == "" {
+		errs = append(errs, errors.New("invoice id is required"))
+	}
+
+	if period, ok := i.ServicePeriod.Get(); ok {
+		if err := period.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("service period: %w", err))
+		}
+	}
+
+	if invoiceAt, ok := i.InvoiceAt.Get(); ok && invoiceAt.IsZero() {
+		errs = append(errs, errors.New("invoice at is required"))
+	}
+
+	if perUnitAmount, ok := i.FlatFeePerUnitAmount.Get(); ok && perUnitAmount.IsNegative() {
+		errs = append(errs, errors.New("flat fee per unit amount must not be negative"))
+	}
+
+	if i.IsNoop() {
+		errs = append(errs, errors.New("at least one line update is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 type PatchLineUpdate struct {
-	TargetState billing.GenericInvoiceLine
+	NewUpdateLinePatchInput
+}
+
+func (p PatchLineUpdate) Apply(line billing.GenericInvoiceLine) (billing.GenericInvoiceLine, error) {
+	if err := p.Validate(); err != nil {
+		return nil, fmt.Errorf("validating update: %w", err)
+	}
+
+	if line == nil {
+		return nil, errors.New("line is required")
+	}
+
+	if line.GetLineID() != p.Line {
+		return nil, fmt.Errorf("line id mismatch: expected %s, got %s", p.Line.ID, line.GetLineID().ID)
+	}
+
+	if line.GetInvoiceID() != p.InvoiceID {
+		return nil, fmt.Errorf("invoice id mismatch: expected %s, got %s", p.InvoiceID, line.GetInvoiceID())
+	}
+
+	updatedLine, err := line.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning line: %w", err)
+	}
+
+	if line.AsInvoiceLine().Type() == billing.InvoiceLineTypeGathering {
+		existingGatheringLine, err := line.AsInvoiceLine().AsGatheringLine()
+		if err != nil {
+			return nil, fmt.Errorf("converting existing line to gathering line: %w", err)
+		}
+
+		if existingGatheringLine.SplitLineHierarchy != nil {
+			hierarchy, err := existingGatheringLine.SplitLineHierarchy.Clone()
+			if err != nil {
+				return nil, fmt.Errorf("cloning split line hierarchy: %w", err)
+			}
+
+			updatedGatheringLine, err := updatedLine.AsInvoiceLine().AsGatheringLine()
+			if err != nil {
+				return nil, fmt.Errorf("converting updated line to gathering line: %w", err)
+			}
+
+			updatedGatheringLine.SplitLineHierarchy = &hierarchy
+			updatedLine = updatedGatheringLine.AsGenericLine()
+		}
+	}
+
+	if period, ok := p.ServicePeriod.Get(); ok {
+		updatedLine.UpdateServicePeriod(func(current *timeutil.ClosedPeriod) {
+			*current = period
+		})
+	}
+
+	if invoiceAt, ok := p.InvoiceAt.Get(); ok {
+		invoiceAtAccessor, ok := updatedLine.(billing.InvoiceAtAccessor)
+		if !ok {
+			return nil, fmt.Errorf("line[%s] does not support invoice at updates", p.Line.ID)
+		}
+
+		invoiceAtAccessor.SetInvoiceAt(invoiceAt)
+	}
+
+	if deletedAt, ok := p.DeletedAt.Get(); ok {
+		updatedLine.SetDeletedAt(deletedAt)
+	}
+
+	if perUnitAmount, ok := p.FlatFeePerUnitAmount.Get(); ok {
+		if err := SetFlatFeePerUnitAmount(updatedLine, perUnitAmount); err != nil {
+			return nil, fmt.Errorf("setting flat fee per unit amount: %w", err)
+		}
+	}
+
+	return updatedLine, nil
 }
 
 type PatchSplitLineGroupDelete struct {
@@ -104,13 +233,17 @@ func NewDeleteLinePatch(lineID billing.LineID, invoiceID string) Patch {
 	}
 }
 
-func NewUpdateLinePatch(line billing.GenericInvoiceLine) Patch {
+func NewUpdateLinePatch(input NewUpdateLinePatchInput) (Patch, error) {
+	if err := input.Validate(); err != nil {
+		return Patch{}, err
+	}
+
 	return Patch{
 		op: PatchOpLineUpdate,
 		updateLinePatch: PatchLineUpdate{
-			TargetState: line,
+			NewUpdateLinePatchInput: input,
 		},
-	}
+	}, nil
 }
 
 func NewDeleteSplitLineGroupPatch(groupID models.NamespacedID) Patch {
@@ -147,7 +280,34 @@ func (p Patch) Log(logger *slog.Logger) {
 	case PatchOpLineDelete:
 		logger.Info("delete line patch", "line_id", p.deleteLinePatch.Line, "invoice_id", p.deleteLinePatch.InvoiceID)
 	case PatchOpLineUpdate:
-		logger.Info("update line patch", "line_id", p.updateLinePatch.TargetState.GetLineID().ID, "invoice_id", p.updateLinePatch.TargetState.GetInvoiceID(), "new_service_period_from", p.updateLinePatch.TargetState.GetServicePeriod().From, "new_service_period_to", p.updateLinePatch.TargetState.GetServicePeriod().To, "unique_reference_id", p.updateLinePatch.TargetState.GetChildUniqueReferenceID())
+		args := []any{
+			"line_id", p.updateLinePatch.Line.ID,
+			"invoice_id", p.updateLinePatch.InvoiceID,
+		}
+		updatedFields := make([]string, 0, 4)
+
+		if period, ok := p.updateLinePatch.ServicePeriod.Get(); ok {
+			updatedFields = append(updatedFields, "service_period")
+			args = append(args, "new_service_period_from", period.From, "new_service_period_to", period.To)
+		}
+
+		if invoiceAt, ok := p.updateLinePatch.InvoiceAt.Get(); ok {
+			updatedFields = append(updatedFields, "invoice_at")
+			args = append(args, "new_invoice_at", invoiceAt)
+		}
+
+		if deletedAt, ok := p.updateLinePatch.DeletedAt.Get(); ok {
+			updatedFields = append(updatedFields, "deleted_at")
+			args = append(args, "new_deleted_at", deletedAt)
+		}
+
+		if perUnitAmount, ok := p.updateLinePatch.FlatFeePerUnitAmount.Get(); ok {
+			updatedFields = append(updatedFields, "flat_fee_per_unit_amount")
+			args = append(args, "new_flat_fee_per_unit_amount", perUnitAmount.String())
+		}
+
+		args = append(args, "updated_fields", updatedFields)
+		logger.Info("update line patch", args...)
 	case PatchOpSplitLineGroupDelete:
 		logger.Info("delete split line group patch", "group_id", p.deleteSplitLineGroupPatch.Group.ID)
 	case PatchOpSplitLineGroupUpdate:

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch_test.go
@@ -1,0 +1,403 @@
+package invoiceupdater
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestNewUpdateLinePatchInputValidate(t *testing.T) {
+	t.Parallel()
+
+	period := updateLinePatchTestPeriod()
+	validIdentity := NewUpdateLinePatchInput{
+		Line: billing.LineID{
+			Namespace: "ns",
+			ID:        "line-1",
+		},
+		InvoiceID: "invoice-1",
+	}
+
+	testCases := []struct {
+		name        string
+		input       NewUpdateLinePatchInput
+		errorString string
+	}{
+		{
+			name: "service period update",
+			input: func() NewUpdateLinePatchInput {
+				input := validIdentity
+				input.ServicePeriod = mo.Some(period)
+				return input
+			}(),
+		},
+		{
+			name: "explicit deleted at clear",
+			input: func() NewUpdateLinePatchInput {
+				input := validIdentity
+				input.DeletedAt = mo.Some[*time.Time](nil)
+				return input
+			}(),
+		},
+		{
+			name:        "empty update",
+			input:       validIdentity,
+			errorString: "at least one line update is required",
+		},
+		{
+			name: "missing identity",
+			input: NewUpdateLinePatchInput{
+				ServicePeriod: mo.Some(period),
+			},
+			errorString: "invoice id is required",
+		},
+		{
+			name: "zero invoice at",
+			input: func() NewUpdateLinePatchInput {
+				input := validIdentity
+				input.InvoiceAt = mo.Some(time.Time{})
+				return input
+			}(),
+			errorString: "invoice at is required",
+		},
+		{
+			name: "negative flat fee per unit amount",
+			input: func() NewUpdateLinePatchInput {
+				input := validIdentity
+				input.FlatFeePerUnitAmount = mo.Some(alpacadecimal.NewFromInt(-1))
+				return input
+			}(),
+			errorString: "flat fee per unit amount must not be negative",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.input.Validate()
+			if tt.errorString == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.errorString)
+		})
+	}
+}
+
+func TestNewUpdateLinePatchInputIsNoop(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, NewUpdateLinePatchInput{}.IsNoop())
+	require.True(t, NewUpdateLinePatchInput{
+		Line: billing.LineID{
+			Namespace: "ns",
+			ID:        "line-1",
+		},
+		InvoiceID: "invoice-1",
+	}.IsNoop())
+	require.False(t, NewUpdateLinePatchInput{ServicePeriod: mo.Some(updateLinePatchTestPeriod())}.IsNoop())
+	require.False(t, NewUpdateLinePatchInput{InvoiceAt: mo.Some(time.Time{})}.IsNoop())
+	require.False(t, NewUpdateLinePatchInput{DeletedAt: mo.Some[*time.Time](nil)}.IsNoop())
+	require.False(t, NewUpdateLinePatchInput{FlatFeePerUnitAmount: mo.Some(alpacadecimal.Zero)}.IsNoop())
+}
+
+func TestPatchLineUpdateApplyGatheringLine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omitted fields are preserved", func(t *testing.T) {
+		t.Parallel()
+
+		line := newUpdateLinePatchTestGatheringLine()
+		originalInvoiceAt := line.InvoiceAt
+		originalDeletedAt := *line.DeletedAt
+		originalDBState := line.DBState
+		updatedPeriod := line.ServicePeriod
+		updatedPeriod.To = updatedPeriod.To.AddDate(0, 1, 0)
+
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:          line.GetLineID(),
+			InvoiceID:     line.InvoiceID,
+			ServicePeriod: mo.Some(updatedPeriod),
+		})
+		require.NoError(t, err)
+
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+		updatedGeneric, err := update.Apply(line.AsGenericLine())
+		require.NoError(t, err)
+		updated, err := updatedGeneric.AsInvoiceLine().AsGatheringLine()
+		require.NoError(t, err)
+
+		require.Equal(t, updatedPeriod, updated.ServicePeriod)
+		require.Equal(t, originalInvoiceAt, updated.InvoiceAt)
+		require.Equal(t, originalDeletedAt, *updated.DeletedAt)
+		require.Same(t, originalDBState, updated.DBState)
+		require.Equal(t, "preserved", updated.Metadata["owner"])
+		require.NotNil(t, updated.SplitLineHierarchy)
+		require.NotSame(t, line.SplitLineHierarchy, updated.SplitLineHierarchy)
+		require.Equal(t, "group-1", updated.SplitLineHierarchy.Group.ID)
+
+		amount, err := GetFlatFeePerUnitAmount(updated.AsGenericLine())
+		require.NoError(t, err)
+		require.True(t, alpacadecimal.NewFromInt(10).Equal(amount))
+
+		updated.Metadata["owner"] = "changed"
+		require.Equal(t, "preserved", line.Metadata["owner"])
+		require.NotEqual(t, updatedPeriod, line.ServicePeriod)
+	})
+
+	t.Run("present nil clears deleted at", func(t *testing.T) {
+		t.Parallel()
+
+		line := newUpdateLinePatchTestGatheringLine()
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:      line.GetLineID(),
+			InvoiceID: line.InvoiceID,
+			DeletedAt: mo.Some[*time.Time](nil),
+		})
+		require.NoError(t, err)
+
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+		updatedGeneric, err := update.Apply(line.AsGenericLine())
+		require.NoError(t, err)
+		updated, err := updatedGeneric.AsInvoiceLine().AsGatheringLine()
+		require.NoError(t, err)
+
+		require.Nil(t, updated.DeletedAt)
+		require.NotNil(t, line.DeletedAt)
+		require.Equal(t, line.ServicePeriod, updated.ServicePeriod)
+		require.Equal(t, line.InvoiceAt, updated.InvoiceAt)
+	})
+
+	t.Run("flat fee amount preserves payment term", func(t *testing.T) {
+		t.Parallel()
+
+		line := newUpdateLinePatchTestGatheringLine()
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:                 line.GetLineID(),
+			InvoiceID:            line.InvoiceID,
+			FlatFeePerUnitAmount: mo.Some(alpacadecimal.NewFromInt(25)),
+		})
+		require.NoError(t, err)
+
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+		updatedGeneric, err := update.Apply(line.AsGenericLine())
+		require.NoError(t, err)
+		updated, err := updatedGeneric.AsInvoiceLine().AsGatheringLine()
+		require.NoError(t, err)
+		flatPrice, err := updated.Price.AsFlat()
+		require.NoError(t, err)
+
+		require.True(t, alpacadecimal.NewFromInt(25).Equal(flatPrice.Amount))
+		require.Equal(t, productcatalog.InAdvancePaymentTerm, flatPrice.PaymentTerm)
+	})
+}
+
+func TestPatchLineUpdateApplyRejectsIncompatibleFields(t *testing.T) {
+	t.Parallel()
+
+	line := newUpdateLinePatchTestStandardLine()
+
+	t.Run("invoice at on standard line", func(t *testing.T) {
+		t.Parallel()
+
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:      line.GetLineID(),
+			InvoiceID: line.InvoiceID,
+			InvoiceAt: mo.Some(line.InvoiceAt.Add(time.Hour)),
+		})
+		require.NoError(t, err)
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+
+		_, err = update.Apply(line.AsGenericLine())
+		require.ErrorContains(t, err, "does not support invoice at updates")
+	})
+
+	t.Run("flat fee amount on usage price", func(t *testing.T) {
+		t.Parallel()
+
+		patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+			Line:                 line.GetLineID(),
+			InvoiceID:            line.InvoiceID,
+			FlatFeePerUnitAmount: mo.Some(alpacadecimal.NewFromInt(2)),
+		})
+		require.NoError(t, err)
+		update, err := patch.AsUpdateLinePatch()
+		require.NoError(t, err)
+
+		_, err = update.Apply(line.AsGenericLine())
+		require.ErrorContains(t, err, "setting flat fee per unit amount")
+	})
+}
+
+func TestPatchLineUpdateApplyStandardLinePreservesOmittedFields(t *testing.T) {
+	t.Parallel()
+
+	line := newUpdateLinePatchTestStandardLine()
+	line.Metadata = models.Metadata{"owner": "preserved"}
+	line.DBState = &billing.StandardLine{}
+	originalDBState := line.DBState
+	originalInvoiceAt := line.InvoiceAt
+	updatedPeriod := line.Period
+	updatedPeriod.To = updatedPeriod.From.AddDate(0, 0, 15)
+	patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+		Line:          line.GetLineID(),
+		InvoiceID:     line.InvoiceID,
+		ServicePeriod: mo.Some(updatedPeriod),
+	})
+	require.NoError(t, err)
+	update, err := patch.AsUpdateLinePatch()
+	require.NoError(t, err)
+
+	updatedGeneric, err := update.Apply(line.AsGenericLine())
+	require.NoError(t, err)
+	updated, err := updatedGeneric.AsInvoiceLine().AsStandardLine()
+	require.NoError(t, err)
+
+	require.Equal(t, updatedPeriod, updated.Period)
+	require.Equal(t, originalInvoiceAt, updated.InvoiceAt)
+	require.Equal(t, models.Metadata{"owner": "preserved"}, updated.Metadata)
+	require.Same(t, originalDBState, updated.DBState)
+	require.NotEqual(t, updatedPeriod, line.Period)
+}
+
+func TestParsePatchesGroupsUpdateByInvoiceID(t *testing.T) {
+	t.Parallel()
+
+	period := updateLinePatchTestPeriod()
+	first, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+		Line: billing.LineID{
+			Namespace: "ns",
+			ID:        "line-1",
+		},
+		InvoiceID:     "invoice-1",
+		ServicePeriod: mo.Some(period),
+	})
+	require.NoError(t, err)
+	second, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+		Line: billing.LineID{
+			Namespace: "ns",
+			ID:        "line-2",
+		},
+		InvoiceID: "invoice-2",
+		DeletedAt: mo.Some[*time.Time](nil),
+	})
+	require.NoError(t, err)
+
+	parsed, err := (&Updater{}).parsePatches([]Patch{first, second})
+	require.NoError(t, err)
+	require.Len(t, parsed.updatedLinesByInvoiceID, 2)
+	require.Equal(t, "line-1", parsed.updatedLinesByInvoiceID["invoice-1"].updatedLines[0].Line.ID)
+	require.Equal(t, "line-2", parsed.updatedLinesByInvoiceID["invoice-2"].updatedLines[0].Line.ID)
+}
+
+func TestUpdateLinePatchLogDistinguishesOmittedFromClear(t *testing.T) {
+	t.Parallel()
+
+	patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
+		Line: billing.LineID{
+			Namespace: "ns",
+			ID:        "line-1",
+		},
+		InvoiceID: "invoice-1",
+		DeletedAt: mo.Some[*time.Time](nil),
+	})
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	patch.Log(slog.New(slog.NewJSONHandler(&output, nil)))
+
+	entry := map[string]any{}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &entry))
+	require.Equal(t, []any{"deleted_at"}, entry["updated_fields"])
+	require.Contains(t, entry, "new_deleted_at")
+	require.Nil(t, entry["new_deleted_at"])
+	require.NotContains(t, entry, "new_service_period_from")
+	require.NotContains(t, entry, "unique_reference_id")
+}
+
+func updateLinePatchTestPeriod() timeutil.ClosedPeriod {
+	return timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func newUpdateLinePatchTestGatheringLine() billing.GatheringLine {
+	period := updateLinePatchTestPeriod()
+	deletedAt := period.From.Add(time.Hour)
+
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "ns",
+				ID:        "line-1",
+				Name:      "line",
+			}),
+			Metadata:      models.Metadata{"owner": "preserved"},
+			ManagedBy:     billing.SubscriptionManagedLine,
+			Engine:        billing.LineEngineTypeInvoice,
+			InvoiceID:     "invoice-1",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.To,
+			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount:      alpacadecimal.NewFromInt(10),
+				PaymentTerm: productcatalog.InAdvancePaymentTerm,
+			}),
+		},
+		DBState: &billing.GatheringLine{},
+		SplitLineHierarchy: &billing.SplitLineHierarchy{
+			Group: billing.SplitLineGroup{
+				NamespacedID: models.NamespacedID{
+					Namespace: "ns",
+					ID:        "group-1",
+				},
+			},
+		},
+	}
+	line.DeletedAt = &deletedAt
+
+	return line
+}
+
+func newUpdateLinePatchTestStandardLine() *billing.StandardLine {
+	period := updateLinePatchTestPeriod()
+
+	return &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "ns",
+				ID:        "line-1",
+				Name:      "line",
+			}),
+			ManagedBy: billing.SubscriptionManagedLine,
+			Engine:    billing.LineEngineTypeInvoice,
+			InvoiceID: "invoice-1",
+			Currency:  currencyx.FiatCode("USD"),
+			Period:    period,
+			InvoiceAt: period.To,
+		},
+		UsageBased: &billing.UsageBasedLine{
+			Price:      productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+			FeatureKey: "feature-key",
+		},
+	}
+}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchhelpers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchhelpers.go
@@ -2,14 +2,15 @@ package reconciler
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func shouldSkipLinePatch(existingLine billing.GenericInvoiceLine, expectedLine billing.GatheringLine) bool {
@@ -51,48 +52,46 @@ func getPatchesForUpdateUsageBasedLine(existingLine billing.GenericInvoiceLine, 
 		return nil, fmt.Errorf("usage based patch cannot be applied to flat fee line[%s]", existingLine.GetLineID().ID)
 	}
 
-	targetLine, err := existingLine.CloneWithoutChildren()
-	if err != nil {
-		return nil, fmt.Errorf("cloning line: %w", err)
+	updateInput := invoiceupdater.NewUpdateLinePatchInput{
+		Line:      existingLine.GetLineID(),
+		InvoiceID: existingLine.GetInvoiceID(),
 	}
+	if !existingLine.GetServicePeriod().Equal(expectedLine.ServicePeriod) {
+		updateInput.ServicePeriod = mo.Some(expectedLine.ServicePeriod)
 
-	wasChange := false
-	if !targetLine.GetServicePeriod().Equal(expectedLine.ServicePeriod) {
-		wasChange = true
-
-		targetLine.UpdateServicePeriod(func(p *timeutil.ClosedPeriod) {
-			*p = expectedLine.ServicePeriod
-		})
-
-		isGatheringInvoice, err := invoices.IsGatheringInvoice(targetLine.GetInvoiceID())
+		isGatheringInvoice, err := invoices.IsGatheringInvoice(existingLine.GetInvoiceID())
 		if err != nil {
-			return nil, fmt.Errorf("getting invoice type for line[%s]: %w", targetLine.GetLineID().ID, err)
+			return nil, fmt.Errorf("getting invoice type for line[%s]: %w", existingLine.GetLineID().ID, err)
 		}
 
 		if isGatheringInvoice {
-			invoiceAtAccessor, ok := targetLine.(billing.InvoiceAtAccessor)
-			if !ok {
-				return nil, fmt.Errorf("target line is not an invoice at accessor: %T", targetLine)
-			}
-
-			invoiceAtAccessor.SetInvoiceAt(expectedLine.InvoiceAt)
+			updateInput.InvoiceAt = mo.Some(expectedLine.InvoiceAt)
 		}
 	}
 
-	if !invoiceupdater.IsFlatFee(targetLine) {
-		if targetLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
+	if !invoiceupdater.IsFlatFee(existingLine) {
+		targetPeriod := existingLine.GetServicePeriod()
+		if period, ok := updateInput.ServicePeriod.Get(); ok {
+			targetPeriod = period
+		}
+
+		if targetPeriod.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 			return lo.ToPtr(invoiceupdater.NewDeleteLinePatch(existingLine.GetLineID(), existingLine.GetInvoiceID())), nil
 		}
 	}
 
-	if targetLine.GetDeletedAt() != nil {
-		targetLine.SetDeletedAt(nil)
-		wasChange = true
+	if existingLine.GetDeletedAt() != nil {
+		updateInput.DeletedAt = mo.Some[*time.Time](nil)
 	}
 
-	if !wasChange {
+	if updateInput.IsNoop() {
 		return nil, nil
 	}
 
-	return lo.ToPtr(invoiceupdater.NewUpdateLinePatch(targetLine)), nil
+	patch, err := invoiceupdater.NewUpdateLinePatch(updateInput)
+	if err != nil {
+		return nil, fmt.Errorf("creating update line patch: %w", err)
+	}
+
+	return lo.ToPtr(patch), nil
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchhelpers_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchhelpers_test.go
@@ -1,0 +1,80 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestGetPatchesForUpdateUsageBasedLineEmitsOnlyIntendedFields(t *testing.T) {
+	t.Parallel()
+
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	deletedAt := period.From.Add(time.Hour)
+	existing := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "ns",
+				ID:        "line-1",
+				Name:      "line",
+			}),
+			ManagedBy:     billing.SubscriptionManagedLine,
+			Engine:        billing.LineEngineTypeInvoice,
+			InvoiceID:     "invoice-1",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.To,
+			FeatureKey:    "feature-key",
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromInt(1),
+			}),
+		},
+	}
+	existing.DeletedAt = &deletedAt
+	expected := existing
+	expected.DeletedAt = nil
+	expected.ServicePeriod.To = expected.ServicePeriod.To.AddDate(0, 1, 0)
+	expected.InvoiceAt = expected.ServicePeriod.To
+	invoices := persistedstate.Invoices{
+		"invoice-1": billing.GatheringInvoice{
+			GatheringInvoiceBase: billing.GatheringInvoiceBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: "ns",
+					ID:        "invoice-1",
+					Name:      "invoice",
+				}),
+			},
+		}.AsInvoice(),
+	}
+
+	patch, err := getPatchesForUpdateUsageBasedLine(existing.AsGenericLine(), expected, invoices)
+	require.NoError(t, err)
+	require.NotNil(t, patch)
+	update, err := patch.AsUpdateLinePatch()
+	require.NoError(t, err)
+
+	servicePeriod, ok := update.ServicePeriod.Get()
+	require.True(t, ok)
+	require.Equal(t, expected.ServicePeriod, servicePeriod)
+	invoiceAt, ok := update.InvoiceAt.Get()
+	require.True(t, ok)
+	require.Equal(t, expected.InvoiceAt, invoiceAt)
+	deletedAtUpdate, ok := update.DeletedAt.Get()
+	require.True(t, ok)
+	require.Nil(t, deletedAtUpdate)
+	require.True(t, update.FlatFeePerUnitAmount.IsAbsent())
+	require.NotNil(t, existing.DeletedAt)
+	require.Equal(t, period, existing.ServicePeriod)
+}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoiceline.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoiceline.go
@@ -2,8 +2,10 @@ package reconciler
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
@@ -157,37 +159,25 @@ func (c *lineInvoicePatchCollection) AddProrate(existing persistedstate.Item, ta
 		return fmt.Errorf("cannot merge flat fee line with usage based line")
 	}
 
-	targetLine, err := existingLine.CloneWithoutChildren()
-	if err != nil {
-		return fmt.Errorf("cloning line: %w", err)
+	updateInput := invoiceupdater.NewUpdateLinePatchInput{
+		Line:      existingLine.GetLineID(),
+		InvoiceID: existingLine.GetInvoiceID(),
 	}
+	if !existingLine.GetServicePeriod().Equal(expectedLine.ServicePeriod) {
+		updateInput.ServicePeriod = mo.Some(expectedLine.ServicePeriod)
 
-	wasChange := false
-	if !targetLine.GetServicePeriod().Equal(expectedLine.ServicePeriod) {
-		wasChange = true
-
-		targetLine.UpdateServicePeriod(func(period *timeutil.ClosedPeriod) {
-			*period = expectedLine.ServicePeriod
-		})
-
-		isGatheringInvoice, err := c.invoices.IsGatheringInvoice(targetLine.GetInvoiceID())
+		isGatheringInvoice, err := c.invoices.IsGatheringInvoice(existingLine.GetInvoiceID())
 		if err != nil {
-			return fmt.Errorf("getting invoice type for line[%s]: %w", targetLine.GetLineID().ID, err)
+			return fmt.Errorf("getting invoice type for line[%s]: %w", existingLine.GetLineID().ID, err)
 		}
 
 		if isGatheringInvoice {
-			invoiceAtAccessor, ok := targetLine.(billing.InvoiceAtAccessor)
-			if !ok {
-				return fmt.Errorf("target line is not an invoice at accessor: %T", targetLine)
-			}
-
-			invoiceAtAccessor.SetInvoiceAt(expectedLine.InvoiceAt)
+			updateInput.InvoiceAt = mo.Some(expectedLine.InvoiceAt)
 		}
 	}
 
-	if targetLine.GetDeletedAt() != nil {
-		targetLine.SetDeletedAt(nil)
-		wasChange = true
+	if existingLine.GetDeletedAt() != nil {
+		updateInput.DeletedAt = mo.Some[*time.Time](nil)
 	}
 
 	perUnitAmountExisting, err := invoiceupdater.GetFlatFeePerUnitAmount(existingLine)
@@ -201,15 +191,17 @@ func (c *lineInvoicePatchCollection) AddProrate(existing persistedstate.Item, ta
 	}
 
 	if !perUnitAmountExisting.Equal(perUnitAmountExpected) {
-		if err := invoiceupdater.SetFlatFeePerUnitAmount(targetLine, perUnitAmountExpected); err != nil {
-			return fmt.Errorf("setting flat fee per unit amount: %w", err)
-		}
-		wasChange = true
+		updateInput.FlatFeePerUnitAmount = mo.Some(perUnitAmountExpected)
 	}
 
-	if !wasChange {
+	if updateInput.IsNoop() {
 		return nil
 	}
 
-	return c.addPatches(target.UniqueID, PatchOperationProrate, invoiceupdater.NewUpdateLinePatch(targetLine))
+	patch, err := invoiceupdater.NewUpdateLinePatch(updateInput)
+	if err != nil {
+		return fmt.Errorf("creating update line patch: %w", err)
+	}
+
+	return c.addPatches(target.UniqueID, PatchOperationProrate, patch)
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoicelinehierarchy.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoicelinehierarchy.go
@@ -3,8 +3,10 @@ package reconciler
 import (
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
@@ -96,33 +98,33 @@ func (c *lineHierarchyPatchCollection) AddShrink(uniqueID string, existing persi
 		}
 
 		if !child.Line.GetServicePeriod().To.Equal(expectedLine.ServicePeriod.To) {
-			updatedLine, err := child.Line.CloneWithoutChildren()
-			if err != nil {
-				return fmt.Errorf("cloning child: %w", err)
+			updatedPeriod := child.Line.GetServicePeriod()
+			updatedPeriod.To = expectedLine.ServicePeriod.To
+			updateInput := invoiceupdater.NewUpdateLinePatchInput{
+				Line:          child.Line.GetLineID(),
+				InvoiceID:     child.Line.GetInvoiceID(),
+				ServicePeriod: mo.Some(updatedPeriod),
 			}
-
-			updatedLine.UpdateServicePeriod(func(p *timeutil.ClosedPeriod) {
-				p.To = expectedLine.ServicePeriod.To
-			})
 
 			if child.Invoice.AsInvoice().Type() == billing.InvoiceTypeGathering {
-				invoiceAtAccessor, ok := updatedLine.(billing.InvoiceAtAccessor)
-				if !ok {
-					return fmt.Errorf("last child is not an invoice at accessor: %T", updatedLine)
-				}
-				invoiceAtAccessor.SetInvoiceAt(expectedLine.InvoiceAt)
+				updateInput.InvoiceAt = mo.Some(expectedLine.InvoiceAt)
 			}
 
-			if updatedLine.GetManagedBy() == billing.SubscriptionManagedLine {
-				updatedLine.SetDeletedAt(nil)
+			if child.Line.GetManagedBy() == billing.SubscriptionManagedLine && child.Line.GetDeletedAt() != nil {
+				updateInput.DeletedAt = mo.Some[*time.Time](nil)
 			}
 
-			if updatedLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
+			if updatedPeriod.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 				patches = append(patches, invoiceupdater.NewDeleteLinePatch(child.Line.GetLineID(), child.Line.GetInvoiceID()))
 				continue
 			}
 
-			patches = append(patches, invoiceupdater.NewUpdateLinePatch(updatedLine))
+			patch, err := invoiceupdater.NewUpdateLinePatch(updateInput)
+			if err != nil {
+				return fmt.Errorf("creating update line patch: %w", err)
+			}
+
+			patches = append(patches, patch)
 		}
 	}
 
@@ -158,34 +160,34 @@ func (c *lineHierarchyPatchCollection) AddExtend(existing persistedstate.Item, t
 	patches := make([]invoiceupdater.Patch, 0, 2)
 
 	if len(existingHierarchy.Lines) > 0 {
-		lines := existingHierarchy.Lines
+		lines := slices.Clone(existingHierarchy.Lines)
 		slices.SortFunc(lines, func(i, j billing.LineWithInvoiceHeader) int {
 			return timeutil.Compare(i.Line.GetServicePeriod().To, j.Line.GetServicePeriod().To)
 		})
 
-		lastChild, err := lines[len(lines)-1].Line.CloneWithoutChildren()
+		lastChild := lines[len(lines)-1]
+		updatedPeriod := lastChild.Line.GetServicePeriod()
+		updatedPeriod.To = expectedLine.ServicePeriod.To
+		updateInput := invoiceupdater.NewUpdateLinePatchInput{
+			Line:          lastChild.Line.GetLineID(),
+			InvoiceID:     lastChild.Line.GetInvoiceID(),
+			ServicePeriod: mo.Some(updatedPeriod),
+		}
+
+		if lastChild.Line.GetManagedBy() == billing.SubscriptionManagedLine && lastChild.Line.GetDeletedAt() != nil {
+			updateInput.DeletedAt = mo.Some[*time.Time](nil)
+		}
+
+		if lastChild.Invoice.AsInvoice().Type() == billing.InvoiceTypeGathering {
+			updateInput.InvoiceAt = mo.Some(expectedLine.InvoiceAt)
+		}
+
+		patch, err := invoiceupdater.NewUpdateLinePatch(updateInput)
 		if err != nil {
-			return fmt.Errorf("cloning last child: %w", err)
+			return fmt.Errorf("creating update line patch: %w", err)
 		}
 
-		if lastChild.GetManagedBy() == billing.SubscriptionManagedLine {
-			lastChild.SetDeletedAt(nil)
-		}
-
-		lastChild.UpdateServicePeriod(func(p *timeutil.ClosedPeriod) {
-			p.To = expectedLine.ServicePeriod.To
-		})
-
-		if lines[len(lines)-1].Invoice.AsInvoice().Type() == billing.InvoiceTypeGathering {
-			invoiceAtAccessor, ok := lastChild.(billing.InvoiceAtAccessor)
-			if !ok {
-				return fmt.Errorf("last child is not an invoice at accessor: %T", lastChild)
-			}
-
-			invoiceAtAccessor.SetInvoiceAt(expectedLine.InvoiceAt)
-		}
-
-		patches = append(patches, invoiceupdater.NewUpdateLinePatch(lastChild))
+		patches = append(patches, patch)
 	}
 
 	updatedGroup := existingHierarchy.Group.ToUpdate()


### PR DESCRIPTION
## Why

Subscription sync currently represents a line update by cloning the complete invoice line and passing that clone as the desired target state. That couples reconciliation to every field on the concrete line representation, even though sync owns only a small set of changes: service period, invoice timing, restoration, and prorated flat-fee amount.

This becomes fragile as split-line hierarchy loading moves toward lightweight line headers and line-engine-owned state. A header contains enough information to describe the intended update, but cannot construct a complete `billing.GenericInvoiceLine`. Requiring a full clone also risks replacing fields that subscription sync did not intend to change, including persisted identity, calculated details, discounts, metadata, and future line-engine state.

This provides the explicit update contract needed by the split-line hierarchy refactor in #4750.

## What changed

- Replace full-line update targets with a validated `NewUpdateLinePatchInput`.
- Represent each mutable field with `mo.Option`, so absence preserves persisted state and `mo.Some[*time.Time](nil)` explicitly clears `DeletedAt`.
- Apply updates to a clone of the canonical line loaded from the invoice.
- Update reconciliation producers to emit only fields they actually own.
- Group and log patches using explicit identity and present-field information.
- Restrict immutable drift evaluation to requested changes while preserving existing flat-fee warning precedence.
- Add focused coverage for validation, no-op detection, explicit clears, preserved fields, incompatible updates, grouping/logging, producer intent, and immutable behavior.

## Impact

This is an internal refactor with no API or schema changes. Subscription-sync behavior remains convergent and immutable invoices remain read-only. The new patch model reduces accidental state replacement and lets reconciliation callers operate with line-header data instead of reconstructing complete invoice lines.

## Validation

- `make test` — 7,415 tests passed, 9 skipped
- `golangci-lint run ./openmeter/billing/worker/subscriptionsync/service/reconciler/...` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice line updates to apply only intended changes while preserving existing details and split-line relationships.
  * Fixed validation for flat-fee amounts, service periods, usage quantities, and immutable invoice rules.
  * Improved handling of deleted and undeleted invoice lines.
  * Added clearer errors when invoice lines are missing or updates cannot be applied.

* **Tests**
  * Expanded coverage for invoice line patches, nullable fields, no-op updates, grouping, logging, and usage-based billing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces complete invoice-line update targets with validated, field-level patches so subscription synchronization changes only the state it owns.
- Applies optional updates to clones of canonical invoice lines while preserving unrelated persisted state.
- Updates usage, prorating, shrink, and extension reconciliation paths to emit explicit field intent.
- Restricts immutable-invoice drift checks to requested changes and adds focused patch and reconciliation coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch.go | Introduces the validated optional-field update contract and applies it to cloned canonical invoice lines. |
| openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go | Groups explicit patches by invoice, applies them to loaded lines, and narrows immutable drift checks to requested fields. |
| openmeter/billing/worker/subscriptionsync/service/reconciler/patchhelpers.go | Converts usage-based reconciliation into explicit service-period, invoice-time, and restoration updates. |
| openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoiceline.go | Emits explicit prorating updates without replacing unrelated invoice-line state. |
| openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoicelinehierarchy.go | Updates split-line shrink and extension reconciliation to patch selected child fields explicitly. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  R[Subscription reconciliation] --> P[Validated line patch]
  P --> L[Load canonical invoice line]
  L --> C[Clone canonical state]
  C --> A[Apply present fields only]
  A --> M{Invoice mutable?}
  M -->|Yes| U[Replace and persist updated line]
  M -->|No| V[Evaluate requested immutable drift]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: make subscription sync line up..."](https://github.com/openmeterio/openmeter/commit/e6ebaaef55c0d894a07059082e7af528a2c39f17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53332652)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->