### PR TITLE
fix(charges): prepare custom overage before invoice sync

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -107,8 +107,9 @@ finalization callback. Engines return fully calculated lines with unchanged
 line IDs; billing replaces those lines, sums their totals, and persists the
 invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
-engine-owned effects. Once line finalization starts, issuing is retry-only;
-invoice deletion requires correction support for any durable preparation.
+engine-owned effects. Line-finalization failures are retry-only. If invoicing
+app synchronization fails after durable preparation succeeds, charge-owned
+cleanup must correct that preparation before the invoice can be deleted.
 
 A deleted app keeps its historical identity and can still be expanded on
 invoices. Its generic app operations return `app.ErrAppDeleted`, while its

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -107,9 +107,12 @@ finalization callback. Engines return fully calculated lines with unchanged
 line IDs; billing replaces those lines, sums their totals, and persists the
 invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
-engine-owned effects. Line-finalization failures are retry-only. If invoicing
-app synchronization fails after durable preparation succeeds, charge-owned
-cleanup must correct that preparation before the invoice can be deleted.
+engine-owned effects. Flat-fee and usage-based accounting preparation complete
+at this boundary; the later external-issued callback validates and advances the
+already-prepared charge lifecycle. Line-finalization failures and subsequent
+issuing are retry-only. If invoicing app synchronization fails after durable
+preparation succeeds, charge-owned cleanup must correct that preparation before
+the invoice can be deleted.
 
 A deleted app keeps its historical identity and can still be expanded on
 invoices. Its generic app operations return `app.ErrAppDeleted`, while its

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -107,13 +107,14 @@ finalization callback. Engines return fully calculated lines with unchanged
 line IDs; billing replaces those lines, sums their totals, and persists the
 invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
-engine-owned effects.
+engine-owned effects. Once line finalization starts, issuing is retry-only;
+invoice deletion requires correction support for any durable preparation.
 
 A deleted app keeps its historical identity and can still be expanded on
 invoices. Its generic app operations return `app.ErrAppDeleted`, while its
 invoicing operations return billing-owned validation issues. Critical issues
-move the invoice into the failed state for that step. Invoice deletion remains
-available and returns a warning when provider cleanup has to be skipped.
+move the invoice into the failed state for that step. Before issuing, invoice
+deletion returns a warning when provider cleanup has to be skipped.
 
 Retrying and deleting are separate domain actions. Use the billing service's
 retry operation for a retryable failure and its delete operation for the

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -280,9 +280,13 @@ Charge-currency and settlement-fiat allocations are separate realization and
 lineage domains. Rating and mutable rerating reconcile charge-currency facts;
 invoice finalization first persists the gross converted overage, then allocates
 settlement-fiat credits once against it. Invoice-issued callbacks only advance
-the prepared custom-currency run. Once preparation starts, invoice issuing is
-retry-only; generic correction of prepared accounting is not part of this
-lifecycle.
+the prepared custom-currency run. A line-finalization failure remains
+retry-only. If synchronization with the invoicing app fails after preparation,
+invoice deletion corrects settlement-fiat allocations, the gross overage, and
+charge-currency allocations before deleting the prepared run. Cleanup and its
+ledger effects share the billing transaction. Failed cleanup rolls back and
+leaves preparation attached for retry from `delete.failed`; committed cleanup
+sets `DeletedAt`, so later invoice-delete sync retries do not dispatch it again.
 
 The converted post-allocation overage and the required fiat transaction are
 separate settlement facts. A zero converted overage controls line omission and

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -236,6 +236,14 @@ one.
   flat-fee run is a one-shot invoice-finalization effect. A persisted
   completion marker distinguishes pending allocation from a successful
   zero-allocation result, so retries do not re-enter completed allocation.
+- Invoice line finalization is the accounting-preparation boundary for flat-fee
+  and usage-based charges. Their state machines book invoice usage, prepare
+  custom-currency overage, and allocate settlement-fiat credits before emitting
+  any authoritative line change as an explicit invoice update patch. No patch
+  means the existing line remains authoritative. Billing consumes an emitted
+  patch before synchronizing the external invoice. The later invoice-issued
+  callback carries no economic effects; it validates and advances the prepared
+  realization into its post-issuance lifecycle.
 - Amount discounts on persisted detailed lines are signed realization facts.
   Their rounded amounts and rounding adjustments reconcile to the line's
   `DiscountsTotal`; correction lines can therefore carry negative discount

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -233,9 +233,9 @@ one.
   run and monetary domain, preserving lineage to the facts previously billed
   or posted.
 - Settlement-fiat overage allocation for a custom-currency usage-based or
-  flat-fee run is a one-shot invoice-finalization effect. It requires an empty
-  settlement-fiat realization history; later cleanup corrects the persisted
-  facts instead of re-entering allocation.
+  flat-fee run is a one-shot invoice-finalization effect. A persisted
+  completion marker distinguishes pending allocation from a successful
+  zero-allocation result, so retries do not re-enter completed allocation.
 - Amount discounts on persisted detailed lines are signed realization facts.
   Their rounded amounts and rounding adjustments reconcile to the line's
   `DiscountsTotal`; correction lines can therefore carry negative discount
@@ -278,9 +278,11 @@ Within the charges domain, custom-currency `credit_then_invoice`:
 
 Charge-currency and settlement-fiat allocations are separate realization and
 lineage domains. Rating and mutable rerating reconcile charge-currency facts;
-invoice finalization allocates settlement-fiat credits once against the final
-converted overage. Cleanup reverses persisted settlement-fiat allocations
-before the charge-currency allocations from which the overage was derived.
+invoice finalization first persists the gross converted overage, then allocates
+settlement-fiat credits once against it. Invoice-issued callbacks only advance
+the prepared custom-currency run. Once preparation starts, invoice issuing is
+retry-only; generic correction of prepared accounting is not part of this
+lifecycle.
 
 The converted post-allocation overage and the required fiat transaction are
 separate settlement facts. A zero converted overage controls line omission and

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -287,14 +287,17 @@ Within the charges domain, custom-currency `credit_then_invoice`:
 Charge-currency and settlement-fiat allocations are separate realization and
 lineage domains. Rating and mutable rerating reconcile charge-currency facts;
 invoice finalization first persists the gross converted overage, then allocates
-settlement-fiat credits once against it. Invoice-issued callbacks only advance
-the prepared custom-currency run. A line-finalization failure remains
-retry-only. If synchronization with the invoicing app fails after preparation,
-invoice deletion corrects settlement-fiat allocations, the gross overage, and
-charge-currency allocations before deleting the prepared run. Cleanup and its
-ledger effects share the billing transaction. Failed cleanup rolls back and
-leaves preparation attached for retry from `delete.failed`; committed cleanup
-sets `DeletedAt`, so later invoice-delete sync retries do not dispatch it again.
+settlement-fiat credits once against it. This preparation remains reversible
+until the invoice-issued callback marks its run immutable after successful
+external synchronization. Deleting a charge corrects settlement-fiat
+allocations, the gross overage, and charge-currency allocations while the run
+is still reversible; an immutable issued run remains durable billing history.
+A line-finalization failure remains retry-only. If synchronization with the
+invoicing app fails after preparation, invoice deletion enters the same charge
+deletion path. Cleanup and its ledger effects share the billing transaction.
+Failed cleanup rolls back and leaves preparation attached for retry from
+`delete.failed`; committed cleanup sets `DeletedAt`, so later invoice-delete
+sync retries do not dispatch it again.
 
 The converted post-allocation overage and the required fiat transaction are
 separate settlement facts. A zero converted overage controls line omission and

--- a/openmeter/billing/charges/flatfee/adapter/mapping.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapping.go
@@ -101,15 +101,16 @@ func fromDBRunBase(dbRun *entdb.ChargeFlatFeeRun) flatfee.RealizationRunBase {
 		},
 		ManagedModel: entutils.MapTimeMixinFromDB(dbRun),
 
-		LineID:                    dbRun.LineID,
-		InvoiceID:                 dbRun.InvoiceID,
-		Type:                      dbRun.Type,
-		InitialType:               dbRun.InitialType,
-		ServicePeriod:             timeutil.ClosedPeriod{From: dbRun.ServicePeriodFrom.UTC(), To: dbRun.ServicePeriodTo.UTC()},
-		AmountAfterProration:      dbRun.AmountAfterProration,
-		Totals:                    totals.FromDB(dbRun),
-		NoFiatTransactionRequired: dbRun.NoFiatTransactionRequired,
-		Immutable:                 dbRun.Immutable,
+		LineID:                               dbRun.LineID,
+		InvoiceID:                            dbRun.InvoiceID,
+		Type:                                 dbRun.Type,
+		InitialType:                          dbRun.InitialType,
+		ServicePeriod:                        timeutil.ClosedPeriod{From: dbRun.ServicePeriodFrom.UTC(), To: dbRun.ServicePeriodTo.UTC()},
+		AmountAfterProration:                 dbRun.AmountAfterProration,
+		Totals:                               totals.FromDB(dbRun),
+		NoFiatTransactionRequired:            dbRun.NoFiatTransactionRequired,
+		FiatOverageCreditAllocationCompleted: dbRun.FiatOverageCreditAllocationCompleted,
+		Immutable:                            dbRun.Immutable,
 	}
 }
 

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun.go
@@ -112,6 +112,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input flatfee.Update
 			update = update.SetNoFiatTransactionRequired(input.NoFiatTransactionRequired.OrEmpty())
 		}
 
