### PR TITLE
fix: tolerate concurrently deleted charges in charge list and get reads

### DIFF
--- a/openmeter/billing/charges/creditpurchase/adapter.go
+++ b/openmeter/billing/charges/creditpurchase/adapter.go
@@ -128,6 +128,10 @@ type GetByIDsInput struct {
 	IDs       []string
 
 	Expands meta.Expands
+	// AllowMissing drops IDs with no matching charge instead of failing the
+	// read: callers set it when the ID set comes from an earlier search
+	// snapshot and charges may have been deleted since.
+	AllowMissing bool
 }
 
 func (i GetByIDsInput) Validate() error {

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -272,7 +272,12 @@ func (a *adapter) GetByIDs(ctx context.Context, input creditpurchase.GetByIDsInp
 			return nil, err
 		}
 
-		entitiesInOrder, err := entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		var entitiesInOrder []*db.ChargeCreditPurchase
+		if input.AllowMissing {
+			entitiesInOrder, err = entutils.InIDOrderSkipMissing(input.Namespace, input.IDs, entities)
+		} else {
+			entitiesInOrder, err = entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -196,6 +196,10 @@ type GetByIDsInput struct {
 	IDs       []string
 
 	Expands meta.Expands
+	// AllowMissing drops IDs with no matching charge instead of failing the
+	// read: callers set it when the ID set comes from an earlier search
+	// snapshot and charges may have been deleted since.
+	AllowMissing bool
 }
 
 func (i GetByIDsInput) Validate() error {

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -339,7 +339,12 @@ func (a *adapter) GetByIDs(ctx context.Context, input flatfee.GetByIDsInput) ([]
 			return nil, err
 		}
 
-		entitiesInOrder, err := entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		var entitiesInOrder []*db.ChargeFlatFee
+		if input.AllowMissing {
+			entitiesInOrder, err = entutils.InIDOrderSkipMissing(input.Namespace, input.IDs, entities)
+		} else {
+			entitiesInOrder, err = entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/openmeter/billing/charges/service/api_list_test.go
+++ b/openmeter/billing/charges/service/api_list_test.go
@@ -249,6 +249,27 @@ func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
 		s.Empty(result.Charges.Items)
 	})
 
+	s.Run("charges vanishing between search and typed loads are dropped", func() {
+		// given:
+		// - a search snapshot referencing the real charge and one whose typed
+		//   row no longer exists (a charge deleted between the search
+		//   transaction and the typed loads)
+		// then:
+		// - the vanished charge is dropped instead of failing the whole read
+		realID, err := created[0].GetChargeID()
+		require.NoError(s.T(), err)
+
+		items := charges.ChargeSearchItems{
+			{ID: realID, Type: created[0].Type(), CustomerID: cust.ID},
+			{ID: meta.ChargeID{Namespace: namespace, ID: ulid.Make().String()}, Type: meta.ChargeTypeUsageBased, CustomerID: cust.ID},
+		}
+
+		out, err := s.Charges.expandChargesWithTypes(ctx, namespace, items, meta.ExpandNone)
+		require.NoError(s.T(), err)
+		require.Len(s.T(), out, 1)
+		s.Equal(created[0].GetID(), out[0].GetID())
+	})
+
 	s.Run("deleted customers still expand", func() {
 		// given:
 		// - the charge's customer is deleted after the charge was created

--- a/openmeter/billing/charges/service/get.go
+++ b/openmeter/billing/charges/service/get.go
@@ -69,28 +69,36 @@ func (s *service) expandChargesWithTypes(ctx context.Context, namespace string, 
 		}
 	}
 
+	// The typed loads run outside the search transaction, so the searched IDs
+	// are a snapshot: a charge deleted in between is tolerated (AllowMissing)
+	// and dropped from the result instead of failing the whole read.
+	// ListCharges keeps serving the rest of the page, and GetByID maps an
+	// empty result to its not-found error.
 	usageBased, err := s.usageBasedService.GetByIDs(ctx, usagebased.GetByIDsInput{
-		Namespace: namespace,
-		IDs:       chargesByType[meta.ChargeTypeUsageBased],
-		Expands:   expands,
+		Namespace:    namespace,
+		IDs:          chargesByType[meta.ChargeTypeUsageBased],
+		Expands:      expands,
+		AllowMissing: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	flatFees, err := s.flatFeeService.GetByIDs(ctx, flatfee.GetByIDsInput{
-		Namespace: namespace,
-		IDs:       chargesByType[meta.ChargeTypeFlatFee],
-		Expands:   expands,
+		Namespace:    namespace,
+		IDs:          chargesByType[meta.ChargeTypeFlatFee],
+		Expands:      expands,
+		AllowMissing: true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	creditPurchases, err := s.creditPurchaseService.GetByIDs(ctx, creditpurchase.GetByIDsInput{
-		Namespace: namespace,
-		IDs:       chargesByType[meta.ChargeTypeCreditPurchase],
-		Expands:   expands,
+		Namespace:    namespace,
+		IDs:          chargesByType[meta.ChargeTypeCreditPurchase],
+		Expands:      expands,
+		AllowMissing: true,
 	})
 	if err != nil {
 		return nil, err
@@ -108,12 +116,17 @@ func (s *service) expandChargesWithTypes(ctx context.Context, namespace string, 
 		}),
 	)
 
-	return entutils.InIDOrder(
-		namespace,
-		lo.Map(
-			chargesItems,
-			func(charge charges.ChargeSearchItem, _ int) string {
-				return charge.ID.ID
-			},
-		), out)
+	// AllowMissing may have dropped vanished charges from the typed loads, so
+	// the ordering set is narrowed to the IDs actually loaded.
+	loadedIDs := make(map[string]struct{}, len(out))
+	for _, charge := range out {
+		loadedIDs[charge.GetID()] = struct{}{}
+	}
+
+	orderedIDs := lo.FilterMap(chargesItems, func(charge charges.ChargeSearchItem, _ int) (string, bool) {
+		_, ok := loadedIDs[charge.ID.ID]
+		return charge.ID.ID, ok
+	})
+
+	return entutils.InIDOrder(namespace, orderedIDs, out)
 }

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -323,7 +323,12 @@ func (a *adapter) GetByIDs(ctx context.Context, input usagebased.GetByIDsInput) 
 			return nil, err
 		}
 
-		entitiesInOrder, err := entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		var entitiesInOrder []*db.ChargeUsageBased
+		if input.AllowMissing {
+			entitiesInOrder, err = entutils.InIDOrderSkipMissing(input.Namespace, input.IDs, entities)
+		} else {
+			entitiesInOrder, err = entutils.InIDOrder(input.Namespace, input.IDs, entities)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -127,6 +127,10 @@ type GetByIDsInput struct {
 	Namespace string
 	IDs       []string
 	Expands   meta.Expands
+	// AllowMissing drops IDs with no matching charge instead of failing the
+	// read: callers set it when the ID set comes from an earlier search
+	// snapshot and charges may have been deleted since.
+	AllowMissing bool
 }
 
 func (i GetByIDsInput) Validate() error {

--- a/pkg/framework/entutils/idorder.go
+++ b/pkg/framework/entutils/idorder.go
@@ -22,6 +22,17 @@ var (
 )
 
 func InIDOrder[T InIDOrderAccessor](namespace string, targetOrderIDs []string, results []T) ([]T, error) {
+	return inIDOrder(namespace, targetOrderIDs, results, false)
+}
+
+// InIDOrderSkipMissing orders results like InIDOrder but drops target IDs with
+// no matching entity instead of failing. Callers use it when the target ID set
+// comes from an earlier snapshot and entities may have been deleted since.
+func InIDOrderSkipMissing[T InIDOrderAccessor](namespace string, targetOrderIDs []string, results []T) ([]T, error) {
+	return inIDOrder(namespace, targetOrderIDs, results, true)
+}
+
+func inIDOrder[T InIDOrderAccessor](namespace string, targetOrderIDs []string, results []T, skipMissing bool) ([]T, error) {
 	// Input validation (let's make sure that namespace/id is set for all entities)
 	if namespace == "" {
 		return nil, ErrNamespaceRequired
@@ -69,7 +80,9 @@ func InIDOrder[T InIDOrderAccessor](namespace string, targetOrderIDs []string, r
 	for _, id := range targetOrderIDs {
 		entities, ok := entitiesByID[models.NamespacedID{Namespace: namespace, ID: id}]
 		if !ok {
-			errs = append(errs, fmt.Errorf("%w [id=%s]", ErrNotFound, id))
+			if !skipMissing {
+				errs = append(errs, fmt.Errorf("%w [id=%s]", ErrNotFound, id))
+			}
 			continue
 		}
 


### PR DESCRIPTION
Stacked on #4933.

The typed charge loads deliberately run outside the search transaction (the realtime usage expand calls ClickHouse per charge, and a remote call must not pin a pooled Postgres connection), so a charge deleted between the search snapshot and the typed loads failed the whole `ListCharges`/`GetByIDs` read with a not-found error. A single read-committed transaction would not close the race either: each statement takes its own snapshot.

This defines the missing-ID contract explicitly instead:

- `entutils.InIDOrderSkipMissing` orders like `InIDOrder` but drops target IDs with no matching entity.
- The typed `GetByIDsInput`s (usage-based, flat fee, credit purchase) gain an opt-in `AllowMissing` flag; strict not-found stays the default for every other caller.
- Only the union charge expansion opts in: a charge that vanishes between the two reads is dropped from the list page, and `GetByID` keeps returning its not-found error through the empty-result path.

Covered by a DB-backed test feeding the expansion a search snapshot with a phantom ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charge lookups now gracefully omit records that are no longer available instead of failing the entire request.
  * Returned charges continue to follow the requested ID order, excluding missing entries.
  * Improved handling of charges that disappear between search and loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes union charge reads tolerate charges deleted between the initial search and subsequent typed loads while preserving strict missing-ID behavior for other callers.
- Adds opt-in missing-ID handling to all three typed charge loaders.
- Filters vanished charges while retaining the requested order of loaded results.
- Adds a database-backed concurrent-deletion scenario.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/service/get.go | Enables missing-row tolerance for union expansion and restores search ordering across the surviving typed charges. |
| pkg/framework/entutils/idorder.go | Adds an opt-in ordering helper that skips target IDs without matching entities while retaining strict behavior by default. |
| openmeter/billing/charges/usagebased/adapter/charge.go | Selects strict or missing-tolerant ID ordering according to the new input flag. |
| openmeter/billing/charges/flatfee/adapter/charge.go | Selects strict or missing-tolerant ID ordering according to the new input flag. |
| openmeter/billing/charges/creditpurchase/adapter/charge.go | Selects strict or missing-tolerant ID ordering according to the new input flag. |
| openmeter/billing/charges/service/api_list_test.go | Adds coverage showing that union expansion returns surviving charges when an earlier search snapshot contains a deleted charge. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Search as Charge search
    participant Expand as Union expansion
    participant Typed as Typed charge loaders
    Caller->>Search: List/Get charge IDs
    Search-->>Expand: Snapshot of IDs by type
    Note over Search,Typed: A charge may be deleted here
    Expand->>Typed: "GetByIDs(AllowMissing=true)"
    Typed-->>Expand: Existing charges only
    Expand-->>Caller: Loaded charges in search order
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: tolerate concurrently deleted charg..."](https://github.com/openmeterio/openmeter/commit/ec8d38817878c4aa627abf208d34f863e2e9a5bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54716078)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/openmeterio/openmeter/blob/main/CLAUDE.md))
- Knowledge Base — [Billing: Invoices, Charges, Tax, and Currency](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing.md)

<!-- /greptile_comment -->