### PR TITLE
feat(productcatalog): enforce rate card feature references

### DIFF
--- a/docs/migration-guides/2026-08-06-feature-reference-integrity.md
+++ b/docs/migration-guides/2026-08-06-feature-reference-integrity.md
@@ -1,7 +1,7 @@
 # Feature Reference Integrity Repair
 
-Status: proposal. The plan/add-on data repair is implemented and tested; the
-database constraints and `FeatureReference` refactor described below are
+Status: the plan/add-on data repair and paired database constraints are
+implemented and tested. The `FeatureReference` refactor described below remains
 follow-up work. Subscription items are explicitly out of scope until their
 feature lifecycle has been researched separately.
 
@@ -157,45 +157,25 @@ In either mode:
 
 ### 4. Enforce paired persistence in Ent
 
-Only add constraints after the backfill and production verification succeed,
-and after every deployed writer is known to persist both values. Otherwise a
-rolling deployment can make an older process fail writes as soon as the
-constraint becomes active.
+Deploy the constraint migration only after the backfill and production
+verification succeed, and after every deployed writer is known to persist both
+values. Otherwise a rolling deployment can make an older process fail writes
+as soon as the constraint becomes active.
 
-Example additions to the existing annotations on both rate-card schemas:
+The authoritative Ent schemas define `feature_key` and `feature_id` as
+non-empty when present and install `plan_rate_card_feature_reference` and
+`addon_rate_card_feature_reference` checks. Each check accepts only a rate card
+with no feature or with both non-empty identifiers. The generated migration is
+[`20260818090123_rate_card_feature_reference_constraints.up.sql`](../../tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.up.sql),
+with rollback in
+[`20260818090123_rate_card_feature_reference_constraints.down.sql`](../../tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.down.sql).
 
-```go
-func (PlanRateCard) Annotations() []entschema.Annotation {
-	return []entschema.Annotation{
-		entsql.Checks(map[string]string{
-			// Existing currency checks omitted.
-			"plan_rate_card_feature_reference":
-				`(feature_key IS NULL AND feature_id IS NULL) OR ` +
-					`(feature_key IS NOT NULL AND feature_key <> '' AND ` +
-						`feature_id IS NOT NULL AND feature_id <> '')`,
-		}),
-	}
-}
-
-func (AddonRateCard) Annotations() []entschema.Annotation {
-	return []entschema.Annotation{
-		entsql.Checks(map[string]string{
-			// Existing currency checks omitted.
-			"addon_rate_card_feature_reference":
-				`(feature_key IS NULL AND feature_id IS NULL) OR ` +
-					`(feature_key IS NOT NULL AND feature_key <> '' AND ` +
-						`feature_id IS NOT NULL AND feature_id <> '')`,
-		}),
-	}
-}
-```
-
-Add `.NotEmpty()` to the optional Ent fields as application-side defense, but
-do not rely on it for database enforcement. Generate the schema migration from
-the authoritative Ent schema. Migration tests must prove that both-null and
-both-populated rows are accepted and either half-populated shape is rejected in
-both tables. For large datasets, decide during production testing whether
-constraint validation needs a staged operational procedure.
+The database-backed
+[`rate_card_feature_reference_constraints_test.go`](../../tools/migrate/rate_card_feature_reference_constraints_test.go)
+proves that existing incomplete rows block the migration, both-null and
+both-populated rows remain valid, and half-populated or empty references are
+rejected in both tables. For large datasets, decide during production testing
+whether constraint validation needs a staged operational procedure.
 
 ### 5. Replace parallel fields with `FeatureReference`
 

--- a/openmeter/ent/db/addonratecard/addonratecard.go
+++ b/openmeter/ent/db/addonratecard/addonratecard.go
@@ -153,12 +153,16 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// KeyValidator is a validator for the "key" field. It is called by the builders before save.
 	KeyValidator func(string) error