+		if input.FiatOverageCreditAllocationCompleted.IsPresent() {
+			update = update.SetFiatOverageCreditAllocationCompleted(input.FiatOverageCreditAllocationCompleted.OrEmpty())
+		}
+
 		if input.Immutable.IsPresent() {
 			update = update.SetImmutable(input.Immutable.OrEmpty())
 		}

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -141,7 +141,9 @@ func (i OnCustomCurrencyOverageAccruedInput) Validate() error {
 
 type OnCustomCurrencyOverageAccruedResult struct {
 	TransactionGroup ledgertransaction.GroupReference `json:"transactionGroup"`
-	TotalFiatAmount  alpacadecimal.Decimal            `json:"totalFiatAmount"`
+	// TotalFiatAmount is the authoritative rounded gross amount persisted for
+	// invoice projection and later settlement-credit allocation.
+	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
@@ -339,14 +341,15 @@ type Handler interface {
 	// OnFlatFeeStandardInvoiceUsageAccrued is called when the remaining usage is sent to the customer on a standard invoice.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency flat-fee value is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
+	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
 	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 
-	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against a custom-currency overage.
+	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against an
+	// already-prepared custom-currency overage.
 	OnAllocateFiatOverageCredits(ctx context.Context, input AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
 
 	// OnCorrectFiatOverageCreditAllocations corrects settlement-fiat allocations for a custom-currency overage.

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -146,6 +146,10 @@ type OnCustomCurrencyOverageAccruedResult struct {
 	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
+
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
 
@@ -344,6 +348,12 @@ type Handler interface {
 	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
 	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
+
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
 	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -53,15 +53,16 @@ func (i RealizationRunID) Validate() error {
 type UpdateRealizationRunInput struct {
 	ID RealizationRunID
 
-	Type                      mo.Option[RealizationRunType]    `json:"type"`
-	DeletedAt                 mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
-	LineID                    mo.Option[*string]               `json:"lineId,omitempty"`
-	InvoiceID                 mo.Option[*string]               `json:"invoiceId,omitempty"`
-	ServicePeriod             mo.Option[timeutil.ClosedPeriod] `json:"servicePeriod"`
-	AmountAfterProration      mo.Option[alpacadecimal.Decimal] `json:"amountAfterProration"`
-	Totals                    mo.Option[totals.Totals]         `json:"totals"`
-	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
-	Immutable                 mo.Option[bool]                  `json:"immutable"`
+	Type                                 mo.Option[RealizationRunType]    `json:"type"`
+	DeletedAt                            mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
+	LineID                               mo.Option[*string]               `json:"lineId,omitempty"`
+	InvoiceID                            mo.Option[*string]               `json:"invoiceId,omitempty"`
+	ServicePeriod                        mo.Option[timeutil.ClosedPeriod] `json:"servicePeriod"`
+	AmountAfterProration                 mo.Option[alpacadecimal.Decimal] `json:"amountAfterProration"`
+	Totals                               mo.Option[totals.Totals]         `json:"totals"`
+	NoFiatTransactionRequired            mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	FiatOverageCreditAllocationCompleted mo.Option[bool]                  `json:"fiatOverageCreditAllocationCompleted"`
+	Immutable                            mo.Option[bool]                  `json:"immutable"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -140,6 +141,9 @@ type RealizationRunBase struct {
 	// Totals includes credit allocations and excludes taxes.
 	Totals                    totals.Totals `json:"totals"`
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
+	// FiatOverageCreditAllocationCompleted distinguishes a successful
+	// zero-allocation result from pending allocation.
+	FiatOverageCreditAllocationCompleted bool `json:"fiatOverageCreditAllocationCompleted"`
 	// Immutable means the backing invoice line can no longer be updated in place.
 	// When true, deleting this run requires issuing a credit note instead of mutating the invoice line.
 	Immutable bool `json:"immutable"`

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -144,8 +144,9 @@ type RealizationRunBase struct {
 	// FiatOverageCreditAllocationCompleted distinguishes a successful
 	// zero-allocation result from pending allocation.
 	FiatOverageCreditAllocationCompleted bool `json:"fiatOverageCreditAllocationCompleted"`
-	// Immutable means the backing invoice line can no longer be updated in place.
-	// When true, deleting this run requires issuing a credit note instead of mutating the invoice line.
+	// Immutable means the backing invoice crossed the external issuance boundary.
+	// AccruedUsage records preparation before that boundary and can be reversed
+	// only through invoice-owned cancellation.
 	Immutable bool `json:"immutable"`
 }
 

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -159,7 +159,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.AccrueInvoiceUsage))
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceUsage))
 
 	// Zero-fiat-amount overages bypass invoice issuance. This state seals the
 	// persisted current run before the charge completes without payment
@@ -337,6 +337,12 @@ func (s *CreditThenInvoiceStateMachine) ClearDeletedChargeOverride(ctx context.C
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if s.Charge.Status == flatfee.StatusActiveRealizationProcessing &&
+		s.Charge.Realizations.CurrentRun != nil &&
+		s.Charge.Realizations.CurrentRun.AccruedUsage != nil {
+		return fmt.Errorf("flat fee charge[%s] cannot be deleted after invoice issuance preparation", s.Charge.ID)
+	}
+
 	deletedAt := lo.ToPtr(clock.Now())
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
@@ -685,21 +691,46 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) AccrueInvoiceUsage(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceUsage(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
 
-	result, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
-		Charge:         s.Charge,
-		LineWithHeader: input,
-	})
-	if err != nil {
-		return fmt.Errorf("post invoice issued: %w", err)
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		result, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
+			Charge:         s.Charge,
+			LineWithHeader: input,
+		})
+		if err != nil {
+			return fmt.Errorf("post invoice issued: %w", err)
+		}
+
+		s.Charge.Realizations.CurrentRun = &result.Run
+		s.Charge.State.AdvanceAfter = nil
+
+		return nil
 	}
 
-	// The state machine persists this clear through StatusFinal's ClearAdvanceAfter hook.
-	s.Charge.Realizations.CurrentRun = &result.Run
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+	if currentRun.AccruedUsage == nil {
+		return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+	}
+	if !currentRun.FiatOverageCreditAllocationCompleted {
+		return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+	}
+	if !currentRun.Immutable {
+		return fmt.Errorf("prepared realization run[%s] must be immutable", currentRun.ID.ID)
+	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -140,7 +140,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			flatfee.StatusActiveRealizationZeroFiatAmountOverageCompleted,
 			statelessx.BoolFn(s.IsCurrentRunZeroFiatAmountOverage),
 		).
-		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationIssuing).
+		Permit(meta.TriggerInvoiceFinalizing, flatfee.StatusActiveRealizationIssuing).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
@@ -151,7 +151,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		OnEntryFrom(meta.TriggerAttachInvoiceLine, statelessx.WithParameters(s.AttachInvoiceLine))
 
 	s.Configure(flatfee.StatusActiveRealizationIssuing).
-		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationCompleted).
+		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationCompleted).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
@@ -159,7 +159,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceUsage))
+		OnEntryFrom(meta.TriggerInvoiceFinalizing, statelessx.WithParameters(s.FinalizeInvoiceRun))
 
 	// Zero-fiat-amount overages bypass invoice issuance. This state seals the
 	// persisted current run before the charge completes without payment
@@ -183,7 +183,8 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
-		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted)))
+		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.ValidateInvoiceIssuedRun))
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
@@ -337,7 +338,8 @@ func (s *CreditThenInvoiceStateMachine) ClearDeletedChargeOverride(ctx context.C
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if s.Charge.Status == flatfee.StatusActiveRealizationProcessing &&
+	if (s.Charge.Status == flatfee.StatusActiveRealizationProcessing ||
+		s.Charge.Status == flatfee.StatusActiveRealizationIssuing) &&
 		s.Charge.Realizations.CurrentRun != nil &&
 		s.Charge.Realizations.CurrentRun.AccruedUsage != nil {
 		return fmt.Errorf("flat fee charge[%s] cannot be deleted after invoice issuance preparation", s.Charge.ID)
@@ -691,9 +693,22 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceUsage(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+// FinalizeInvoiceRun performs durable accounting preparation and emits any
+// authoritative line change while the charge remains issuing until InvoiceIssued.
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
+	}
+
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("realization run[%s] line does not match finalizing line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("realization run[%s] invoice does not match finalizing invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
 	}
 
 	if !s.Charge.Intent.GetCurrency().IsCustom() {
@@ -702,7 +717,7 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceUsage(ctx context.Context
 			LineWithHeader: input,
 		})
 		if err != nil {
-			return fmt.Errorf("post invoice issued: %w", err)
+			return fmt.Errorf("finalizing invoice usage: %w", err)
 		}
 
 		s.Charge.Realizations.CurrentRun = &result.Run
@@ -711,16 +726,86 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceUsage(ctx context.Context
 		return nil
 	}
 
+	run := *currentRun
+	if run.AccruedUsage == nil && (len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted) {
+		return fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
+	}
+
+	line, err := input.Line.Clone()
+	if err != nil {
+		return fmt.Errorf("cloning finalizing line[%s]: %w", input.Line.ID, err)
+	}
+
+	if run.AccruedUsage == nil {
+		if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+			Charge: s.Charge,
+			Run:    run,
+			Stage:  standardLinePopulationStageInvoiceFinalizing,
+		}); err != nil {
+			return fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", line.ID, run.ID.ID, err)
+		}
+
+		prepared, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
+			Charge: s.Charge,
+			LineWithHeader: billing.StandardLineWithInvoiceHeader{
+				Line:    line,
+				Invoice: input.Invoice,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", line.ID, err)
+		}
+		run = prepared.Run
+		s.Charge.Realizations.CurrentRun = &run
+	}
+
+	if !run.FiatOverageCreditAllocationCompleted {
+		allocated, err := s.Realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
+			Charge: s.Charge,
+			Run:    run,
+		})
+		if err != nil {
+			return fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", line.ID, err)
+		}
+		run = allocated.Run
+		s.Charge.Realizations.CurrentRun = &run
+	}
+
+	if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+		Charge: s.Charge,
+		Run:    run,
+		Stage:  standardLinePopulationStageInvoiceFinalizing,
+	}); err != nil {
+		return fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", line.ID, run.ID.ID, err)
+	}
+
+	s.Charge.State.AdvanceAfter = nil
+	s.AddInvoicePatch(invoiceupdater.NewUpdateLinePatch(line.AsGenericLine()))
+
+	return nil
+}
+
+// ValidateInvoiceIssuedRun verifies that invoice finalization left the current
+// run in the durable state required to accept the external issuance event.
+func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
 	currentRun := s.Charge.Realizations.CurrentRun
 	if currentRun == nil {
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
 	}
-	if currentRun.AccruedUsage == nil {
-		return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+
+	if s.Charge.Intent.GetCurrency().IsCustom() {
+		if currentRun.AccruedUsage == nil {
+			return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+		}
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+		}
 	}
-	if !currentRun.FiatOverageCreditAllocationCompleted {
-		return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
-	}
+
 	if !currentRun.Immutable {
 		return fmt.Errorf("prepared realization run[%s] must be immutable", currentRun.ID.ID)
 	}
@@ -730,8 +815,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceUsage(ctx context.Context
 	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
 		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
 	}
-
-	s.Charge.State.AdvanceAfter = nil
 
 	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -184,7 +184,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.ValidateInvoiceIssuedRun))
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceIssuedRun))
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
@@ -338,13 +338,6 @@ func (s *CreditThenInvoiceStateMachine) ClearDeletedChargeOverride(ctx context.C
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if (s.Charge.Status == flatfee.StatusActiveRealizationProcessing ||
-		s.Charge.Status == flatfee.StatusActiveRealizationIssuing) &&
-		s.Charge.Realizations.CurrentRun != nil &&
-		s.Charge.Realizations.CurrentRun.AccruedUsage != nil {
-		return fmt.Errorf("flat fee charge[%s] cannot be deleted after invoice issuance preparation", s.Charge.ID)
-	}
-
 	deletedAt := lo.ToPtr(clock.Now())
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
@@ -368,7 +361,49 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 	return nil
 }
 
+func (s *CreditThenInvoiceStateMachine) correctReversibleCurrentRun(ctx context.Context) error {
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil || currentRun.AccruedUsage == nil || currentRun.Immutable {
+		return nil
+	}
+
+	run := *currentRun
+	if err := s.Realizations.CorrectAllCreditRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
+		Charge:     s.Charge,
+		Run:        run,
+		AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
+	}); err != nil {
+		return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	if err := s.Adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
+		return fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:        run.ID,
+		DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+	})
+	if err != nil {
+		return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+	run.RealizationRunBase = runBase
+
+	if err := s.Adapter.DetachCurrentRun(ctx, s.Charge.GetChargeID()); err != nil {
+		return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, run)
+	s.Charge.Realizations.CurrentRun = nil
+
+	return nil
+}
+
 func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
+	if err := s.correctReversibleCurrentRun(ctx); err != nil {
+		return err
+	}
+
 	s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
 
 	if err := s.cancelCurrentRealization(ctx); err != nil {
@@ -444,6 +479,9 @@ func (s *CreditThenInvoiceStateMachine) LineManualEdit(ctx context.Context, patc
 
 		if currentRun.Immutable {
 			return fmt.Errorf("immutable current run [charge_id=%s,run_id=%s]: %w", s.Charge.ID, currentRun.ID.ID, billing.ErrCannotUpdateChargeManagedLine)
+		}
+		if currentRun.AccruedUsage != nil {
+			return fmt.Errorf("prepared current run [charge_id=%s,run_id=%s]: %w", s.Charge.ID, currentRun.ID.ID, billing.ErrCannotUpdateChargeManagedLine)
 		}
 
 		if currentRun.LineID == nil || *currentRun.LineID != editedLine.GetID() {
@@ -785,9 +823,9 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	return nil
 }
 
-// ValidateInvoiceIssuedRun verifies that invoice finalization left the current
-// run in the durable state required to accept the external issuance event.
-func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Context, input billing.StandardLineWithInvoiceHeader) error {
+// FinalizeInvoiceIssuedRun verifies the prepared run and marks its externally
+// issued invoice history immutable.
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceIssuedRun(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
@@ -806,15 +844,22 @@ func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Conte
 		}
 	}
 
-	if !currentRun.Immutable {
-		return fmt.Errorf("prepared realization run[%s] must be immutable", currentRun.ID.ID)
-	}
 	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
 		return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
 	}
 	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
 		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
 	}
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:        currentRun.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
+	}
+
+	currentRun.RealizationRunBase = runBase
 
 	return nil
 }
@@ -854,9 +899,9 @@ func (s *CreditThenInvoiceStateMachine) IsCurrentRunZeroFiatAmountOverage() bool
 	return fiatOverage.ShouldOmitInvoiceLine
 }
 
-// FinalizeZeroFiatAmountOverageRun seals the persisted current run while the
-// state machine is in zero-fiat-amount overage completion.
-func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx context.Context) error {
+// FinalizeZeroFiatAmountOverageRun completes a run without crossing the
+// external invoice issuance boundary.
+func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(_ context.Context) error {
 	currentRun := s.Charge.Realizations.CurrentRun
 	if currentRun == nil {
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
@@ -871,18 +916,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx con
 		return fmt.Errorf("current realization run %s is not a zero fiat amount overage", currentRun.ID.ID)
 	}
 
-	// Mark the run immutable because its deleted line might already belong to an
-	// issued invoice. This is safe because a zero-fiat line cannot yield a credit note, where
-	// the deleted line would be an issue.
-	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:        currentRun.ID,
-		Immutable: mo.Some(true),
-	})
-	if err != nil {
-		return fmt.Errorf("mark zero-fiat-amount overage run immutable: %w", err)
-	}
-
-	currentRun.RealizationRunBase = runBase
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil
@@ -897,6 +930,11 @@ type reconcileInvoicingStateInput struct {
 
 func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Context, input reconcileInvoicingStateInput) error {
 	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun != nil && currentRun.AccruedUsage != nil && !currentRun.Immutable {
+		return models.NewGenericPreConditionFailedError(
+			fmt.Errorf("cannot %s flat-fee charge %s while current realization run %s has reversible invoice preparation", input.Op, s.Charge.ID, currentRun.ID.ID),
+		)
+	}
 
 	// TODO(credit-note support): this branch is a temporary fallback for
 	// immutable invoice lines until the line updater can correct them with
@@ -994,8 +1032,8 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		)
 	}
 
-	// If the run is not immutable, we can just update the invoice standard line.
-	if !currentRun.Immutable {
+	// A mutable, non-terminal run can update its draft invoice standard line in place.
+	if !currentRun.Immutable && !s.IsCurrentRunZeroFiatAmountOverage() {
 		// Case #1: If the new amount is zero we just need to delete the old line
 		if input.NewAmountAfterProration.IsZero() {
 			s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
@@ -1058,7 +1096,8 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		return nil
 	}
 
-	// Final case: we have an immutable invoice, so we need to invoke the prorating path, unless the amount haven't changed
+	// Final case: externally issued and zero-fiat terminal history cannot be
+	// rerated in place, so invoke the replacement path unless the amount is unchanged.
 	if input.NewAmountAfterProration.Equal(input.OldAmountAfterProration) {
 		return nil
 	}

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -1032,93 +1032,30 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
-		meta.ExpandRealizations,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	return slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
-		charge, ok := chargesByID[*stdLine.ChargeID]
-		if !ok {
-			return nil, fmt.Errorf("flat fee charge[%s] not found for finalizing line[%s]", *stdLine.ChargeID, stdLine.ID)
-		}
-
-		if stdLine.IsDeleted() ||
-			charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
-			!charge.Intent.GetCurrency().IsCustom() {
+		if stdLine.IsDeleted() {
 			return stdLine, nil
 		}
 
-		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, fmt.Errorf("getting realization run for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, err
 		}
 
-		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
-			return nil, fmt.Errorf(
-				"realization run[%s] for finalizing line[%s] is not associated with invoice[%s]",
-				run.ID.ID,
-				stdLine.ID,
-				input.Invoice.ID,
-			)
-		}
-
-		updatedLine, err := stdLine.Clone()
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerInvoiceFinalizing, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("finalizing invoice line for charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		if run.AccruedUsage == nil {
-			if len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted {
-				return nil, fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
-			}
-
-			if err := populateFlatFeeStandardLineFromRun(updatedLine, populateFlatFeeStandardLineFromRunInput{
-				Charge: charge,
-				Run:    run,
-				Stage:  standardLinePopulationStageInvoiceFinalizing,
-			}); err != nil {
-				return nil, fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-			}
-
-			prepared, err := e.service.realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
-				Charge: charge,
-				LineWithHeader: billing.StandardLineWithInvoiceHeader{
-					Invoice: input.Invoice,
-					Line:    updatedLine,
-				},
-			})
-			if err != nil {
-				return nil, fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", stdLine.ID, err)
-			}
-			run = prepared.Run
-			charge.Realizations.CurrentRun = &run
+		updatedLine, err := patches.RequireSingularStandardLineUpdateOrEmpty(stdLine.GetLineID(), input.Invoice.ID)
+		if err != nil {
+			return nil, fmt.Errorf("validating finalizing update for line[%s]: %w", stdLine.ID, err)
 		}
-
-		if !run.FiatOverageCreditAllocationCompleted {
-			allocated, err := e.service.realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
-				Charge: charge,
-				Run:    run,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
-			}
-			charge = allocated.Charge
-			run = allocated.Run
-		}
-
-		if err := populateFlatFeeStandardLineFromRun(updatedLine, populateFlatFeeStandardLineFromRunInput{
-			Charge: charge,
-			Run:    run,
-			Stage:  standardLinePopulationStageInvoiceFinalizing,
-		}); err != nil {
-			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if err := updatedLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating finalizing line[%s]: %w", stdLine.ID, err)
+		if updatedLine == nil {
+			return stdLine, nil
 		}
 
 		return updatedLine, nil

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -376,36 +377,30 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		}
 
 		if charge.Intent.GetCurrency().IsCustom() {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf(
-				"custom-currency flat fee line[%s] cannot be deleted: %w",
-				line.GetID(),
-				billing.ErrCannotUpdateChargeManagedLine,
-			)
+			err := transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+				if err := validatePreparedCustomCurrencyInvoiceDelete(input.Invoice, charge, line); err != nil {
+					return err
+				}
+
+				charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge)
+				if err != nil {
+					return fmt.Errorf("canceling prepared flat fee run for line[%s]: %w", line.GetID(), err)
+				}
+
+				return e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID)
+			})
+			if err != nil {
+				return billing.OnMutableInvoiceUpdateResult{}, err
+			}
+
+			continue
 		}
 
 		if err := validateManualDeleteLine(charge, line); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 
-		stateMachine, err := e.service.newStateMachineForCharge(charge)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
-		}
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceAPIRequest,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
-		})
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
-		}
-
-		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
-		}
-
-		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, patches); err != nil {
+		if err := e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -414,6 +409,34 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		CreatedLines: createdLines,
 		UpdatedLines: updatedLines,
 	}, nil
+}
+
+func (e *LineEngine) deleteLineViaAPI(
+	ctx context.Context,
+	invoice billing.GenericInvoiceReader,
+	charge flatfee.Charge,
+	line billing.GenericInvoiceLine,
+	chargeID string,
+) error {
+	stateMachine, err := e.service.newStateMachineForCharge(charge)
+	if err != nil {
+		return fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
+	}
+
+	deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		Policy:       meta.RefundAsCreditsDeletePolicy,
+	})
+	if err != nil {
+		return fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
+	}
+
+	patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
+	if err != nil {
+		return fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
+	}
+
+	return e.handleManualDeleteInvoicePatches(ctx, invoice, line, chargeID, patches)
 }
 
 func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) error {
@@ -438,7 +461,7 @@ func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, i
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.validateManualDeleteLineViaAPI(ctx, line); err != nil {
+		if err := e.validateManualDeleteLineViaAPI(ctx, input.Invoice, line); err != nil {
 			return err
 		}
 	}
@@ -495,7 +518,7 @@ func (e *LineEngine) validateManualUpdateLineViaAPI(ctx context.Context, overrid
 	return nil
 }
 
-func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line billing.GenericInvoiceLine) error {
+func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
 	chargeID := line.GetChargeID()
 	if chargeID == nil || *chargeID == "" {
 		return fmt.Errorf("flat fee line[%s]: charge id is required", line.GetID())
@@ -523,14 +546,76 @@ func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line bi
 	}
 
 	if charge.Intent.GetCurrency().IsCustom() {
-		return fmt.Errorf(
-			"custom-currency flat fee line[%s] cannot be deleted: %w",
-			line.GetID(),
-			billing.ErrCannotUpdateChargeManagedLine,
-		)
+		return validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, line)
 	}
 
 	return validateManualDeleteLine(charge, line)
+}
+
+func validatePreparedCustomCurrencyInvoiceDelete(invoice billing.GenericInvoiceReader, charge flatfee.Charge, line billing.GenericInvoiceLine) error {
+	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
+		return fmt.Errorf("custom-currency flat fee line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("flat fee line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	switch standardInvoice.Status {
+	case billing.StandardInvoiceStatusIssuingSyncFailed,
+		billing.StandardInvoiceStatusDeleteInProgress,
+		billing.StandardInvoiceStatusDeleteFailed:
+	default:
+		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	run := charge.Realizations.CurrentRun
+	if run == nil || run.LineID == nil || *run.LineID != line.GetID() || run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.AccruedUsage == nil || !run.FiatOverageCreditAllocationCompleted || !run.Immutable {
+		return fmt.Errorf("custom-currency flat fee line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.Payment != nil {
+		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) cancelPreparedCustomCurrencyRun(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
+	run := *charge.Realizations.CurrentRun
+	if err := e.service.realizations.CorrectAllCreditRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
+		Charge:     charge,
+		Run:        run,
+		AllocateAt: flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
+	}); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	if err := e.service.adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	deletedAt := clock.Now()
+	runBase, err := e.service.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:        run.ID,
+		DeletedAt: mo.Some(lo.ToPtr(deletedAt)),
+	})
+	if err != nil {
+		return flatfee.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+	run.RealizationRunBase = runBase
+
+	if err := e.service.adapter.DetachCurrentRun(ctx, charge.GetChargeID()); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	charge.Realizations.PriorRuns = append(charge.Realizations.PriorRuns, run)
+	charge.Realizations.CurrentRun = nil
+
+	return charge, nil
 }
 
 type manualCreatedInvoiceLine struct {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -980,22 +980,53 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 			)
 		}
 
-		allocated, err := e.service.realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
-			Charge: charge,
-			Run:    run,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
-		}
-
 		updatedLine, err := stdLine.Clone()
 		if err != nil {
 			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
 		}
 
+		if run.AccruedUsage == nil {
+			if len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted {
+				return nil, fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
+			}
+
+			if err := populateFlatFeeStandardLineFromRun(updatedLine, populateFlatFeeStandardLineFromRunInput{
+				Charge: charge,
+				Run:    run,
+				Stage:  standardLinePopulationStageInvoiceFinalizing,
+			}); err != nil {
+				return nil, fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
+			}
+
+			prepared, err := e.service.realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
+				Charge: charge,
+				LineWithHeader: billing.StandardLineWithInvoiceHeader{
+					Invoice: input.Invoice,
+					Line:    updatedLine,
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", stdLine.ID, err)
+			}
+			run = prepared.Run
+			charge.Realizations.CurrentRun = &run
+		}
+
+		if !run.FiatOverageCreditAllocationCompleted {
+			allocated, err := e.service.realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
+				Charge: charge,
+				Run:    run,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
+			}
+			charge = allocated.Charge
+			run = allocated.Run
+		}
+
 		if err := populateFlatFeeStandardLineFromRun(updatedLine, populateFlatFeeStandardLineFromRunInput{
-			Charge: allocated.Charge,
-			Run:    allocated.Run,
+			Charge: charge,
+			Run:    run,
 			Stage:  standardLinePopulationStageInvoiceFinalizing,
 		}); err != nil {
 			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -378,13 +378,8 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 
 		if charge.Intent.GetCurrency().IsCustom() {
 			err := transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
-				if err := validatePreparedCustomCurrencyInvoiceDelete(input.Invoice, charge, line); err != nil {
+				if err := validateCustomCurrencyInvoiceLineDelete(input.Invoice, line, charge); err != nil {
 					return err
-				}
-
-				charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge)
-				if err != nil {
-					return fmt.Errorf("canceling prepared flat fee run for line[%s]: %w", line.GetID(), err)
 				}
 
 				return e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID)
@@ -546,13 +541,15 @@ func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, invoice
 	}
 
 	if charge.Intent.GetCurrency().IsCustom() {
-		return validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, line)
+		return validateCustomCurrencyInvoiceLineDelete(invoice, line, charge)
 	}
 
 	return validateManualDeleteLine(charge, line)
 }
 
-func validatePreparedCustomCurrencyInvoiceDelete(invoice billing.GenericInvoiceReader, charge flatfee.Charge, line billing.GenericInvoiceLine) error {
+// validateCustomCurrencyInvoiceLineDelete verifies the billing-owned invoice
+// state and charge association required to delete a custom-currency line.
+func validateCustomCurrencyInvoiceLineDelete(invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine, charge flatfee.Charge) error {
 	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
 		return fmt.Errorf("custom-currency flat fee line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
 	}
@@ -570,52 +567,19 @@ func validatePreparedCustomCurrencyInvoiceDelete(invoice billing.GenericInvoiceR
 		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
 	}
 
-	run := charge.Realizations.CurrentRun
-	if run == nil || run.LineID == nil || *run.LineID != line.GetID() || run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID {
-		return fmt.Errorf("custom-currency flat fee line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	if standardInvoice.Namespace != charge.Namespace || line.GetLineID().Namespace != charge.Namespace {
+		return fmt.Errorf("custom-currency flat fee line[%s] namespace does not match charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
 	}
-	if run.AccruedUsage == nil || !run.FiatOverageCreditAllocationCompleted || !run.Immutable {
-		return fmt.Errorf("custom-currency flat fee line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	if line.GetChargeID() == nil || *line.GetChargeID() != charge.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] does not match charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
 	}
-	if run.Payment != nil {
-		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+
+	currentRun := charge.Realizations.CurrentRun
+	if currentRun == nil || currentRun.LineID == nil || *currentRun.LineID != line.GetID() || currentRun.InvoiceID == nil || *currentRun.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] must reference the current realization run of charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
 	}
 
 	return nil
-}
-
-func (e *LineEngine) cancelPreparedCustomCurrencyRun(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
-	run := *charge.Realizations.CurrentRun
-	if err := e.service.realizations.CorrectAllCreditRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
-		Charge:     charge,
-		Run:        run,
-		AllocateAt: flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
-	}); err != nil {
-		return flatfee.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
-	}
-
-	if err := e.service.adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
-		return flatfee.Charge{}, fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
-	}
-
-	deletedAt := clock.Now()
-	runBase, err := e.service.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:        run.ID,
-		DeletedAt: mo.Some(lo.ToPtr(deletedAt)),
-	})
-	if err != nil {
-		return flatfee.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
-	}
-	run.RealizationRunBase = runBase
-
-	if err := e.service.adapter.DetachCurrentRun(ctx, charge.GetChargeID()); err != nil {
-		return flatfee.Charge{}, fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
-	}
-
-	charge.Realizations.PriorRuns = append(charge.Realizations.PriorRuns, run)
-	charge.Realizations.CurrentRun = nil
-
-	return charge, nil
 }
 
 type manualCreatedInvoiceLine struct {
@@ -758,6 +722,9 @@ func validateManualDeleteLine(charge flatfee.Charge, line billing.GenericInvoice
 		if currentRun.Immutable {
 			return fmt.Errorf("immutable current run [charge_id=%s,run_id=%s,line_id=%s]: %w", charge.ID, currentRun.ID.ID, line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
 		}
+		if currentRun.AccruedUsage != nil {
+			return fmt.Errorf("prepared current run [charge_id=%s,run_id=%s,line_id=%s]: %w", charge.ID, currentRun.ID.ID, line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+		}
 
 		if currentRun.LineID == nil || *currentRun.LineID != line.GetID() {
 			return fmt.Errorf("line[%s]: current realization run must be attached to deleted line", line.GetID())
@@ -856,6 +823,12 @@ func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input bill
 
 		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
 			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
+		}
+
+		// Issued runs remain durable billing history when their presentation
+		// line is deleted; only reversible runs enter correction cleanup.
+		if run.Immutable {
+			continue
 		}
 
 		if run.AccruedUsage != nil {

--- a/openmeter/billing/charges/flatfee/service/linemapper.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper.go
@@ -76,6 +76,37 @@ func calculateFiatOverageForRun(charge flatfee.Charge, run flatfee.RealizationRu
 	}, nil
 }
 
+// resolveFiatOverageForLinePopulation reuses the gross FIAT amount persisted
+// by invoice preparation. This keeps retries from repeating conversion after
+// the durable accounting boundary has been crossed.
+func resolveFiatOverageForLinePopulation(
+	charge flatfee.Charge,
+	run flatfee.RealizationRun,
+	stage standardLinePopulationStage,
+) (calculateFiatOverageForRunResult, error) {
+	if stage != standardLinePopulationStageInvoiceFinalizing || run.AccruedUsage == nil {
+		return calculateFiatOverageForRun(charge, run)
+	}
+
+	costBasisIntent := charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return calculateFiatOverageForRunResult{}, errors.New("cost basis intent is required for a custom-currency invoice")
+	}
+
+	fiatCurrency, err := costBasisIntent.GetFiatCurrency()
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	grossFiatAmount := run.AccruedUsage.Totals.Total
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatCurrency,
+		FiatOverage:           grossFiatAmount,
+		ShouldOmitInvoiceLine: grossFiatAmount.IsZero(),
+	}, nil
+}
+
 func (i populateFlatFeeStandardLineFromRunInput) Validate() error {
 	var errs []error
 
@@ -168,7 +199,7 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := calculateFiatOverageForRun(charge, run)
+	fiatOverage, err := resolveFiatOverageForLinePopulation(charge, run, input.Stage)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}

--- a/openmeter/billing/charges/flatfee/service/linemapper_test.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -89,6 +90,36 @@ func TestCalculateFiatOverageForRun(t *testing.T) {
 			require.Equal(t, test.expectOmitInvoiceLine, fiatOverage.ShouldOmitInvoiceLine)
 		})
 	}
+}
+
+func TestResolveFlatFeeCustomCurrencyFinalizationOverageReusesPreparedGrossAmount(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge := newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+	run := newFlatFeeCustomCurrencyRunForTest(
+		servicePeriod,
+		totals.Totals{Amount: alpacadecimal.NewFromInt(3), Total: alpacadecimal.NewFromInt(3)},
+		false,
+	)
+	run.AccruedUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: servicePeriod,
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
+		},
+	}
+
+	// The current cost basis would convert the run to 6 USD. Finalization must
+	// reuse the persisted 5 USD result instead of converting again.
+	fiatOverage, err := resolveFiatOverageForLinePopulation(
+		charge,
+		run,
+		standardLinePopulationStageInvoiceFinalizing,
+	)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), fiatOverage.FiatOverage.InexactFloat64())
 }
 
 func TestPopulateFlatFeeCustomCurrencyOverageLineDeletionUsesConvertedOverage(t *testing.T) {

--- a/openmeter/billing/charges/flatfee/service/realizations/credits.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credits.go
@@ -304,12 +304,12 @@ func (i AllocateFiatOverageCreditsInput) Validate() error {
 		))
 	}
 
-	if i.Run.AccruedUsage != nil {
-		errs = append(errs, errors.New("run already has accrued invoice usage"))
+	if i.Run.AccruedUsage == nil {
+		errs = append(errs, errors.New("run must have prepared invoice usage before fiat allocation"))
 	}
 
-	if len(i.Run.FiatOverageCreditRealizations) > 0 {
-		errs = append(errs, errors.New("run already has fiat overage credit realizations"))
+	if i.Run.FiatOverageCreditAllocationCompleted {
+		errs = append(errs, errors.New("fiat overage credit allocation already completed"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -331,33 +331,44 @@ func (s *Service) AllocateFiatOverageCredits(
 		return AllocateFiatOverageCreditsResult{}, err
 	}
 
-	fiatOverage, err := in.Charge.ConvertCustomCurrencyOverageToFiat(in.Run.Totals)
+	fiatCurrency, err := in.Charge.GetInvoiceCurrency()
 	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("get invoice currency: %w", err)
 	}
+	grossFiatAmount := in.Run.AccruedUsage.Totals.Total
 
 	run := in.Run
-	allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
-		Amount: fiatOverage.Amount,
-		Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
-			Charge: in.Charge,
-			Run:    run,
-			// Fiat overage allocation is an invoice-finalization effect. Current
-			// time makes the outstanding settlement-fiat balance eligible then.
-			AllocateAt: clock.Now(),
-		}),
-	})
-	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+	if len(run.FiatOverageCreditRealizations) == 0 {
+		allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
+			Amount: grossFiatAmount,
+			Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
+				Charge: in.Charge,
+				Run:    run,
+				// Fiat overage allocation is an invoice-finalization effect. Current
+				// time makes the outstanding settlement-fiat balance eligible then.
+				AllocateAt: clock.Now(),
+			}),
+		})
+		if err != nil {
+			return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+		}
+
+		run.FiatOverageCreditRealizations = allocationResult.Realizations
 	}
 
-	run.FiatOverageCreditRealizations = allocationResult.Realizations
-
-	allocated := fiatOverage.Currency.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
-	remainingFiatOverage := fiatOverage.Currency.RoundToPrecision(fiatOverage.Amount.Sub(allocated))
+	fiatCurrencyCalculator, err := currencyx.NewFiatCurrency(fiatCurrency)
+	if err != nil {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("create invoice currency calculator: %w", err)
+	}
+	allocated := fiatCurrencyCalculator.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
+	if allocated.GreaterThan(grossFiatAmount) {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("fiat overage credit allocations exceed prepared gross amount: %s > %s", allocated, grossFiatAmount)
+	}
+	remainingFiatOverage := fiatCurrencyCalculator.RoundToPrecision(grossFiatAmount.Sub(allocated))
 	runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:                        run.ID,
-		NoFiatTransactionRequired: mo.Some(remainingFiatOverage.IsZero()),
+		ID:                                   run.ID,
+		NoFiatTransactionRequired:            mo.Some(remainingFiatOverage.IsZero()),
+		FiatOverageCreditAllocationCompleted: mo.Some(true),
 	})
 	if err != nil {
 		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("update realization run after fiat overage allocation: %w", err)

--- a/openmeter/billing/charges/flatfee/service/realizations/credits.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credits.go
@@ -402,6 +402,19 @@ func (s *Service) CorrectAllCreditRealizations(
 		}); err != nil {
 			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
 		}
+
+		if input.Run.AccruedUsage != nil {
+			correctionInput := flatfee.OnCustomCurrencyOverageAccruedCorrectionInput{
+				Charge: input.Charge,
+				Run:    input.Run,
+			}
+			if err := correctionInput.Validate(); err != nil {
+				return fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+			}
+			if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+				return fmt.Errorf("correct custom-currency overage accrual: %w", err)
+			}
+		}
 	}
 
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{

--- a/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/samber/mo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
@@ -149,16 +147,6 @@ func (s *Service) AccrueInvoiceUsage(ctx context.Context, in AccrueInvoiceUsageI
 			result.AccruedUsage = &accruedUsage
 			result.Run.AccruedUsage = &accruedUsage
 		}
-
-		runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-			ID:        currentRun.ID,
-			Immutable: mo.Some(true),
-		})
-		if err != nil {
-			return AccrueInvoiceUsageResult{}, fmt.Errorf("updating standard invoice run: %w", err)
-		}
-
-		result.Run.RealizationRunBase = runBase
 
 		return result, nil
 	})

--- a/openmeter/billing/charges/invoiceupdater/patches.go
+++ b/openmeter/billing/charges/invoiceupdater/patches.go
@@ -1,6 +1,7 @@
 package invoiceupdater
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -73,6 +74,56 @@ func (p Patches) RequireSingularLineUpdatePatchForTarget(line billing.GenericInv
 	}
 
 	return updatePatch, nil
+}
+
+// RequireSingularStandardLineUpdateOrEmpty returns nil when no line update was
+// emitted and the target standard line when exactly one matching update was emitted.
+func (p Patches) RequireSingularStandardLineUpdateOrEmpty(lineID billing.LineID, invoiceID string) (*billing.StandardLine, error) {
+	if err := lineID.Validate(); err != nil {
+		return nil, fmt.Errorf("validating line ID: %w", err)
+	}
+
+	if invoiceID == "" {
+		return nil, errors.New("invoice ID is required")
+	}
+
+	if len(p) == 0 {
+		return nil, nil
+	}
+
+	patch, err := p.requireSingularPatch("standard line update")
+	if err != nil {
+		return nil, err
+	}
+
+	updatePatch, err := patch.AsUpdateLinePatch()
+	if err != nil {
+		return nil, err
+	}
+
+	target := updatePatch.TargetState
+	if target == nil {
+		return nil, errors.New("target state is required")
+	}
+
+	if target.GetLineID() != lineID {
+		return nil, fmt.Errorf("target line[%s] does not match line[%s]", target.GetLineID(), lineID)
+	}
+
+	if target.GetInvoiceID() != invoiceID {
+		return nil, fmt.Errorf("target invoice[%s] does not match invoice[%s]", target.GetInvoiceID(), invoiceID)
+	}
+
+	line, err := target.AsInvoiceLine().AsStandardLine()
+	if err != nil {
+		return nil, fmt.Errorf("target state must be a standard line: %w", err)
+	}
+
+	if err := line.Validate(); err != nil {
+		return nil, fmt.Errorf("validating target standard line: %w", err)
+	}
+
+	return &line, nil
 }
 
 func (p Patches) RequireSingularGatheringLinePatchForCharge(chargeID string) (Patch, error) {

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -8,6 +8,7 @@ var (
 	TriggerNext                   Trigger = "next"
 	TriggerInvoiceCreated         Trigger = "invoice_created"
 	TriggerCollectionCompleted    Trigger = "collection_completed"
+	TriggerInvoiceFinalizing      Trigger = "invoice_finalizing"
 	TriggerInvoiceIssued          Trigger = "invoice_issued"
 	TriggerLineManualEdit         Trigger = "line_manual_edit"
 	TriggerSetOverride            Trigger = "set_override"

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -37,15 +37,16 @@ func (m *mockLineageService) BackfillAdvanceLineageSegments(ctx context.Context,
 var _ flatfee.Handler = (*flatFeeTestHandler)(nil)
 
 type flatFeeTestHandler struct {
-	onAllocateCredits                     func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onInvoiceUsageAccrued                 func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
-	onCorrectCreditAllocations            func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onPaymentAuthorized                   func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onPaymentUncollectible                func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
+	onAllocateCredits                        func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onCorrectCreditAllocations               func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onPaymentAuthorized                      func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onPaymentUncollectible                   func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
 }
 
 func newFlatFeeTestHandler() *flatFeeTestHandler {
@@ -74,6 +75,14 @@ func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Context,
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
@@ -180,14 +189,15 @@ func (h *creditPurchaseTestHandler) Reset() {
 var _ usagebased.Handler = (*usageBasedTestHandler)(nil)
 
 type usageBasedTestHandler struct {
-	onInvoiceUsageAccrued                 func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
-	onPaymentAuthorized                   func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onCreditsOnlyUsageAccrued             func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
-	onCreditsOnlyUsageAccruedCorrection   func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onPaymentAuthorized                      func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onCreditsOnlyUsageAccrued                func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
+	onCreditsOnlyUsageAccruedCorrection      func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 }
 
 func newUsageBasedTestHandler() *usageBasedTestHandler {
@@ -208,6 +218,14 @@ func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Conte
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *usageBasedTestHandler) OnPaymentAuthorized(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -194,6 +194,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 		creditsAllocated float64
 		// fiatOverageCreditsAvailable is the USD balance available for the converted overage.
 		fiatOverageCreditsAvailable float64
+		// disableFiatOverageCredits models the settlement handler rejecting FIAT credit use.
+		disableFiatOverageCredits bool
 
 		// expectRunTotals contains the realization run totals in TOKENS.
 		expectRunTotals billingtest.ExpectedTotals
@@ -225,6 +227,21 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 			expectDraftInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			expectInvoiceTotals:      billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			expectPaymentSettled:     true,
+		},
+		// given:
+		// - a 5 USD overage and enough settlement-fiat credits to cover it
+		// - the settlement handler does not allow those credits to be used
+		// then:
+		// - gross preparation still runs and the full 5 USD remains payable
+		{
+			name:                        "fiat overage credits disabled by handler",
+			chargeAmount:                10,
+			fiatOverageCreditsAvailable: 5,
+			disableFiatOverageCredits:   true,
+			expectRunTotals:             billingtest.ExpectedTotals{Amount: 10, Total: 10},
+			expectDraftInvoiceTotals:    billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			expectInvoiceTotals:         billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			expectPaymentSettled:        true,
 		},
 		// given:
 		// - a 10 TOKENS flat fee with 2 TOKENS allocated from credits
@@ -362,6 +379,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				input flatfee.AllocateFiatOverageCreditsInput,
 			) (creditrealization.CreateAllocationInputs, error) {
 				fiatOverageAllocationInvocations++
+				if test.disableFiatOverageCredits {
+					return nil, nil
+				}
 
 				return fiatOverageCreditsHandler.Allocate(ctx, input)
 			}
@@ -539,7 +559,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 			s.Run("approve invoice and settle overage", func() {
 				fiatOverageCreditsHandler.AddAvailable(test.fiatOverageCreditsAvailable)
 
-				if test.expectPaymentSettled {
+				if !test.expectLineDeleted {
 					s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
 						customCurrencyOverageAccruedCalls++
 						s.Equal(chargeID.ID, input.Charge.ID)
@@ -560,9 +580,12 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 							TransactionGroup: ledgertransaction.GroupReference{
 								TransactionGroupID: accruedTransactionGroupID,
 							},
-							TotalFiatAmount: alpacadecimal.NewFromFloat(test.expectInvoiceTotals.Total),
+							TotalFiatAmount: alpacadecimal.NewFromFloat(test.expectInvoiceTotals.Amount),
 						}, nil
 					}
+				}
+
+				if test.expectPaymentSettled {
 
 					authorizedCallback = newCountedLedgerTransactionCallback[flatfee.OnPaymentAuthorizedInput]()
 					s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input flatfee.OnPaymentAuthorizedInput) {
@@ -623,27 +646,40 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				s.RequireTotals(test.expectRunTotals, run.Totals)
 				s.Equal(!test.expectPaymentSettled, run.NoFiatTransactionRequired)
 				s.Equal(test.creditsAllocated, run.CreditRealizations.Sum().InexactFloat64())
-				s.Equal(test.fiatOverageCreditsAvailable, run.FiatOverageCreditRealizations.Sum().InexactFloat64())
+				expectedFiatCreditsAllocated := test.fiatOverageCreditsAvailable
+				if test.disableFiatOverageCredits {
+					expectedFiatCreditsAllocated = 0
+				}
+				s.Equal(expectedFiatCreditsAllocated, run.FiatOverageCreditRealizations.Sum().InexactFloat64())
 				s.True(run.DetailedLines.IsPresent())
 				s.Require().Len(run.DetailedLines.OrEmpty(), 1)
 				s.RequireTotals(test.expectRunTotals, run.DetailedLines.OrEmpty()[0].Totals)
 				expectedFiatRealizations := 0
-				if test.fiatOverageCreditsAvailable > 0 {
+				if expectedFiatCreditsAllocated > 0 {
 					expectedFiatRealizations = 1
 				}
 				s.Len(run.FiatOverageCreditRealizations, expectedFiatRealizations)
 
-				if test.expectPaymentSettled {
+				if !test.expectLineDeleted {
 					s.Equal(1, customCurrencyOverageAccruedCalls)
+					s.Require().NotNil(run.AccruedUsage)
+					s.Equal(servicePeriod, run.AccruedUsage.ServicePeriod)
+					s.Equal(accruedTransactionGroupID, run.AccruedUsage.LedgerTransaction.TransactionGroupID)
+					s.RequireTotals(billingtest.ExpectedTotals{
+						Amount: test.expectInvoiceTotals.Amount,
+						Total:  test.expectInvoiceTotals.Amount,
+					}, run.AccruedUsage.Totals)
+				} else {
+					s.Zero(customCurrencyOverageAccruedCalls)
+					s.Nil(run.AccruedUsage)
+				}
+
+				if test.expectPaymentSettled {
 					s.Require().NotNil(authorizedCallback)
 					s.Equal(1, authorizedCallback.nrInvocations)
 					s.Require().NotNil(settledCallback)
 					s.Equal(1, settledCallback.nrInvocations)
 
-					s.Require().NotNil(run.AccruedUsage)
-					s.Equal(servicePeriod, run.AccruedUsage.ServicePeriod)
-					s.Equal(accruedTransactionGroupID, run.AccruedUsage.LedgerTransaction.TransactionGroupID)
-					s.RequireTotals(test.expectInvoiceTotals, run.AccruedUsage.Totals)
 					s.Require().NotNil(run.Payment)
 					s.Equal(payment.StatusSettled, run.Payment.Status)
 					s.Equal(test.expectInvoiceTotals.Total, run.Payment.FiatAmount.InexactFloat64())
@@ -652,8 +688,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 					s.Require().NotNil(run.Payment.Settled)
 					s.Equal(settledCallback.id, run.Payment.Settled.TransactionGroupID)
 				} else {
-					s.Zero(customCurrencyOverageAccruedCalls)
-					s.Nil(run.AccruedUsage)
 					s.Nil(run.Payment)
 				}
 
@@ -758,6 +792,22 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 	fiatOverageCreditsHandler := &flatFeeFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
 	}
+	accountingEvents := make([]string, 0, 2)
+	customCurrencyOverageAccruedInvocations := 0
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedInvocations++
+		accountingEvents = append(accountingEvents, "gross_overage")
+
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+
+		return flatfee.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
+	}
 	s.FlatFeeTestHandler.onAllocateCredits = func(
 		_ context.Context,
 		_ flatfee.OnAllocateCreditsInput,
@@ -770,6 +820,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		input flatfee.AllocateFiatOverageCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
 		fiatOverageAllocationInvocations++
+		accountingEvents = append(accountingEvents, "fiat_coverage")
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
@@ -854,17 +905,49 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 		s.Equal(1, invoiceSyncAttempts)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
 		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
 		s.Zero(mockApp.FinalizeInvoiceCallCount())
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 
 		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		run := charge.Realizations.CurrentRun
+		s.Require().NotNil(run.AccruedUsage)
+		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
+		s.True(run.FiatOverageCreditAllocationCompleted)
 		s.True(run.NoFiatTransactionRequired)
 		s.Require().Len(run.FiatOverageCreditRealizations, 1)
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(5), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+
+		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+			ChangeSource: billing.ChangeSourceSystem,
+			Policy:       meta.RefundAsCreditsDeletePolicy,
+		})
+		s.Require().NoError(err)
+		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+			CustomerID: customer.GetID(),
+			PatchesByChargeID: map[string]charges.Patch{
+				chargeID.ID: deletePatch,
+			},
+		})
+		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
@@ -873,6 +956,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.Equal(2, invoiceSyncAttempts)
 		s.Equal(1, mockApp.FinalizeInvoiceCallCount())
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
 		s.Equal(1, fiatOverageAllocationInvocations)
 
 		err = s.BillingService.TriggerInvoice(ctx, billing.InvoiceTriggerServiceInput{
@@ -958,6 +1042,19 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceR
 
 	fiatOverageCreditsHandler := &flatFeeFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
+	}
+	customCurrencyOverageAccruedCalls := 0
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedCalls++
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+
+		return flatfee.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
 	}
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = fiatOverageCreditsHandler.Allocate
 	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
@@ -1128,6 +1225,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceR
 		s.Require().Len(run.FiatOverageCreditRealizations, 1)
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(2), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
+		s.Equal(1, customCurrencyOverageAccruedCalls)
 		s.True(run.NoFiatTransactionRequired)
 	})
 }
@@ -1691,7 +1789,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 			// when:
 			// - billing approves the invoice through the normal service lifecycle
 			// then:
-			// - invoice issuing becomes retryable without persisting accrued usage or payment
+			// - invoice finalization becomes retryable without persisting accrued usage or payment
 			ctx := s.T().Context()
 			ns := s.GetUniqueNamespace("charges-service-flatfee-custom-currency-invalid-accrual")
 
@@ -1802,7 +1900,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 
 			invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
 			s.Require().NoError(err)
-			s.Equal(billing.StandardInvoiceStatusIssuingChargeBookingFailed, invoice.Status)
+			s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
 			s.True(invoice.StatusDetails.Failed)
 			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
 			s.Require().NotEmpty(invoice.ValidationIssues)
@@ -1815,6 +1913,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 			s.Equal(runID, persistedCharge.Realizations.CurrentRun.ID)
 			s.False(persistedCharge.Realizations.CurrentRun.Immutable)
 			s.Nil(persistedCharge.Realizations.CurrentRun.AccruedUsage)
+			s.Empty(persistedCharge.Realizations.CurrentRun.FiatOverageCreditRealizations)
+			s.False(persistedCharge.Realizations.CurrentRun.FiatOverageCreditAllocationCompleted)
 			s.Nil(persistedCharge.Realizations.CurrentRun.Payment)
 			s.Equal(1, accrualCalls)
 			s.Zero(authorizedCallback.nrInvocations)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -4149,6 +4149,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
+		s.True(finalRun.Immutable)
 		s.Equal(float64(125), finalRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)
@@ -4403,6 +4404,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
+		s.True(finalRun.Immutable)
 		s.Equal(float64(100), finalRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -551,7 +551,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				s.Len(run.CreditRealizations, expectedCreditsApplied)
 				s.Len(run.DetailedLines.OrEmpty()[0].CreditsApplied, expectedCreditsApplied)
 				s.Equal(test.expectLineDeleted, run.NoFiatTransactionRequired)
-				s.Equal(test.expectLineDeleted, run.Immutable)
+				s.False(run.Immutable)
 				s.Equal(1, allocationCallback.nrInvocations)
 				s.Zero(fiatOverageAllocationInvocations)
 			})
@@ -639,7 +639,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				s.Require().NotNil(charge.Realizations.CurrentRun)
 				s.Empty(charge.Realizations.PriorRuns)
 				run := charge.Realizations.CurrentRun
-				s.True(run.Immutable)
+				s.Equal(!test.expectLineDeleted, run.Immutable)
 
 				s.Equal(runID, run.ID.ID)
 				s.RequireTotals(test.expectRunTotals, run.Totals)
@@ -743,6 +743,31 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 					s.Nil(line.DeletedAt)
 				}
 			})
+
+			if test.name == "happy path" {
+				s.Run("delete issued charge without correcting immutable run", func() {
+					deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+						ChangeSource: billing.ChangeSourceSystem,
+						Policy:       meta.RefundAsCreditsDeletePolicy,
+					})
+					s.Require().NoError(err)
+					s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+						CustomerID: customer.GetID(),
+						PatchesByChargeID: map[string]charges.Patch{
+							chargeID.ID: deletePatch,
+						},
+					}))
+
+					charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+					s.Equal(flatfee.StatusDeleted, charge.Status)
+					s.Nil(charge.Realizations.CurrentRun)
+					s.Require().Len(charge.Realizations.PriorRuns, 1)
+					run := charge.Realizations.PriorRuns[0]
+					s.True(run.Immutable)
+					s.Nil(run.DeletedAt)
+					s.Require().NotNil(run.AccruedUsage)
+				})
+			}
 		})
 	}
 }
@@ -966,6 +991,7 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		run := charge.Realizations.CurrentRun
 		s.Require().NotNil(run.AccruedUsage)
+		s.False(run.Immutable)
 		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
 		s.False(run.FiatOverageCreditAllocationCompleted)
@@ -977,19 +1003,6 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 			DeletionSource: billing.ChangeSourceSystem,
 		})
 		s.ErrorContains(err, "invoice action not available")
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceSystem,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
-		})
-		s.Require().NoError(err)
-		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
-			CustomerID: customer.GetID(),
-			PatchesByChargeID: map[string]charges.Patch{
-				chargeID.ID: deletePatch,
-			},
-		})
-		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
 	})
 
 	returnFiatAllocationError = false
@@ -1011,6 +1024,7 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		run := charge.Realizations.CurrentRun
 		s.Require().NotNil(run.AccruedUsage)
+		s.False(run.Immutable)
 		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
 		s.True(run.FiatOverageCreditAllocationCompleted)
@@ -1020,19 +1034,6 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Equal(float64(5), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
 
 		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceSystem,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
-		})
-		s.Require().NoError(err)
-		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
-			CustomerID: customer.GetID(),
-			PatchesByChargeID: map[string]charges.Patch{
-				chargeID.ID: deletePatch,
-			},
-		})
-		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
 
 		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),
@@ -2409,7 +2410,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Equal(zeroFiatServicePeriodTo, charge.Realizations.CurrentRun.ServicePeriod.To)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 0.001, Total: 0.001}, charge.Realizations.CurrentRun.Totals)
 		s.True(charge.Realizations.CurrentRun.NoFiatTransactionRequired)
-		s.True(charge.Realizations.CurrentRun.Immutable)
+		s.False(charge.Realizations.CurrentRun.Immutable)
 		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
 		s.Nil(charge.Realizations.CurrentRun.Payment)
 		s.Empty(activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID))
@@ -2454,7 +2455,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Require().Len(charge.Realizations.PriorRuns, 1)
 		s.Equal(runID, charge.Realizations.PriorRuns[0].ID)
 		s.True(charge.Realizations.PriorRuns[0].NoFiatTransactionRequired)
-		s.True(charge.Realizations.PriorRuns[0].Immutable)
+		s.False(charge.Realizations.PriorRuns[0].Immutable)
 
 		gatheringLines := activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID)
 		s.Require().Len(gatheringLines, 1)
@@ -3480,7 +3481,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
-		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
+		s.False(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
 		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 
@@ -3500,7 +3501,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		})
 		s.NoError(err)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
-		s.Equal(flatfee.StatusFinal, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
+		updatedFlatFeeCharge = s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 	})
 }
 
@@ -3631,6 +3635,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
 		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.False(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.LedgerTransaction)
 		s.Equal(invoiceUsageAccruedCallback.id, updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.LedgerTransaction.TransactionGroupID)
@@ -3646,7 +3651,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		})
 		s.NoError(err)
 		s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
-		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
+		updatedFlatFeeCharge = s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 	})
 }
 
@@ -4731,6 +4739,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Len(usageBasedCharge.Realizations, 1)
 
 		preparedRun := usageBasedCharge.Realizations[0]
+		s.False(preparedRun.Immutable)
 		s.Equal(float64(100), preparedRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(preparedRun.LineID)
 		s.Equal(stdLineID.ID, *preparedRun.LineID)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -586,7 +586,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				}
 
 				if test.expectPaymentSettled {
-
 					authorizedCallback = newCountedLedgerTransactionCallback[flatfee.OnPaymentAuthorizedInput]()
 					s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input flatfee.OnPaymentAuthorizedInput) {
 						assert.Equal(t, chargeID.ID, input.Charge.ID)
@@ -749,6 +748,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a custom-currency flat-fee run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -810,9 +817,17 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 	}
 	s.FlatFeeTestHandler.onAllocateCredits = func(
 		_ context.Context,
-		_ flatfee.OnAllocateCreditsInput,
+		input flatfee.OnAllocateCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
-		return nil, nil
+		return creditrealization.CreateAllocationInputs{
+			{
+				ServicePeriod: input.ServicePeriod,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+				Amount: alpacadecimal.NewFromInt(2),
+			},
+		}, nil
 	}
 	fiatOverageAllocationInvocations := 0
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = func(
@@ -824,7 +839,34 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
+	correctionEvents := make([]string, 0, 6)
+	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input flatfee.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ flatfee.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.FlatFeeTestHandler.onCorrectCreditAllocations = func(
+		_ context.Context,
+		input flatfee.CorrectCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -859,7 +901,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 						},
 						InvoiceAt:             invoiceAt,
 						PaymentTerm:           productcatalog.InArrearsPaymentTerm,
-						AmountBeforeProration: alpacadecimal.NewFromInt(10),
+						AmountBeforeProration: alpacadecimal.NewFromInt(12),
 					},
 					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 					CostBasis:      &costBasisIntent,
@@ -898,7 +940,11 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
 	s.Run("when invoice sync fails after fiat allocation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
@@ -923,11 +969,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(5), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
 
-		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
-			Invoice:        invoice.GetInvoiceID(),
-			DeletionSource: billing.ChangeSourceSystem,
-		})
-		s.ErrorContains(err, "invoice action not available")
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceSystem,
@@ -949,6 +991,94 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Require().NotNil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.CurrentRun.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.CreditRealizations[0].Type)
+			s.Nil(charge.Realizations.CurrentRun.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Equal(flatfee.StatusDeleted, charge.Status)
+			s.Nil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.PriorRuns, 1)
+			run := charge.Realizations.PriorRuns[0]
+			s.Require().NotNil(run.DeletedAt)
+			s.Require().Len(run.FiatOverageCreditRealizations, 2)
+			s.Zero(run.FiatOverageCreditRealizations.Sum().InexactFloat64())
+			s.Require().Len(run.CreditRealizations, 2)
+			s.Zero(run.CreditRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -830,12 +830,16 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		}, nil
 	}
 	fiatOverageAllocationInvocations := 0
+	returnFiatAllocationError := true
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = func(
 		ctx context.Context,
 		input flatfee.AllocateFiatOverageCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
 		fiatOverageAllocationInvocations++
 		accountingEvents = append(accountingEvents, "fiat_coverage")
+		if returnFiatAllocationError {
+			return nil, errors.New("simulated fiat allocation failure")
+		}
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
@@ -946,18 +950,64 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		mockApp.OnFinalizeStandardInvoice(nil)
 	}
 
-	s.Run("when invoice sync fails after fiat allocation", func() {
+	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Nil(invoice.StatusDetails.AvailableActions.Delete)
+		s.Zero(invoiceSyncAttempts)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
+
+		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+		s.Equal(flatfee.StatusActiveRealizationProcessing, charge.Status)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		run := charge.Realizations.CurrentRun
+		s.Require().NotNil(run.AccruedUsage)
+		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
+		s.False(run.FiatOverageCreditAllocationCompleted)
+		s.False(run.NoFiatTransactionRequired)
+		s.Empty(run.FiatOverageCreditRealizations)
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+
+		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+			ChangeSource: billing.ChangeSourceSystem,
+			Policy:       meta.RefundAsCreditsDeletePolicy,
+		})
+		s.Require().NoError(err)
+		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+			CustomerID: customer.GetID(),
+			PatchesByChargeID: map[string]charges.Patch{
+				chargeID.ID: deletePatch,
+			},
+		})
+		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
+	})
+
+	returnFiatAllocationError = false
+	accountingEvents = accountingEvents[:0]
+
+	s.Run("when retry reaches sync after fiat allocation", func() {
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 		s.Equal(1, invoiceSyncAttempts)
 		s.Equal(1, customCurrencyOverageAccruedInvocations)
-		s.Equal(1, fiatOverageAllocationInvocations)
-		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal([]string{"fiat_coverage"}, accountingEvents)
 		s.Zero(mockApp.FinalizeInvoiceCallCount())
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 
 		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, charge.Status)
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		run := charge.Realizations.CurrentRun
 		s.Require().NotNil(run.AccruedUsage)
@@ -1087,7 +1137,8 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Equal(2, invoiceSyncAttempts)
 		s.Equal(1, mockApp.FinalizeInvoiceCallCount())
 		s.Equal(1, customCurrencyOverageAccruedInvocations)
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal(flatfee.StatusFinal, s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID).Status)
 
 		err = s.BillingService.TriggerInvoice(ctx, billing.InvoiceTriggerServiceInput{
 			InvoiceTriggerInput: billing.InvoiceTriggerInput{
@@ -1107,7 +1158,7 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 		s.Equal(5.0, invoice.Lines.OrEmpty()[0].CreditsApplied.SumAmount(fiatCurrency).InexactFloat64())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 		mockApp.AssertExpectations(s.T())
 	})
 }
@@ -3403,7 +3454,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.Len(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 
-	s.Run("post invoice issued without invoice usage accrual", func() {
+	s.Run("finalize invoice without invoice usage accrual", func() {
 		defer s.FlatFeeTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]()
@@ -3417,18 +3468,39 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.NoError(err)
 		invoice.Lines = billing.NewStandardInvoiceLines(lines)
 
+		lines, err = lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		invoice.Lines = billing.NewStandardInvoiceLines(lines)
+		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
+
+		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+
+		mismatchedLine, err := invoice.Lines.OrEmpty()[0].Clone()
+		s.NoError(err)
+		mismatchedLine.ID = "mismatched-issued-line"
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   billing.StandardLines{mismatchedLine},
+		})
+		s.ErrorContains(err, "does not match issued line")
+		s.Equal(flatfee.StatusActiveRealizationIssuing, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
+
 		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
 			Invoice: invoice,
 			Lines:   invoice.Lines.OrEmpty(),
 		})
 		s.NoError(err)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
-
-		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
-		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
-		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
-		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
-		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+		s.Equal(flatfee.StatusFinal, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
 	})
 }
 
@@ -3507,11 +3579,11 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		s.Equal(flatfee.StatusActiveRealizationProcessing, fetchedFlatFeeCharge.Status)
 	})
 
-	s.Run("issue invoice with zero amount and non-zero charges", func() {
+	s.Run("finalize invoice with zero amount and non-zero charges", func() {
 		// given:
 		// - the standard line has zero Amount but non-zero ChargesTotal and Total
 		// when:
-		// - the flat-fee line engine receives the invoice-issued callback
+		// - the flat-fee line engine receives the invoice-finalizing callback
 		// then:
 		// - invoice usage accrual still runs because the payable total is non-zero
 		defer s.FlatFeeTestHandler.Reset()
@@ -3542,15 +3614,22 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		})
 		s.NoError(err)
 		invoice.Lines = billing.NewStandardInvoiceLines(updatedLines)
+		finalizingLine := invoice.Lines.OrEmpty()[0]
+		expectedFinalizingLine, err := finalizingLine.Clone()
+		s.NoError(err)
 
-		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+		updatedLines, err = lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
 			Invoice: invoice,
 			Lines:   invoice.Lines.OrEmpty(),
 		})
 		s.NoError(err)
+		s.Equal(expectedFinalizingLine, finalizingLine)
+		s.Same(finalizingLine, updatedLines[0])
+		invoice.Lines = billing.NewStandardInvoiceLines(updatedLines)
 		s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
 
 		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.LedgerTransaction)
@@ -3560,6 +3639,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 			ChargesTotal: 100,
 			Total:        100,
 		}, updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.Totals)
+
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
 	})
 }
 
@@ -4616,22 +4703,66 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(float64(10), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
 	})
 
-	s.Run("#5 approve invoice with no fiat invoice usage accrual", func() {
+	s.Run("#5 finalize and issue invoice with no fiat invoice usage accrual", func() {
 		defer s.UsageBasedTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[usagebased.OnInvoiceUsageAccruedInput]()
 		s.UsageBasedTestHandler.onInvoiceUsageAccrued = invoiceUsageAccruedCallback.Handler(s.T())
 
-		var err error
-		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		lineEngine := s.Charges.usageBasedService.GetLineEngine()
+		finalizingLine := invoice.Lines.OrEmpty()[0]
+		expectedFinalizingLine, err := finalizingLine.Clone()
 		s.NoError(err)
+
+		finalizedLines, err := lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(expectedFinalizingLine, finalizingLine)
+		s.Same(finalizingLine, finalizedLines[0])
+		invoice.Lines = billing.NewStandardInvoiceLines(finalizedLines)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
 		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusActiveRealizationIssuing, usageBasedCharge.Status)
+		s.NotNil(usageBasedCharge.State.CurrentRealizationRunID)
+		s.Nil(usageBasedCharge.State.AdvanceAfter)
+		s.Len(usageBasedCharge.Realizations, 1)
+
+		preparedRun := usageBasedCharge.Realizations[0]
+		s.Equal(float64(100), preparedRun.MeteredQuantity.InexactFloat64())
+		s.NotNil(preparedRun.LineID)
+		s.Equal(stdLineID.ID, *preparedRun.LineID)
+		s.True(preparedRun.NoFiatTransactionRequired)
+		s.NotNil(preparedRun.InvoiceUsage)
+		s.Nil(preparedRun.InvoiceUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       10,
+			CreditsTotal: 10,
+		}, preparedRun.InvoiceUsage.Totals)
+
+		mismatchedLine, err := finalizingLine.Clone()
+		s.NoError(err)
+		mismatchedLine.ID = "mismatched-issued-line"
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   billing.StandardLines{mismatchedLine},
+		})
+		s.ErrorContains(err, "does not match issued line")
+		s.Equal(usagebased.StatusActiveRealizationIssuing, s.mustGetUsageBasedChargeByID(usageBasedChargeID).Status)
+
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
+
+		usageBasedCharge = s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
 		s.Nil(usageBasedCharge.State.CurrentRealizationRunID)
 		s.Nil(usageBasedCharge.State.AdvanceAfter)
-		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
 		s.True(finalRun.Immutable)

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -329,10 +329,11 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 	// - a collected custom-currency usage run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
 	// when:
-	// - invoice finalization persists the fiat allocation but external invoice sync fails
+	// - the first settlement attempt fails after gross preparation
+	// - retry completes settlement, then external invoice sync fails
 	// - issuing is retried after the invoicing app recovers
 	// then:
-	// - issuing reuses the persisted allocation without invoking allocation again
+	// - retry reuses gross preparation, and sync retry reuses completed settlement
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-fiat-overage-sync-retry")
@@ -375,12 +376,33 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 	fiatOverageCreditsHandler := &usageBasedFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
 	}
+	accountingEvents := make([]string, 0, 2)
+	customCurrencyOverageAccruedInvocations := 0
+	s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedInvocations++
+		accountingEvents = append(accountingEvents, "gross_overage")
+
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+
+		return usagebased.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
+	}
 	fiatOverageAllocationInvocations := 0
+	returnFiatAllocationError := true
 	s.UsageBasedTestHandler.onAllocateFiatOverageCredits = func(
 		ctx context.Context,
 		input usagebased.AllocateFiatOverageCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
 		fiatOverageAllocationInvocations++
+		accountingEvents = append(accountingEvents, "fiat_coverage")
+		if returnFiatAllocationError {
+			return nil, errors.New("simulated fiat allocation failure")
+		}
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
@@ -476,24 +498,93 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 	})
 	mockApp.OnFinalizeStandardInvoice(nil)
 
-	s.Run("when invoice sync fails after fiat allocation", func() {
+	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Nil(invoice.StatusDetails.AvailableActions.Delete)
+		s.Zero(invoiceSyncAttempts)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
+
+		charge := s.mustGetUsageBasedChargeByID(chargeID)
+		run, err := charge.GetCurrentRealizationRun()
+		s.Require().NoError(err)
+		s.Require().NotNil(run.InvoiceUsage)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
+		s.Empty(run.FiatOverageCreditRealizations)
+		s.False(run.FiatOverageCreditAllocationCompleted)
+		s.False(run.NoFiatTransactionRequired)
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+	})
+
+	returnFiatAllocationError = false
+	accountingEvents = accountingEvents[:0]
+
+	s.Run("when retry reaches sync after fiat allocation", func() {
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 		s.Equal(1, invoiceSyncAttempts)
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal([]string{"fiat_coverage"}, accountingEvents)
 		s.Zero(mockApp.FinalizeInvoiceCallCount())
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 
 		charge := s.mustGetUsageBasedChargeByID(chargeID)
 		run, err := charge.GetCurrentRealizationRun()
 		s.Require().NoError(err)
+		s.Require().NotNil(run.InvoiceUsage)
+		s.Require().NotNil(run.InvoiceUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
+		s.True(run.FiatOverageCreditAllocationCompleted)
 		s.True(run.NoFiatTransactionRequired)
 		s.requireCreditRealizations(
 			[]expectedCreditRealization{{Type: creditrealization.TypeAllocation, Amount: 5}},
 			run.FiatOverageCreditRealizations,
 			"fiat overage",
 		)
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+
+		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+			ChangeSource: billing.ChangeSourceSystem,
+			Policy:       meta.RefundAsCreditsDeletePolicy,
+		})
+		s.Require().NoError(err)
+		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+			CustomerID: customer.GetID(),
+			PatchesByChargeID: map[string]charges.Patch{
+				chargeID.ID: deletePatch,
+			},
+		})
+		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
@@ -502,7 +593,8 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.Equal(2, invoiceSyncAttempts)
 		s.Equal(1, mockApp.FinalizeInvoiceCallCount())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 
 		err = s.BillingService.TriggerInvoice(ctx, billing.InvoiceTriggerServiceInput{
 			InvoiceTriggerInput: billing.InvoiceTriggerInput{
@@ -522,7 +614,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 		s.Equal(5.0, invoice.Lines.OrEmpty()[0].CreditsApplied.SumAmount(fiatCurrency).InexactFloat64())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 		mockApp.AssertExpectations(s.T())
 	})
 }
@@ -804,6 +896,8 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 	type invoiceFinalizationPhase struct {
 		// fiatOverageCreditsAvailable is the USD balance available when the invoice is finalized.
 		fiatOverageCreditsAvailable float64
+		// disableFiatOverageCredits models the settlement handler rejecting FIAT credit use.
+		disableFiatOverageCredits bool
 		// expectInvoiceTotals contains the finalized invoice line totals in USD.
 		expectInvoiceTotals billingtest.ExpectedTotals
 		// expectFiatRealizations contains the immutable USD allocation and correction facts persisted so far.
@@ -850,6 +944,29 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 			},
 			onInvoiceFinalization: invoiceFinalizationPhase{
 				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			expectPaymentSettled: true,
+		},
+		// given:
+		// - a 5 USD overage and enough settlement-fiat credits to cover it
+		// - the settlement handler does not allow those credits to be used
+		// then:
+		// - gross preparation still runs and the full 5 USD remains payable
+		{
+			name: "fiat overage credits disabled by handler",
+			onRunCreated: runPhase{
+				usageAdded:          5,
+				expectRunTotals:     billingtest.ExpectedTotals{Amount: 10, Total: 10},
+				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			onCollectionComplete: runPhase{
+				expectRunTotals:     billingtest.ExpectedTotals{Amount: 10, Total: 10},
+				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			onInvoiceFinalization: invoiceFinalizationPhase{
+				fiatOverageCreditsAvailable: 5,
+				disableFiatOverageCredits:   true,
+				expectInvoiceTotals:         billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			},
 			expectPaymentSettled: true,
 		},
@@ -1161,7 +1278,16 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 			fiatOverageCreditsHandler := &usageBasedFiatOverageCreditsHandler{
 				available: alpacadecimal.Zero,
 			}
-			s.UsageBasedTestHandler.onAllocateFiatOverageCredits = fiatOverageCreditsHandler.Allocate
+			s.UsageBasedTestHandler.onAllocateFiatOverageCredits = func(
+				ctx context.Context,
+				input usagebased.AllocateFiatOverageCreditsInput,
+			) (creditrealization.CreateAllocationInputs, error) {
+				if test.onInvoiceFinalization.disableFiatOverageCredits {
+					return nil, nil
+				}
+
+				return fiatOverageCreditsHandler.Allocate(ctx, input)
+			}
 			s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
 
 			s.Run("create realization run and fiat overage line", func() {
@@ -1353,27 +1479,28 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 
 				fiatOverageCreditsHandler.AddAvailable(test.onInvoiceFinalization.fiatOverageCreditsAvailable)
 
+				s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
+					customCurrencyOverageAccruedInvocations++
+					s.Equal(chargeID.ID, input.Charge.ID)
+					s.Equal(test.onCollectionComplete.expectRunTotals.Total, input.GetCustomCurrencyAmountAccrued().InexactFloat64())
+
+					resolvedCostBasis, err := input.GetCostBasis()
+					s.Require().NoError(err)
+					s.Equal(float64(0.5), resolvedCostBasis.InexactFloat64())
+
+					resolvedFiatCurrency, err := input.GetFiatCurrency()
+					s.Require().NoError(err)
+					s.Equal(USD, resolvedFiatCurrency.Details().Code)
+
+					return usagebased.OnCustomCurrencyOverageAccruedResult{
+						TransactionGroup: ledgertransaction.GroupReference{
+							TransactionGroupID: ulid.Make().String(),
+						},
+						TotalFiatAmount: alpacadecimal.NewFromFloat(test.onCollectionComplete.expectInvoiceTotals.Total),
+					}, nil
+				}
+
 				if test.expectPaymentSettled {
-					s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
-						customCurrencyOverageAccruedInvocations++
-						s.Equal(chargeID.ID, input.Charge.ID)
-						s.Equal(test.onCollectionComplete.expectRunTotals.Total, input.GetCustomCurrencyAmountAccrued().InexactFloat64())
-
-						resolvedCostBasis, err := input.GetCostBasis()
-						s.Require().NoError(err)
-						s.Equal(float64(0.5), resolvedCostBasis.InexactFloat64())
-
-						resolvedFiatCurrency, err := input.GetFiatCurrency()
-						s.Require().NoError(err)
-						s.Equal(USD, resolvedFiatCurrency.Details().Code)
-
-						return usagebased.OnCustomCurrencyOverageAccruedResult{
-							TransactionGroup: ledgertransaction.GroupReference{
-								TransactionGroupID: ulid.Make().String(),
-							},
-							TotalFiatAmount: alpacadecimal.NewFromFloat(test.onInvoiceFinalization.expectInvoiceTotals.Total),
-						}, nil
-					}
 
 					authorizedCallback = newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
 					s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(_ *testing.T, input usagebased.OnPaymentAuthorizedInput) {
@@ -1446,7 +1573,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.Nil(realizedRun.InvoiceUsage)
 				} else {
 					s.Require().NotNil(realizedRun.InvoiceUsage)
-					s.RequireTotals(expectInvoiceTotals, realizedRun.InvoiceUsage.Totals)
+					s.RequireTotals(test.onCollectionComplete.expectInvoiceTotals, realizedRun.InvoiceUsage.Totals)
 				}
 
 				if test.expectPaymentSettled {
@@ -1460,7 +1587,11 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.Equal(expectInvoiceTotals.Total, realizedRun.Payment.FiatAmount.InexactFloat64())
 					s.False(realizedRun.NoFiatTransactionRequired)
 				} else {
-					s.Zero(customCurrencyOverageAccruedInvocations)
+					if test.expectLineDeleted {
+						s.Zero(customCurrencyOverageAccruedInvocations)
+					} else {
+						s.Equal(1, customCurrencyOverageAccruedInvocations)
+					}
 					s.Nil(realizedRun.Payment)
 					s.True(realizedRun.NoFiatTransactionRequired)
 				}

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -553,6 +553,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 		run, err := charge.GetCurrentRealizationRun()
 		s.Require().NoError(err)
 		s.Require().NotNil(run.InvoiceUsage)
+		s.False(run.Immutable)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
 		s.Empty(run.FiatOverageCreditRealizations)
 		s.False(run.FiatOverageCreditAllocationCompleted)
@@ -591,6 +592,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 		s.Require().NoError(err)
 		runID = run.ID
 		s.Require().NotNil(run.InvoiceUsage)
+		s.False(run.Immutable)
 		s.Require().NotNil(run.InvoiceUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
 		s.True(run.FiatOverageCreditAllocationCompleted)
@@ -602,19 +604,6 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 		)
 
 		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceSystem,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
-		})
-		s.Require().NoError(err)
-		err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
-			CustomerID: customer.GetID(),
-			PatchesByChargeID: map[string]charges.Patch{
-				chargeID.ID: deletePatch,
-			},
-		})
-		s.ErrorContains(err, "cannot be deleted after invoice issuance preparation")
 
 		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),
@@ -1691,6 +1680,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 				realizedRun, ok := charge.Realizations.Latest()
 				s.Require().True(ok)
 				s.Equal(realizationVariant.expectedRunType, realizedRun.Type)
+				s.Equal(!test.expectLineDeleted, realizedRun.Immutable)
 				s.Equal(
 					test.onCollectionComplete.expectRunTotals.CreditsTotal,
 					realizedRun.CreditsAllocated.Sum().InexactFloat64(),
@@ -1800,6 +1790,32 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.True(servicePeriod.To.Equal(remainingLine.ServicePeriod.To))
 				}
 			})
+
+			if test.name == "happy path" && !realizationVariant.enableProgressiveBilling {
+				s.Run("delete issued charge without correcting immutable run", func() {
+					deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+						ChangeSource: billing.ChangeSourceSystem,
+						Policy:       meta.RefundAsCreditsDeletePolicy,
+					})
+					s.Require().NoError(err)
+					s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+						CustomerID: customer.GetID(),
+						PatchesByChargeID: map[string]charges.Patch{
+							chargeID.ID: deletePatch,
+						},
+					}))
+
+					charge := s.mustGetUsageBasedChargeByID(chargeID)
+					s.Equal(usagebased.StatusDeleted, charge.Status)
+					s.Nil(charge.State.CurrentRealizationRunID)
+					s.Require().Len(charge.Realizations, 1)
+					run, ok := charge.Realizations.Latest()
+					s.Require().True(ok)
+					s.True(run.Immutable)
+					s.Nil(run.DeletedAt)
+					s.Require().NotNil(run.InvoiceUsage)
+				})
+			}
 		})
 	}
 }

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -325,6 +325,14 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyCreditThenInvoi
 }
 
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a collected custom-currency usage run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -406,8 +414,35 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
-	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(0)
+	correctionEvents := make([]string, 0, 6)
+	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input usagebased.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.UsageBasedTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ usagebased.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(2)
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccruedCorrection = func(
+		_ context.Context,
+		input usagebased.CreditsOnlyUsageAccruedCorrectionInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -419,6 +454,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 	var (
 		chargeID meta.ChargeID
+		runID    usagebased.RealizationRunID
 		invoice  billing.StandardInvoice
 	)
 
@@ -460,7 +496,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		s.MockStreamingConnector.AddSimpleEvent(
 			feature.Feature.Key,
-			5,
+			6,
 			usageAt,
 			streamingtestutils.WithStoredAt(usageAt),
 		)
@@ -496,7 +532,11 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
 	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
@@ -549,6 +589,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		charge := s.mustGetUsageBasedChargeByID(chargeID)
 		run, err := charge.GetCurrentRealizationRun()
 		s.Require().NoError(err)
+		runID = run.ID
 		s.Require().NotNil(run.InvoiceUsage)
 		s.Require().NotNil(run.InvoiceUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
@@ -560,11 +601,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 			"fiat overage",
 		)
 
-		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
-			Invoice:        invoice.GetInvoiceID(),
-			DeletionSource: billing.ChangeSourceSystem,
-		})
-		s.ErrorContains(err, "invoice action not available")
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceSystem,
@@ -586,6 +623,101 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			run, err := charge.GetCurrentRealizationRun()
+			s.Require().NoError(err)
+			s.Require().Len(run.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(run.CreditsAllocated, 1)
+			s.Equal(creditrealization.TypeAllocation, run.CreditsAllocated[0].Type)
+			s.Nil(run.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			s.Equal(usagebased.StatusDeleted, charge.Status)
+			s.Nil(charge.State.CurrentRealizationRunID)
+			dbRun, err := s.DBClient.ChargeUsageBasedRuns.Get(ctx, runID.ID)
+			s.Require().NoError(err)
+			s.Require().NotNil(dbRun.DeletedAt)
+			dbFiatRealizations, err := dbRun.QueryFiatOverageCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			fiatRealizations := creditrealization.FromDBRealizations(dbFiatRealizations)
+			s.Require().Len(fiatRealizations, 2)
+			s.Zero(fiatRealizations.Sum().InexactFloat64())
+			dbChargeRealizations, err := dbRun.QueryCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			chargeRealizations := creditrealization.FromDBRealizations(dbChargeRealizations)
+			s.Require().Len(chargeRealizations, 2)
+			s.Zero(chargeRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
@@ -1501,7 +1633,6 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 				}
 
 				if test.expectPaymentSettled {
-
 					authorizedCallback = newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
 					s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(_ *testing.T, input usagebased.OnPaymentAuthorizedInput) {
 						s.Equal(chargeID.ID, input.Charge.ID)

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -66,6 +66,10 @@ func (mockFlatFeeHandler) OnCustomCurrencyOverageAccrued(_ context.Context, inpu
 	}, nil
 }
 
+func (mockFlatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
+}
+
 func (mockFlatFeeHandler) OnCorrectCreditAllocations(_ context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
 	return lo.Map(input.Corrections, func(correction creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
 		return creditrealization.CreateCorrectionInput{
@@ -151,6 +155,10 @@ func (mockUsageBasedHandler) OnCustomCurrencyOverageAccrued(_ context.Context, i
 		TransactionGroup: newMockLedgerTransactionGroupReference(),
 		TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
 	}, nil
+}
+
+func (mockUsageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
 }
 
 func (mockUsageBasedHandler) OnPaymentAuthorized(context.Context, usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -507,6 +507,40 @@ func (s *DetailedLineAdapterSuite) TestExpandRealizationsExcludesDeletedRuns() {
 	s.Equal(runBase.ID, fetchedCharge.Realizations[0].ID)
 }
 
+func (s *DetailedLineAdapterSuite) TestRealizationRunImmutableFlag() {
+	ctx := s.T().Context()
+	charge, _, servicePeriod := s.createChargeWithRun("usagebased-run-immutable")
+
+	createdRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:       charge.State.FeatureID,
+		Type:            usagebased.RealizationRunTypePartialInvoice,
+		StoredAtLT:      servicePeriod.To,
+		ServicePeriodTo: servicePeriod.To,
+		MeteredQuantity: alpacadecimal.Zero,
+		Totals:          totals.Totals{},
+	})
+	s.Require().NoError(err)
+	s.False(createdRun.Immutable)
+
+	updatedRun, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        createdRun.ID,
+		Immutable: mo.Some(true),
+	})
+	s.Require().NoError(err)
+	s.True(updatedRun.Immutable)
+
+	fetchedCharge, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands:  chargesmeta.Expands{chargesmeta.ExpandRealizations},
+	})
+	s.Require().NoError(err)
+	fetchedRun, ok := lo.Find(fetchedCharge.Realizations, func(run usagebased.RealizationRun) bool {
+		return run.ID == createdRun.ID
+	})
+	s.Require().True(ok)
+	s.True(fetchedRun.Immutable)
+}
+
 func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usagebased.Charge, usagebased.RealizationRunBase, timeutil.ClosedPeriod) {
 	s.T().Helper()
 

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -170,6 +170,7 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunB
 		MeteredQuantity:                       dbRun.MeteredQuantity,
 		Totals:                                totals.FromDB(dbRun),
 		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
+		Immutable:                             dbRun.Immutable,
 		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
 	}
 }

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -171,6 +171,7 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunB
 		Totals:                                totals.FromDB(dbRun),
 		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
 		Immutable:                             dbRun.Immutable,
+		FiatOverageCreditAllocationCompleted:  dbRun.FiatOverageCreditAllocationCompleted,
 		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
 	}
 }

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -90,6 +90,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 			update = update.SetImmutable(input.Immutable.OrEmpty())
 		}
 
+		if input.FiatOverageCreditAllocationCompleted.IsPresent() {
+			update = update.SetFiatOverageCreditAllocationCompleted(input.FiatOverageCreditAllocationCompleted.OrEmpty())
+		}
+
 		dbRun, err := update.Save(ctx)
 		if err != nil {
 			return usagebased.RealizationRunBase{}, err

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -86,6 +86,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 			update = update.SetNoFiatTransactionRequired(input.NoFiatTransactionRequired.OrEmpty())
 		}
 
+		if input.Immutable.IsPresent() {
+			update = update.SetImmutable(input.Immutable.OrEmpty())
+		}
+
 		dbRun, err := update.Save(ctx)
 		if err != nil {
 			return usagebased.RealizationRunBase{}, err

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -293,7 +293,9 @@ func (i OnCustomCurrencyOverageAccruedInput) Validate() error {
 
 type OnCustomCurrencyOverageAccruedResult struct {
 	TransactionGroup ledgertransaction.GroupReference `json:"transactionGroup"`
-	TotalFiatAmount  alpacadecimal.Decimal            `json:"totalFiatAmount"`
+	// TotalFiatAmount is the authoritative rounded gross amount persisted for
+	// invoice projection and later settlement-credit allocation.
+	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
@@ -354,8 +356,8 @@ type Handler interface {
 	// OnPaymentSettled is called when an invoice-backed usage-based run payment is settled.
 	OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency usage is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
+	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.
@@ -364,7 +366,8 @@ type Handler interface {
 	// OnCreditsOnlyUsageAccruedCorrection is called when a credit-only usage-based charge needs to be corrected.
 	OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
 
-	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against a custom-currency overage.
+	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against an
+	// already-prepared custom-currency overage.
 	OnAllocateFiatOverageCredits(ctx context.Context, input AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
 
 	// OnCorrectFiatOverageCreditAllocations corrects settlement-fiat allocations for a custom-currency overage.

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -298,6 +298,10 @@ type OnCustomCurrencyOverageAccruedResult struct {
 	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
+
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
 
@@ -360,6 +364,12 @@ type Handler interface {
 	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
+
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.
 	OnCreditsOnlyUsageAccrued(ctx context.Context, input CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
 
@@ -384,6 +394,10 @@ func (h UnimplementedHandler) OnInvoiceUsageAccrued(ctx context.Context, input O
 
 func (h UnimplementedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error) {
 	return OnCustomCurrencyOverageAccruedResult{}, errors.New("not implemented")
+}
+
+func (h UnimplementedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return errors.New("not implemented")
 }
 
 func (h UnimplementedHandler) OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -132,14 +132,15 @@ func (r CreateRealizationRunInput) Validate() error {
 type UpdateRealizationRunInput struct {
 	ID RealizationRunID
 
-	Type                      mo.Option[RealizationRunType]    `json:"type"`
-	StoredAtLT                mo.Option[time.Time]             `json:"storedAtLT"`
-	DeletedAt                 mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
-	LineID                    mo.Option[*string]               `json:"lineId,omitempty"`
-	MeteredQuantity           mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
-	Totals                    mo.Option[totals.Totals]         `json:"totals"`
-	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
-	Immutable                 mo.Option[bool]                  `json:"immutable"`
+	Type                                 mo.Option[RealizationRunType]    `json:"type"`
+	StoredAtLT                           mo.Option[time.Time]             `json:"storedAtLT"`
+	DeletedAt                            mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
+	LineID                               mo.Option[*string]               `json:"lineId,omitempty"`
+	MeteredQuantity                      mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
+	Totals                               mo.Option[totals.Totals]         `json:"totals"`
+	NoFiatTransactionRequired            mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	Immutable                            mo.Option[bool]                  `json:"immutable"`
+	FiatOverageCreditAllocationCompleted mo.Option[bool]                  `json:"fiatOverageCreditAllocationCompleted"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -215,6 +216,9 @@ type RealizationRunBase struct {
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
 	// Immutable means the backing invoice crossed the external issuance boundary.
 	Immutable bool `json:"immutable"`
+	// FiatOverageCreditAllocationCompleted distinguishes a successful
+	// zero-allocation result from pending allocation.
+	FiatOverageCreditAllocationCompleted bool `json:"fiatOverageCreditAllocationCompleted"`
 	// DetailedLinesIncludeCreditAllocations describes if credit allocation is applied to the detailed lines.
 	// Credits-only: always false
 	// Credit-then-invoice:

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -139,6 +139,7 @@ type UpdateRealizationRunInput struct {
 	MeteredQuantity           mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
 	Totals                    mo.Option[totals.Totals]         `json:"totals"`
 	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	Immutable                 mo.Option[bool]                  `json:"immutable"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -212,6 +213,8 @@ type RealizationRunBase struct {
 	// Totals includes credit allocations and excludes taxes.
 	Totals                    totals.Totals `json:"totals"`
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
+	// Immutable means the backing invoice crossed the external issuance boundary.
+	Immutable bool `json:"immutable"`
 	// DetailedLinesIncludeCreditAllocations describes if credit allocation is applied to the detailed lines.
 	// Credits-only: always false
 	// Credit-then-invoice:

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -212,7 +212,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// effective period to that completed run, and the next transition still
 		// owns routing the charge to active or payment settlement.
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.ValidateInvoiceIssuedRun)).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceIssuedRun)).
 		OnActive(s.ReleaseInvoiceIssuedRun)
 
 	// Payment + final
@@ -398,16 +398,6 @@ func (s *CreditThenInvoiceStateMachine) updateGatheringLineForEffectiveIntent() 
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if s.Charge.State.CurrentRealizationRunID != nil {
-		currentRun, err := s.Charge.GetCurrentRealizationRun()
-		if err != nil {
-			return fmt.Errorf("get current realization run before delete: %w", err)
-		}
-		if currentRun.InvoiceUsage != nil {
-			return fmt.Errorf("usage based charge[%s] cannot be deleted after invoice issuance preparation", s.Charge.ID)
-		}
-	}
-
 	deletedAt := lo.ToPtr(clock.Now())
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
@@ -433,7 +423,52 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 	return nil
 }
 
+func (s *CreditThenInvoiceStateMachine) correctReversibleCurrentRun(ctx context.Context) error {
+	if s.Charge.State.CurrentRealizationRunID == nil {
+		return nil
+	}
+
+	run, err := s.Charge.GetCurrentRealizationRun()
+	if err != nil {
+		return fmt.Errorf("getting current realization run before delete: %w", err)
+	}
+	if run.InvoiceUsage == nil || run.Immutable {
+		return nil
+	}
+
+	if err := s.Runs.CorrectAllCreditRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
+		Charge:     s.Charge,
+		Run:        run,
+		AllocateAt: run.ServicePeriodTo,
+	}); err != nil {
+		return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        run.ID,
+		DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+	})
+	if err != nil {
+		return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+	run.RealizationRunBase = runBase
+
+	s.Charge.Realizations = s.Charge.Realizations.Without(run.ID)
+	s.Charge.State.CurrentRealizationRunID = nil
+	updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
+	if err != nil {
+		return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+	s.Charge.ChargeBase = updatedChargeBase
+
+	return nil
+}
+
 func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
+	if err := s.correctReversibleCurrentRun(ctx); err != nil {
+		return err
+	}
+
 	patches := invoiceupdater.Patches{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
@@ -555,6 +590,10 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkToRealizedPeriod(ctx context.Context, patch meta.PatchShrinkToRealizedPeriod) error {
+	if err := s.rejectReversibleInvoicePreparation(patch.Op()); err != nil {
+		return err
+	}
+
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
 		return fmt.Errorf("getting patch target layer: %w", err)
@@ -619,6 +658,10 @@ type creditThenInvoiceApplyPeriodPatchResult struct {
 }
 
 func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(ctx context.Context, patch periodPatch) (creditThenInvoiceApplyPeriodPatchResult, error) {
+	if err := s.rejectReversibleInvoicePreparation(patch.Op()); err != nil {
+		return creditThenInvoiceApplyPeriodPatchResult{}, err
+	}
+
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
 		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("getting patch target layer: %w", err)
@@ -648,6 +691,22 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(ctx context.Context, pa
 	return creditThenInvoiceApplyPeriodPatchResult{
 		OldServicePeriod: oldServicePeriod,
 	}, nil
+}
+
+func (s *CreditThenInvoiceStateMachine) rejectReversibleInvoicePreparation(op meta.PatchType) error {
+	if s.Charge.State.CurrentRealizationRunID != nil {
+		currentRun, err := s.Charge.GetCurrentRealizationRun()
+		if err != nil {
+			return fmt.Errorf("getting current realization run before %s: %w", op, err)
+		}
+		if currentRun.InvoiceUsage != nil && !currentRun.Immutable {
+			return models.NewGenericPreConditionFailedError(
+				fmt.Errorf("cannot %s usage-based charge %s while current realization run %s has reversible invoice preparation", op, s.Charge.ID, currentRun.ID.ID),
+			)
+		}
+	}
+
+	return nil
 }
 
 func (s *CreditThenInvoiceStateMachine) UnsupportedExtendOperation(_ context.Context, _ meta.PatchExtend) error {
@@ -1140,7 +1199,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 				return fmt.Errorf("accrue invoice usage: %w", err)
 			}
 			currentRun = accrueResult.Run
-
 		}
 	} else {
 		if currentRun.InvoiceUsage == nil && (len(currentRun.FiatOverageCreditRealizations) > 0 || currentRun.FiatOverageCreditAllocationCompleted) {
@@ -1195,27 +1253,14 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 		s.AddInvoicePatch(invoiceupdater.NewUpdateLinePatch(line.AsGenericLine()))
 	}
 
-	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:        currentRun.ID,
-		Immutable: mo.Some(true),
-	})
-	if err != nil {
-		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
-	}
-	currentRun.RealizationRunBase = runBase
-
-	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
-		return fmt.Errorf("updating realization run[%s]: %w", currentRun.ID.ID, err)
-	}
-
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil
 }
 
-// ValidateInvoiceIssuedRun verifies that invoice finalization prepared the
-// current run before accepting the external issuance event.
-func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Context, input billing.StandardLineWithInvoiceHeader) error {
+// FinalizeInvoiceIssuedRun verifies the prepared run and marks its externally
+// issued invoice history immutable.
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceIssuedRun(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
@@ -1239,6 +1284,19 @@ func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Conte
 	}
 	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
 		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        currentRun.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
+	}
+	currentRun.RealizationRunBase = runBase
+
+	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
+		return fmt.Errorf("updating issued realization run[%s]: %w", currentRun.ID.ID, err)
 	}
 
 	return nil

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -149,7 +149,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsCurrentRunZeroFiatAmountOverage),
 		).
 		Permit(
-			meta.TriggerInvoiceIssued,
+			meta.TriggerInvoiceFinalizing,
 			usagebased.StatusActiveRealizationIssuing,
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
@@ -163,19 +163,19 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 
 	s.Configure(usagebased.StatusActiveRealizationIssuing).
 		Permit(
-			meta.TriggerNext,
+			meta.TriggerInvoiceIssued,
 			usagebased.StatusActiveRealizationCompleted,
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		// Extend is rejected while invoice-issued callbacks own this state.
+		// Extend is rejected while invoice callbacks own this state.
 		// Subscription sync can retry after billing advances the charge.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.UnsupportedShrinkToRealizedPeriodOperation)).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
+		OnEntryFrom(meta.TriggerInvoiceFinalizing, statelessx.WithParameters(s.FinalizeInvoiceRun))
 
 	// Zero-fiat-amount overages bypass invoice issuance after the run's converted
 	// fiat amount is durable. This state finalizes that run before normal
@@ -207,11 +207,13 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// transition to payment settlement. Subscription sync can retry.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		// Invoice-issued callbacks have already finalized the run in the
-		// issuing state. A gathering-line API delete may now shorten the
+		// Invoice-issued callbacks have already released the prepared run. A
+		// gathering-line API delete may now shorten the
 		// effective period to that completed run, and the next transition still
 		// owns routing the charge to active or payment settlement.
-		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.ValidateInvoiceIssuedRun)).
+		OnActive(s.ReleaseInvoiceIssuedRun)
 
 	// Payment + final
 
@@ -1120,30 +1122,77 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("get current realization run: %w", err)
 	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("realization run[%s] line does not match finalizing line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("realization run[%s] invoice does not match finalizing invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
 
 	if !s.Charge.Intent.GetCurrency().IsCustom() {
-		accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+		if currentRun.InvoiceUsage == nil {
+			accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+				Line:   *input.Line,
+			})
+			if err != nil {
+				return fmt.Errorf("accrue invoice usage: %w", err)
+			}
+			currentRun = accrueResult.Run
+
+		}
+	} else {
+		if currentRun.InvoiceUsage == nil && (len(currentRun.FiatOverageCreditRealizations) > 0 || currentRun.FiatOverageCreditAllocationCompleted) {
+			return fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", currentRun.ID.ID)
+		}
+
+		line, err := input.Line.Clone()
+		if err != nil {
+			return fmt.Errorf("cloning finalizing line[%s]: %w", input.Line.ID, err)
+		}
+
+		if currentRun.InvoiceUsage == nil {
+			if err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+				Stage:  standardLinePopulationStageInvoiceFinalizing,
+			}); err != nil {
+				return fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", line.ID, currentRun.ID.ID, err)
+			}
+
+			prepared, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+				Line:   *line,
+			})
+			if err != nil {
+				return fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", line.ID, err)
+			}
+			currentRun = prepared.Run
+		}
+
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			allocated, err := s.Runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+			})
+			if err != nil {
+				return fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", line.ID, err)
+			}
+			s.Charge = allocated.Charge
+			currentRun = allocated.Run
+		}
+
+		if err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
 			Charge: s.Charge,
 			Run:    currentRun,
-			Line:   *input.Line,
-		})
-		if err != nil {
-			return fmt.Errorf("accrue invoice usage: %w", err)
+			Stage:  standardLinePopulationStageInvoiceFinalizing,
+		}); err != nil {
+			return fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", line.ID, currentRun.ID.ID, err)
 		}
-		currentRun = accrueResult.Run
-	} else {
-		if currentRun.InvoiceUsage == nil {
-			return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
-		}
-		if !currentRun.FiatOverageCreditAllocationCompleted {
-			return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
-		}
-		if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
-			return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
-		}
-		if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
-			return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
-		}
+
+		s.AddInvoicePatch(invoiceupdater.NewUpdateLinePatch(line.AsGenericLine()))
 	}
 
 	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
@@ -1156,18 +1205,50 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	currentRun.RealizationRunBase = runBase
 
 	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
-		return fmt.Errorf("update realization run: %w", err)
+		return fmt.Errorf("updating realization run[%s]: %w", currentRun.ID.ID, err)
 	}
 
-	s.Charge.State.CurrentRealizationRunID = nil
 	s.Charge.State.AdvanceAfter = nil
 
-	updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
-	if err != nil {
-		return fmt.Errorf("update charge: %w", err)
+	return nil
+}
+
+// ValidateInvoiceIssuedRun verifies that invoice finalization prepared the
+// current run before accepting the external issuance event.
+func (s *CreditThenInvoiceStateMachine) ValidateInvoiceIssuedRun(_ context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
 	}
 
-	s.Charge.ChargeBase = updatedChargeBase
+	if s.Charge.State.CurrentRealizationRunID == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+
+	currentRun, err := s.Charge.GetCurrentRealizationRun()
+	if err != nil {
+		return fmt.Errorf("get current realization run: %w", err)
+	}
+	if currentRun.InvoiceUsage == nil {
+		return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+	}
+	if s.Charge.Intent.GetCurrency().IsCustom() && !currentRun.FiatOverageCreditAllocationCompleted {
+		return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
+	return nil
+}
+
+// ReleaseInvoiceIssuedRun clears lifecycle scheduling after the prepared run
+// has accepted the external issuance event.
+func (s *CreditThenInvoiceStateMachine) ReleaseInvoiceIssuedRun(_ context.Context) error {
+	s.Charge.State.CurrentRealizationRunID = nil
+	s.Charge.State.AdvanceAfter = nil
 
 	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -1120,6 +1120,14 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 		return fmt.Errorf("accrue invoice usage: %w", err)
 	}
 	currentRun = accrueResult.Run
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        currentRun.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
+	}
+	currentRun.RealizationRunBase = runBase
 
 	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
 		return fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -396,6 +396,16 @@ func (s *CreditThenInvoiceStateMachine) updateGatheringLineForEffectiveIntent() 
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if s.Charge.State.CurrentRealizationRunID != nil {
+		currentRun, err := s.Charge.GetCurrentRealizationRun()
+		if err != nil {
+			return fmt.Errorf("get current realization run before delete: %w", err)
+		}
+		if currentRun.InvoiceUsage != nil {
+			return fmt.Errorf("usage based charge[%s] cannot be deleted after invoice issuance preparation", s.Charge.ID)
+		}
+	}
+
 	deletedAt := lo.ToPtr(clock.Now())
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
@@ -1111,15 +1121,31 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 		return fmt.Errorf("get current realization run: %w", err)
 	}
 
-	accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
-		Charge: s.Charge,
-		Run:    currentRun,
-		Line:   *input.Line,
-	})
-	if err != nil {
-		return fmt.Errorf("accrue invoice usage: %w", err)
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+			Charge: s.Charge,
+			Run:    currentRun,
+			Line:   *input.Line,
+		})
+		if err != nil {
+			return fmt.Errorf("accrue invoice usage: %w", err)
+		}
+		currentRun = accrueResult.Run
+	} else {
+		if currentRun.InvoiceUsage == nil {
+			return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+		}
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+		}
+		if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+			return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
+		}
+		if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+			return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+		}
 	}
-	currentRun = accrueResult.Run
+
 	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
 		ID:        currentRun.ID,
 		Immutable: mo.Some(true),

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -731,6 +731,9 @@ func (a *creditThenInvoiceStateMachineAdapter) UpdateRealizationRun(_ context.Co
 	if input.Type.IsPresent() {
 		run.Type = input.Type.OrEmpty()
 	}
+	if input.Immutable.IsPresent() {
+		run.Immutable = input.Immutable.OrEmpty()
+	}
 
 	a.runs[input.ID.ID] = run
 	return run, nil

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -563,6 +563,46 @@ func TestShrinkToRealizedPeriodFinalizesCurrentPartialRunAndPreservesChargeState
 	require.Equal(t, invoiceupdater.PatchOpDeleteGatheringLineByChargeID, patches[0].Op())
 }
 
+func TestShrinkToRealizedPeriodRejectsReversibleInvoicePreparation(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+	}
+	currentRunID := "run-1"
+	newServicePeriodTo := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	run := newUsageBasedRunForShrinkTest(currentRunID, usagebased.RealizationRunTypePartialInvoice, newServicePeriodTo)
+	run.InvoiceUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: timeutil.ClosedPeriod{
+			From: servicePeriod.From,
+			To:   newServicePeriodTo,
+		},
+	}
+
+	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "charge-id",
+			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(t, servicePeriod),
+			Status: usagebased.StatusActiveRealizationProcessing,
+			State: usagebased.State{
+				CurrentRealizationRunID: &currentRunID,
+			},
+		},
+		Realizations: usagebased.RealizationRuns{run},
+	})
+
+	err := machine.ShrinkToRealizedPeriod(t.Context(), mustNewPatchShrinkToRealizedPeriod(t, newServicePeriodTo))
+
+	require.ErrorContains(t, err, "has reversible invoice preparation")
+	charge := machine.GetCharge()
+	require.False(t, charge.Intent.HasOverrideLayer())
+	run, err = charge.Realizations.GetByID(currentRunID)
+	require.NoError(t, err)
+	require.Equal(t, usagebased.RealizationRunTypePartialInvoice, run.Type)
+}
+
 func newCreditThenInvoiceStateMachineForTest(t *testing.T, status usagebased.Status) *CreditThenInvoiceStateMachine {
 	t.Helper()
 

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
@@ -357,7 +358,10 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line); err != nil {
+		err := transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+			return e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line)
+		})
+		if err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -600,6 +604,16 @@ func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoic
 			// This is an internal consistency error, we are not supposed to surface this to the user, so no typed error wrapping.
 			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
 		}
+
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return usagebased.Charge{}, fmt.Errorf("getting usage based realization run for line[%s]: %w", line.GetID(), err)
+		}
+		if charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil {
+			if err := validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, run, line); err != nil {
+				return usagebased.Charge{}, err
+			}
+		}
 	default:
 		return usagebased.Charge{}, fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
 	}
@@ -665,6 +679,17 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		return nil
 	case billing.InvoiceLineTypeStandard:
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: getting realization run: %w", line.GetID(), err)
+		}
+		preparedRunCanceled := charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil
+		if preparedRunCanceled {
+			charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge, &run)
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: canceling prepared realization run: %w", line.GetID(), err)
+			}
+		}
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,
@@ -689,27 +714,33 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		if len(stdInvoicePatches) != 1 {
-			return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
-		}
+		if preparedRunCanceled {
+			if len(stdInvoicePatches) != 0 {
+				return fmt.Errorf("usage based line[%s]: prepared cancellation emitted unexpected standard invoice patches: %v", line.GetID(), stdInvoicePatches)
+			}
+		} else {
+			if len(stdInvoicePatches) != 1 {
+				return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
+			}
 
-		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		if err := stdInvoicePatch.RequireTarget(line); err != nil {
-			return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			if err := stdInvoicePatch.RequireTarget(line); err != nil {
+				return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		standardLine, err := line.AsInvoiceLine().AsStandardLine()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			standardLine, err := line.AsInvoiceLine().AsStandardLine()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 		}
 
 		// Handle the remaining gathering line patches
@@ -728,6 +759,66 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 	default:
 		return fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
 	}
+}
+
+func validatePreparedCustomCurrencyInvoiceDelete(
+	invoice billing.GenericInvoiceReader,
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	line billing.GenericInvoiceLine,
+) error {
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("usage based line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	switch standardInvoice.Status {
+	case billing.StandardInvoiceStatusIssuingSyncFailed,
+		billing.StandardInvoiceStatusDeleteInProgress,
+		billing.StandardInvoiceStatusDeleteFailed:
+	default:
+		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	intent := charge.Intent.GetEffectiveIntent()
+	if !intent.Currency.IsCustom() || intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return fmt.Errorf("usage based line[%s] is not a custom-currency credit-then-invoice line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if charge.State.CurrentRealizationRunID == nil || *charge.State.CurrentRealizationRunID != run.ID.ID {
+		return fmt.Errorf("custom-currency usage based line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID || run.LineID == nil || *run.LineID != line.GetID() {
+		return fmt.Errorf("custom-currency usage based line[%s] has mismatched invoice preparation references: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if !run.FiatOverageCreditAllocationCompleted {
+		return fmt.Errorf("custom-currency usage based line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.Payment != nil {
+		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) cancelPreparedCustomCurrencyRun(
+	ctx context.Context,
+	charge usagebased.Charge,
+	run *usagebased.RealizationRun,
+) (usagebased.Charge, error) {
+	if err := e.service.runs.CorrectAllCreditRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
+		Charge:     charge,
+		Run:        *run,
+		AllocateAt: run.ServicePeriodTo,
+	}); err != nil {
+		return usagebased.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	charge, err := e.markMutableStandardLineRunDeleted(ctx, charge, *run, clock.Now())
+	if err != nil {
+		return usagebased.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+
+	return charge, nil
 }
 
 func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Context, charge usagebased.Charge, patch meta.Patch) (usagebased.Charge, invoiceupdater.Patches, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -1014,22 +1014,53 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 			)
 		}
 
-		allocated, err := e.service.runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
-			Charge: charge,
-			Run:    run,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
-		}
-
 		updatedLine, err := stdLine.Clone()
 		if err != nil {
 			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
 		}
 
+		if run.InvoiceUsage == nil {
+			if len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted {
+				return nil, fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
+			}
+
+			if err := populateStandardLineFromRun(updatedLine, populateStandardLineFromRunInput{
+				Charge: charge,
+				Run:    run,
+				Stage:  standardLinePopulationStageInvoiceFinalizing,
+			}); err != nil {
+				return nil, fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
+			}
+
+			prepared, err := e.service.runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+				Charge: charge,
+				Run:    run,
+				Line:   *updatedLine,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", stdLine.ID, err)
+			}
+			run = prepared.Run
+			if err := charge.Realizations.SetRealizationRun(run); err != nil {
+				return nil, fmt.Errorf("updating prepared realization run[%s]: %w", run.ID.ID, err)
+			}
+		}
+
+		if !run.FiatOverageCreditAllocationCompleted {
+			allocated, err := e.service.runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
+				Charge: charge,
+				Run:    run,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
+			}
+			charge = allocated.Charge
+			run = allocated.Run
+		}
+
 		if err := populateStandardLineFromRun(updatedLine, populateStandardLineFromRunInput{
-			Charge: allocated.Charge,
-			Run:    allocated.Run,
+			Charge: charge,
+			Run:    run,
 			Stage:  standardLinePopulationStageInvoiceFinalizing,
 		}); err != nil {
 			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -610,7 +610,7 @@ func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoic
 			return usagebased.Charge{}, fmt.Errorf("getting usage based realization run for line[%s]: %w", line.GetID(), err)
 		}
 		if charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil {
-			if err := validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, run, line); err != nil {
+			if err := validateCustomCurrencyInvoiceLineDelete(invoice, line, run); err != nil {
 				return usagebased.Charge{}, err
 			}
 		}
@@ -683,13 +683,7 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 		if err != nil {
 			return fmt.Errorf("usage based line[%s]: getting realization run: %w", line.GetID(), err)
 		}
-		preparedRunCanceled := charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil
-		if preparedRunCanceled {
-			charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge, &run)
-			if err != nil {
-				return fmt.Errorf("usage based line[%s]: canceling prepared realization run: %w", line.GetID(), err)
-			}
-		}
+		reversibleRunDeleted := charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil && !run.Immutable
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,
@@ -714,9 +708,9 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		if preparedRunCanceled {
+		if reversibleRunDeleted {
 			if len(stdInvoicePatches) != 0 {
-				return fmt.Errorf("usage based line[%s]: prepared cancellation emitted unexpected standard invoice patches: %v", line.GetID(), stdInvoicePatches)
+				return fmt.Errorf("usage based line[%s]: reversible run deletion emitted unexpected standard invoice patches: %v", line.GetID(), stdInvoicePatches)
 			}
 		} else {
 			if len(stdInvoicePatches) != 1 {
@@ -737,9 +731,11 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 				return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
 			}
 
-			_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
-			if err != nil {
-				return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			if !run.Immutable {
+				_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+				if err != nil {
+					return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+				}
 			}
 		}
 
@@ -761,12 +757,17 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 	}
 }
 
-func validatePreparedCustomCurrencyInvoiceDelete(
+// validateCustomCurrencyInvoiceLineDelete verifies the billing-owned invoice
+// state and run association required to delete a custom-currency line.
+func validateCustomCurrencyInvoiceLineDelete(
 	invoice billing.GenericInvoiceReader,
-	charge usagebased.Charge,
-	run usagebased.RealizationRun,
 	line billing.GenericInvoiceLine,
+	run usagebased.RealizationRun,
 ) error {
+	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
+		return fmt.Errorf("custom-currency usage based line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
 	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
 	if err != nil {
 		return fmt.Errorf("usage based line[%s]: getting standard invoice: %w", line.GetID(), err)
@@ -780,48 +781,18 @@ func validatePreparedCustomCurrencyInvoiceDelete(
 		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
 	}
 
-	intent := charge.Intent.GetEffectiveIntent()
-	if !intent.Currency.IsCustom() || intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
-		return fmt.Errorf("usage based line[%s] is not a custom-currency credit-then-invoice line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
-	}
-	if charge.State.CurrentRealizationRunID == nil || *charge.State.CurrentRealizationRunID != run.ID.ID {
-		return fmt.Errorf("custom-currency usage based line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
-	}
-	if run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID || run.LineID == nil || *run.LineID != line.GetID() {
-		return fmt.Errorf("custom-currency usage based line[%s] has mismatched invoice preparation references: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
-	}
-	if !run.FiatOverageCreditAllocationCompleted {
-		return fmt.Errorf("custom-currency usage based line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
-	}
-	if run.Payment != nil {
-		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	if run.LineID == nil || *run.LineID != line.GetID() || run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency usage based line[%s] does not match realization run[%s]: %w", line.GetID(), run.ID.ID, billing.ErrCannotUpdateChargeManagedLine)
 	}
 
 	return nil
 }
 
-func (e *LineEngine) cancelPreparedCustomCurrencyRun(
+func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(
 	ctx context.Context,
 	charge usagebased.Charge,
-	run *usagebased.RealizationRun,
-) (usagebased.Charge, error) {
-	if err := e.service.runs.CorrectAllCreditRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
-		Charge:     charge,
-		Run:        *run,
-		AllocateAt: run.ServicePeriodTo,
-	}); err != nil {
-		return usagebased.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
-	}
-
-	charge, err := e.markMutableStandardLineRunDeleted(ctx, charge, *run, clock.Now())
-	if err != nil {
-		return usagebased.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
-	}
-
-	return charge, nil
-}
-
-func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Context, charge usagebased.Charge, patch meta.Patch) (usagebased.Charge, invoiceupdater.Patches, error) {
+	patch meta.Patch,
+) (usagebased.Charge, invoiceupdater.Patches, error) {
 	if err := patch.Validate(); err != nil {
 		return usagebased.Charge{}, nil, fmt.Errorf("validating usage based charge[%s] API line edit patch: %w", charge.ID, err)
 	}
@@ -925,6 +896,10 @@ func (e *LineEngine) deleteMutableStandardLineRealization(
 
 	if run.Payment != nil {
 		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
+	}
+
+	if run.Immutable {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] was issued", stdLine.ID, run.ID.ID)
 	}
 
 	if run.InvoiceUsage != nil {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -1072,93 +1072,34 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
-		meta.ExpandRealizations,
-	}, "invoice finalization")
-	if err != nil {
-		return nil, err
-	}
-
 	return slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
-		charge, ok := chargesByID[*stdLine.ChargeID]
-		if !ok {
-			return nil, fmt.Errorf("usage based charge[%s] not found for finalizing line[%s]", *stdLine.ChargeID, stdLine.ID)
-		}
-
-		if stdLine.IsDeleted() ||
-			charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
-			!charge.Intent.GetCurrency().IsCustom() {
+		if stdLine.IsDeleted() {
 			return stdLine, nil
 		}
 
-		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, fmt.Errorf("getting realization run for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, err
 		}
 
-		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
-			return nil, fmt.Errorf(
-				"realization run[%s] for finalizing line[%s] is not associated with invoice[%s]",
-				run.ID.ID,
-				stdLine.ID,
-				input.Invoice.ID,
-			)
+		if stateMachine.GetCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+			return stdLine, nil
 		}
 
-		updatedLine, err := stdLine.Clone()
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerInvoiceFinalizing, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		})
 		if err != nil {
-			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("finalizing invoice line for charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		if run.InvoiceUsage == nil {
-			if len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted {
-				return nil, fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
-			}
-
-			if err := populateStandardLineFromRun(updatedLine, populateStandardLineFromRunInput{
-				Charge: charge,
-				Run:    run,
-				Stage:  standardLinePopulationStageInvoiceFinalizing,
-			}); err != nil {
-				return nil, fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-			}
-
-			prepared, err := e.service.runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
-				Charge: charge,
-				Run:    run,
-				Line:   *updatedLine,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", stdLine.ID, err)
-			}
-			run = prepared.Run
-			if err := charge.Realizations.SetRealizationRun(run); err != nil {
-				return nil, fmt.Errorf("updating prepared realization run[%s]: %w", run.ID.ID, err)
-			}
+		updatedLine, err := patches.RequireSingularStandardLineUpdateOrEmpty(stdLine.GetLineID(), input.Invoice.ID)
+		if err != nil {
+			return nil, fmt.Errorf("validating finalizing update for line[%s]: %w", stdLine.ID, err)
 		}
-
-		if !run.FiatOverageCreditAllocationCompleted {
-			allocated, err := e.service.runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
-				Charge: charge,
-				Run:    run,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
-			}
-			charge = allocated.Charge
-			run = allocated.Run
-		}
-
-		if err := populateStandardLineFromRun(updatedLine, populateStandardLineFromRunInput{
-			Charge: charge,
-			Run:    run,
-			Stage:  standardLinePopulationStageInvoiceFinalizing,
-		}); err != nil {
-			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if err := updatedLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating finalizing line[%s]: %w", stdLine.ID, err)
+		if updatedLine == nil {
+			return stdLine, nil
 		}
 
 		return updatedLine, nil

--- a/openmeter/billing/charges/usagebased/service/linemapper.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper.go
@@ -183,6 +183,37 @@ func calculateFiatOverageForRun(charge usagebased.Charge, run usagebased.Realiza
 	}, nil
 }
 
+// resolveFiatOverageForLinePopulation reuses the gross FIAT amount persisted
+// by invoice preparation. This keeps retries from repeating conversion after
+// the durable accounting boundary has been crossed.
+func resolveFiatOverageForLinePopulation(
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	stage standardLinePopulationStage,
+) (calculateFiatOverageForRunResult, error) {
+	if stage != standardLinePopulationStageInvoiceFinalizing || run.InvoiceUsage == nil {
+		return calculateFiatOverageForRun(charge, run)
+	}
+
+	costBasisIntent := charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return calculateFiatOverageForRunResult{}, errors.New("cost basis intent is required for a custom-currency invoice")
+	}
+
+	fiatCurrency, err := costBasisIntent.GetFiatCurrency()
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	grossFiatAmount := run.InvoiceUsage.Totals.Total
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatCurrency,
+		FiatOverage:           grossFiatAmount,
+		ShouldOmitInvoiceLine: grossFiatAmount.IsZero(),
+	}, nil
+}
+
 func (i populateStandardLineFromRunInput) Validate() error {
 	var errs []error
 
@@ -279,7 +310,7 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := calculateFiatOverageForRun(charge, run)
+	fiatOverage, err := resolveFiatOverageForLinePopulation(charge, run, input.Stage)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	chargedetailedline "github.com/openmeterio/openmeter/openmeter/billing/charges/models/detailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
@@ -368,6 +369,25 @@ func TestPopulateUsageBasedStandardLineFromCustomCurrencyRunCreatesFiatOverage(t
 	require.Len(t, line.DetailedLines, 1)
 	require.Equal(t, "existing-overage-id", line.DetailedLines[0].ID)
 	require.Nil(t, line.DeletedAt)
+
+	preparedRun := run
+	preparedRun.InvoiceUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: period,
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
+		},
+	}
+
+	// The current cost basis would convert the run to 6 USD. Finalization must
+	// reuse the persisted 5 USD result instead of converting again.
+	preparedFiatOverage, err := resolveFiatOverageForLinePopulation(
+		charge,
+		preparedRun,
+		standardLinePopulationStageInvoiceFinalizing,
+	)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), preparedFiatOverage.FiatOverage.InexactFloat64())
 
 	for _, stage := range []standardLinePopulationStage{
 		standardLinePopulationStageGatheringPreview,

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -436,6 +436,19 @@ func (s *Service) CorrectAllCreditRealizations(
 		}); err != nil {
 			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
 		}
+
+		if input.Run.InvoiceUsage != nil {
+			correctionInput := usagebased.OnCustomCurrencyOverageAccruedCorrectionInput{
+				Charge: input.Charge,
+				Run:    input.Run,
+			}
+			if err := correctionInput.Validate(); err != nil {
+				return fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+			}
+			if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+				return fmt.Errorf("correct custom-currency overage accrual: %w", err)
+			}
+		}
 	}
 
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -334,12 +334,12 @@ func (i AllocateFiatOverageCreditsInput) Validate() error {
 		))
 	}
 
-	if i.Run.InvoiceUsage != nil {
-		errs = append(errs, errors.New("run already has accrued invoice usage"))
+	if i.Run.InvoiceUsage == nil {
+		errs = append(errs, errors.New("run must have prepared invoice usage before fiat allocation"))
 	}
 
-	if len(i.Run.FiatOverageCreditRealizations) > 0 {
-		errs = append(errs, errors.New("run already has fiat overage credit realizations"))
+	if i.Run.FiatOverageCreditAllocationCompleted {
+		errs = append(errs, errors.New("fiat overage credit allocation already completed"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -362,34 +362,45 @@ func (s *Service) AllocateFiatOverageCredits(
 		return AllocateFiatOverageCreditsResult{}, err
 	}
 
-	fiatOverage, err := in.Charge.ConvertCustomCurrencyOverageToFiat(in.Run.Totals)
+	fiatCurrency, err := in.Charge.GetInvoiceCurrency()
 	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("get invoice currency: %w", err)
 	}
+	grossFiatAmount := in.Run.InvoiceUsage.Totals.Total
 
 	run := in.Run
-	allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
-		Amount: fiatOverage.Amount,
-		Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
-			Charge: in.Charge,
-			Run:    run,
-			// Fiat overage allocation is an invoice-finalization effect. Using the
-			// current time makes any outstanding settlement-fiat balance, such as
-			// USD credits, eligible for allocation when the invoice is finalized.
-			AllocateAt: clock.Now(),
-		}),
-	})
-	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+	if len(run.FiatOverageCreditRealizations) == 0 {
+		allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
+			Amount: grossFiatAmount,
+			Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
+				Charge: in.Charge,
+				Run:    run,
+				// Fiat overage allocation is an invoice-finalization effect. Using the
+				// current time makes any outstanding settlement-fiat balance, such as
+				// USD credits, eligible for allocation when the invoice is finalized.
+				AllocateAt: clock.Now(),
+			}),
+		})
+		if err != nil {
+			return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+		}
+
+		run.FiatOverageCreditRealizations = allocationResult.Realizations
 	}
 
-	run.FiatOverageCreditRealizations = allocationResult.Realizations
-
-	allocated := fiatOverage.Currency.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
-	remainingFiatOverage := fiatOverage.Currency.RoundToPrecision(fiatOverage.Amount.Sub(allocated))
+	fiatCurrencyCalculator, err := currencyx.NewFiatCurrency(fiatCurrency)
+	if err != nil {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("create invoice currency calculator: %w", err)
+	}
+	allocated := fiatCurrencyCalculator.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
+	if allocated.GreaterThan(grossFiatAmount) {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("fiat overage credit allocations exceed prepared gross amount: %s > %s", allocated, grossFiatAmount)
+	}
+	remainingFiatOverage := fiatCurrencyCalculator.RoundToPrecision(grossFiatAmount.Sub(allocated))
 	runBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:                        run.ID,
-		NoFiatTransactionRequired: mo.Some(remainingFiatOverage.IsZero()),
+		ID:                                   run.ID,
+		NoFiatTransactionRequired:            mo.Some(remainingFiatOverage.IsZero()),
+		FiatOverageCreditAllocationCompleted: mo.Some(true),
 	})
 	if err != nil {
 		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("update realization run after fiat overage allocation: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/credits_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
@@ -26,9 +26,9 @@ func TestChargeCurrencyCreditReconciliationHandlerOwnsCurrencyCalculator(t *test
 	require.Equal(t, "USD", handler.CurrencyCalculator().Details().Code.String())
 }
 
-func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T) {
+func TestAllocateFiatOverageCreditsInputRejectsCompletedAllocation(t *testing.T) {
 	// given:
-	// - a custom-currency credit-then-invoice run already has a fiat allocation
+	// - a custom-currency credit-then-invoice run already completed fiat allocation
 	charge := newUsageBasedCharge(t)
 	baseIntent := charge.Intent.GetBaseIntent()
 	baseIntent.Currency = currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)
@@ -46,22 +46,17 @@ func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T
 	run := newUsageBasedRun("line-1")
 	currentRunID := run.ID.ID
 	charge.State.CurrentRealizationRunID = &currentRunID
-	run.FiatOverageCreditRealizations = creditrealization.Realizations{
-		{
-			CreateInput: creditrealization.CreateInput{
-				ID:            "fiat-allocation-1",
-				ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
-				LedgerTransaction: ledgertransaction.GroupReference{
-					TransactionGroupID: "fiat-allocation-transaction-1",
-				},
-				Amount: alpacadecimal.NewFromInt(5),
-				Type:   creditrealization.TypeAllocation,
-			},
+	run.InvoiceUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
 		},
 	}
+	run.FiatOverageCreditAllocationCompleted = true
 
 	// when:
-	// - invoice finalization attempts the one-shot fiat allocation again
+	// - invoice finalization attempts the completed allocation again
 	err = (AllocateFiatOverageCreditsInput{
 		Charge: charge,
 		Run:    run,
@@ -69,5 +64,5 @@ func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T
 
 	// then:
 	// - validation rejects the repeated allocation before any handler effect
-	require.ErrorContains(t, err, "run already has fiat overage credit realizations")
+	require.ErrorContains(t, err, "fiat overage credit allocation already completed")
 }

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -766,6 +766,11 @@ func (s *Service) DeleteInvoice(ctx context.Context, input billing.DeleteInvoice
 			if input.DeletionSource != billing.ChangeSourceAPIRequest {
 				return nil
 			}
+			// Charge cleanup committed before invoice-app synchronization. A retry
+			// must not validate or dispatch those already-applied line deletions.
+			if sm.Invoice.DeletedAt != nil {
+				return nil
+			}
 
 			if err := s.validateAPIStandardLineDeletions(
 				ctx,

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -222,8 +222,8 @@ func allocateStateMachine() *InvoiceStateMachine {
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleted)
 
 	// Issuing state. Line finalization handlers can persist durable preparation
-	// before returning, so failed and later issuing states are retry-only until
-	// correction support can make deletion safe.
+	// before returning. Preparation failures remain retry-only, while invoice-app
+	// synchronization can be abandoned through the charge-owned correction path.
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalization).
 		Permit(
@@ -250,6 +250,7 @@ func allocateStateMachine() *InvoiceStateMachine {
 		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingSyncFailed).
+		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingSyncing)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBooking).

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -221,7 +221,9 @@ func allocateStateMachine() *InvoiceStateMachine {
 
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleted)
 
-	// Issuing state
+	// Issuing state. Line finalization handlers can persist durable preparation
+	// before returning, so failed and later issuing states are retry-only until
+	// correction support can make deletion safe.
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalization).
 		Permit(
@@ -229,14 +231,12 @@ func allocateStateMachine() *InvoiceStateMachine {
 			billing.StandardInvoiceStatusIssuingSyncing,
 		).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingLineFinalizationFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(statelessx.AllOf(
 			out.onInvoiceFinalizing,
 			out.requireDBSave,
 		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalizationFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingLineFinalization)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingSyncing).
@@ -245,23 +245,19 @@ func allocateStateMachine() *InvoiceStateMachine {
 			statelessx.BoolFn(out.canIssuingSyncAdvance),
 		).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingSyncFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(statelessx.AllOf(
 			out.finalizeInvoice,
 		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingSyncFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingSyncing)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBooking).
 		Permit(billing.TriggerNext, billing.StandardInvoiceStatusIssued).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingChargeBookingFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(out.onInvoiceIssued)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBookingFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingChargeBooking)
 
 	// Issued state

--- a/openmeter/ent/db/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun.go
@@ -66,6 +66,8 @@ type ChargeFlatFeeRun struct {
 	AmountAfterProration alpacadecimal.Decimal `json:"amount_after_proration,omitempty"`
 	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
+	// FiatOverageCreditAllocationCompleted holds the value of the "fiat_overage_credit_allocation_completed" field.
+	FiatOverageCreditAllocationCompleted bool `json:"fiat_overage_credit_allocation_completed,omitempty"`
 	// Immutable holds the value of the "immutable" field.
 	Immutable bool `json:"immutable,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -186,7 +188,7 @@ func (*ChargeFlatFeeRun) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeflatfeerun.FieldAmount, chargeflatfeerun.FieldTaxesTotal, chargeflatfeerun.FieldTaxesInclusiveTotal, chargeflatfeerun.FieldTaxesExclusiveTotal, chargeflatfeerun.FieldChargesTotal, chargeflatfeerun.FieldDiscountsTotal, chargeflatfeerun.FieldCreditsTotal, chargeflatfeerun.FieldTotal, chargeflatfeerun.FieldAmountAfterProration:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeflatfeerun.FieldNoFiatTransactionRequired, chargeflatfeerun.FieldImmutable:
+		case chargeflatfeerun.FieldNoFiatTransactionRequired, chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, chargeflatfeerun.FieldImmutable:
 			values[i] = new(sql.NullBool)
 		case chargeflatfeerun.FieldID, chargeflatfeerun.FieldNamespace, chargeflatfeerun.FieldChargeID, chargeflatfeerun.FieldType, chargeflatfeerun.FieldInitialType, chargeflatfeerun.FieldLineID, chargeflatfeerun.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -342,6 +344,12 @@ func (_m *ChargeFlatFeeRun) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.NoFiatTransactionRequired = value.Bool
 			}
+		case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field fiat_overage_credit_allocation_completed", values[i])
+			} else if value.Valid {
+				_m.FiatOverageCreditAllocationCompleted = value.Bool
+			}
 		case chargeflatfeerun.FieldImmutable:
 			if value, ok := values[i].(*sql.NullBool); !ok {
 				return fmt.Errorf("unexpected type %T for field immutable", values[i])
@@ -492,6 +500,9 @@ func (_m *ChargeFlatFeeRun) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("no_fiat_transaction_required=")
 	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
+	builder.WriteString(", ")
+	builder.WriteString("fiat_overage_credit_allocation_completed=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatOverageCreditAllocationCompleted))
 	builder.WriteString(", ")
 	builder.WriteString("immutable=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))

--- a/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
@@ -58,6 +58,8 @@ const (
 	FieldAmountAfterProration = "amount_after_proration"
 	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
+	// FieldFiatOverageCreditAllocationCompleted holds the string denoting the fiat_overage_credit_allocation_completed field in the database.
+	FieldFiatOverageCreditAllocationCompleted = "fiat_overage_credit_allocation_completed"
 	// FieldImmutable holds the string denoting the immutable field in the database.
 	FieldImmutable = "immutable"
 	// EdgeFlatFee holds the string denoting the flat_fee edge name in mutations.
@@ -160,6 +162,7 @@ var Columns = []string{
 	FieldInvoiceID,
 	FieldAmountAfterProration,
 	FieldNoFiatTransactionRequired,
+	FieldFiatOverageCreditAllocationCompleted,
 	FieldImmutable,
 }
 
@@ -186,6 +189,8 @@ var (
 	LineIDValidator func(string) error
 	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	InvoiceIDValidator func(string) error
+	// DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the "fiat_overage_credit_allocation_completed" field.
+	DefaultFiatOverageCreditAllocationCompleted bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -321,6 +326,11 @@ func ByAmountAfterProration(opts ...sql.OrderTermOption) OrderOption {
 // ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
 func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
+}
+
+// ByFiatOverageCreditAllocationCompleted orders the results by the fiat_overage_credit_allocation_completed field.
+func ByFiatOverageCreditAllocationCompleted(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatOverageCreditAllocationCompleted, opts...).ToFunc()
 }
 
 // ByImmutable orders the results by the immutable field.

--- a/openmeter/ent/db/chargeflatfeerun/where.go
+++ b/openmeter/ent/db/chargeflatfeerun/where.go
@@ -162,6 +162,11 @@ func NoFiatTransactionRequired(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
 }
 
+// FiatOverageCreditAllocationCompleted applies equality check predicate on the "fiat_overage_credit_allocation_completed" field. It's identical to FiatOverageCreditAllocationCompletedEQ.
+func FiatOverageCreditAllocationCompleted(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
 // Immutable applies equality check predicate on the "immutable" field. It's identical to ImmutableEQ.
 func Immutable(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldImmutable, v))
@@ -1085,6 +1090,16 @@ func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeFlatFeeRun {
 // NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
 func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// FiatOverageCreditAllocationCompletedEQ applies the EQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
+// FiatOverageCreditAllocationCompletedNEQ applies the NEQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedNEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldFiatOverageCreditAllocationCompleted, v))
 }
 
 // ImmutableEQ applies the EQ predicate on the "immutable" field.

--- a/openmeter/ent/db/chargeflatfeerun_create.go
+++ b/openmeter/ent/db/chargeflatfeerun_create.go
@@ -199,6 +199,20 @@ func (_c *ChargeFlatFeeRunCreate) SetNoFiatTransactionRequired(v bool) *ChargeFl
 	return _c
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_c *ChargeFlatFeeRunCreate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _c
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunCreate {
+	if v != nil {
+		_c.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _c
+}
+
 // SetImmutable sets the "immutable" field.
 func (_c *ChargeFlatFeeRunCreate) SetImmutable(v bool) *ChargeFlatFeeRunCreate {
 	_c.mutation.SetImmutable(v)
@@ -394,6 +408,10 @@ func (_c *ChargeFlatFeeRunCreate) defaults() {
 		v := chargeflatfeerun.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		v := chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted
+		_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeflatfeerun.DefaultID()
 		_c.mutation.SetID(v)
@@ -480,6 +498,9 @@ func (_c *ChargeFlatFeeRunCreate) check() error {
 	}
 	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
 		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeFlatFeeRun.no_fiat_transaction_required"`)}
+	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		return &ValidationError{Name: "fiat_overage_credit_allocation_completed", err: errors.New(`db: missing required field "ChargeFlatFeeRun.fiat_overage_credit_allocation_completed"`)}
 	}
 	if _, ok := _c.mutation.Immutable(); !ok {
 		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeFlatFeeRun.immutable"`)}
@@ -594,6 +615,10 @@ func (_c *ChargeFlatFeeRunCreate) createSpec() (*ChargeFlatFeeRun, *sqlgraph.Cre
 	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
 		_node.NoFiatTransactionRequired = value
+	}
+	if value, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
+		_node.FiatOverageCreditAllocationCompleted = value
 	}
 	if value, ok := _c.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)
@@ -1004,6 +1029,18 @@ func (u *ChargeFlatFeeRunUpsert) UpdateNoFiatTransactionRequired() *ChargeFlatFe
 	return u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsert) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsert {
+	u.Set(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, v)
+	return u
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsert) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsert {
+	u.SetExcluded(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted)
+	return u
+}
+
 // SetImmutable sets the "immutable" field.
 func (u *ChargeFlatFeeRunUpsert) SetImmutable(v bool) *ChargeFlatFeeRunUpsert {
 	u.Set(chargeflatfeerun.FieldImmutable, v)
@@ -1332,6 +1369,20 @@ func (u *ChargeFlatFeeRunUpsertOne) SetNoFiatTransactionRequired(v bool) *Charge
 func (u *ChargeFlatFeeRunUpsertOne) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsertOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertOne) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 
@@ -1832,6 +1883,20 @@ func (u *ChargeFlatFeeRunUpsertBulk) SetNoFiatTransactionRequired(v bool) *Charg
 func (u *ChargeFlatFeeRunUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsertBulk) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertBulk) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeerun_update.go
+++ b/openmeter/ent/db/chargeflatfeerun_update.go
@@ -285,6 +285,20 @@ func (_u *ChargeFlatFeeRunUpdate) SetNillableNoFiatTransactionRequired(v *bool) 
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeFlatFeeRunUpdate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunUpdate {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetImmutable sets the "immutable" field.
 func (_u *ChargeFlatFeeRunUpdate) SetImmutable(v bool) *ChargeFlatFeeRunUpdate {
 	_u.mutation.SetImmutable(v)
@@ -630,6 +644,9 @@ func (_u *ChargeFlatFeeRunUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)
@@ -1153,6 +1170,20 @@ func (_u *ChargeFlatFeeRunUpdateOne) SetNillableNoFiatTransactionRequired(v *boo
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeFlatFeeRunUpdateOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunUpdateOne {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetImmutable sets the "immutable" field.
 func (_u *ChargeFlatFeeRunUpdateOne) SetImmutable(v bool) *ChargeFlatFeeRunUpdateOne {
 	_u.mutation.SetImmutable(v)
@@ -1528,6 +1559,9 @@ func (_u *ChargeFlatFeeRunUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -73,6 +73,8 @@ type ChargeUsageBasedRuns struct {
 	MeteredQuantity alpacadecimal.Decimal `json:"metered_quantity,omitempty"`
 	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
+	// Immutable holds the value of the "immutable" field.
+	Immutable bool `json:"immutable,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunsQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunsEdges `json:"edges"`
@@ -215,7 +217,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -389,6 +391,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.NoFiatTransactionRequired = value.Bool
 			}
+		case chargeusagebasedruns.FieldImmutable:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field immutable", values[i])
+			} else if value.Valid {
+				_m.Immutable = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -552,6 +560,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("no_fiat_transaction_required=")
 	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
+	builder.WriteString(", ")
+	builder.WriteString("immutable=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -75,6 +75,8 @@ type ChargeUsageBasedRuns struct {
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
 	// Immutable holds the value of the "immutable" field.
 	Immutable bool `json:"immutable,omitempty"`
+	// FiatOverageCreditAllocationCompleted holds the value of the "fiat_overage_credit_allocation_completed" field.
+	FiatOverageCreditAllocationCompleted bool `json:"fiat_overage_credit_allocation_completed,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunsQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunsEdges `json:"edges"`
@@ -217,7 +219,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable, chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -397,6 +399,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.Immutable = value.Bool
 			}
+		case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field fiat_overage_credit_allocation_completed", values[i])
+			} else if value.Valid {
+				_m.FiatOverageCreditAllocationCompleted = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -563,6 +571,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("immutable=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))
+	builder.WriteString(", ")
+	builder.WriteString("fiat_overage_credit_allocation_completed=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatOverageCreditAllocationCompleted))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -64,6 +64,8 @@ const (
 	FieldMeteredQuantity = "metered_quantity"
 	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
+	// FieldImmutable holds the string denoting the immutable field in the database.
+	FieldImmutable = "immutable"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeFeature holds the string denoting the feature edge name in mutations.
@@ -185,6 +187,7 @@ var Columns = []string{
 	FieldInvoiceID,
 	FieldMeteredQuantity,
 	FieldNoFiatTransactionRequired,
+	FieldImmutable,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -214,6 +217,8 @@ var (
 	LineIDValidator func(string) error
 	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	InvoiceIDValidator func(string) error
+	// DefaultImmutable holds the default value on creation for the "immutable" field.
+	DefaultImmutable bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -364,6 +369,11 @@ func ByMeteredQuantity(opts ...sql.OrderTermOption) OrderOption {
 // ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
 func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
+}
+
+// ByImmutable orders the results by the immutable field.
+func ByImmutable(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldImmutable, opts...).ToFunc()
 }
 
 // ByUsageBasedField orders the results by usage_based field.

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -66,6 +66,8 @@ const (
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
 	// FieldImmutable holds the string denoting the immutable field in the database.
 	FieldImmutable = "immutable"
+	// FieldFiatOverageCreditAllocationCompleted holds the string denoting the fiat_overage_credit_allocation_completed field in the database.
+	FieldFiatOverageCreditAllocationCompleted = "fiat_overage_credit_allocation_completed"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeFeature holds the string denoting the feature edge name in mutations.
@@ -188,6 +190,7 @@ var Columns = []string{
 	FieldMeteredQuantity,
 	FieldNoFiatTransactionRequired,
 	FieldImmutable,
+	FieldFiatOverageCreditAllocationCompleted,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -219,6 +222,8 @@ var (
 	InvoiceIDValidator func(string) error
 	// DefaultImmutable holds the default value on creation for the "immutable" field.
 	DefaultImmutable bool
+	// DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the "fiat_overage_credit_allocation_completed" field.
+	DefaultFiatOverageCreditAllocationCompleted bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -374,6 +379,11 @@ func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 // ByImmutable orders the results by the immutable field.
 func ByImmutable(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldImmutable, opts...).ToFunc()
+}
+
+// ByFiatOverageCreditAllocationCompleted orders the results by the fiat_overage_credit_allocation_completed field.
+func ByFiatOverageCreditAllocationCompleted(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatOverageCreditAllocationCompleted, opts...).ToFunc()
 }
 
 // ByUsageBasedField orders the results by usage_based field.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -177,6 +177,11 @@ func NoFiatTransactionRequired(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
 }
 
+// Immutable applies equality check predicate on the "immutable" field. It's identical to ImmutableEQ.
+func Immutable(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNamespace, v))
@@ -1180,6 +1185,16 @@ func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeUsageBasedRuns {
 // NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
 func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// ImmutableEQ applies the EQ predicate on the "immutable" field.
+func ImmutableEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
+}
+
+// ImmutableNEQ applies the NEQ predicate on the "immutable" field.
+func ImmutableNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldImmutable, v))
 }
 
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -182,6 +182,11 @@ func Immutable(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
 }
 
+// FiatOverageCreditAllocationCompleted applies equality check predicate on the "fiat_overage_credit_allocation_completed" field. It's identical to FiatOverageCreditAllocationCompletedEQ.
+func FiatOverageCreditAllocationCompleted(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNamespace, v))
@@ -1195,6 +1200,16 @@ func ImmutableEQ(v bool) predicate.ChargeUsageBasedRuns {
 // ImmutableNEQ applies the NEQ predicate on the "immutable" field.
 func ImmutableNEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldImmutable, v))
+}
+
+// FiatOverageCreditAllocationCompletedEQ applies the EQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
+// FiatOverageCreditAllocationCompletedNEQ applies the NEQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldFiatOverageCreditAllocationCompleted, v))
 }
 
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -226,6 +226,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetNoFiatTransactionRequired(v bool) *Char
 	return _c
 }
 
+// SetImmutable sets the "immutable" field.
+func (_c *ChargeUsageBasedRunsCreate) SetImmutable(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetImmutable(v)
+	return _c
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetImmutable(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetID(v)
@@ -439,6 +453,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations
 		_c.mutation.SetDetailedLinesIncludeCreditAllocations(v)
 	}
+	if _, ok := _c.mutation.Immutable(); !ok {
+		v := chargeusagebasedruns.DefaultImmutable
+		_c.mutation.SetImmutable(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeusagebasedruns.DefaultID()
 		_c.mutation.SetID(v)
@@ -539,6 +557,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
 		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.no_fiat_transaction_required"`)}
+	}
+	if _, ok := _c.mutation.Immutable(); !ok {
+		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.immutable"`)}
 	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedRuns.usage_based"`)}
@@ -661,6 +682,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
 		_node.NoFiatTransactionRequired = value
+	}
+	if value, ok := _c.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+		_node.Immutable = value
 	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1094,6 +1119,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateNoFiatTransactionRequired() *ChargeUs
 	return u
 }
 
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsert) SetImmutable(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldImmutable, v)
+	return u
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateImmutable() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldImmutable)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1412,6 +1449,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetNoFiatTransactionRequired(v bool) *Ch
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetImmutable(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetImmutable(v)
+	})
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateImmutable() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateImmutable()
 	})
 }
 
@@ -1900,6 +1951,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetNoFiatTransactionRequired(v bool) *C
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetImmutable(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetImmutable(v)
+	})
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateImmutable() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateImmutable()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -240,6 +240,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetNillableImmutable(v *bool) *ChargeUsage
 	return _c
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_c *ChargeUsageBasedRunsCreate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _c
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetID(v)
@@ -457,6 +471,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultImmutable
 		_c.mutation.SetImmutable(v)
 	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		v := chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted
+		_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeusagebasedruns.DefaultID()
 		_c.mutation.SetID(v)
@@ -560,6 +578,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.Immutable(); !ok {
 		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.immutable"`)}
+	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		return &ValidationError{Name: "fiat_overage_credit_allocation_completed", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.fiat_overage_credit_allocation_completed"`)}
 	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedRuns.usage_based"`)}
@@ -686,6 +707,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 		_node.Immutable = value
+	}
+	if value, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
+		_node.FiatOverageCreditAllocationCompleted = value
 	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1131,6 +1156,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateImmutable() *ChargeUsageBasedRunsUpse
 	return u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsert) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, v)
+	return u
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1463,6 +1500,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetImmutable(v bool) *ChargeUsageBasedRu
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateImmutable() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateImmutable()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 
@@ -1965,6 +2016,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetImmutable(v bool) *ChargeUsageBasedR
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateImmutable() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateImmutable()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -292,6 +292,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableImmutable(v *bool) *ChargeUsage
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -638,6 +652,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1182,6 +1199,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableImmutable(v *bool) *ChargeUs
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -1558,6 +1589,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -278,6 +278,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableNoFiatTransactionRequired(v *bo
 	return _u
 }
 
+// SetImmutable sets the "immutable" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetImmutable(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetImmutable(v)
+	return _u
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetImmutable(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -621,6 +635,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1151,6 +1168,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableNoFiatTransactionRequired(v 
 	return _u
 }
 
+// SetImmutable sets the "immutable" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetImmutable(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetImmutable(v)
+	return _u
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetImmutable(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -1524,6 +1555,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2480,6 +2480,7 @@ var (
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "amount_after_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
+		{Name: "fiat_overage_credit_allocation_completed", Type: field.TypeBool, Default: false},
 		{Name: "immutable", Type: field.TypeBool},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2493,19 +2494,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_flat_fee_runs_billing_invoices_charge_flat_fee_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[20]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[21]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fee_runs_billing_invoice_lines_charge_flat_fee_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[21]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[22]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fee_runs_charge_flat_fees_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[23]},
 				RefColumns: []*schema.Column{ChargeFlatFeesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -2524,7 +2525,7 @@ var (
 			{
 				Name:    "chargeflatfeerun_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[22]},
+				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[23]},
 			},
 		},
 	}
@@ -3519,6 +3520,7 @@ var (
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
 		{Name: "immutable", Type: field.TypeBool, Default: false},
+		{Name: "fiat_overage_credit_allocation_completed", Type: field.TypeBool, Default: false},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -3532,25 +3534,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[26]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3569,7 +3571,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[24]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[25]},
 			},
 		},
 	}

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3518,6 +3518,7 @@ var (
 		{Name: "detailed_lines_include_credit_allocations", Type: field.TypeBool, Default: false},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
+		{Name: "immutable", Type: field.TypeBool, Default: false},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -3531,25 +3532,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3568,7 +3569,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[23]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[24]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -77904,6 +77904,7 @@ type ChargeUsageBasedRunsMutation struct {
 	detailed_lines_include_credit_allocations *bool
 	metered_quantity                          *alpacadecimal.Decimal
 	no_fiat_transaction_required              *bool
+	immutable                                 *bool
 	clearedFields                             map[string]struct{}
 	usage_based                               *string
 	clearedusage_based                        bool
@@ -78941,6 +78942,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetNoFiatTransactionRequired() {
 	m.no_fiat_transaction_required = nil
 }
 
+// SetImmutable sets the "immutable" field.
+func (m *ChargeUsageBasedRunsMutation) SetImmutable(b bool) {
+	m.immutable = &b
+}
+
+// Immutable returns the value of the "immutable" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) Immutable() (r bool, exists bool) {
+	v := m.immutable
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldImmutable returns the old "immutable" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldImmutable(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldImmutable is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldImmutable requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldImmutable: %w", err)
+	}
+	return oldValue.Immutable, nil
+}
+
+// ResetImmutable resets all changes to the "immutable" field.
+func (m *ChargeUsageBasedRunsMutation) ResetImmutable() {
+	m.immutable = nil
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -79416,7 +79453,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 24)
+	fields := make([]string, 0, 25)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -79489,6 +79526,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.no_fiat_transaction_required != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNoFiatTransactionRequired)
 	}
+	if m.immutable != nil {
+		fields = append(fields, chargeusagebasedruns.FieldImmutable)
+	}
 	return fields
 }
 
