### PR TITLE
fix(productcatalog): make PUT /addons/{addonId} replace omitted fields

### DIFF
--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -532,3 +532,18 @@ func TestUnitConfigMapping(t *testing.T) {
 		assert.Equal(t, lo.ToPtr("GB"), uc.DisplayUnit)
 	})
 }
+
+func TestFromAPIUpsertAddonRequestOmittedFields(t *testing.T) {
+	body := apiv3.UpsertAddonRequest{
+		Name:         "Addon",
+		InstanceType: apiv3.AddonInstanceTypeMultiple,
+		RateCards:    []apiv3.BillingRateCard{},
+	}
+
+	result, err := FromAPIUpsertAddonRequest("ns", "id", body)
+	require.NoError(t, err)
+
+	assert.Nil(t, result.Description)
+	require.NotNil(t, result.Metadata)
+	assert.Empty(t, *result.Metadata)
+}

--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -394,3 +394,35 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 		})
 	}
 }
+
+func TestV3AddonUpdateClearsOmittedFields(t *testing.T) {
+	c := newV3Client(t)
+
+	createBody := validAddonRequest("test_v3_addon_replace")
+	createBody.Description = lo.ToPtr("Original description")
+	createBody.Labels = &map[string]string{"env": "prod"}
+
+	created, err := c.Addons.Create(t.Context(), createBody)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, created)
+	require.NotNil(t, created.Description)
+	require.NotEmpty(t, created.Labels)
+
+	updated, err := c.Addons.Update(t.Context(), created.ID, v3sdk.UpsertAddonRequest{
+		Name:         createBody.Name,
+		InstanceType: createBody.InstanceType,
+		RateCards:    createBody.RateCards,
+	})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, updated)
+
+	assert.Nil(t, updated.Description, "omitted description must be cleared, not carried over")
+	assert.Empty(t, updated.Labels, "omitted labels must be cleared, not carried over")
+
+	fetched, err := c.Addons.Get(t.Context(), created.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, fetched)
+
+	assert.Nil(t, fetched.Description)
+	assert.Empty(t, fetched.Labels)
+}

--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -303,6 +303,36 @@ func TestPostgresAdapter(t *testing.T) {
 				addon.AssertAddonUpdateInputEqual(t, addonV1Update, *addonV1)
 			})
 
