### PR TITLE
docs(api): document PUT replace semantics for v3 update endpoints

### DIFF
--- a/.agents/skills/api/rules/aip-134-135-crud.md
+++ b/.agents/skills/api/rules/aip-134-135-crud.md
@@ -72,6 +72,19 @@ Two things stay out of the replace surface:
   path, or they will clear everything the caller did not repeat. Give them their own named
   adapter method — see `UpdatePlanEffectivePeriod` / `UpdateAddonEffectivePeriod`.
 
+This is the default, so **do not comment it**. Do not explain in code that a field is
+cleared because PUT replaces, that `SetOrClear` is used instead of `SetNillable`, or that
+`Equal()`/`applyTo` are presence-aware. Comment only deviations: a field that is
+deliberately merged, or a nil that means "leave alone" rather than "clear".
+
+Tests to add with the change:
+
+- Handler: an omitted field maps to its zero/nil value (a plain converter test — no
+  `given`/`when`/`then` narration).
+- Adapter: an update that omits a field clears it in the returned entity **and** on
+  re-read.
+- Lifecycle operations (publish, archive, …): unrelated fields survive.
+
 The one deliberate exception is a write-only credential with no cleared state, such as the
 Stripe app's `secret_api_key`: make the field **required** so nothing silently persists,
 rather than clearing a key the app cannot run without.

--- a/.agents/skills/api/rules/aip-134-135-crud.md
+++ b/.agents/skills/api/rules/aip-134-135-crud.md
@@ -40,6 +40,45 @@ Both `PATCH` and `PUT` are **required** for all entities (mandate introduced 202
 - **Creation via PUT only works when the entity uses customer-supplied IDs** (unique within the organization or parent scope, not globally).
 - For entities with system-generated globally-unique IDs, PUT only supports **replacement**; missing entities must return `404 Not Found`.
 
+#### PUT is a replace, all the way down
+
+The request body is the resource's complete new representation. A field the client
+left out is **cleared**, never carried over from the stored value. This holds
+recursively: an omitted sub-object resets that whole sub-object, and an omitted array
+is the same as an empty one.
+
+Use `Shared.UpsertRequest<T>` so required fields stay required — `Shared.UpdateRequest<T>`
+makes every property optional and belongs to PATCH. A `@put` operation paired with
+`UpdateRequest<T>` publishes a contract that says "everything is optional" while the
+server still rejects a missing required field.
+
+Implementing it takes both layers:
+
+- **v3 handler / `convert.go`** builds the complete target state. No `if body.X != nil { … }`
+  guards on a PUT path — always hand the service a value, the zero value included.
+- **Adapter** uses the generated `SetOrClear<Field>` helpers (nil clears), never Ent's
+  stock `SetNillable<Field>` (nil is a no-op). This choice is the replace-vs-merge switch.
+- **`Equal()` short-circuits** must compare an omitted field against the stored value, or
+  they skip the write that would have cleared it.
+- **`applyTo` / validation projections** must apply the same clearing, so validation sees
+  the state the update is about to produce.
+
+Two things stay out of the replace surface:
+
+- **Fields the representation does not expose**, such as server-managed annotations.
+  A client cannot send them, so a PUT cannot clear them.
+- **Partial internal mutations.** Lifecycle operations that move one attribute (publishing
+  or archiving a plan shifts only its effective period) must not ride the general update
+  path, or they will clear everything the caller did not repeat. Give them their own named
+  adapter method — see `UpdatePlanEffectivePeriod` / `UpdateAddonEffectivePeriod`.
+
+The one deliberate exception is a write-only credential with no cleared state, such as the
+Stripe app's `secret_api_key`: make the field **required** so nothing silently persists,
+rather than clearing a key the app cannot run without.
+
+PATCH is the partial-update verb and v3 currently ships it only for `update-feature`;
+adding it for the remaining entities per the AIP-134 mandate is outstanding.
+
 ## AIP-135 delete rules
 
 - DELETE returns `204 No Content` on success.


### PR DESCRIPTION
## Overview

`aip-134-135-crud.md` said which request template a PUT should use, but not what the server must then do with a field the client omitted. That gap is why the v3 PUT surface drifted into three different behaviours — true replacement, silent partial merge, and a hand-written scoped merge — with no rule to point at in review.

This documents the contract: **PUT is a full replace, all the way down.** A field left out is cleared, an omitted sub-object resets that sub-object, and an omitted array means an empty one.

It also records the two-layer implementation the contract needs, because getting one layer right and not the other is exactly how the current inconsistencies arose:

- v3 handlers build a complete target state — no `if body.X != nil { … }` guards on a PUT path.
- Adapters use the generated `SetOrClear<Field>` helpers (nil clears), never Ent's stock `SetNillable<Field>` (nil is a no-op). This choice *is* the replace-vs-merge switch.
- `Equal()` short-circuits and `applyTo`/validation projections must apply the same clearing, or they skip the write that would have cleared a field, or validate against the pre-update state.

And what stays out of the replace surface: fields the representation does not expose (server-managed annotations — a client cannot send them, so a PUT cannot clear them), and partial internal mutations such as publishing or archiving, which need their own named adapter method rather than riding the general update path.

## Notes for reviewer

Docs only — no code, no generated output.

This is the convention that the ten per-endpoint PRs alongside it implement, so it is worth agreeing on this one first. The one deliberate exception it carves out is a write-only credential with no cleared state (the Stripe app's `secret_api_key`), which becomes required rather than clearable.

It also notes the outstanding AIP-134 item: PATCH is the partial-update verb and v3 ships it only for `update-feature`. Adding it for the remaining entities is deliberately out of scope here, but worth tracking — once PUT is strictly destructive, clients have no partial-update path at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that PUT requests fully replace existing resources.
  - Documented how omitted fields, nested objects, and arrays are cleared.
  - Added guidance for complete-state construction, validation, equality checks, and adapter behavior.
  - Clarified handling of excluded fields, partial mutations, and write-only credentials.
  - Documented that PATCH support remains outside the current scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR defines PUT as full-resource replacement and explains the coordinated handler, adapter, equality, validation, and lifecycle behavior needed to preserve those semantics.
- Clarifies how omitted fields, nested objects, and arrays are reset.
- Distinguishes PUT request templates from PATCH request templates.
- Documents persistence-helper requirements and exceptions for unexposed fields, partial lifecycle mutations, and write-only credentials.
- Records remaining PATCH coverage as out of scope.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .agents/skills/api/rules/aip-134-135-crud.md | Adds comprehensive guidance for implementing full-replacement PUT semantics across API conversion, validation, equality checks, and persistence adapters. |

<sub>Reviews (2): Last reviewed commit: ["docs(api): tell PUT implementers what no..."](https://github.com/openmeterio/openmeter/commit/4b4a381dc0821e9cdd3b88693de4619fe1415857) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874565)</sub>

<!-- /greptile_comment -->