### PR TITLE
docs(agents): preserve command output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
   clean them up separately after confirming no active shell uses them.
 - `.nvmrc` is the GitHub Actions source of truth for Node. Keep it aligned with
   `node -v` in the Nix `.#ci` shell.
+- For slow or noisy commands, save complete output to a temporary log outside the repository, preserve and report the exit status and log path, inspect bounded slices, and never rerun solely because displayed output was truncated.
 
 ## Repository invariants
 


### PR DESCRIPTION
## Summary

- preserve output from slow or noisy commands in temporary logs
- avoid expensive reruns when displayed output is truncated

## Why

Long command output can be truncated before failure details are inspected. Persisting it makes the original run reusable.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for handling slow or noisy commands.
  * Documented how to preserve command output, report exit status and log locations, and inspect logs efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only change updates agent guidance to preserve complete output from slow or noisy commands without unnecessary reruns.
- Requires temporary logs to be stored outside the repository.
- Requires reporting the command status and log path.
- Directs agents to inspect bounded portions of preserved output.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The documentation change explicitly requires preserving command exit status and complete output, and no concrete conflicting repository convention or actionable failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds clear command-output preservation guidance without introducing a concrete repository workflow or runtime defect. |

<sub>Reviews (1): Last reviewed commit: ["docs(agents): preserve command output"](https://github.com/openmeterio/openmeter/commit/de9bc5805a3e8698a8407f61f7c32457427da04e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54414776)</sub>

<!-- /greptile_comment -->