@@ -79545,6 +79585,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.MeteredQuantity()
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		return m.NoFiatTransactionRequired()
+	case chargeusagebasedruns.FieldImmutable:
+		return m.Immutable()
 	}
 	return nil, false
 }
@@ -79602,6 +79644,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldMeteredQuantity(ctx)
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		return m.OldNoFiatTransactionRequired(ctx)
+	case chargeusagebasedruns.FieldImmutable:
+		return m.OldImmutable(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79779,6 +79823,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetNoFiatTransactionRequired(v)
 		return nil
+	case chargeusagebasedruns.FieldImmutable:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetImmutable(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79920,6 +79971,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		m.ResetNoFiatTransactionRequired()
+		return nil
+	case chargeusagebasedruns.FieldImmutable:
+		m.ResetImmutable()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -54266,51 +54266,52 @@ func (m *ChargeFlatFeeOverrideMutation) ResetEdge(name string) error {
 // ChargeFlatFeeRunMutation represents an operation that mutates the ChargeFlatFeeRun nodes in the graph.
 type ChargeFlatFeeRunMutation struct {
 	config
-	op                                     Op
-	typ                                    string
-	id                                     *string
-	namespace                              *string
-	created_at                             *time.Time
-	updated_at                             *time.Time
-	deleted_at                             *time.Time
-	amount                                 *alpacadecimal.Decimal
-	taxes_total                            *alpacadecimal.Decimal
-	taxes_inclusive_total                  *alpacadecimal.Decimal
-	taxes_exclusive_total                  *alpacadecimal.Decimal
-	charges_total                          *alpacadecimal.Decimal
-	discounts_total                        *alpacadecimal.Decimal
-	credits_total                          *alpacadecimal.Decimal
-	total                                  *alpacadecimal.Decimal
-	_type                                  *flatfee.RealizationRunType
-	initial_type                           *flatfee.RealizationRunType
-	service_period_from                    *time.Time
-	service_period_to                      *time.Time
-	amount_after_proration                 *alpacadecimal.Decimal
-	no_fiat_transaction_required           *bool
-	immutable                              *bool
-	clearedFields                          map[string]struct{}
-	flat_fee                               *string
-	clearedflat_fee                        bool
-	billing_invoice_line                   *string
-	clearedbilling_invoice_line            bool
-	billing_invoice                        *string
-	clearedbilling_invoice                 bool
-	credit_allocations                     map[string]struct{}
-	removedcredit_allocations              map[string]struct{}
-	clearedcredit_allocations              bool
-	fiat_overage_credit_allocations        map[string]struct{}
-	removedfiat_overage_credit_allocations map[string]struct{}
-	clearedfiat_overage_credit_allocations bool
-	detailed_lines                         map[string]struct{}
-	removeddetailed_lines                  map[string]struct{}
-	cleareddetailed_lines                  bool
-	invoiced_usage                         *string
-	clearedinvoiced_usage                  bool
-	payment                                *string
-	clearedpayment                         bool
-	done                                   bool
-	oldValue                               func(context.Context) (*ChargeFlatFeeRun, error)
-	predicates                             []predicate.ChargeFlatFeeRun
+	op                                       Op
+	typ                                      string
+	id                                       *string
+	namespace                                *string
+	created_at                               *time.Time
+	updated_at                               *time.Time
+	deleted_at                               *time.Time
+	amount                                   *alpacadecimal.Decimal
+	taxes_total                              *alpacadecimal.Decimal
+	taxes_inclusive_total                    *alpacadecimal.Decimal
+	taxes_exclusive_total                    *alpacadecimal.Decimal
+	charges_total                            *alpacadecimal.Decimal
+	discounts_total                          *alpacadecimal.Decimal
+	credits_total                            *alpacadecimal.Decimal
+	total                                    *alpacadecimal.Decimal
+	_type                                    *flatfee.RealizationRunType
+	initial_type                             *flatfee.RealizationRunType
+	service_period_from                      *time.Time
+	service_period_to                        *time.Time
+	amount_after_proration                   *alpacadecimal.Decimal
+	no_fiat_transaction_required             *bool
+	fiat_overage_credit_allocation_completed *bool
+	immutable                                *bool
+	clearedFields                            map[string]struct{}
+	flat_fee                                 *string
+	clearedflat_fee                          bool
+	billing_invoice_line                     *string
+	clearedbilling_invoice_line              bool
+	billing_invoice                          *string
+	clearedbilling_invoice                   bool
+	credit_allocations                       map[string]struct{}
+	removedcredit_allocations                map[string]struct{}
+	clearedcredit_allocations                bool
+	fiat_overage_credit_allocations          map[string]struct{}
+	removedfiat_overage_credit_allocations   map[string]struct{}
+	clearedfiat_overage_credit_allocations   bool
+	detailed_lines                           map[string]struct{}
+	removeddetailed_lines                    map[string]struct{}
+	cleareddetailed_lines                    bool
+	invoiced_usage                           *string
+	clearedinvoiced_usage                    bool
+	payment                                  *string
+	clearedpayment                           bool
+	done                                     bool
+	oldValue                                 func(context.Context) (*ChargeFlatFeeRun, error)
+	predicates                               []predicate.ChargeFlatFeeRun
 }
 
 var _ ent.Mutation = (*ChargeFlatFeeRunMutation)(nil)
@@ -55212,6 +55213,42 @@ func (m *ChargeFlatFeeRunMutation) ResetNoFiatTransactionRequired() {
 	m.no_fiat_transaction_required = nil
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeFlatFeeRunMutation) SetFiatOverageCreditAllocationCompleted(b bool) {
+	m.fiat_overage_credit_allocation_completed = &b
+}
+
+// FiatOverageCreditAllocationCompleted returns the value of the "fiat_overage_credit_allocation_completed" field in the mutation.
+func (m *ChargeFlatFeeRunMutation) FiatOverageCreditAllocationCompleted() (r bool, exists bool) {
+	v := m.fiat_overage_credit_allocation_completed
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFiatOverageCreditAllocationCompleted returns the old "fiat_overage_credit_allocation_completed" field's value of the ChargeFlatFeeRun entity.
+// If the ChargeFlatFeeRun object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeRunMutation) OldFiatOverageCreditAllocationCompleted(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFiatOverageCreditAllocationCompleted: %w", err)
+	}
+	return oldValue.FiatOverageCreditAllocationCompleted, nil
+}
+
+// ResetFiatOverageCreditAllocationCompleted resets all changes to the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeFlatFeeRunMutation) ResetFiatOverageCreditAllocationCompleted() {
+	m.fiat_overage_credit_allocation_completed = nil
+}
+
 // SetImmutable sets the "immutable" field.
 func (m *ChargeFlatFeeRunMutation) SetImmutable(b bool) {
 	m.immutable = &b
@@ -55642,7 +55679,7 @@ func (m *ChargeFlatFeeRunMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeRunMutation) Fields() []string {
-	fields := make([]string, 0, 22)
+	fields := make([]string, 0, 23)
 	if m.namespace != nil {
 		fields = append(fields, chargeflatfeerun.FieldNamespace)
 	}
@@ -55706,6 +55743,9 @@ func (m *ChargeFlatFeeRunMutation) Fields() []string {
 	if m.no_fiat_transaction_required != nil {
 		fields = append(fields, chargeflatfeerun.FieldNoFiatTransactionRequired)
 	}
+	if m.fiat_overage_credit_allocation_completed != nil {
+		fields = append(fields, chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted)
+	}
 	if m.immutable != nil {
 		fields = append(fields, chargeflatfeerun.FieldImmutable)
 	}
@@ -55759,6 +55799,8 @@ func (m *ChargeFlatFeeRunMutation) Field(name string) (ent.Value, bool) {
 		return m.AmountAfterProration()
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		return m.NoFiatTransactionRequired()
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		return m.FiatOverageCreditAllocationCompleted()
 	case chargeflatfeerun.FieldImmutable:
 		return m.Immutable()
 	}
@@ -55812,6 +55854,8 @@ func (m *ChargeFlatFeeRunMutation) OldField(ctx context.Context, name string) (e
 		return m.OldAmountAfterProration(ctx)
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		return m.OldNoFiatTransactionRequired(ctx)
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		return m.OldFiatOverageCreditAllocationCompleted(ctx)
 	case chargeflatfeerun.FieldImmutable:
 		return m.OldImmutable(ctx)
 	}
@@ -55970,6 +56014,13 @@ func (m *ChargeFlatFeeRunMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetNoFiatTransactionRequired(v)
 		return nil
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFiatOverageCreditAllocationCompleted(v)
+		return nil
 	case chargeflatfeerun.FieldImmutable:
 		v, ok := value.(bool)
 		if !ok {
@@ -56109,6 +56160,9 @@ func (m *ChargeFlatFeeRunMutation) ResetField(name string) error {
 		return nil
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		m.ResetNoFiatTransactionRequired()
+		return nil
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		m.ResetFiatOverageCreditAllocationCompleted()
 		return nil
 	case chargeflatfeerun.FieldImmutable:
 		m.ResetImmutable()
@@ -77905,6 +77959,7 @@ type ChargeUsageBasedRunsMutation struct {
 	metered_quantity                          *alpacadecimal.Decimal
 	no_fiat_transaction_required              *bool
 	immutable                                 *bool
+	fiat_overage_credit_allocation_completed  *bool
 	clearedFields                             map[string]struct{}
 	usage_based                               *string
 	clearedusage_based                        bool
@@ -78978,6 +79033,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetImmutable() {
 	m.immutable = nil
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeUsageBasedRunsMutation) SetFiatOverageCreditAllocationCompleted(b bool) {
+	m.fiat_overage_credit_allocation_completed = &b
+}
+
+// FiatOverageCreditAllocationCompleted returns the value of the "fiat_overage_credit_allocation_completed" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) FiatOverageCreditAllocationCompleted() (r bool, exists bool) {
+	v := m.fiat_overage_credit_allocation_completed
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFiatOverageCreditAllocationCompleted returns the old "fiat_overage_credit_allocation_completed" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldFiatOverageCreditAllocationCompleted(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFiatOverageCreditAllocationCompleted: %w", err)
+	}
+	return oldValue.FiatOverageCreditAllocationCompleted, nil
+}
+
+// ResetFiatOverageCreditAllocationCompleted resets all changes to the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeUsageBasedRunsMutation) ResetFiatOverageCreditAllocationCompleted() {
+	m.fiat_overage_credit_allocation_completed = nil
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -79453,7 +79544,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 25)
+	fields := make([]string, 0, 26)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -79529,6 +79620,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.immutable != nil {
 		fields = append(fields, chargeusagebasedruns.FieldImmutable)
 	}
+	if m.fiat_overage_credit_allocation_completed != nil {
+		fields = append(fields, chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted)
+	}
 	return fields
 }
 
@@ -79587,6 +79681,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.NoFiatTransactionRequired()
 	case chargeusagebasedruns.FieldImmutable:
 		return m.Immutable()
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		return m.FiatOverageCreditAllocationCompleted()
 	}
 	return nil, false
 }
@@ -79646,6 +79742,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldNoFiatTransactionRequired(ctx)
 	case chargeusagebasedruns.FieldImmutable:
 		return m.OldImmutable(ctx)
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		return m.OldFiatOverageCreditAllocationCompleted(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79830,6 +79928,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetImmutable(v)
 		return nil
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFiatOverageCreditAllocationCompleted(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79974,6 +80079,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldImmutable:
 		m.ResetImmutable()
+		return nil
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		m.ResetFiatOverageCreditAllocationCompleted()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1841,6 +1841,10 @@ func init() {
 	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[9].Descriptor()
 	// chargeusagebasedruns.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeusagebasedruns.InvoiceIDValidator = chargeusagebasedrunsDescInvoiceID.Validators[0].(func(string) error)
+	// chargeusagebasedrunsDescImmutable is the schema descriptor for immutable field.
+	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[12].Descriptor()
+	// chargeusagebasedruns.DefaultImmutable holds the default value on creation for the immutable field.
+	chargeusagebasedruns.DefaultImmutable = chargeusagebasedrunsDescImmutable.Default.(bool)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.
 	chargeusagebasedrunsDescID := chargeusagebasedrunsMixinFields1[0].Descriptor()
 	// chargeusagebasedruns.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1354,6 +1354,10 @@ func init() {
 	chargeflatfeerunDescInvoiceID := chargeflatfeerunFields[6].Descriptor()
 	// chargeflatfeerun.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeflatfeerun.InvoiceIDValidator = chargeflatfeerunDescInvoiceID.Validators[0].(func(string) error)
+	// chargeflatfeerunDescFiatOverageCreditAllocationCompleted is the schema descriptor for fiat_overage_credit_allocation_completed field.
+	chargeflatfeerunDescFiatOverageCreditAllocationCompleted := chargeflatfeerunFields[9].Descriptor()
+	// chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the fiat_overage_credit_allocation_completed field.
+	chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted = chargeflatfeerunDescFiatOverageCreditAllocationCompleted.Default.(bool)
 	// chargeflatfeerunDescID is the schema descriptor for id field.
 	chargeflatfeerunDescID := chargeflatfeerunMixinFields1[0].Descriptor()
 	// chargeflatfeerun.DefaultID holds the default value on creation for the id field.
@@ -1845,6 +1849,10 @@ func init() {
 	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[12].Descriptor()
 	// chargeusagebasedruns.DefaultImmutable holds the default value on creation for the immutable field.
 	chargeusagebasedruns.DefaultImmutable = chargeusagebasedrunsDescImmutable.Default.(bool)
+	// chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted is the schema descriptor for fiat_overage_credit_allocation_completed field.
+	chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted := chargeusagebasedrunsFields[13].Descriptor()
+	// chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the fiat_overage_credit_allocation_completed field.
+	chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted = chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted.Default.(bool)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.
 	chargeusagebasedrunsDescID := chargeusagebasedrunsMixinFields1[0].Descriptor()
 	// chargeusagebasedruns.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -371,6 +371,9 @@ func (ChargeFlatFeeRun) Fields() []ent.Field {
 
 		field.Bool("no_fiat_transaction_required"),
 
+		field.Bool("fiat_overage_credit_allocation_completed").
+			Default(false),
+
 		field.Bool("immutable"),
 	}
 }

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -388,6 +388,9 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 			}),
 
 		field.Bool("no_fiat_transaction_required"),
+
+		field.Bool("immutable").
+			Default(false),
 	}
 }
 

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -391,6 +391,9 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 
 		field.Bool("immutable").
 			Default(false),
+
+		field.Bool("fiat_overage_credit_allocation_completed").
+			Default(false),
 	}
 }
 

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -165,6 +165,14 @@ func (h *flatFeeHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, inp
 	return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *flatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *flatFeeHandler) OnAllocateFiatOverageCredits(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -179,6 +179,14 @@ func (h *usageBasedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, 
 	return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *usageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *usageBasedHandler) OnAllocateFiatOverageCredits(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.down.sql
+++ b/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "immutable";

--- a/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.up.sql
+++ b/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.up.sql
@@ -1,0 +1,2 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "immutable" boolean NOT NULL DEFAULT false;

--- a/tools/migrate/migrations/20260825083218_add_charge_overage_allocation_completion.down.sql
+++ b/tools/migrate/migrations/20260825083218_add_charge_overage_allocation_completion.down.sql
@@ -1,0 +1,4 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "fiat_overage_credit_allocation_completed";
+-- reverse: modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" DROP COLUMN "fiat_overage_credit_allocation_completed";

--- a/tools/migrate/migrations/20260825083218_add_charge_overage_allocation_completion.up.sql
+++ b/tools/migrate/migrations/20260825083218_add_charge_overage_allocation_completion.up.sql
@@ -1,0 +1,4 @@
+-- modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" ADD COLUMN "fiat_overage_credit_allocation_completed" boolean NOT NULL DEFAULT false;
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "fiat_overage_credit_allocation_completed" boolean NOT NULL DEFAULT false;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4XSY59ElhpfWLOW+jQLPXMcNy9wMb/SqecP+nM+G3MM=
+h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -269,3 +269,4 @@ h1:4XSY59ElhpfWLOW+jQLPXMcNy9wMb/SqecP+nM+G3MM=
 20260814114215_charges-search-feature-filters.up.sql h1:ttOzcueUboyfQKgIV2Pv7lRzUXus2AknzqeD40VQvSE=
 20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=
 20260824141945_repair_distributed_locks.up.sql h1:2yMrvYEgMu69u2VehzaZMyESZmD/HrwOZaOU1xQsTDY=
+20260825073524_add_usage_based_run_immutable.up.sql h1:gtNDCpb60imuRqnncnjB/xHjAWKUa44SrnJbFl152wo=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
+h1:lX06R0eo5VBFJoRA2P5FPYumCGKHE9ER4OcTuqIsDE8=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -270,3 +270,4 @@ h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
 20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=
 20260824141945_repair_distributed_locks.up.sql h1:2yMrvYEgMu69u2VehzaZMyESZmD/HrwOZaOU1xQsTDY=
 20260825073524_add_usage_based_run_immutable.up.sql h1:gtNDCpb60imuRqnncnjB/xHjAWKUa44SrnJbFl152wo=
+20260825083218_add_charge_overage_allocation_completion.up.sql h1:VdtZnYK+k3uxPZtD+ox9pNKUG0L4vi/b8W1znnNtv2o=


### PR DESCRIPTION
## Summary

- move flat-fee and usage-based custom-currency `credit_then_invoice` overage preparation to `issuing.line_finalization`
- prepare and persist the gross FIAT overage before invoking settlement-FIAT credit allocation
- persist an allocation-completion marker so retries reuse gross preparation and completed zero/partial/full allocation results
- project gross amount, applied FIAT credits, and net due onto the invoice line
- make invoice issuing retry-only after finalization starts, and reject charge deletion while prepared accounting is attached to the current run
- leave production ledger, collector, payment-routing, and transaction implementations unchanged and unsupported

## Root cause

The previous lifecycle invoked settlement-FIAT allocation during line finalization but deferred gross custom-currency overage preparation until `OnInvoiceIssued`. That allowed FIAT coverage to be persisted before the gross FIAT receivable existed, and external invoice synchronization could fail between those steps.

## Lifecycle and retry semantics

Line finalization now establishes the durable boundary:

1. finalize the custom-credit snapshot and compute the gross FIAT amount
2. invoke gross overage preparation and persist its authoritative rounded result
3. invoke settlement-FIAT credit allocation against that persisted gross amount
4. persist completion, including successful zero-allocation results, and project credits/net due to the invoice

Retries reuse persisted gross and allocation results without repeating conversion or completed handlers. `OnInvoiceIssued` only validates and advances prepared custom-currency runs. Generic accounting correction remains out of scope, so issuing states do not expose invoice deletion after finalization begins.

## Tests

- service-backed flat-fee and usage-based lifecycle coverage
- gross-before-FIAT handler ordering and failure between the two steps
- allocation disabled, none, partial, and full FIAT coverage
- gross, credits, and net invoice projection
- finalization and sync retry idempotency
- prepared-state invoice/charge deletion rejection
- migration generation, lint, validation, and affected Go package tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice processing now separates preparation from final issuance, improving lifecycle tracking for flat-fee and usage-based charges.
  * Custom-currency overage credits are prepared and allocated more reliably during invoice finalization.
  * Eligible prepared invoice lines can now be deleted transactionally through the API.

* **Bug Fixes**
  * Prevented repeated overage-credit allocations during retries.
  * Improved cleanup and rollback after invoice synchronization failures.
  * Prevented duplicate deletion processing and preserved prepared billing data across retries.

* **Documentation**
  * Clarified invoice finalization, issuance, retry, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves custom-currency overage preparation and settlement-credit allocation into invoice line finalization, persists allocation completion for retry reuse, and delays immutability until external issuance.
- Projects persisted gross overage, applied credits, and net due onto finalized invoice lines.
- Adds reversible cleanup for prepared runs and restricts deletion or mutation after accounting preparation begins.
- Adds run schema fields and migrations for allocation-completion and usage-based immutability state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure is established on the current HEAD.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Moves flat-fee accounting preparation to line finalization, adds prepared-run cleanup, and marks runs immutable after invoice issuance. |
| openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go | Persists gross invoice usage after invoking the accounting handler; the prior retry concern cannot be conclusively reclassified from the available transaction evidence. |
| openmeter/billing/charges/flatfee/service/realizations/credits.go | Allocates against persisted gross FIAT and records an explicit completion marker, including zero-allocation results. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Applies the corresponding finalization, issuance, and reversible-cleanup lifecycle to usage-based charges. |
| openmeter/billing/service/stdinvoicestate.go | Makes issuing failures retry-only once line finalization begins and routes failed synchronization through prepared-run cleanup. |
| tools/migrate/migrations/20260825083218_add_charge_overage_allocation_completion.up.sql | Adds durable allocation-completion fields for flat-fee and usage-based realization runs. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant I as Invoice issuing
    participant C as Charge finalization
    participant G as Gross overage handler
    participant A as Fiat credit allocation
    participant D as Run persistence
    participant X as External invoice sync
    I->>C: Finalize line
    C->>G: Prepare gross overage
    G-->>C: Authoritative rounded gross
    C->>D: Persist accrued usage
    C->>A: Allocate against persisted gross
    A-->>C: Zero, partial, or full allocation
    C->>D: Persist completion and projection
    C-->>I: Updated invoice line
    I->>X: Synchronize invoice
    X-->>I: Issued
    I->>C: Mark prepared run immutable
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(charges): gate prepared usage revers..."](https://github.com/openmeterio/openmeter/commit/ee988078e0784d4c62e30302b4cdfdeb5aa56950) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54419922)</sub>

<!-- /greptile_comment -->