+	// FeatureKeyValidator is a validator for the "feature_key" field. It is called by the builders before save.
+	FeatureKeyValidator func(string) error
 	// CurrencyCodeValidator is a validator for the "currency_code" field. It is called by the builders before save.
 	CurrencyCodeValidator func(string) error
 	// CustomCurrencyIDValidator is a validator for the "custom_currency_id" field. It is called by the builders before save.
 	CustomCurrencyIDValidator func(string) error
 	// AddonIDValidator is a validator for the "addon_id" field. It is called by the builders before save.
 	AddonIDValidator func(string) error
+	// FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
+	FeatureIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 	// ValueScanner of all AddonRateCard fields.

--- a/openmeter/ent/db/addonratecard_create.go
+++ b/openmeter/ent/db/addonratecard_create.go
@@ -394,6 +394,11 @@ func (_c *AddonRateCardCreate) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.type": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.FeatureKey(); ok {
+		if err := addonratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _c.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.entitlement_template": %w`, err)}
@@ -435,6 +440,11 @@ func (_c *AddonRateCardCreate) check() error {
 	if v, ok := _c.mutation.AddonID(); ok {
 		if err := addonratecard.AddonIDValidator(v); err != nil {
 			return &ValidationError{Name: "addon_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.addon_id": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.FeatureID(); ok {
+		if err := addonratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_id": %w`, err)}
 		}
 	}
 	if len(_c.mutation.AddonIDs()) == 0 {

--- a/openmeter/ent/db/addonratecard_update.go
+++ b/openmeter/ent/db/addonratecard_update.go
@@ -440,6 +440,11 @@ func (_u *AddonRateCardUpdate) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FeatureKey(); ok {
+		if err := addonratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.entitlement_template": %w`, err)}
@@ -478,6 +483,11 @@ func (_u *AddonRateCardUpdate) check() error {
 	if v, ok := _u.mutation.AddonID(); ok {
 		if err := addonratecard.AddonIDValidator(v); err != nil {
 			return &ValidationError{Name: "addon_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.addon_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FeatureID(); ok {
+		if err := addonratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_id": %w`, err)}
 		}
 	}
 	if _u.mutation.AddonCleared() && len(_u.mutation.AddonIDs()) > 0 {
@@ -1155,6 +1165,11 @@ func (_u *AddonRateCardUpdateOne) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FeatureKey(); ok {
+		if err := addonratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.entitlement_template": %w`, err)}
@@ -1193,6 +1208,11 @@ func (_u *AddonRateCardUpdateOne) check() error {
 	if v, ok := _u.mutation.AddonID(); ok {
 		if err := addonratecard.AddonIDValidator(v); err != nil {
 			return &ValidationError{Name: "addon_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.addon_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FeatureID(); ok {
+		if err := addonratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.feature_id": %w`, err)}
 		}
 	}
 	if _u.mutation.AddonCleared() && len(_u.mutation.AddonIDs()) > 0 {

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -6228,6 +6228,7 @@ func init() {
 		"addon_rate_card_currency_code_length": "currency IS NULL OR char_length(currency) BETWEEN 3 AND 24",
 		"addon_rate_card_currency_has_price":   "price IS NOT NULL OR currency IS NULL",
 		"addon_rate_card_currency_reference":   "(currency IS NULL AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) = 3 AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) > 3 AND custom_currency_id IS NOT NULL)",
+		"addon_rate_card_feature_reference":    "(feature_key IS NULL AND feature_id IS NULL) OR (feature_key IS NOT NULL AND feature_key <> '' AND feature_id IS NOT NULL AND feature_id <> '')",
 	}
 	AppCustomInvoicingsTable.ForeignKeys[0].RefTable = AppsTable
 	AppCustomInvoicingCustomersTable.ForeignKeys[0].RefTable = AppCustomInvoicingsTable
@@ -6469,6 +6470,7 @@ func init() {
 		"plan_rate_card_currency_code_length": "currency IS NULL OR char_length(currency) BETWEEN 3 AND 24",
 		"plan_rate_card_currency_has_price":   "price IS NOT NULL OR currency IS NULL",
 		"plan_rate_card_currency_reference":   "(currency IS NULL AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) = 3 AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) > 3 AND custom_currency_id IS NOT NULL)",
+		"plan_rate_card_feature_reference":    "(feature_key IS NULL AND feature_id IS NULL) OR (feature_key IS NOT NULL AND feature_key <> '' AND feature_id IS NOT NULL AND feature_id <> '')",
 	}
 	SubscriptionsTable.ForeignKeys[0].RefTable = CustomersTable
 	SubscriptionsTable.ForeignKeys[1].RefTable = PlansTable

--- a/openmeter/ent/db/planratecard/planratecard.go
+++ b/openmeter/ent/db/planratecard/planratecard.go
@@ -153,12 +153,16 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// KeyValidator is a validator for the "key" field. It is called by the builders before save.
 	KeyValidator func(string) error
+	// FeatureKeyValidator is a validator for the "feature_key" field. It is called by the builders before save.
+	FeatureKeyValidator func(string) error
 	// CurrencyCodeValidator is a validator for the "currency_code" field. It is called by the builders before save.
 	CurrencyCodeValidator func(string) error
 	// CustomCurrencyIDValidator is a validator for the "custom_currency_id" field. It is called by the builders before save.
 	CustomCurrencyIDValidator func(string) error
 	// PhaseIDValidator is a validator for the "phase_id" field. It is called by the builders before save.
 	PhaseIDValidator func(string) error
+	// FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
+	FeatureIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 	// ValueScanner of all PlanRateCard fields.

--- a/openmeter/ent/db/planratecard_create.go
+++ b/openmeter/ent/db/planratecard_create.go
@@ -394,6 +394,11 @@ func (_c *PlanRateCardCreate) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.type": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.FeatureKey(); ok {
+		if err := planratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _c.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.entitlement_template": %w`, err)}
@@ -435,6 +440,11 @@ func (_c *PlanRateCardCreate) check() error {
 	if v, ok := _c.mutation.PhaseID(); ok {
 		if err := planratecard.PhaseIDValidator(v); err != nil {
 			return &ValidationError{Name: "phase_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.phase_id": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.FeatureID(); ok {
+		if err := planratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_id": %w`, err)}
 		}
 	}
 	if len(_c.mutation.PhaseIDs()) == 0 {

--- a/openmeter/ent/db/planratecard_update.go
+++ b/openmeter/ent/db/planratecard_update.go
@@ -440,6 +440,11 @@ func (_u *PlanRateCardUpdate) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FeatureKey(); ok {
+		if err := planratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.entitlement_template": %w`, err)}
@@ -478,6 +483,11 @@ func (_u *PlanRateCardUpdate) check() error {
 	if v, ok := _u.mutation.PhaseID(); ok {
 		if err := planratecard.PhaseIDValidator(v); err != nil {
 			return &ValidationError{Name: "phase_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.phase_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FeatureID(); ok {
+		if err := planratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_id": %w`, err)}
 		}
 	}
 	if _u.mutation.PhaseCleared() && len(_u.mutation.PhaseIDs()) > 0 {
@@ -1155,6 +1165,11 @@ func (_u *PlanRateCardUpdateOne) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.FeatureKey(); ok {
+		if err := planratecard.FeatureKeyValidator(v); err != nil {
+			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_key": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.EntitlementTemplate(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "entitlement_template", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.entitlement_template": %w`, err)}
@@ -1193,6 +1208,11 @@ func (_u *PlanRateCardUpdateOne) check() error {
 	if v, ok := _u.mutation.PhaseID(); ok {
 		if err := planratecard.PhaseIDValidator(v); err != nil {
 			return &ValidationError{Name: "phase_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.phase_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.FeatureID(); ok {
+		if err := planratecard.FeatureIDValidator(v); err != nil {
+			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.feature_id": %w`, err)}
 		}
 	}
 	if _u.mutation.PhaseCleared() && len(_u.mutation.PhaseIDs()) > 0 {

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -193,6 +193,10 @@ func init() {
 	addonratecardDescKey := addonratecardMixinFields0[8].Descriptor()
 	// addonratecard.KeyValidator is a validator for the "key" field. It is called by the builders before save.
 	addonratecard.KeyValidator = addonratecardDescKey.Validators[0].(func(string) error)
+	// addonratecardDescFeatureKey is the schema descriptor for feature_key field.
+	addonratecardDescFeatureKey := addonratecardFields[1].Descriptor()
+	// addonratecard.FeatureKeyValidator is a validator for the "feature_key" field. It is called by the builders before save.
+	addonratecard.FeatureKeyValidator = addonratecardDescFeatureKey.Validators[0].(func(string) error)
 	// addonratecardDescEntitlementTemplate is the schema descriptor for entitlement_template field.
 	addonratecardDescEntitlementTemplate := addonratecardFields[3].Descriptor()
 	addonratecard.ValueScanner.EntitlementTemplate = addonratecardDescEntitlementTemplate.ValueScanner.(field.TypeValueScanner[*productcatalog.EntitlementTemplate])
@@ -235,6 +239,10 @@ func init() {
 	addonratecardDescAddonID := addonratecardFields[11].Descriptor()
 	// addonratecard.AddonIDValidator is a validator for the "addon_id" field. It is called by the builders before save.
 	addonratecard.AddonIDValidator = addonratecardDescAddonID.Validators[0].(func(string) error)
+	// addonratecardDescFeatureID is the schema descriptor for feature_id field.
+	addonratecardDescFeatureID := addonratecardFields[12].Descriptor()
+	// addonratecard.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
+	addonratecard.FeatureIDValidator = addonratecardDescFeatureID.Validators[0].(func(string) error)
 	// addonratecardDescID is the schema descriptor for id field.
 	addonratecardDescID := addonratecardMixinFields0[0].Descriptor()
 	// addonratecard.DefaultID holds the default value on creation for the id field.
@@ -2932,6 +2940,10 @@ func init() {
 	planratecardDescKey := planratecardMixinFields0[8].Descriptor()
 	// planratecard.KeyValidator is a validator for the "key" field. It is called by the builders before save.
 	planratecard.KeyValidator = planratecardDescKey.Validators[0].(func(string) error)
+	// planratecardDescFeatureKey is the schema descriptor for feature_key field.
+	planratecardDescFeatureKey := planratecardFields[1].Descriptor()
+	// planratecard.FeatureKeyValidator is a validator for the "feature_key" field. It is called by the builders before save.
+	planratecard.FeatureKeyValidator = planratecardDescFeatureKey.Validators[0].(func(string) error)
 	// planratecardDescEntitlementTemplate is the schema descriptor for entitlement_template field.
 	planratecardDescEntitlementTemplate := planratecardFields[3].Descriptor()
 	planratecard.ValueScanner.EntitlementTemplate = planratecardDescEntitlementTemplate.ValueScanner.(field.TypeValueScanner[*productcatalog.EntitlementTemplate])
@@ -2974,6 +2986,10 @@ func init() {
 	planratecardDescPhaseID := planratecardFields[11].Descriptor()
 	// planratecard.PhaseIDValidator is a validator for the "phase_id" field. It is called by the builders before save.
 	planratecard.PhaseIDValidator = planratecardDescPhaseID.Validators[0].(func(string) error)
+	// planratecardDescFeatureID is the schema descriptor for feature_id field.
+	planratecardDescFeatureID := planratecardFields[12].Descriptor()
+	// planratecard.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
+	planratecard.FeatureIDValidator = planratecardDescFeatureID.Validators[0].(func(string) error)
 	// planratecardDescID is the schema descriptor for id field.
 	planratecardDescID := planratecardMixinFields0[0].Descriptor()
 	// planratecard.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/addon.go
+++ b/openmeter/ent/schema/addon.go
@@ -130,6 +130,7 @@ func (AddonRateCard) Fields() []ent.Field {
 			NotEmpty().
 			Comment("The add-on identifier the ratecard is assigned to."),
 		field.String("feature_id").
+			NotEmpty().
 			Optional().
 			Nillable().
 			Comment("The feature identifier the ratecard is related to."),
@@ -182,6 +183,7 @@ func (AddonRateCard) Annotations() []entschema.Annotation {
 			"addon_rate_card_currency_code_length": `currency IS NULL OR char_length(currency) BETWEEN 3 AND 24`,
 			"addon_rate_card_currency_reference":   `(currency IS NULL AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) = 3 AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) > 3 AND custom_currency_id IS NOT NULL)`,
 			"addon_rate_card_currency_has_price":   `price IS NOT NULL OR currency IS NULL`,
+			"addon_rate_card_feature_reference":    `(feature_key IS NULL AND feature_id IS NULL) OR (feature_key IS NOT NULL AND feature_key <> '' AND feature_id IS NOT NULL AND feature_id <> '')`,
 		}),
 	}
 }

--- a/openmeter/ent/schema/productcatalog.go
+++ b/openmeter/ent/schema/productcatalog.go
@@ -184,6 +184,7 @@ func (PlanRateCard) Fields() []ent.Field {
 			NotEmpty().
 			Comment("The phase identifier the ratecard is assigned to."),
 		field.String("feature_id").
+			NotEmpty().
 			Optional().
 			Nillable().
 			Comment("The feature identifier the ratecard is related to."),
@@ -236,6 +237,7 @@ func (PlanRateCard) Annotations() []entschema.Annotation {
 			"plan_rate_card_currency_code_length": `currency IS NULL OR char_length(currency) BETWEEN 3 AND 24`,
 			"plan_rate_card_currency_reference":   `(currency IS NULL AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) = 3 AND custom_currency_id IS NULL) OR (currency IS NOT NULL AND char_length(currency) > 3 AND custom_currency_id IS NOT NULL)`,
 			"plan_rate_card_currency_has_price":   `price IS NOT NULL OR currency IS NULL`,
+			"plan_rate_card_feature_reference":    `(feature_key IS NULL AND feature_id IS NULL) OR (feature_key IS NOT NULL AND feature_key <> '' AND feature_id IS NOT NULL AND feature_id <> '')`,
 		}),
 	}
 }

--- a/openmeter/ent/schema/ratecard.go
+++ b/openmeter/ent/schema/ratecard.go
@@ -25,6 +25,7 @@ func (RateCard) Fields() []ent.Field {
 			GoType(productcatalog.RateCardType("")).
 			Immutable(),
 		field.String("feature_key").
+			NotEmpty().
 			Optional().
 			Nillable(),
 		field.JSON("annotations", models.Annotations{}).

--- a/tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.down.sql
+++ b/tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.down.sql
@@ -1,0 +1,4 @@
+-- reverse: modify "plan_rate_cards" table
+ALTER TABLE "plan_rate_cards" DROP CONSTRAINT "plan_rate_card_feature_reference";
+-- reverse: modify "addon_rate_cards" table
+ALTER TABLE "addon_rate_cards" DROP CONSTRAINT "addon_rate_card_feature_reference";

--- a/tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.up.sql
+++ b/tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.up.sql
@@ -1,0 +1,4 @@
+-- modify "addon_rate_cards" table
+ALTER TABLE "addon_rate_cards" ADD CONSTRAINT "addon_rate_card_feature_reference" CHECK (((feature_key IS NULL) AND (feature_id IS NULL)) OR ((feature_key IS NOT NULL) AND ((feature_key)::text <> ''::text) AND (feature_id IS NOT NULL) AND (feature_id <> ''::bpchar)));
+-- modify "plan_rate_cards" table
+ALTER TABLE "plan_rate_cards" ADD CONSTRAINT "plan_rate_card_feature_reference" CHECK (((feature_key IS NULL) AND (feature_id IS NULL)) OR ((feature_key IS NOT NULL) AND ((feature_key)::text <> ''::text) AND (feature_id IS NOT NULL) AND (feature_id <> ''::bpchar)));

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:McCqJVYW5IXI70K9BM032vWY9LtU6xoFtqnrPlCb3Ns=
+h1:qQ6gNLxEMsePP997hF7MrK17QRL1WuILBaeC3jbc79M=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -267,3 +267,4 @@ h1:McCqJVYW5IXI70K9BM032vWY9LtU6xoFtqnrPlCb3Ns=
 20260814113138_add_rate_card_annotations.up.sql h1:t4ndznUbmigfF3p28iR3VXzGndJieWQV7OKKvuiecs4=
 20260814113139_backfill_rate_card_feature_references.up.sql h1:iA5yWo3AC0sXJIt10Lr7/Wic6cLbQDpPkW51upFJK10=
 20260814114215_charges-search-feature-filters.up.sql h1:ttOzcueUboyfQKgIV2Pv7lRzUXus2AknzqeD40VQvSE=
+20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=

--- a/tools/migrate/rate_card_feature_reference_constraints_test.go
+++ b/tools/migrate/rate_card_feature_reference_constraints_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 type rateCardFeatureReferenceConstraintTable struct {
-	name         string
-	parentColumn string
-	parentID     string
+	name                           string
+	parentColumn                   string
+	parentID                       string
+	featureReferenceConstraintName string
 }
 
 type rateCardFeatureReferenceConstraintRow struct {
@@ -85,14 +86,17 @@ func TestRateCardFeatureReferenceConstraintsMigration(t *testing.T) {
 	db := testDB.PGDriver.DB()
 	featureID := ulid.Make().String()
 	featureKey := "constraint_feature"
+	emptyIDFeatureKey := "empty_id_constraint_feature"
 	planID := ulid.Make().String()
 	phaseID := ulid.Make().String()
 	addonID := ulid.Make().String()
 
 	_, err = db.ExecContext(t.Context(), `
 		INSERT INTO features (id, namespace, created_at, updated_at, name, key)
-		VALUES ($1, $2, NOW(), NOW(), 'Constraint feature', $3)
-	`, featureID, namespace, featureKey)
+		VALUES
+			($1, $2, NOW(), NOW(), 'Constraint feature', $3),
+			('', $2, NOW(), NOW(), 'Empty ID constraint feature', $4)
+	`, featureID, namespace, featureKey, emptyIDFeatureKey)
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(t.Context(), `
@@ -125,8 +129,18 @@ func TestRateCardFeatureReferenceConstraintsMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	tables := []rateCardFeatureReferenceConstraintTable{
-		{name: "plan_rate_cards", parentColumn: "phase_id", parentID: phaseID},
-		{name: "addon_rate_cards", parentColumn: "addon_id", parentID: addonID},
+		{
+			name:                           "plan_rate_cards",
+			parentColumn:                   "phase_id",
+			parentID:                       phaseID,
+			featureReferenceConstraintName: "plan_rate_card_feature_reference",
+		},
+		{
+			name:                           "addon_rate_cards",
+			parentColumn:                   "addon_id",
+			parentID:                       addonID,
+			featureReferenceConstraintName: "addon_rate_card_feature_reference",
+		},
 	}
 
 	for index, table := range tables {
@@ -187,6 +201,15 @@ func TestRateCardFeatureReferenceConstraintsMigration(t *testing.T) {
 				featureID:  featureID,
 				featureKey: "",
 			}))
+
+			err := insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "empty_id",
+				featureID:  "",
+				featureKey: emptyIDFeatureKey,
+			})
+			require.ErrorContains(t, err, table.featureReferenceConstraintName)
 		})
 	}
 

--- a/tools/migrate/rate_card_feature_reference_constraints_test.go
+++ b/tools/migrate/rate_card_feature_reference_constraints_test.go
@@ -1,0 +1,203 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+type rateCardFeatureReferenceConstraintTable struct {
+	name         string
+	parentColumn string
+	parentID     string
+}
+
+type rateCardFeatureReferenceConstraintRow struct {
+	table      rateCardFeatureReferenceConstraintTable
+	namespace  string
+	key        string
+	featureID  any
+	featureKey any
+}
+
+func insertRateCardFeatureReferenceConstraintRow(
+	t testing.TB,
+	db *sql.DB,
+	row rateCardFeatureReferenceConstraintRow,
+) error {
+	t.Helper()
+
+	_, err := db.ExecContext(t.Context(), fmt.Sprintf(`
+		INSERT INTO %s (
+			id, namespace, created_at, updated_at, name, key, type,
+			%s, feature_id, feature_key
+		) VALUES (
+			$1, $2, NOW(), NOW(), $3, $3, 'FLAT_FEE', $4, $5, $6
+		)
+	`, row.table.name, row.table.parentColumn),
+		ulid.Make().String(),
+		row.namespace,
+		row.key,
+		row.table.parentID,
+		row.featureID,
+		row.featureKey,
+	)
+
+	return err
+}
+
+func TestRateCardFeatureReferenceConstraintsMigration(t *testing.T) {
+	const (
+		namespace       = "rate_card_feature_reference_constraints"
+		previousVersion = uint(20260814114215)
+		targetVersion   = uint(20260818090123)
+	)
+
+	// given:
+	// - the completed rate-card backfill and both valid and incomplete feature references
+	// when:
+	// - the feature-reference constraint migration is applied and rolled back
+	// then:
+	// - existing incomplete rows block rollout, both-null and complete rows remain valid,
+	//   and new incomplete or empty references are rejected until rollback
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	t.Cleanup(func() { testDB.Close(t) })
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           testutils.NewLogger(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sourceErr, databaseErr := migrator.Close()
+		require.NoError(t, errors.Join(sourceErr, databaseErr))
+	})
+	require.NoError(t, migrator.Migrate(previousVersion))
+
+	db := testDB.PGDriver.DB()
+	featureID := ulid.Make().String()
+	featureKey := "constraint_feature"
+	planID := ulid.Make().String()
+	phaseID := ulid.Make().String()
+	addonID := ulid.Make().String()
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO features (id, namespace, created_at, updated_at, name, key)
+		VALUES ($1, $2, NOW(), NOW(), 'Constraint feature', $3)
+	`, featureID, namespace, featureKey)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO plans (
+			id, namespace, created_at, updated_at, name, key, version,
+			currency, billing_cadence, pro_rating_config
+		) VALUES (
+			$1, $2, NOW(), NOW(), 'Constraint plan', 'constraint_plan', 1,
+			'USD', 'P1M', '{"enabled":true,"mode":"prorate_prices"}'::jsonb
+		)
+	`, planID, namespace)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO plan_phases (
+			id, namespace, created_at, updated_at, name, key, plan_id, index
+		) VALUES (
+			$1, $2, NOW(), NOW(), 'Constraint phase', 'constraint_phase', $3, 0
+		)
+	`, phaseID, namespace, planID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO addons (
+			id, namespace, created_at, updated_at, name, key, version, currency
+		) VALUES (
+			$1, $2, NOW(), NOW(), 'Constraint add-on', 'constraint_addon', 1, 'USD'
+		)
+	`, addonID, namespace)
+	require.NoError(t, err)
+
+	tables := []rateCardFeatureReferenceConstraintTable{
+		{name: "plan_rate_cards", parentColumn: "phase_id", parentID: phaseID},
+		{name: "addon_rate_cards", parentColumn: "addon_id", parentID: addonID},
+	}
+
+	for index, table := range tables {
+		require.NoError(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+			table:      table,
+			namespace:  namespace,
+			key:        fmt.Sprintf("legacy_incomplete_%d", index),
+			featureID:  featureID,
+			featureKey: nil,
+		}))
+	}
+
+	err = migrator.Migrate(targetVersion)
+	require.Error(t, err, "existing incomplete rate cards must block the constraint migration")
+	require.NoError(t, migrator.Force(previousVersion), "clear the failed migration marker after DDL rollback")
+
+	for _, table := range tables {
+		_, err = db.ExecContext(t.Context(), fmt.Sprintf(`DELETE FROM %s`, table.name))
+		require.NoError(t, err)
+	}
+	require.NoError(t, migrator.Migrate(targetVersion))
+
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			require.NoError(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "without_feature",
+				featureID:  nil,
+				featureKey: nil,
+			}))
+			require.NoError(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "complete_feature",
+				featureID:  featureID,
+				featureKey: featureKey,
+			}))
+
+			require.Error(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "id_only",
+				featureID:  featureID,
+				featureKey: nil,
+			}))
+			require.Error(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "key_only",
+				featureID:  nil,
+				featureKey: featureKey,
+			}))
+			require.Error(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+				table:      table,
+				namespace:  namespace,
+				key:        "empty_key",
+				featureID:  featureID,
+				featureKey: "",
+			}))
+		})
+	}
+
+	require.NoError(t, migrator.Migrate(previousVersion))
+	for index, table := range tables {
+		require.NoError(t, insertRateCardFeatureReferenceConstraintRow(t, db, rateCardFeatureReferenceConstraintRow{
+			table:      table,
+			namespace:  namespace,
+			key:        fmt.Sprintf("incomplete_after_rollback_%d", index),
+			featureID:  featureID,
+			featureKey: nil,
+		}))
+	}
+}


