### PR TITLE
Fix/err data race  in invoice collector

### DIFF
--- a/openmeter/billing/worker/collect/collect.go
+++ b/openmeter/billing/worker/collect/collect.go
@@ -163,15 +163,15 @@ func (a *InvoiceCollector) All(ctx context.Context, namespaces []string, custome
 			go func() {
 				defer wg.Done()
 
-				_, err = a.CollectCustomerInvoice(ctx, CollectCustomerInvoiceInput{
+				_, collectErr := a.CollectCustomerInvoice(ctx, CollectCustomerInvoiceInput{
 					CustomerID: customerID,
 					AsOf:       time.Now(),
 				})
-				if err != nil {
-					err = fmt.Errorf("failed to collect invoice for customer [namespace=%s customer=%s]: %w", customerID.Namespace, customerID.ID, err)
+				if collectErr != nil {
+					collectErr = fmt.Errorf("failed to collect invoice for customer [namespace=%s customer=%s]: %w", customerID.Namespace, customerID.ID, collectErr)
 				}
 
-				errChan <- err
+				errChan <- collectErr
 			}()
 		}
 
@@ -180,8 +180,8 @@ func (a *InvoiceCollector) All(ctx context.Context, namespaces []string, custome
 	closeErrChan()
 
 	var errs []error
-	for err = range errChan {
-		errs = append(errs, err)
+	for collectErr := range errChan {
+		errs = append(errs, collectErr)
 	}
 
 	return errors.Join(errs...)

--- a/openmeter/billing/worker/collect/collect_race_test.go
+++ b/openmeter/billing/worker/collect/collect_race_test.go
@@ -68,6 +68,13 @@ func TestInvoiceCollectorAllPreservesConcurrentCollectionErrors(t *testing.T) {
 
 	for attempt := range attempts {
 		t.Run(fmt.Sprintf("attempt-%d", attempt), func(t *testing.T) {
+			// given:
+			// - 128 customers and a billing service that releases all collection calls
+			//   together before returning a customer-specific error.
+			// when:
+			// - InvoiceCollector.All collects the customers concurrently.
+			// then:
+			// - the joined error contains exactly one correctly attributed error per customer.
 			billingService := &concurrentErrorBillingService{
 				ready: make(chan struct{}),
 				total: customerCount,

--- a/openmeter/billing/worker/collect/collect_race_test.go
+++ b/openmeter/billing/worker/collect/collect_race_test.go
@@ -3,7 +3,6 @@ package billingworkercollect
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"strings"
 	"sync/atomic"
@@ -85,9 +84,7 @@ func TestInvoiceCollectorAllPreservesConcurrentCollectionErrors(t *testing.T) {
 					customers: customers,
 				},
 				BillingService: billingService,
-				Logger: slog.New(
-					slog.NewTextHandler(io.Discard, nil),
-				),
+				Logger:         slog.New(slog.DiscardHandler),
 			})
 			require.NoError(t, err)
 

--- a/openmeter/billing/worker/collect/collect_race_test.go
+++ b/openmeter/billing/worker/collect/collect_race_test.go
@@ -2,10 +2,10 @@ package billingworkercollect
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -15,10 +15,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 )
 
-// raceBillingService releases all collection calls together. This makes the
-// unsynchronized writes to the collector's shared err variable overlap under
-// the race detector instead of relying on scheduler timing.
-type raceBillingService struct {
+// concurrentErrorBillingService releases all collection calls together. This
+// makes the shared error in InvoiceCollector.All observable without relying
+// exclusively on the race detector.
+type concurrentErrorBillingService struct {
 	billing.Service
 
 	entered atomic.Int32
@@ -26,17 +26,17 @@ type raceBillingService struct {
 	total   int32
 }
 
-func (s *raceBillingService) InvoicePendingLines(
-	context.Context,
-	billing.InvoicePendingLinesInput,
-	...billing.InvoicePendingLinesOption,
+func (s *concurrentErrorBillingService) InvoicePendingLines(
+	_ context.Context,
+	input billing.InvoicePendingLinesInput,
+	_ ...billing.InvoicePendingLinesOption,
 ) ([]billing.StandardInvoice, error) {
 	if s.entered.Add(1) == s.total {
 		close(s.ready)
 	}
 	<-s.ready
 
-	return nil, errors.New("synthetic invoice failure")
+	return nil, fmt.Errorf("synthetic invoice failure for %s", input.Customer.ID)
 }
 
 type raceGatheringInvoiceService struct {
@@ -52,8 +52,11 @@ func (s *raceGatheringInvoiceService) ListCustomerIDsPendingCollection(
 	return s.customers, nil
 }
 
-func TestInvoiceCollectorAllReportsConcurrentCollectionErrors(t *testing.T) {
-	const customerCount = 32
+func TestInvoiceCollectorAllPreservesConcurrentCollectionErrors(t *testing.T) {
+	const (
+		customerCount = 128
+		attempts      = 10
+	)
 
 	customers := make([]customer.CustomerID, customerCount)
 	for index := range customers {
@@ -63,18 +66,62 @@ func TestInvoiceCollectorAllReportsConcurrentCollectionErrors(t *testing.T) {
 		}
 	}
 
-	billingService := &raceBillingService{
-		ready: make(chan struct{}),
-		total: customerCount,
-	}
-	collector, err := NewInvoiceCollector(Config{
-		GatheringInvoiceService: &raceGatheringInvoiceService{customers: customers},
-		BillingService:          billingService,
-		Logger:                  slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
-	require.NoError(t, err)
+	for attempt := range attempts {
+		t.Run(fmt.Sprintf("attempt-%d", attempt), func(t *testing.T) {
+			billingService := &concurrentErrorBillingService{
+				ready: make(chan struct{}),
+				total: customerCount,
+			}
 
-	err = collector.All(t.Context(), []string{"default"}, nil, 0)
-	require.ErrorContains(t, err, "synthetic invoice failure")
-	require.Equal(t, int32(customerCount), billingService.entered.Load())
+			collector, err := NewInvoiceCollector(Config{
+				GatheringInvoiceService: &raceGatheringInvoiceService{
+					customers: customers,
+				},
+				BillingService: billingService,
+				Logger: slog.New(
+					slog.NewTextHandler(io.Discard, nil),
+				),
+			})
+			require.NoError(t, err)
+
+			err = collector.All(
+				t.Context(),
+				[]string{"default"},
+				nil,
+				0,
+			)
+			require.Error(t, err)
+
+			lines := strings.Split(err.Error(), "\n")
+			require.Len(t, lines, customerCount)
+
+			for _, customer := range customers {
+				prefix := fmt.Sprintf(
+					"failed to collect invoice for customer [namespace=%s customer=%s]:",
+					customer.Namespace,
+					customer.ID,
+				)
+
+				var customerLine string
+				for _, line := range lines {
+					if strings.HasPrefix(line, prefix) {
+						customerLine = line
+						break
+					}
+				}
+
+				require.NotEmptyf(
+					t,
+					customerLine,
+					"missing collection error for %s",
+					customer.ID,
+				)
+				require.Contains(
+					t,
+					customerLine,
+					"synthetic invoice failure for "+customer.ID,
+				)
+			}
+		})
+	}
 }

--- a/openmeter/billing/worker/collect/collect_race_test.go
+++ b/openmeter/billing/worker/collect/collect_race_test.go
@@ -1,0 +1,80 @@
+package billingworkercollect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+)
+
+// raceBillingService releases all collection calls together. This makes the
+// unsynchronized writes to the collector's shared err variable overlap under
+// the race detector instead of relying on scheduler timing.
+type raceBillingService struct {
+	billing.Service
+
+	entered atomic.Int32
+	ready   chan struct{}
+	total   int32
+}
+
+func (s *raceBillingService) InvoicePendingLines(
+	context.Context,
+	billing.InvoicePendingLinesInput,
+	...billing.InvoicePendingLinesOption,
+) ([]billing.StandardInvoice, error) {
+	if s.entered.Add(1) == s.total {
+		close(s.ready)
+	}
+	<-s.ready
+
+	return nil, errors.New("synthetic invoice failure")
+}
+
+type raceGatheringInvoiceService struct {
+	billing.GatheringInvoiceService
+
+	customers []customer.CustomerID
+}
+
+func (s *raceGatheringInvoiceService) ListCustomerIDsPendingCollection(
+	context.Context,
+	billing.ListCustomerIDsPendingCollectionInput,
+) ([]customer.CustomerID, error) {
+	return s.customers, nil
+}
+
+func TestInvoiceCollectorAllReportsConcurrentCollectionErrors(t *testing.T) {
+	const customerCount = 32
+
+	customers := make([]customer.CustomerID, customerCount)
+	for index := range customers {
+		customers[index] = customer.CustomerID{
+			Namespace: "default",
+			ID:        fmt.Sprintf("customer-%d", index),
+		}
+	}
+
+	billingService := &raceBillingService{
+		ready: make(chan struct{}),
+		total: customerCount,
+	}
+	collector, err := NewInvoiceCollector(Config{
+		GatheringInvoiceService: &raceGatheringInvoiceService{customers: customers},
+		BillingService:          billingService,
+		Logger:                  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	require.NoError(t, err)
+
+	err = collector.All(t.Context(), []string{"default"}, nil, 0)
+	require.ErrorContains(t, err, "synthetic invoice failure")
+	require.Equal(t, int32(customerCount), billingService.entered.Load())
+}


### PR DESCRIPTION
## Overview

The invoice collector runs customer collections concurrently but reused one outer `err` variable inside every goroutine. This can race while collecting errors and can corrupt the reported error value.

This PR adds a deterministic race-focused unit test before applying the fix, then scopes the collection error per goroutine.

Fixes #4945

## Notes for reviewer

The reproduction test synchronizes 128 concurrent collection calls and verifies that every customer-specific error is preserved, making the bug reproducible even without the race detector.

Validation:

- `go test ./openmeter/billing/worker/collect`
- In case the test doesn't reproduce the bug, rerun with `go test -race ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when collecting invoices concurrently.
  * Ensured collection errors are correctly attributed and combined without cross-contamination between parallel operations.

* **Tests**
  * Added coverage for concurrent invoice collection across many customers and repeated executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes a data race in invoice collection by keeping each goroutine’s collection error local.
- Preserves customer-specific errors during concurrent collection.
- Adds a synchronized regression test covering 128 concurrent customers across repeated attempts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/worker/collect/collect.go | Replaces shared error-variable writes with goroutine-local and range-local variables, eliminating concurrent mutation while preserving joined-error behavior. |
| openmeter/billing/worker/collect/collect_race_test.go | Adds deterministic concurrent error-attribution coverage, and the previously requested given/when/then structure is now present. |

<sub>Reviews (8): Last reviewed commit: ["ci: replaced deprected io.Discard with s..."](https://github.com/openmeterio/openmeter/commit/fb0d90beb26f8969d4f23a830b406cc2224bd6e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53948033)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->