+			t.Run("UpdateClearsOmittedFields", func(t *testing.T) {
+				require.NotNilf(t, addonV1.Description, "add-on must have a description to clear")
+				require.NotEmptyf(t, addonV1.Metadata, "add-on must have labels to clear")
+
+				updated, err := env.AddonRepository.UpdateAddon(ctx, addon.UpdateAddonInput{
+					NamespacedID: models.NamespacedID{
+						Namespace: namespace,
+						ID:        addonV1.ID,
+					},
+					Name: lo.ToPtr("Addon v1 Published"),
+				})
+				require.NoErrorf(t, err, "updating add-on must not fail")
+				require.NotNilf(t, updated, "add-on must not be nil")
+
+				assert.Nilf(t, updated.Description, "omitted description must be cleared")
+				assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
+
+				fetched, err := env.AddonRepository.GetAddon(ctx, addon.GetAddonInput{
+					NamespacedID: models.NamespacedID{
+						Namespace: namespace,
+						ID:        addonV1.ID,
+					},
+				})
+				require.NoErrorf(t, err, "getting add-on by id must not fail")
+				assert.Nilf(t, fetched.Description, "cleared description must be persisted")
+				assert.Emptyf(t, fetched.Metadata, "cleared labels must be persisted")
+
+				addonV1 = updated
+			})
+
 			t.Run("Delete", func(t *testing.T) {
 				err = env.AddonRepository.DeleteAddon(ctx, addon.DeleteAddonInput{
 					NamespacedID: models.NamespacedID{

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -491,16 +491,16 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 		}
 
 		if !params.Equal(*add) {
+			// The effective period is outside the update request body -- it is moved by
+			// UpdateAddonEffectivePeriod -- and annotations are server-managed, so both must
+			// survive an update that omits them.
 			query := a.db.Addon.UpdateOneID(add.ID).
 				Where(addondb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
-				SetNillableDescription(params.Description).
+				SetOrClearDescription(params.Description).
+				SetOrClearMetadata((*map[string]string)(params.Metadata)).
 				SetNillableEffectiveFrom(params.EffectiveFrom).
 				SetNillableEffectiveTo(params.EffectiveTo)
-
-			if params.Metadata != nil {
-				query = query.SetMetadata(*params.Metadata)
-			}
 
 			if params.Annotations != nil {
 				query = query.SetAnnotations(*params.Annotations)
@@ -575,6 +575,47 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 		add, err = FromAddonRow(*addonRow)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cast updated add-on [namespace=%s id:%s]: %w", params.Namespace, addonRow.ID, err)
+		}
+
+		return add, nil
+	}
+
+	return entutils.TransactingRepo[*addon.Addon, *adapter](ctx, a, fn)
+}
+
+// UpdateAddonEffectivePeriod exists because UpdateAddon is a full replace: routing the publish
+// and archive flows through UpdateAddon would clear the name, description and labels they do
+// not carry.
+func (a *adapter) UpdateAddonEffectivePeriod(ctx context.Context, params addon.UpdateAddonEffectivePeriodInput) (*addon.Addon, error) {
+	fn := func(ctx context.Context, a *adapter) (*addon.Addon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid update add-on effective period parameters: %w", err)
+		}
+
+		err := a.db.Addon.UpdateOneID(params.ID).
+			Where(addondb.Namespace(params.Namespace)).
+			SetNillableEffectiveFrom(params.EffectiveFrom).
+			SetNillableEffectiveTo(params.EffectiveTo).
+			Exec(ctx)
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, addon.NewNotFoundError(addon.NotFoundErrorParams{
+					Namespace: params.Namespace,
+					ID:        params.ID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to update add-on effective period: %w", err)
+		}
+
+		add, err := a.GetAddon(ctx, addon.GetAddonInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        params.ID,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get updated add-on: %w", err)
 		}
 
 		return add, nil

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -491,9 +491,6 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 		}
 
 		if !params.Equal(*add) {
-			// The effective period is outside the update request body -- it is moved by
-			// UpdateAddonEffectivePeriod -- and annotations are server-managed, so both must
-			// survive an update that omits them.
 			query := a.db.Addon.UpdateOneID(add.ID).
 				Where(addondb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
@@ -583,9 +580,6 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 	return entutils.TransactingRepo[*addon.Addon, *adapter](ctx, a, fn)
 }
 
-// UpdateAddonEffectivePeriod exists because UpdateAddon is a replace: routing the publish
-// and archive flows through UpdateAddon would clear the description and labels they do
-// not carry.
 func (a *adapter) UpdateAddonEffectivePeriod(ctx context.Context, params addon.UpdateAddonEffectivePeriodInput) (*addon.Addon, error) {
 	fn := func(ctx context.Context, a *adapter) (*addon.Addon, error) {
 		if err := params.Validate(); err != nil {

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -583,8 +583,8 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 	return entutils.TransactingRepo[*addon.Addon, *adapter](ctx, a, fn)
 }
 
-// UpdateAddonEffectivePeriod exists because UpdateAddon is a full replace: routing the publish
-// and archive flows through UpdateAddon would clear the name, description and labels they do
+// UpdateAddonEffectivePeriod exists because UpdateAddon is a replace: routing the publish
+// and archive flows through UpdateAddon would clear the description and labels they do
 // not carry.
 func (a *adapter) UpdateAddonEffectivePeriod(ctx context.Context, params addon.UpdateAddonEffectivePeriodInput) (*addon.Addon, error) {
 	fn := func(ctx context.Context, a *adapter) (*addon.Addon, error) {

--- a/openmeter/productcatalog/addon/repository.go
+++ b/openmeter/productcatalog/addon/repository.go
@@ -17,4 +17,5 @@ type Repository interface {
 	DeleteAddon(ctx context.Context, params DeleteAddonInput) error
 	GetAddon(ctx context.Context, params GetAddonInput) (*Addon, error)
 	UpdateAddon(ctx context.Context, params UpdateAddonInput) (*Addon, error)
+	UpdateAddonEffectivePeriod(ctx context.Context, params UpdateAddonEffectivePeriodInput) (*Addon, error)
 }

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -246,9 +246,6 @@ func (i UpdateAddonInput) Equal(p Addon) bool {
 		return false
 	}
 
-	// Compared presence-aware, unlike the guarded fields above: nil means the update omitted
-	// the description and is about to clear it, so nil only equals an already-absent stored
-	// value -- an explicitly empty stored description still needs the clearing write.
 	if (i.Description == nil) != (p.Description == nil) || lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
@@ -345,8 +342,6 @@ func (i UpdateAddonInput) applyTo(a productcatalog.Addon) productcatalog.Addon {
 		a.Name = *i.Name
 	}
 
-	// Assigned unguarded, unlike the fields below: the adapter clears these when the update
-	// omits them, so validation has to see the cleared state rather than the stored one.
 	a.Description = i.Description
 	a.Metadata = lo.FromPtr(i.Metadata)
 
@@ -367,10 +362,8 @@ func (i UpdateAddonInput) applyTo(a productcatalog.Addon) productcatalog.Addon {
 
 var _ models.Validator = (*UpdateAddonEffectivePeriodInput)(nil)
 
-// UpdateAddonEffectivePeriodInput is deliberately separate from UpdateAddonInput, whose PUT
-// replace semantics clear an omitted description and metadata. Publishing and archiving
-// shift only the schedule, so reusing UpdateAddonInput for them would wipe those fields.
-// Each boundary is updated independently, so a publish can set only EffectiveFrom.
+// UpdateAddonEffectivePeriodInput moves only the add-on's schedule; a nil boundary is left
+// untouched rather than cleared, so a publish can set EffectiveFrom alone.
 type UpdateAddonEffectivePeriodInput struct {
 	models.NamespacedID
 

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -366,11 +366,10 @@ func (i UpdateAddonInput) applyTo(a productcatalog.Addon) productcatalog.Addon {
 
 var _ models.Validator = (*UpdateAddonEffectivePeriodInput)(nil)
 
-// UpdateAddonEffectivePeriodInput is deliberately separate from UpdateAddonInput, which
-// carries the complete replacement state of a PUT and clears every field the caller omitted.
-// Publishing and archiving shift only the schedule, so reusing UpdateAddonInput for them would
-// wipe the add-on's name, description and labels. Each boundary is updated independently, so a
-// publish can set only EffectiveFrom.
+// UpdateAddonEffectivePeriodInput is deliberately separate from UpdateAddonInput, whose PUT
+// replace semantics clear an omitted description and metadata. Publishing and archiving
+// shift only the schedule, so reusing UpdateAddonInput for them would wipe those fields.
+// Each boundary is updated independently, so a publish can set only EffectiveFrom.
 type UpdateAddonEffectivePeriodInput struct {
 	models.NamespacedID
 

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -246,9 +246,10 @@ func (i UpdateAddonInput) Equal(p Addon) bool {
 		return false
 	}
 
-	// Compared unguarded, unlike the fields above: nil means the update omitted them and they
-	// are about to be cleared, so nil only equals an already-empty stored value.
-	if lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
+	// Compared presence-aware, unlike the guarded fields above: nil means the update omitted
+	// the description and is about to clear it, so nil only equals an already-absent stored
+	// value -- an explicitly empty stored description still needs the clearing write.
+	if (i.Description == nil) != (p.Description == nil) || lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -246,11 +246,13 @@ func (i UpdateAddonInput) Equal(p Addon) bool {
 		return false
 	}
 
-	if i.Description != nil && lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
+	// Compared unguarded, unlike the fields above: nil means the update omitted them and they
+	// are about to be cleared, so nil only equals an already-empty stored value.
+	if lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 
-	if i.Metadata != nil && !i.Metadata.Equal(p.Metadata) {
+	if !lo.FromPtr(i.Metadata).Equal(p.Metadata) {
 		return false
 	}
 
@@ -342,13 +344,10 @@ func (i UpdateAddonInput) applyTo(a productcatalog.Addon) productcatalog.Addon {
 		a.Name = *i.Name
 	}
 
-	if i.Description != nil {
-		a.Description = i.Description
-	}
-
-	if i.Metadata != nil {
-		a.Metadata = *i.Metadata
-	}
+	// Assigned unguarded, unlike the fields below: the adapter clears these when the update
+	// omits them, so validation has to see the cleared state rather than the stored one.
+	a.Description = i.Description
+	a.Metadata = lo.FromPtr(i.Metadata)
 
 	if i.Annotations != nil {
 		a.Annotations = *i.Annotations
@@ -363,6 +362,39 @@ func (i UpdateAddonInput) applyTo(a productcatalog.Addon) productcatalog.Addon {
 	}
 
 	return a
+}
+
+var _ models.Validator = (*UpdateAddonEffectivePeriodInput)(nil)
+
+// UpdateAddonEffectivePeriodInput is deliberately separate from UpdateAddonInput, which
+// carries the complete replacement state of a PUT and clears every field the caller omitted.
+// Publishing and archiving shift only the schedule, so reusing UpdateAddonInput for them would
+// wipe the add-on's name, description and labels. Each boundary is updated independently, so a
+// publish can set only EffectiveFrom.
+type UpdateAddonEffectivePeriodInput struct {
+	models.NamespacedID
+
+	productcatalog.EffectivePeriod
+}
+
+func (i UpdateAddonEffectivePeriodInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, productcatalog.ErrNamespaceEmpty)
+	}
+
+	if i.ID == "" {
+		errs = append(errs, productcatalog.ErrIDEmpty)
+	}
+
+	if i.EffectiveFrom != nil || i.EffectiveTo != nil {
+		if err := i.EffectivePeriod.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid EffectivePeriod: %w", err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type ExpandFields struct {

--- a/openmeter/productcatalog/addon/service/addon.go
+++ b/openmeter/productcatalog/addon/service/addon.go
@@ -553,7 +553,7 @@ func (s service) PublishAddon(ctx context.Context, params addon.PublishAddonInpu
 
 		// Publish new add-on version
 
-		input := addon.UpdateAddonInput{
+		input := addon.UpdateAddonEffectivePeriodInput{
 			NamespacedID: params.NamespacedID,
 		}
 
@@ -565,7 +565,7 @@ func (s service) PublishAddon(ctx context.Context, params addon.PublishAddonInpu
 			input.EffectiveTo = lo.ToPtr(params.EffectiveTo.UTC())
 		}
 
-		add, err = s.adapter.UpdateAddon(ctx, input)
+		add, err = s.adapter.UpdateAddonEffectivePeriod(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to publish add-on: %w", err)
 		}
@@ -633,7 +633,7 @@ func (s service) ArchiveAddon(ctx context.Context, params addon.ArchiveAddonInpu
 			return nil, err
 		}
 
-		add, err = s.adapter.UpdateAddon(ctx, addon.UpdateAddonInput{
+		add, err = s.adapter.UpdateAddonEffectivePeriod(ctx, addon.UpdateAddonEffectivePeriodInput{
 			NamespacedID: models.NamespacedID{
 				Namespace: add.Namespace,
 				ID:        add.ID,

--- a/openmeter/productcatalog/addon/service/service_test.go
+++ b/openmeter/productcatalog/addon/service/service_test.go
@@ -218,8 +218,14 @@ func TestAddonService(t *testing.T) {
 			})
 
 			t.Run("Update", func(t *testing.T) {
+				// UpdateAddonInput is the add-on's full replacement state, so the fields that
+				// should survive have to be carried over explicitly; anything left out is
+				// cleared.
 				updateInput := addon.UpdateAddonInput{
 					NamespacedID: addonV1.NamespacedID,
+					Name:         lo.ToPtr(addonV1.Name),
+					Description:  addonV1.Description,
+					Metadata:     lo.ToPtr(addonV1.Metadata),
 					RateCards: &productcatalog.RateCards{
 						&productcatalog.FlatFeeRateCard{
 							RateCardMeta: productcatalog.RateCardMeta{
@@ -323,6 +329,12 @@ func TestAddonService(t *testing.T) {
 
 				assert.Equalf(t, productcatalog.AddonStatusActive, publishedAddonV1.Status(),
 					"add-on Status mismatch: expected=%s, actual=%s", productcatalog.AddonStatusActive, publishedAddonV1.Status())
+
+				// Publishing only moves the add-on's schedule. It must not ride the replace
+				// update path, which would clear every field the publish input does not repeat.
+				assert.Equalf(t, addonV1.Name, publishedAddonV1.Name, "publishing must preserve the name")
+				assert.Equalf(t, addonV1.Description, publishedAddonV1.Description, "publishing must preserve the description")
+				assert.Equalf(t, addonV1.Metadata, publishedAddonV1.Metadata, "publishing must preserve the labels")
 
 				t.Run("Update", func(t *testing.T) {
 					updateInput := addon.UpdateAddonInput{

--- a/openmeter/productcatalog/addon/service/service_test.go
+++ b/openmeter/productcatalog/addon/service/service_test.go
@@ -218,9 +218,6 @@ func TestAddonService(t *testing.T) {
 			})
 
 			t.Run("Update", func(t *testing.T) {
-				// UpdateAddonInput is the add-on's full replacement state, so the fields that
-				// should survive have to be carried over explicitly; anything left out is
-				// cleared.
 				updateInput := addon.UpdateAddonInput{
 					NamespacedID: addonV1.NamespacedID,
 					Name:         lo.ToPtr(addonV1.Name),
@@ -330,8 +327,6 @@ func TestAddonService(t *testing.T) {
 				assert.Equalf(t, productcatalog.AddonStatusActive, publishedAddonV1.Status(),
 					"add-on Status mismatch: expected=%s, actual=%s", productcatalog.AddonStatusActive, publishedAddonV1.Status())
 
-				// Publishing only moves the add-on's schedule. It must not ride the replace
-				// update path, which would clear every field the publish input does not repeat.
 				assert.Equalf(t, addonV1.Name, publishedAddonV1.Name, "publishing must preserve the name")
 				assert.Equalf(t, addonV1.Description, publishedAddonV1.Description, "publishing must preserve the description")
 				assert.Equalf(t, addonV1.Metadata, publishedAddonV1.Metadata, "publishing must preserve the labels")

--- a/openmeter/productcatalog/addon/service_equal_test.go
+++ b/openmeter/productcatalog/addon/service_equal_test.go
@@ -1,0 +1,36 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateAddonInputEqualDescriptionPresence(t *testing.T) {
+	stored := Addon{}
+
+	tests := []struct {
+		name        string
+		input       *string
+		stored      *string
+		expectEqual bool
+	}{
+		{name: "omitted equals absent", input: nil, stored: nil, expectEqual: true},
+		{name: "omitted must clear a stored value", input: nil, stored: lo.ToPtr("desc"), expectEqual: false},
+		{name: "omitted must clear a stored empty string", input: nil, stored: lo.ToPtr(""), expectEqual: false},
+		{name: "matching values are equal", input: lo.ToPtr("desc"), stored: lo.ToPtr("desc"), expectEqual: true},
+		{name: "differing values are not equal", input: lo.ToPtr("new"), stored: lo.ToPtr("old"), expectEqual: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := stored
+			a.Description = tc.stored
+
+			i := UpdateAddonInput{Description: tc.input}
+
+			assert.Equal(t, tc.expectEqual, i.Equal(a))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

`PUT /openmeter/addons/{addonId}` was half-correct, which is arguably worse than being wrong consistently: `FromAPIUpsertAddonRequest` always sets `Metadata`, so omitting `labels` cleared them — but the adapter used Ent's `SetNillableDescription`, where nil is a no-op, so omitting `description` kept the stored one. Two fields in the same request body, opposite semantics.

- Description and metadata switch to the generated `SetOrClear` helpers.
- `Equal()` and `applyTo()` now compare and project an omitted field against the stored value, so a legitimate clear is neither skipped by the no-op short-circuit nor validated against the pre-update state.

## Notes for reviewer

**The publish/archive split is the load-bearing part of this PR.** `PublishAddon` and `ArchiveAddon` called `adapter.UpdateAddon` with nothing but an effective period, relying on nil-means-unchanged for everything else. Flipping the adapter to `SetOrClear` in place would have wiped every add-on's name, description and labels on publish. They now go through a new `UpdateAddonEffectivePeriod` adapter method that touches only the two schedule columns.

The regression test for that caught a real ordering bug while I was writing it: the existing `Update` subtest passed only `RateCards`, so under the new contract it cleared the description and labels before `Publish` ever ran. That subtest now carries the full state, which is what the replace contract requires of any caller.

**Annotations are deliberately excluded from the replace.** They are server-managed, are not something a client can send, and the read path only surfaces them as `openmeter_`-prefixed labels that the write path drops. Clearing them on omission would be unrecoverable data loss with no way for a client to preserve them, so they survive an update that does not carry them. Same call as meters, where the service already backfills them.

**This affects v1 as well** — `PUT /api/v1/addons/{addonId}` shares this adapter. Not a v3-only change.

Tests: `go test ./openmeter/productcatalog/addon/... ./api/v3/handlers/addons/` against Postgres. E2E `TestV3AddonUpdateClearsOmittedFields` covers create → PUT-omitting → GET-cleared over HTTP (compiles and vets; not run here — needs a live server).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Add-on updates now clear omitted descriptions and metadata.
  * Publishing and archiving preserve existing add-on details.
  * Effective-period changes no longer modify other add-on details.
  * Effective-period updates now validate inputs and report missing add-ons appropriately.

* **Tests**
  * Added coverage confirming cleared fields in update responses and subsequent retrievals.
  * Added coverage confirming publishing preserves existing add-on details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











## Update (review round 1)

- **`Equal` is now presence-aware for description**: an omitted description no longer short-circuits against a stored empty string, so the clearing write always runs; pinned by `TestUpdateAddonInputEqualDescriptionPresence`. (Mirrors the same fix on the plans PR, where review caught it.)
- Corrected the effective-period docblocks: an omitted name survives `UpdateAddon`, so they no longer claim every omitted field is cleared.
- E2E `TestV3Addon*` verified against a live local stack built from this branch.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes add-on PUT updates replace omitted description and metadata fields while preserving server-managed annotations. It separates publish/archive schedule mutations into an effective-period-only repository operation so lifecycle transitions preserve other add-on data.
- Uses generated clear-or-set persistence helpers for replaceable fields.
- Makes equality and validation projection account for omitted-field clearing.
- Routes publishing and archiving through a schedule-only update method.
- Adds adapter, service, conversion, and end-to-end regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/addon/adapter/addon.go | Uses clear-or-set helpers for replaceable fields and introduces a namespace-scoped effective-period-only update. |
| openmeter/productcatalog/addon/service.go | Aligns equality and validation projection with omitted-field replacement semantics and defines schedule-only update input validation. |
| openmeter/productcatalog/addon/service/addon.go | Routes publish and archive operations through the schedule-only repository method. |
| openmeter/productcatalog/addon/repository.go | Extends the repository contract with the effective-period-only update operation. |
| e2e/addons_v3_test.go | Covers clearing omitted description and labels through the v3 HTTP update flow. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PUT[PUT add-on request] --> Convert[Convert request]
    Convert --> Replace[UpdateAddon replacement path]
    Replace --> Fields[Replace description and metadata]
    Replace --> Preserve[Preserve server-managed annotations]
    Publish[Publish or archive] --> Schedule[UpdateAddonEffectivePeriod]
    Schedule --> Boundaries[Update schedule boundaries only]
    Boundaries --> Keep[Preserve name, description, metadata, and rate cards]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(productcatalog): drop replace-s..."](https://github.com/openmeterio/openmeter/commit/84682c6b16c44fc4388f96585b635bf0c3440e96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874630)</sub>

<!-- /greptile_comment -->