### PR TITLE
fix(subscription): allow free plan currency mismatch

### DIFF
--- a/openmeter/subscription/README.md
+++ b/openmeter/subscription/README.md
@@ -121,6 +121,8 @@ and phase; do not persist a derived absolute end as independent source truth.
 - newly materialized priced items snapshot their effective currency code; custom
   currencies also retain their managed currency ID, while legacy items may lack
   this snapshot
+- customer and subscription invoice currencies must match whenever the spec has
+  priced items; unpriced items have no materialized currency
 - item and entitlement cadences cannot escape their phase or subscription
 - downstream work must be derived from the committed view and tolerate event
   retries

--- a/openmeter/subscription/workflow/service/currency_test.go
+++ b/openmeter/subscription/workflow/service/currency_test.go
@@ -52,10 +52,10 @@ func TestResolveSubscriptionInvoiceCurrency(t *testing.T) {
 			expected:         currencyx.Code("USD"),
 		},
 		{
-			name:             "mismatching fiat customer currency",
+			name:             "fiat plan defines invoice currency despite customer mismatch",
 			planCurrency:     currencies.NewCurrencyReference("USD"),
 			customerCurrency: lo.ToPtr(currencyx.Code("EUR")),
-			wantErr:          true,
+			expected:         currencyx.Code("USD"),
 		},
 		{
 			name:         "custom plan requires customer currency",

--- a/openmeter/subscription/workflow/service/subscription.go
+++ b/openmeter/subscription/workflow/service/subscription.go
@@ -114,25 +114,17 @@ func resolveSubscriptionInvoiceCurrency(cus customer.Customer, plan subscription
 		return "", models.NewGenericValidationError(fmt.Errorf("invalid plan currency: %w", err))
 	}
 
-	if cus.Currency == nil {
-		if planCurrency.IsFiat() {
-			return planCurrency.GetCode(), nil
-		}
-
-		return "", models.NewGenericValidationError(fmt.Errorf(
-			"customer currency is required when plan currency %q is custom",
-			planCurrency.GetCode(),
-		))
-	}
-
-	if !cus.Currency.IsFiat() {
+	if cus.Currency != nil && !cus.Currency.IsFiat() {
 		return "", models.NewGenericValidationError(fmt.Errorf("customer currency %q must be fiat", *cus.Currency))
 	}
 
-	if planCurrency.IsFiat() && planCurrency.GetCode() != *cus.Currency {
+	if planCurrency.IsFiat() {
+		return planCurrency.GetCode(), nil
+	}
+
+	if cus.Currency == nil {
 		return "", models.NewGenericValidationError(fmt.Errorf(
-			"currency mismatch: customer currency is %s, but plan currency is %s",
-			*cus.Currency,
+			"customer currency is required when plan currency %q is custom",
 			planCurrency.GetCode(),
 		))
 	}

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -161,6 +161,82 @@ func TestCreateFromPlan(t *testing.T) {
 		require.NotNil(t, boolItem)
 		require.Equal(t, 1, subscription.AnnotationParser.GetBooleanEntitlementCount(boolItem.SubscriptionItem.Annotations))
 	})
+
+	t.Run("Should allow a free plan with a different customer currency", func(t *testing.T) {
+		// given:
+		// - a USD customer and a EUR plan without priced rate cards
+		// when:
+		// - the subscription is started and later revalidated by an update
+		// then:
+		// - both operations succeed because the plan has no billable contents
+		now := testutils.GetRFC3339Time(t, "2021-01-01T00:00:00Z")
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		planInput := subscriptiontestutils.BuildTestPlanInput(t).
+			AddPhase(nil, subscriptiontestutils.ExampleAddonRateCard2.Clone()).
+			Build()
+		planInput.Plan.Currency = currencies.NewCurrencyReference(currencyx.Code(currency.EUR))
+		freePlan := deps.PlanHelper.CreatePlan(t, planInput)
+		cust := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		created, err := deps.WorkflowService.CreateFromPlan(t.Context(), subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{Custom: &now},
+			},
+			CustomerID: cust.ID,
+			Namespace:  subscriptiontestutils.ExampleNamespace,
+		}, freePlan)
+		require.NoError(t, err)
+		require.False(t, created.Spec.HasBillables())
+		require.Equal(t, currencyx.Code(currency.EUR), created.Subscription.InvoiceCurrency)
+
+		updated, err := deps.SubscriptionService.Update(t.Context(), created.Subscription.NamespacedID, created.AsSpec())
+		require.NoError(t, err)
+		require.Equal(t, currencyx.Code(currency.EUR), updated.InvoiceCurrency)
+	})
+
+	t.Run("Should reject a priced plan with a different customer currency", func(t *testing.T) {
+		// given:
+		// - a USD customer and a EUR plan with a priced rate card
+		// when:
+		// - subscription creation reaches the service validation boundary
+		// then:
+		// - the customer and subscription invoice currency mismatch is rejected
+		now := testutils.GetRFC3339Time(t, "2021-01-01T00:00:00Z")
+		clock.FreezeTime(now)
+		defer clock.UnFreeze()
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		pricedRateCard := subscriptiontestutils.ExampleAddonRateCard2.Clone()
+		require.NoError(t, pricedRateCard.ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+			meta.Price = productcatalog.NewPriceFrom(productcatalog.FlatPrice{Amount: alpacadecimal.NewFromInt(1)})
+			return meta, nil
+		}))
+		planInput := subscriptiontestutils.BuildTestPlanInput(t).
+			AddPhase(nil, pricedRateCard).
+			Build()
+		planInput.Plan.Currency = currencies.NewCurrencyReference(currencyx.Code(currency.EUR))
+		pricedPlan := deps.PlanHelper.CreatePlan(t, planInput)
+		cust := deps.CustomerAdapter.CreateExampleCustomer(t)
+
+		_, err := deps.WorkflowService.CreateFromPlan(t.Context(), subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{Custom: &now},
+			},
+			CustomerID: cust.ID,
+			Namespace:  subscriptiontestutils.ExampleNamespace,
+		}, pricedPlan)
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "currency mismatch: customer currency is USD, but subscription invoice currency is EUR")
+	})
 }
 
 func TestEditRunning(t *testing.T) {


### PR DESCRIPTION
## Summary

- let fiat plans define the subscription invoice currency without rejecting customer mismatches in the resolver
- retain customer/invoice currency mismatch validation for subscriptions with billable contents
- allow free plans to differ from the customer currency while keeping unpriced items currency-less
- keep custom-currency plans invoiced in the customer's fiat currency

## Root cause

The plan-start currency resolver enforced customer and fiat-plan currency equality before a subscription spec existed. That duplicated price-dependent validation at a layer that could not distinguish priced from unpriced contents.

The resolver now only selects the invoice currency: the plan currency for fiat plans, or the customer fiat for custom-currency plans. The subscription service remains the owning validation boundary and rejects customer/invoice currency mismatches when `spec.HasBillables()` is true.

## Impact

Free subscriptions can start and be updated without spurious currency errors. Priced fiat-plan subscriptions retain the existing customer currency mismatch protection.

## Validation

- `go test -tags=dynamic ./openmeter/subscription/workflow/service -run 'Test(ResolveSubscriptionInvoiceCurrency|CreateFromPlan)$' -count=1`
- `go test -tags=dynamic ./openmeter/subscription/... ./openmeter/productcatalog/subscription/... -count=1`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves fiat customer/plan mismatch handling from the early invoice-currency resolver to the subscription spec’s billability-aware validation.
- Allows unpriced plans to use a plan currency different from the customer currency.
- Keeps mismatching priced plans rejected before persistence.
- Adds resolver and workflow regression coverage and documents the price-dependent invariant.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/subscription/workflow/service/subscription.go | Defers fiat mismatch rejection to the existing billability-aware core validation while preserving custom-currency requirements. |
| openmeter/subscription/workflow/service/currency_test.go | Updates resolver expectations to verify that a fiat plan determines invoice currency independently of customer mismatch. |
| openmeter/subscription/workflow/service/subscription_test.go | Covers successful free-plan mismatch creation and update, plus rejection of mismatching priced plans. |
| openmeter/subscription/README.md | Documents that customer and invoice currencies must match only when the subscription contains priced items. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Subscription workflow
  participant R as Currency resolver
  participant S as Subscription spec
  participant V as Core service validation
  participant DB as Persistence
  W->>R: Resolve invoice currency
  R-->>W: Fiat plan currency
  W->>S: Build spec from plan
  W->>V: Create subscription
  alt Spec has priced items
    V->>V: Compare customer and invoice currencies
    alt Currencies mismatch
      V-->>W: Validation error
    else Currencies match
      V->>DB: Persist subscription
    end
  else Spec has no priced items
    V->>DB: Persist subscription
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(subscription): allow free plan curre..."](https://github.com/openmeterio/openmeter/commit/1cec0c26fb76431de60012480a5b8c1032509b58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54330697)</sub>

**Context used:**

- Knowledge Base — [Subscription](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription.md)
- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subscriptions using priced items now require the customer and invoice currencies to match.
  - Free or unpriced plans can be created and revalidated across different fiat currencies.
  - Fiat-priced plans consistently use the plan’s currency.
  - Custom plans continue to require a customer currency.

- **Bug Fixes**
  - Improved validation and clearer errors for unsupported currency combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->