### PR TITLE
ci: group kong actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -75,6 +75,9 @@ updates:
         patterns:
           - "github/codeql-action"
           - "github/codeql-action/*"
+      kong:
+        patterns:
+          - "Kong/public-shared-actions/*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Overview

Update Dependabot configuration to group updates for Kong actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated grouping for related GitHub Actions dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates Dependabot configuration so the repository’s existing Kong shared GitHub Actions receive grouped dependency updates.
- Adds a `kong` group to the GitHub Actions ecosystem.
- Matches the active `Kong/public-shared-actions/*` sub-actions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new group pattern matches all current Kong shared-action dependencies.

The Dependabot change only groups existing SHA-pinned Kong sub-actions and does not alter workflow execution, dependency versions, permissions, or trust boundaries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yaml | Adds a Kong dependency group whose pattern matches the repository’s current Kong shared-action references. |

<sub>Reviews (1): Last reviewed commit: ["ci: group kong actions updates"](https://github.com/openmeterio/openmeter/commit/f811d09130853da8bfe3ecea3c055813911c16cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54379960)</sub>

<!-- /greptile_comment -->