### PR TITLE
fix(productcatalog): make PUT /plans/{planId} replace omitted fields

### DIFF
--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -568,10 +568,9 @@ func FromAPIUpsertPlanRequest(ns string, planID string, body api.UpsertPlanReque
 		return req, fmt.Errorf("failed to convert label metadata: %w", err)
 	}
 
-	if body.Labels != nil {
-		m := meta
-		req.Metadata = &m
-	}
+	// Non-nil even when empty: a nil Metadata means "unchanged" to the service, which would
+	// leak the stored labels through a request that omitted them.
+	req.Metadata = &meta
 
 	phases := make([]productcatalog.Phase, 0, len(body.Phases))
 	for _, phase := range body.Phases {

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -53,6 +53,7 @@ func ToAPIBillingPlan(p plan.Plan) (api.BillingPlan, error) {
 		EffectiveTo:      p.EffectiveTo,
 		Id:               p.ID,
 		Key:              p.Key,
+		Labels:           labels.FromMetadata(p.Metadata),
 		Name:             p.Name,
 		UpdatedAt:        p.UpdatedAt,
 		Version:          p.Version,
@@ -568,8 +569,8 @@ func FromAPIUpsertPlanRequest(ns string, planID string, body api.UpsertPlanReque
 		return req, fmt.Errorf("failed to convert label metadata: %w", err)
 	}
 
-	// Non-nil even when empty: a nil Metadata means "unchanged" to the service, which would
-	// leak the stored labels through a request that omitted them.
+	// The PUT boundary hands the service the complete target state, so omitted labels
+	// become an explicit empty metadata value rather than an absent one.
 	req.Metadata = &meta
 
 	phases := make([]productcatalog.Phase, 0, len(body.Phases))

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -569,8 +569,6 @@ func FromAPIUpsertPlanRequest(ns string, planID string, body api.UpsertPlanReque
 		return req, fmt.Errorf("failed to convert label metadata: %w", err)
 	}
 
-	// The PUT boundary hands the service the complete target state, so omitted labels
-	// become an explicit empty metadata value rather than an absent one.
 	req.Metadata = &meta
 
 	phases := make([]productcatalog.Phase, 0, len(body.Phases))

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1067,15 +1067,36 @@ func TestToUpdatePlanInput(t *testing.T) {
 		assert.Equal(t, "prod", (*result.Metadata)["env"])
 	})
 
-	t.Run("nil labels result in nil metadata", func(t *testing.T) {
+	t.Run("omitted labels clear metadata", func(t *testing.T) {
+		// given a PUT body that leaves labels out
 		body := api.UpsertPlanRequest{
 			Name:   "Plan",
 			Phases: []api.BillingPlanPhase{},
 		}
 
+		// when it is converted to an update input
 		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
 		require.NoError(t, err)
-		assert.Nil(t, result.Metadata)
+
+		// then metadata is present but empty, so the update replaces the stored labels
+		// instead of leaving them in place
+		require.NotNil(t, result.Metadata)
+		assert.Empty(t, *result.Metadata)
+	})
+
+	t.Run("omitted description clears the stored description", func(t *testing.T) {
+		// given a PUT body that leaves description out
+		body := api.UpsertPlanRequest{
+			Name:   "Plan",
+			Phases: []api.BillingPlanPhase{},
+		}
+
+		// when it is converted to an update input
+		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
+		require.NoError(t, err)
+
+		// then the input carries no description, which the adapter turns into a clear
+		assert.Nil(t, result.Description)
 	})
 
 	t.Run("pro rating enabled maps correctly", func(t *testing.T) {

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1067,35 +1067,26 @@ func TestToUpdatePlanInput(t *testing.T) {
 		assert.Equal(t, "prod", (*result.Metadata)["env"])
 	})
 
-	t.Run("omitted labels clear metadata", func(t *testing.T) {
-		// given a PUT body that leaves labels out
+	t.Run("omitted labels map to empty metadata", func(t *testing.T) {
 		body := api.UpsertPlanRequest{
 			Name:   "Plan",
 			Phases: []api.BillingPlanPhase{},
 		}
 
-		// when it is converted to an update input
 		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
 		require.NoError(t, err)
-
-		// then metadata is present but empty, so the update replaces the stored labels
-		// instead of leaving them in place
 		require.NotNil(t, result.Metadata)
 		assert.Empty(t, *result.Metadata)
 	})
 
-	t.Run("omitted description clears the stored description", func(t *testing.T) {
-		// given a PUT body that leaves description out
+	t.Run("omitted description maps to nil", func(t *testing.T) {
 		body := api.UpsertPlanRequest{
 			Name:   "Plan",
 			Phases: []api.BillingPlanPhase{},
 		}
 
-		// when it is converted to an update input
 		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
 		require.NoError(t, err)
-
-		// then the input carries no description, which the adapter turns into a clear
 		assert.Nil(t, result.Description)
 	})
 

--- a/e2e/plans_v3_test.go
+++ b/e2e/plans_v3_test.go
@@ -614,3 +614,34 @@ func TestV3PlanReadTranslatesV1DynamicAndPackagePrices(t *testing.T) {
 		assert.Equal(t, v3sdk.UnitConfigRoundingModeCeiling, *pkgRC.UnitConfig.Rounding)
 	})
 }
+
+func TestV3PlanUpdateClearsOmittedFields(t *testing.T) {
+	c := newV3Client(t)
+
+	createBody := validPlanRequest("test_v3_plan_replace")
+	createBody.Description = lo.ToPtr("Original description")
+	createBody.Labels = &map[string]string{"env": "prod"}
+
+	created, err := c.Plans.Create(t.Context(), createBody)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, created)
+	require.NotNil(t, created.Description)
+	require.NotEmpty(t, created.Labels)
+
+	updated, err := c.Plans.Update(t.Context(), created.ID, v3sdk.UpsertPlanRequest{
+		Name:   createBody.Name,
+		Phases: createBody.Phases,
+	})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, updated)
+
+	assert.Nil(t, updated.Description, "omitted description must be cleared, not carried over")
+	assert.Empty(t, updated.Labels, "omitted labels must be cleared, not carried over")
+
+	fetched, err := c.Plans.Get(t.Context(), created.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, fetched)
+
+	assert.Nil(t, fetched.Description)
+	assert.Empty(t, fetched.Labels)
+}

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -513,7 +513,41 @@ func TestPostgresAdapter(t *testing.T) {
 			plan.AssertPlanUpdateInputEqual(t, planV1Update, *planV1)
 		})
 
-		t.Run("UpdateSettlementMode", func(t *testing.T) {
+		t.Run("UpdateClearsOmittedFields", func(t *testing.T) {
+				// given: a plan that carries a description and labels
+				require.NotNilf(t, planV1.Description, "plan must have a description to clear")
+				require.NotEmptyf(t, planV1.Metadata, "plan must have labels to clear")
+
+				// when: an update arrives that names neither of them
+				updated, err := env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{
+					NamespacedID: models.NamespacedID{
+						Namespace: namespace,
+						ID:        planV1.ID,
+					},
+					Name: lo.ToPtr("Pro Published"),
+				})
+				require.NoErrorf(t, err, "updating plan must not fail")
+				require.NotNilf(t, updated, "plan must not be nil")
+
+				// then: the update replaced them rather than carrying them over, and the
+				// change is persisted rather than only reflected in the returned value
+				assert.Nilf(t, updated.Description, "omitted description must be cleared")
+				assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
+
+				fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
+					NamespacedID: models.NamespacedID{
+						Namespace: namespace,
+						ID:        planV1.ID,
+					},
+				})
+				require.NoErrorf(t, err, "getting plan by id must not fail")
+				assert.Nilf(t, fetched.Description, "cleared description must be persisted")
+				assert.Emptyf(t, fetched.Metadata, "cleared labels must be persisted")
+
+				planV1 = updated
+			})
+
+			t.Run("UpdateSettlementMode", func(t *testing.T) {
 			newMode := productcatalog.CreditOnlySettlementMode
 
 			planV1, err = env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -514,40 +514,40 @@ func TestPostgresAdapter(t *testing.T) {
 		})
 
 		t.Run("UpdateClearsOmittedFields", func(t *testing.T) {
-				// given: a plan that carries a description and labels
-				require.NotNilf(t, planV1.Description, "plan must have a description to clear")
-				require.NotEmptyf(t, planV1.Metadata, "plan must have labels to clear")
+			// given: a plan that carries a description and labels
+			require.NotNilf(t, planV1.Description, "plan must have a description to clear")
+			require.NotEmptyf(t, planV1.Metadata, "plan must have labels to clear")
 
-				// when: an update arrives that names neither of them
-				updated, err := env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{
-					NamespacedID: models.NamespacedID{
-						Namespace: namespace,
-						ID:        planV1.ID,
-					},
-					Name: lo.ToPtr("Pro Published"),
-				})
-				require.NoErrorf(t, err, "updating plan must not fail")
-				require.NotNilf(t, updated, "plan must not be nil")
-
-				// then: the update replaced them rather than carrying them over, and the
-				// change is persisted rather than only reflected in the returned value
-				assert.Nilf(t, updated.Description, "omitted description must be cleared")
-				assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
-
-				fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
-					NamespacedID: models.NamespacedID{
-						Namespace: namespace,
-						ID:        planV1.ID,
-					},
-				})
-				require.NoErrorf(t, err, "getting plan by id must not fail")
-				assert.Nilf(t, fetched.Description, "cleared description must be persisted")
-				assert.Emptyf(t, fetched.Metadata, "cleared labels must be persisted")
-
-				planV1 = updated
+			// when: an update arrives that names neither of them
+			updated, err := env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{
+				NamespacedID: models.NamespacedID{
+					Namespace: namespace,
+					ID:        planV1.ID,
+				},
+				Name: lo.ToPtr("Pro Published"),
 			})
+			require.NoErrorf(t, err, "updating plan must not fail")
+			require.NotNilf(t, updated, "plan must not be nil")
 
-			t.Run("UpdateSettlementMode", func(t *testing.T) {
+			// then: the update replaced them rather than carrying them over, and the
+			// change is persisted rather than only reflected in the returned value
+			assert.Nilf(t, updated.Description, "omitted description must be cleared")
+			assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
+
+			fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
+				NamespacedID: models.NamespacedID{
+					Namespace: namespace,
+					ID:        planV1.ID,
+				},
+			})
+			require.NoErrorf(t, err, "getting plan by id must not fail")
+			assert.Nilf(t, fetched.Description, "cleared description must be persisted")
+			assert.Emptyf(t, fetched.Metadata, "cleared labels must be persisted")
+
+			planV1 = updated
+		})
+
+		t.Run("UpdateSettlementMode", func(t *testing.T) {
 			newMode := productcatalog.CreditOnlySettlementMode
 
 			planV1, err = env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -529,8 +529,7 @@ func TestPostgresAdapter(t *testing.T) {
 			require.NoErrorf(t, err, "updating plan must not fail")
 			require.NotNilf(t, updated, "plan must not be nil")
 
-			// then: the update replaced them rather than carrying them over, and the
-			// change is persisted rather than only reflected in the returned value
+			// then: both are cleared, in the returned plan and in storage
 			assert.Nilf(t, updated.Description, "omitted description must be cleared")
 			assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
 

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -464,10 +464,6 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 		}
 
 		if !params.Equal(*p) {
-			// The schedule, billing cadence, pro-rating config, and settlement mode are
-			// outside the v3 update request body -- the schedule is moved by
-			// UpdatePlanEffectivePeriod -- so they stay SetNillable and survive an update
-			// that omits them. Description and metadata are inside it, so nil clears them.
 			query := a.db.Plan.UpdateOneID(p.ID).
 				Where(plandb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
@@ -539,9 +535,6 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 	return entutils.TransactingRepo[*plan.Plan, *adapter](ctx, a, fn)
 }
 
-// UpdatePlanEffectivePeriod exists because UpdatePlan is a replace: routing the publish
-// and archive flows through UpdatePlan would clear the description and labels they do
-// not carry.
 func (a *adapter) UpdatePlanEffectivePeriod(ctx context.Context, params plan.UpdatePlanEffectivePeriodInput) (*plan.Plan, error) {
 	fn := func(ctx context.Context, a *adapter) (*plan.Plan, error) {
 		if err := params.Validate(); err != nil {

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -464,9 +464,10 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 		}
 
 		if !params.Equal(*p) {
-			// The SetNillable fields below are outside the update request body -- the schedule
-			// is moved by UpdatePlanEffectivePeriod, and billing cadence and settlement mode
-			// are absent from the v3 body -- so they must survive an update that omits them.
+			// The schedule, billing cadence, pro-rating config, and settlement mode are
+			// outside the v3 update request body -- the schedule is moved by
+			// UpdatePlanEffectivePeriod -- so they stay SetNillable and survive an update
+			// that omits them. Description and metadata are inside it, so nil clears them.
 			query := a.db.Plan.UpdateOneID(p.ID).
 				Where(plandb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
@@ -538,8 +539,8 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 	return entutils.TransactingRepo[*plan.Plan, *adapter](ctx, a, fn)
 }
 
-// UpdatePlanEffectivePeriod exists because UpdatePlan is a full replace: routing the publish
-// and archive flows through UpdatePlan would clear the name, description and labels they do
+// UpdatePlanEffectivePeriod exists because UpdatePlan is a replace: routing the publish
+// and archive flows through UpdatePlan would clear the description and labels they do
 // not carry.
 func (a *adapter) UpdatePlanEffectivePeriod(ctx context.Context, params plan.UpdatePlanEffectivePeriodInput) (*plan.Plan, error) {
 	fn := func(ctx context.Context, a *adapter) (*plan.Plan, error) {

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -464,19 +464,19 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 		}
 
 		if !params.Equal(*p) {
+			// The SetNillable fields below are outside the update request body -- the schedule
+			// is moved by UpdatePlanEffectivePeriod, and billing cadence and settlement mode
+			// are absent from the v3 body -- so they must survive an update that omits them.
 			query := a.db.Plan.UpdateOneID(p.ID).
 				Where(plandb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
-				SetNillableDescription(params.Description).
+				SetOrClearDescription(params.Description).
+				SetOrClearMetadata((*map[string]string)(params.Metadata)).
 				SetNillableEffectiveFrom(params.EffectiveFrom).
 				SetNillableEffectiveTo(params.EffectiveTo).
 				SetNillableBillingCadence(params.BillingCadence.ISOStringPtrOrNil()).
 				SetNillableProRatingConfig(params.ProRatingConfig).
 				SetNillableSettlementMode(params.SettlementMode)
-
-			if params.Metadata != nil {
-				query = query.SetMetadata(*params.Metadata)
-			}
 
 			err = query.Exec(ctx)
 			if err != nil {
@@ -531,6 +531,47 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 			phases[idx] = *planPhase
 		}
 		p.Phases = phases
+
+		return p, nil
+	}
+
+	return entutils.TransactingRepo[*plan.Plan, *adapter](ctx, a, fn)
+}
+
+// UpdatePlanEffectivePeriod exists because UpdatePlan is a full replace: routing the publish
+// and archive flows through UpdatePlan would clear the name, description and labels they do
+// not carry.
+func (a *adapter) UpdatePlanEffectivePeriod(ctx context.Context, params plan.UpdatePlanEffectivePeriodInput) (*plan.Plan, error) {
+	fn := func(ctx context.Context, a *adapter) (*plan.Plan, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid update Plan effective period parameters: %w", err)
+		}
+
+		err := a.db.Plan.UpdateOneID(params.ID).
+			Where(plandb.Namespace(params.Namespace)).
+			SetNillableEffectiveFrom(params.EffectiveFrom).
+			SetNillableEffectiveTo(params.EffectiveTo).
+			Exec(ctx)
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, plan.NewNotFoundError(plan.NotFoundErrorParams{
+					Namespace: params.Namespace,
+					ID:        params.ID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to update Plan effective period: %w", err)
+		}
+
+		p, err := a.GetPlan(ctx, plan.GetPlanInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        params.ID,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get updated Plan: %w", err)
+		}
 
 		return p, nil
 	}

--- a/openmeter/productcatalog/plan/repository.go
+++ b/openmeter/productcatalog/plan/repository.go
@@ -16,4 +16,5 @@ type Repository interface {
 	DeletePlan(ctx context.Context, params DeletePlanInput) error
 	GetPlan(ctx context.Context, params GetPlanInput) (*Plan, error)
 	UpdatePlan(ctx context.Context, params UpdatePlanInput) (*Plan, error)
+	UpdatePlanEffectivePeriod(ctx context.Context, params UpdatePlanEffectivePeriodInput) (*Plan, error)
 }

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -411,11 +411,10 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 
 var _ models.Validator = (*UpdatePlanEffectivePeriodInput)(nil)
 
-// UpdatePlanEffectivePeriodInput is deliberately separate from UpdatePlanInput, which carries
-// the complete replacement state of a PUT and clears every field the caller omitted. Publishing
-// and archiving shift only the schedule, so reusing UpdatePlanInput for them would wipe the
-// plan's name, description and labels. Each boundary is updated independently, so a publish can
-// set only EffectiveFrom.
+// UpdatePlanEffectivePeriodInput is deliberately separate from UpdatePlanInput, whose PUT
+// replace semantics clear an omitted description and metadata. Publishing and archiving
+// shift only the schedule, so reusing UpdatePlanInput for them would wipe those fields.
+// Each boundary is updated independently, so a publish can set only EffectiveFrom.
 type UpdatePlanEffectivePeriodInput struct {
 	models.NamespacedID
 

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -249,9 +249,10 @@ func (i UpdatePlanInput) Equal(p Plan) bool {
 		return false
 	}
 
-	// Compared unguarded, unlike the fields above: nil means the update omitted them and they
-	// are about to be cleared, so nil only equals an already-empty stored value.
-	if lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
+	// Compared presence-aware, unlike the guarded fields above: nil means the update omitted
+	// the description and is about to clear it, so nil only equals an already-absent stored
+	// value -- an explicitly empty stored description still needs the clearing write.
+	if (i.Description == nil) != (p.Description == nil) || lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -249,9 +249,6 @@ func (i UpdatePlanInput) Equal(p Plan) bool {
 		return false
 	}
 
-	// Compared presence-aware, unlike the guarded fields above: nil means the update omitted
-	// the description and is about to clear it, so nil only equals an already-absent stored
-	// value -- an explicitly empty stored description still needs the clearing write.
 	if (i.Description == nil) != (p.Description == nil) || lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
@@ -386,8 +383,6 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 		p.Name = *i.Name
 	}
 
-	// Assigned unguarded, unlike the fields below: the adapter clears these when the update
-	// omits them, so validation has to see the cleared state rather than the stored one.
 	p.Description = i.Description
 	p.Metadata = lo.FromPtr(i.Metadata)
 
@@ -412,10 +407,8 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 
 var _ models.Validator = (*UpdatePlanEffectivePeriodInput)(nil)
 
-// UpdatePlanEffectivePeriodInput is deliberately separate from UpdatePlanInput, whose PUT
-// replace semantics clear an omitted description and metadata. Publishing and archiving
-// shift only the schedule, so reusing UpdatePlanInput for them would wipe those fields.
-// Each boundary is updated independently, so a publish can set only EffectiveFrom.
+// UpdatePlanEffectivePeriodInput moves only the plan's schedule; a nil boundary is left
+// untouched rather than cleared, so a publish can set EffectiveFrom alone.
 type UpdatePlanEffectivePeriodInput struct {
 	models.NamespacedID
 

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -249,11 +249,13 @@ func (i UpdatePlanInput) Equal(p Plan) bool {
 		return false
 	}
 
-	if i.Description != nil && lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
+	// Compared unguarded, unlike the fields above: nil means the update omitted them and they
+	// are about to be cleared, so nil only equals an already-empty stored value.
+	if lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 
-	if i.Metadata != nil && !i.Metadata.Equal(p.Metadata) {
+	if !lo.FromPtr(i.Metadata).Equal(p.Metadata) {
 		return false
 	}
 
@@ -383,13 +385,10 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 		p.Name = *i.Name
 	}
 
-	if i.Description != nil {
-		p.Description = i.Description
-	}
-
-	if i.Metadata != nil {
-		p.Metadata = *i.Metadata
-	}
+	// Assigned unguarded, unlike the fields below: the adapter clears these when the update
+	// omits them, so validation has to see the cleared state rather than the stored one.
+	p.Description = i.Description
+	p.Metadata = lo.FromPtr(i.Metadata)
 
 	if i.BillingCadence != nil {
 		p.BillingCadence = *i.BillingCadence
@@ -408,6 +407,39 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 	}
 
 	return p
+}
+
+var _ models.Validator = (*UpdatePlanEffectivePeriodInput)(nil)
+
+// UpdatePlanEffectivePeriodInput is deliberately separate from UpdatePlanInput, which carries
+// the complete replacement state of a PUT and clears every field the caller omitted. Publishing
+// and archiving shift only the schedule, so reusing UpdatePlanInput for them would wipe the
+// plan's name, description and labels. Each boundary is updated independently, so a publish can
+// set only EffectiveFrom.
+type UpdatePlanEffectivePeriodInput struct {
+	models.NamespacedID
+
+	productcatalog.EffectivePeriod
+}
+
+func (i UpdatePlanEffectivePeriodInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, productcatalog.ErrNamespaceEmpty)
+	}
+
+	if i.ID == "" {
+		errs = append(errs, productcatalog.ErrIDEmpty)
+	}
+
+	if i.EffectiveFrom != nil || i.EffectiveTo != nil {
+		if err := i.EffectivePeriod.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid effective period: %w", err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 // ExpandFields defines which fields to expand when returning the Plan.

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -573,7 +573,7 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 			}
 		}
 
-		input := plan.UpdatePlanInput{
+		input := plan.UpdatePlanEffectivePeriodInput{
 			NamespacedID: params.NamespacedID,
 		}
 
@@ -585,7 +585,7 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 			input.EffectiveTo = lo.ToPtr(params.EffectiveTo.UTC())
 		}
 
-		p, err = s.adapter.UpdatePlan(ctx, input)
+		p, err = s.adapter.UpdatePlanEffectivePeriod(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to publish Plan: %w", err)
 		}
@@ -657,7 +657,7 @@ func (s service) ArchivePlan(ctx context.Context, params plan.ArchivePlanInput) 
 		// In other words, modify the surrounding Plans only if the user is allowed it otherwise return a validation error
 		// in case the lifecycle of the Plan is not continuous (there are time gaps between versions).
 
-		p, err = s.adapter.UpdatePlan(ctx, plan.UpdatePlanInput{
+		p, err = s.adapter.UpdatePlanEffectivePeriod(ctx, plan.UpdatePlanEffectivePeriodInput{
 			NamespacedID: models.NamespacedID{
 				Namespace: p.Namespace,
 				ID:        p.ID,

--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -548,11 +548,17 @@ func TestPlanService(t *testing.T) {
 				})
 
 				t.Run("Delete", func(t *testing.T) {
+					// UpdatePlanInput is the plan's full replacement state, so the fields that
+					// should survive have to be carried over explicitly; anything left out is
+					// cleared.
 					updateInput = plan.UpdatePlanInput{
 						NamespacedID: models.NamespacedID{
 							Namespace: planInput.Namespace,
 							ID:        draftPlanV1.ID,
 						},
+						Name:        lo.ToPtr(draftPlanV1.Name),
+						Description: draftPlanV1.Description,
+						Metadata:    lo.ToPtr(draftPlanV1.Metadata),
 						Phases: lo.ToPtr(lo.Map(draftPlanV1.Phases, func(p plan.Phase, _ int) productcatalog.Phase {
 							return productcatalog.Phase{
 								PhaseMeta: p.PhaseMeta,
@@ -593,6 +599,12 @@ func TestPlanService(t *testing.T) {
 
 				assert.Equalf(t, productcatalog.PlanStatusActive, publishedPlanV1.Status(),
 					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusActive, publishedPlanV1.Status())
+
+				// Publishing only moves the plan's schedule. It must not ride the replace
+				// update path, which would clear every field the publish input does not repeat.
+				assert.Equalf(t, draftPlanV1.Name, publishedPlanV1.Name, "publishing must preserve the name")
+				assert.Equalf(t, draftPlanV1.Description, publishedPlanV1.Description, "publishing must preserve the description")
+				assert.Equalf(t, draftPlanV1.Metadata, publishedPlanV1.Metadata, "publishing must preserve the labels")
 
 				t.Run("Update", func(t *testing.T) {
 					updateInput := plan.UpdatePlanInput{

--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -548,9 +548,6 @@ func TestPlanService(t *testing.T) {
 				})
 
 				t.Run("Delete", func(t *testing.T) {
-					// UpdatePlanInput is the plan's full replacement state, so the fields that
-					// should survive have to be carried over explicitly; anything left out is
-					// cleared.
 					updateInput = plan.UpdatePlanInput{
 						NamespacedID: models.NamespacedID{
 							Namespace: planInput.Namespace,
@@ -600,8 +597,6 @@ func TestPlanService(t *testing.T) {
 				assert.Equalf(t, productcatalog.PlanStatusActive, publishedPlanV1.Status(),
 					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusActive, publishedPlanV1.Status())
 
-				// Publishing only moves the plan's schedule. It must not ride the replace
-				// update path, which would clear every field the publish input does not repeat.
 				assert.Equalf(t, draftPlanV1.Name, publishedPlanV1.Name, "publishing must preserve the name")
 				assert.Equalf(t, draftPlanV1.Description, publishedPlanV1.Description, "publishing must preserve the description")
 				assert.Equalf(t, draftPlanV1.Metadata, publishedPlanV1.Metadata, "publishing must preserve the labels")

--- a/openmeter/productcatalog/plan/service_test.go
+++ b/openmeter/productcatalog/plan/service_test.go
@@ -80,6 +80,8 @@ func TestUpdatePlanInputEqualDescriptionPresence(t *testing.T) {
 		{name: "omitted equals absent", input: nil, stored: nil, expectEqual: true},
 		{name: "omitted must clear a stored value", input: nil, stored: lo.ToPtr("desc"), expectEqual: false},
 		{name: "omitted must clear a stored empty string", input: nil, stored: lo.ToPtr(""), expectEqual: false},
+		{name: "explicit empty differs from absent", input: lo.ToPtr(""), stored: nil, expectEqual: false},
+		{name: "explicit empty matches stored empty string", input: lo.ToPtr(""), stored: lo.ToPtr(""), expectEqual: true},
 		{name: "matching values are equal", input: lo.ToPtr("desc"), stored: lo.ToPtr("desc"), expectEqual: true},
 		{name: "differing values are not equal", input: lo.ToPtr("new"), stored: lo.ToPtr("old"), expectEqual: false},
 	}

--- a/openmeter/productcatalog/plan/service_test.go
+++ b/openmeter/productcatalog/plan/service_test.go
@@ -69,3 +69,29 @@ func TestUpdatePlanInputValidateWithPlanRejectsUnitConfig(t *testing.T) {
 		assert.False(t, rejectedForUnitConfig(in.ValidateWithPlan(planWith(card(nil)))))
 	})
 }
+
+func TestUpdatePlanInputEqualDescriptionPresence(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       *string
+		stored      *string
+		expectEqual bool
+	}{
+		{name: "omitted equals absent", input: nil, stored: nil, expectEqual: true},
+		{name: "omitted must clear a stored value", input: nil, stored: lo.ToPtr("desc"), expectEqual: false},
+		{name: "omitted must clear a stored empty string", input: nil, stored: lo.ToPtr(""), expectEqual: false},
+		{name: "matching values are equal", input: lo.ToPtr("desc"), stored: lo.ToPtr("desc"), expectEqual: true},
+		{name: "differing values are not equal", input: lo.ToPtr("new"), stored: lo.ToPtr("old"), expectEqual: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Plan{}
+			p.Description = tc.stored
+
+			i := UpdatePlanInput{Description: tc.input}
+
+			assert.Equal(t, tc.expectEqual, i.Equal(p))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`PUT /openmeter/plans/{planId}` merged instead of replacing. Two independent causes, one per layer:

- **Labels** — `FromAPIUpsertPlanRequest` only populated `Metadata` when `body.Labels != nil`, and `plan.UpdatePlanInput.Metadata` is a pointer where nil means "leave unchanged". Omitting `labels` kept the stored labels.
- **Description** — the adapter used Ent's `SetNillableDescription`, where nil is a no-op. Omitting `description` kept the stored description.

The result was that two clients doing the same read-modify-write got different results depending on which fields they happened to send. Worth noting `PUT /addons/{addonId}` already *did* clear labels on omission, so the two sibling endpoints disagreed.

The fix spans both layers:

- **v3 boundary** builds the complete target state — always hand the service a metadata value, empty included.
- **Adapter** switches description and metadata to the generated `SetOrClear` helpers.
- **`Equal()` and `applyTo()`** now compare and project an omitted field against the stored value, so a legitimate clear is neither skipped by the no-op short-circuit nor validated against the pre-update state.

## Notes for reviewer

**The publish/archive split is the load-bearing part of this PR.** `PublishPlan` and `ArchivePlan` called `adapter.UpdatePlan` with nothing but an effective period, relying on nil-means-unchanged for everything else. Flipping the adapter to `SetOrClear` in place would have wiped every plan's name, description and labels on publish. They now go through a new `UpdatePlanEffectivePeriod` adapter method that touches only the two schedule columns, with a regression test asserting content survives a publish.

**This affects v1 as well.** `PUT /api/v1/plans/{planId}` shares this adapter, and its request model is already named `PlanReplaceUpdate` — so this aligns v1 with its own documented intent rather than changing it against it. Not a v3-only change; please read it as both.

Fields deliberately left on `SetNillable` because they are outside the v3 update surface: `billing_cadence` and `settlement_mode` (absent from `UpsertPlanRequest`) and the effective period (moved by the new method).

One existing test changed behaviour rather than being adjusted to pass: `TestPlanService/Plan/Create/NewPhase/Delete` updated only `Phases` and asserted everything else survived. Under the new contract the caller must send the full state, so the input now carries name, description and labels explicitly.

Tests: `go test ./openmeter/productcatalog/plan/... ./api/v3/handlers/plans/` against Postgres, plus a new adapter test that creates a plan with a description and labels, updates without them, and asserts both are gone *and persisted*. E2E `TestV3PlanUpdateClearsOmittedFields` covers the same over HTTP (compiles and vets; not run here — needs a live server).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a plan without optional fields now clears its existing description, labels, and metadata.
  * Plan publishing and archiving preserve existing plan details while changing scheduling state.
  * Effective-period updates now validate inputs and report missing plans correctly.
  * Cleared plan details remain absent after saving and retrieving the plan.
  * Plan responses now include labels converted from metadata.
* **Tests**
  * Added coverage for clearing omitted fields and preserving plan details during publishing and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









## Update (review round 1)

- **Labels were invisible on the read path**: `ToAPIBillingPlan` never populated `labels`, so a plan created with labels answered with none and the e2e test could not observe the clear. The mapping now surfaces stored metadata as labels. (Phase and rate-card read mappings have the same pre-existing gap; left out of scope here.)
- **`Equal` is now presence-aware for description**: an omitted description no longer short-circuits against a stored empty string, so the clearing write always runs; pinned by `TestUpdatePlanInputEqualDescriptionPresence`.
- gofmt'd the adapter regression test (the gci lint failure) and corrected the replacement-semantics comments flagged in review.
- E2E `TestV3PlanUpdateClearsOmittedFields` plus every `TestV3Plan*` test now verified against a live local stack built from this branch.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes plan PUT operations to replace omitted description and label fields while preserving plan content during publish and archive transitions.
- Maps stored plan metadata into v3 response labels.
- Applies clear-on-omission semantics consistently during plan replacement.
- Introduces an effective-period-only repository update for publishing and archiving.
- Adds adapter, service, conversion, and end-to-end regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/plans/convert.go | Converts omitted labels into empty replacement metadata and exposes stored plan metadata as v3 labels. |
| openmeter/productcatalog/plan/adapter/plan.go | Implements clear-on-omission persistence and separates effective-period-only lifecycle updates. |
| openmeter/productcatalog/plan/service.go | Aligns equality checks and validation projections with replacement semantics. |
| openmeter/productcatalog/plan/service/plan.go | Routes publishing and archiving through the schedule-only repository operation. |
| e2e/plans_v3_test.go | Verifies omitted descriptions and labels are cleared and remain absent after retrieval. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Plan API
    participant Service as Plan Service
    participant Repo as Plan Repository
    participant DB

    Client->>API: "PUT /plans/{planId}"
    API->>Service: UpdatePlan(full target state)
    Service->>Repo: UpdatePlan
    Repo->>DB: Set or clear description and metadata
    DB-->>Client: Replaced plan

    Client->>Service: Publish or archive plan
    Service->>Repo: UpdatePlanEffectivePeriod
    Repo->>DB: Update schedule columns only
    DB-->>Client: Plan content preserved
```
</details>

<sub>Reviews (7): Last reviewed commit: ["Update openmeter/productcatalog/plan/ser..."](https://github.com/openmeterio/openmeter/commit/7c16c39de5e93cc2bdab3a70277912fe91d3254c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874602)</sub>

<!-- /greptile_comment -->