### PR TITLE
feat: export the feature API converter for cross-handler reuse

### DIFF
--- a/api/v3/handlers/features/convert.go
+++ b/api/v3/handlers/features/convert.go
@@ -34,7 +34,9 @@ func FromAPIFeatureSortField(ctx context.Context, field string) (feature.Feature
 	}
 }
 
-func convertFeatureToAPI(f feature.Feature) (api.Feature, error) {
+// ConvertFeatureToAPI maps a domain feature to its API representation. It is
+// exported for handler packages that embed full features behind an expand.
+func ConvertFeatureToAPI(f feature.Feature) (api.Feature, error) {
 	resp := api.Feature{
 		Id:          f.ID,
 		Key:         f.Key,

--- a/api/v3/handlers/features/convert_test.go
+++ b/api/v3/handlers/features/convert_test.go
@@ -205,7 +205,7 @@ func TestConvertFeatureToAPI(t *testing.T) {
 			UpdatedAt: now,
 		}
 
-		result, err := convertFeatureToAPI(f)
+		result, err := ConvertFeatureToAPI(f)
 		require.NoError(t, err)
 		assert.Equal(t, "feat-1", result.Id)
 		assert.Equal(t, api.ResourceKey("my_feature"), result.Key)
@@ -231,7 +231,7 @@ func TestConvertFeatureToAPI(t *testing.T) {
 			UpdatedAt: now,
 		}
 
-		result, err := convertFeatureToAPI(f)
+		result, err := ConvertFeatureToAPI(f)
 		require.NoError(t, err)
 		require.NotNil(t, result.Meter)
 		assert.Equal(t, api.ULID("01ARZ3NDEKTSV4RRFFQ69G5FAV"), result.Meter.Id)
@@ -257,7 +257,7 @@ func TestConvertFeatureToAPI(t *testing.T) {
 			UpdatedAt: now,
 		}
 
-		result, err := convertFeatureToAPI(f)
+		result, err := ConvertFeatureToAPI(f)
 		require.NoError(t, err)
 		require.NotNil(t, result.UnitCost)
 
@@ -278,7 +278,7 @@ func TestConvertFeatureToAPI(t *testing.T) {
 			UpdatedAt:  now,
 		}
 
-		result, err := convertFeatureToAPI(f)
+		result, err := ConvertFeatureToAPI(f)
 		require.NoError(t, err)
 		require.NotNil(t, result.DeletedAt)
 		assert.Equal(t, archived, *result.DeletedAt)

--- a/api/v3/handlers/features/create.go
+++ b/api/v3/handlers/features/create.go
@@ -68,7 +68,7 @@ func (h *handler) CreateFeature() CreateFeatureHandler {
 				return CreateFeatureResponse{}, err
 			}
 
-			return convertFeatureToAPI(created)
+			return ConvertFeatureToAPI(created)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[CreateFeatureResponse](http.StatusCreated),
 		httptransport.AppendOptions(

--- a/api/v3/handlers/features/get.go
+++ b/api/v3/handlers/features/get.go
@@ -40,7 +40,7 @@ func (h *handler) GetFeature() GetFeatureHandler {
 				return GetFeatureResponse{}, err
 			}
 
-			resp, err := convertFeatureToAPI(*feat)
+			resp, err := ConvertFeatureToAPI(*feat)
 			if err != nil {
 				return GetFeatureResponse{}, err
 			}

--- a/api/v3/handlers/features/list.go
+++ b/api/v3/handlers/features/list.go
@@ -107,7 +107,7 @@ func (h *handler) ListFeatures() ListFeaturesHandler {
 
 			items := make([]api.Feature, 0, len(result.Items))
 			for _, f := range result.Items {
-				apiFeature, err := convertFeatureToAPI(f)
+				apiFeature, err := ConvertFeatureToAPI(f)
 				if err != nil {
 					return ListFeaturesResponse{}, err
 				}

--- a/api/v3/handlers/features/update.go
+++ b/api/v3/handlers/features/update.go
@@ -40,7 +40,7 @@ func (h *handler) UpdateFeature() UpdateFeatureHandler {
 				return UpdateFeatureResponse{}, err
 			}
 
-			resp, err := convertFeatureToAPI(updated)
+			resp, err := ConvertFeatureToAPI(updated)
 			if err != nil {
 				return UpdateFeatureResponse{}, err
 			}


### PR DESCRIPTION
## What

Exports the feature handler's API converter: `convertFeatureToAPI` becomes `ConvertFeatureToAPI` (with a doc comment), and the in-package call sites and tests are updated. No behavior change.

## Why

The spend API stack (#4810 / #4933) needs this export: the customer charges handlers embed the full feature entity behind the `feature` expand and reuse this single feature-to-wire mapping instead of duplicating it. Landing the rename independently keeps that stack's diffs focused on the spend API itself.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exports the existing feature-to-API converter for reuse by other handler packages without changing its mapping behavior.
- Renames the converter to an exported symbol and adds API documentation.
- Updates feature create, get, list, update, and converter-test call sites.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/v3/handlers/features/convert.go | Exports the existing feature-to-API conversion function and documents its cross-handler purpose. |
| api/v3/handlers/features/convert_test.go | Updates converter tests to call the exported symbol. |
| api/v3/handlers/features/create.go | Updates the create handler to use the exported converter. |
| api/v3/handlers/features/get.go | Updates the get handler to use the exported converter. |
| api/v3/handlers/features/list.go | Updates list-item conversion to use the exported converter. |
| api/v3/handlers/features/update.go | Updates the update handler to use the exported converter. |

<sub>Reviews (2): Last reviewed commit: ["feat: export the feature API converter f..."](https://github.com/openmeterio/openmeter/commit/b1dc7d25425c4c786781b41325b91cdb07dce379) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53968579)</sub>

<!-- /greptile_comment -->