### PR DESCRIPTION
## What

Enforce feature-reference integrity for plan and add-on rate cards so `feature_id` and `feature_key` are either both populated or both absent.

## Why

The existing backfill repairs incomplete references created by the former resolution bug. Database constraints are needed to prevent invalid rate cards from being persisted again.

## How

- Add Ent-side non-empty validation for both fields.
- Add PostgreSQL `CHECK` constraints for plan and add-on rate cards.
- Generate the corresponding Atlas migration.
- Add database-backed tests covering valid, incomplete, empty, pre-existing, and rollback scenarios.
- Update the migration guide with the enforced constraint contract.

JIRA: OM-464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation ensuring feature references are complete and non-empty when provided.
  * Added database safeguards for plan and add-on rate-card feature references.

* **Bug Fixes**
  * Prevented incomplete, empty, or mismatched feature references from being saved.

* **Tests**
  * Added coverage for valid references, invalid data, migration failures, and rollback behavior.

* **Documentation**
  * Updated migration guidance to reflect the implemented validation and database safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enforces complete, non-empty feature references for plan and add-on rate cards at both the Ent and PostgreSQL layers.
- Adds paired feature-reference checks to the authoritative Ent schemas and generated clients.
- Adds a checksummed migration and rollback for both rate-card tables.
- Adds database-backed coverage for valid, invalid, pre-existing, and rolled-back states.
- Documents the migration’s rollout prerequisites and enforced persistence contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/ent/schema/ratecard.go | Adds non-empty validation for the shared optional feature key. |
| openmeter/ent/schema/productcatalog.go | Adds non-empty plan-rate-card feature IDs and the paired database constraint. |
| openmeter/ent/schema/addon.go | Adds non-empty add-on-rate-card feature IDs and the paired database constraint. |
| tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.up.sql | Installs validated checks that accept only absent or fully populated feature references. |
| tools/migrate/migrations/20260818090123_rate_card_feature_reference_constraints.down.sql | Removes both feature-reference checks during rollback. |
| tools/migrate/rate_card_feature_reference_constraints_test.go | Exercises migration blocking, accepted reference shapes, rejected invalid shapes, and rollback behavior. |
| docs/migration-guides/2026-08-06-feature-reference-integrity.md | Documents the implemented constraints and the operational prerequisites for enabling them. |

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    W[Rate-card writer] --> E[Ent non-empty validation]
    E -->|Empty value| R[Reject mutation]
    E -->|Values absent or non-empty| D[(PostgreSQL)]
    D --> C{Paired-reference CHECK}
    C -->|Both absent| A[Accept row]
    C -->|Both non-empty| A
    C -->|Incomplete reference| X[Reject write]
    M[Migration] --> C
    L[Existing incomplete row] -->|Blocks validation| M
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(migrate): cover empty rate card fea..."](https://github.com/openmeterio/openmeter/commit/b5e43d2c32a3f59b289c7e8527854c57e80005a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54378522)</sub>

**Context used:**

- Knowledge Base — [Data layer: ent schema, migrations, and generated client](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/data-layer.md)

<!-- /greptile_comment -->