### PR TITLE
fix: use Stripe invoice item IDs for line mutations

### DIFF
--- a/openmeter/app/stripe/appinvoice.go
+++ b/openmeter/app/stripe/appinvoice.go
@@ -449,7 +449,9 @@ func (a appOperations) updateInvoice(ctx context.Context, invoice billing.Standa
 	}
 
 	// Remove Stripe lines from the Stripe invoice
-	stripeLinesRemove = append(stripeLinesRemove, lo.Keys(stripeLinesToRemove)...)
+	for lineID := range stripeLinesToRemove {
+		stripeLinesRemove = append(stripeLinesRemove, stripeLinesByID[lineID].InvoiceItem.ID)
+	}
 
 	if len(stripeLinesRemove) > 0 {
 		err = stripeClient.RemoveInvoiceLines(ctx, stripeclient.RemoveInvoiceLinesInput{
@@ -503,7 +505,7 @@ func getDiscountStripeUpdateInvoiceItemParams(
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
 	return &stripeclient.StripeInvoiceItemWithID{
-		ID:                stripeLine.ID,
+		ID:                stripeLine.InvoiceItem.ID,
 		InvoiceItemParams: getDiscountStripeInvoiceItemParams(calculator, line, discount),
 	}
 }
@@ -541,7 +543,7 @@ func getCreditStripeUpdateInvoiceItemParams(
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
 	return &stripeclient.StripeInvoiceItemWithID{
-		ID:                stripeLine.ID,
+		ID:                stripeLine.InvoiceItem.ID,
 		InvoiceItemParams: getCreditStripeInvoiceItemParams(calculator, line, credit),
 	}
 }
@@ -592,7 +594,7 @@ func getStripeUpdateInvoiceItemParams(
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
 	return &stripeclient.StripeInvoiceItemWithID{
-		ID:                stripeLine.ID,
+		ID:                stripeLine.InvoiceItem.ID,
 		InvoiceItemParams: getStripeInvoiceItemParams(line, calculator),
 	}
 }

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -573,6 +573,10 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 	})
 
 	s.Run("upsert invoice", func() {
+		// Given Stripe returns distinct invoice line (il_*) and invoice item (ii_*) IDs.
+		// When OpenMeter synchronizes an existing invoice after removing one line.
+		// Then every Stripe line mutation is addressed with the invoice item ID.
+
 		// Mock the stripe client to return the created invoice.
 		s.StripeAppClient.
 			On("CreateInvoice", stripeclient.CreateInvoiceInput{

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -816,8 +816,9 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			Currency: "USD",
 			Lines: &stripe.InvoiceLineItemList{
 				Data: lo.Map(expectedInvoiceAddLines, func(line *stripe.InvoiceItemParams, idx int) *stripe.InvoiceLineItem {
-					return &stripe.InvoiceLineItem{
+					stripeLine := &stripe.InvoiceLineItem{
 						ID:          fmt.Sprintf("il_%d", idx),
+						InvoiceItem: &stripe.InvoiceItem{ID: fmt.Sprintf("ii_%d", idx)},
 						Amount:      *line.Amount,
 						Description: *line.Description,
 						Period: &stripe.Period{
@@ -826,6 +827,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 						},
 						Metadata: line.Metadata,
 					}
+
+					if idx == 0 {
+						stripeLine.ID = "il_test_line"
+						stripeLine.InvoiceItem.ID = "ii_test_item"
+					}
+
+					return stripeLine
 				}),
 			},
 			StatementDescriptor: invoice.Supplier.Name,
@@ -840,7 +848,12 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			Return(lo.Map(
 				expectedInvoiceAddLines,
 				func(line *stripe.InvoiceItemParams, idx int) stripeclient.StripeInvoiceItemWithLineID {
-					return mapInvoiceItemParamsToInvoiceItem(fmt.Sprintf("%d", idx), line)
+					result := mapInvoiceItemParamsToInvoiceItem(fmt.Sprintf("%d", idx), line)
+					if idx == 0 {
+						result.LineID = "il_test_line"
+						result.InvoiceItem.ID = "ii_test_item"
+					}
+					return result
 				},
 			), nil)
 
@@ -885,16 +898,21 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 
 		// Find the stripe line ID to remove.
 		var stripeLineIDToRemove string
+		var stripeLineToRemove *stripe.InvoiceLineItem
 
 		for lineID, stripeLineID := range expectedResult {
 			if lineID == lineToRemove.ID {
 				stripeLineIDToRemove = stripeLineID
+				stripeLineToRemove = lo.FindOrElse(stripeInvoice.Lines.Data, nil, func(stripeLine *stripe.InvoiceLineItem) bool {
+					return stripeLine.ID == stripeLineID
+				})
 			}
 		}
 
 		delete(expectedResult, lineToRemove.ID)
 
 		s.NotEmpty(stripeLineIDToRemove, "stripe line ID to remove is empty")
+		s.NotNil(stripeLineToRemove, "stripe line to remove is not found")
 
 		parentLine := getParentOfDetailedLine(*lineToRemove)
 		s.NotNil(parentLine, "parent line is not found")
@@ -960,12 +978,15 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 
 			// No changes to the line items.
 			return &stripeclient.StripeInvoiceItemWithID{
-				ID:                line.ID,
+				ID:                line.InvoiceItem.ID,
 				InvoiceItemParams: params,
 			}, line.ID != stripeLineIDToRemove
 		})
 
 		s.StripeAppClient.StableSortStripeInvoiceItemWithID(filteredUpdatedLines)
+		s.Require().Contains(lo.Map(filteredUpdatedLines, func(line *stripeclient.StripeInvoiceItemWithID, _ int) string {
+			return line.ID
+		}), "ii_test_item")
 
 		s.StripeAppClient.
 			On("UpdateInvoiceLines", stripeclient.UpdateInvoiceLinesInput{
@@ -980,7 +1001,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		s.StripeAppClient.
 			On("RemoveInvoiceLines", stripeclient.RemoveInvoiceLinesInput{
 				StripeInvoiceID: updateInvoice.ExternalIDs.Invoicing,
-				Lines:           []string{stripeLineIDToRemove},
+				Lines:           []string{stripeLineToRemove.InvoiceItem.ID},
 			}).
 			Once().
 			Return(nil)
@@ -990,7 +1011,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 
 		// Update the invoice.
 		results, err = invoicingApp.UpsertStandardInvoice(ctx, updateInvoice)
-		s.NoError(err, "failed to upsert invoice")
+		s.Require().NoError(err, "failed to upsert invoice")
 
 		// Assert results.
 		s.Equal(expectedResult, results.GetLineExternalIDs())

--- a/test/app/stripe/stripe_mock.go
+++ b/test/app/stripe/stripe_mock.go
@@ -2,6 +2,7 @@ package appstripe
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -133,7 +134,21 @@ func (c *StripeAppClientMock) FinalizeInvoice(ctx context.Context, input stripec
 // Invoice Lines
 func (c *StripeAppClientMock) ListInvoiceLineItems(ctx context.Context, stripeInvoiceID string) ([]*stripe.InvoiceLineItem, error) {
 	args := c.Called(stripeInvoiceID)
-	return args.Get(0).([]*stripe.InvoiceLineItem), args.Error(1)
+	if err := args.Error(1); err != nil {
+		return nil, err
+	}
+
+	lines := args.Get(0).([]*stripe.InvoiceLineItem)
+	for _, line := range lines {
+		if line == nil || !strings.HasPrefix(line.ID, "il_") {
+			return nil, fmt.Errorf("stripe invoice line ID must start with il_: %v", line)
+		}
+		if line.InvoiceItem == nil || !strings.HasPrefix(line.InvoiceItem.ID, "ii_") {
+			return nil, fmt.Errorf("stripe invoice item ID must start with ii_ for line %s", line.ID)
+		}
+	}
+
+	return lines, nil
 }
 
 func (c *StripeAppClientMock) AddInvoiceLines(ctx context.Context, input stripeclient.AddInvoiceLinesInput) ([]stripeclient.StripeInvoiceItemWithLineID, error) {
@@ -157,6 +172,11 @@ func (c *StripeAppClientMock) UpdateInvoiceLines(ctx context.Context, input stri
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
+	for _, line := range input.Lines {
+		if line == nil || !strings.HasPrefix(line.ID, "ii_") {
+			return nil, fmt.Errorf("stripe invoice item ID must start with ii_: %v", line)
+		}
+	}
 
 	c.StableSortStripeInvoiceItemWithID(input.Lines)
 
@@ -173,6 +193,11 @@ func (c *StripeAppClientMock) StableSortStripeInvoiceItemWithID(lines []*stripec
 func (c *StripeAppClientMock) RemoveInvoiceLines(ctx context.Context, input stripeclient.RemoveInvoiceLinesInput) error {
 	if err := input.Validate(); err != nil {
 		return err
+	}
+	for _, id := range input.Lines {
+		if !strings.HasPrefix(id, "ii_") {
+			return fmt.Errorf("stripe invoice item ID must start with ii_: %s", id)
+		}
 	}
 
 	args := c.Called(input)


### PR DESCRIPTION
## Overview

Stripe exposes separate invoice line IDs (il_*) and invoice-item IDs (ii_*). OpenMeter must use invoice-item IDs for Stripe invoice-item updates and removals. This PR adds a regression test with distinct IDs and fixes all affected mutation paths.

Fixes #(issue)

## Notes for reviewer

The regression test enforces Stripe's ID distinction and fails on the pre-fix implementation because it sends il_* IDs to invoice-item operations.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Stripe invoice synchronization to address update and removal operations using invoice-item IDs rather than invoice-line IDs.
- Uses each line’s associated `ii_*` identifier for standard, discount, and credit updates.
- Resolves removed invoice lines to their corresponding invoice-item identifiers.
- Strengthens regression fixtures and Stripe mocks to preserve and validate the distinction between `il_*` and `ii_*` identifiers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the production mutations aligned to the Stripe invoice-item client operations and regression coverage enforcing the identifier distinction.

The changed update and removal paths receive invoice lines whose associated invoice items are present, then pass those invoice-item IDs to client methods that invoke Stripe invoice-item update and deletion APIs; no actionable regression remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/app/stripe/appinvoice.go | Correctly translates Stripe invoice-line records to their associated invoice-item IDs for every update and removal mutation path. |
| test/app/stripe/invoice_test.go | Adds distinct line/item identifiers to the complex invoice regression scenario and verifies mutations use invoice-item IDs. |
| test/app/stripe/stripe_mock.go | Validates the expected identifier namespace at Stripe mock boundaries so line/item ID regressions fail clearly. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OM as OpenMeter
    participant Lines as Stripe Invoice Lines
    participant Items as Stripe Invoice Items API
    OM->>Lines: List invoice lines
    Lines-->>OM: "il_* line ID + ii_* invoice-item ID"
    OM->>Items: "Update(ii_*, params)"
    OM->>Items: "Delete(ii_*)"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: document Stripe invoice ID expecta..."](https://github.com/openmeterio/openmeter/commit/b6243027caeb6950592bd29bf93c5fdaeb295124) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53983425)</sub>

<!-- /greptile_comment -->