### PR TITLE
fix(productcatalog): make PUT /plans/{planId}/addons/{planAddonId} replace labels

### DIFF
--- a/api/v3/handlers/plans/planaddons/update.go
+++ b/api/v3/handlers/plans/planaddons/update.go
@@ -48,13 +48,14 @@ func (h *handler) UpdatePlanAddon() UpdatePlanAddonHandler {
 				MaxQuantity:   body.MaxQuantity,
 			}
 
-			if body.Labels != nil {
-				m, err := labels.ToMetadata(body.Labels)
-				if err != nil {
-					return UpdatePlanAddonRequest{}, err
-				}
-				req.Metadata = &m
+			// Non-nil even when empty: a nil Metadata means "unchanged" to the service, which
+			// would leak the stored labels through a request that omitted them.
+			m, err := labels.ToMetadata(body.Labels)
+			if err != nil {
+				return UpdatePlanAddonRequest{}, err
 			}
+
+			req.Metadata = &m
 
 			return req, nil
 		},

--- a/api/v3/handlers/plans/planaddons/update.go
+++ b/api/v3/handlers/plans/planaddons/update.go
@@ -48,8 +48,8 @@ func (h *handler) UpdatePlanAddon() UpdatePlanAddonHandler {
 				MaxQuantity:   body.MaxQuantity,
 			}
 
-			// Non-nil even when empty: a nil Metadata means "unchanged" to the service, which
-			// would leak the stored labels through a request that omitted them.
+			// The PUT boundary hands the service the complete target state, so omitted labels
+			// become an explicit empty metadata value rather than an absent one.
 			m, err := labels.ToMetadata(body.Labels)
 			if err != nil {
 				return UpdatePlanAddonRequest{}, err

--- a/e2e/planaddons_v3_test.go
+++ b/e2e/planaddons_v3_test.go
@@ -489,3 +489,46 @@ func makeAddonWithStatus(t *testing.T, c *v3Client, keyPrefix string, target v3s
 		return nil
 	}
 }
+
+func TestV3PlanAddonUpdateClearsOmittedLabels(t *testing.T) {
+	c := newV3Client(t)
+
+	standardPhase := validPlanPhase("standard", true /* isLast */)
+	planBody := validPlanRequest("test_v3_plan_addon_replace")
+	planBody.Phases = []v3sdk.PlanPhaseInput{standardPhase}
+
+	plan, err := c.Plans.Create(t.Context(), planBody)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, plan)
+
+	addon, err := c.Addons.Create(t.Context(), validAddonRequest("test_v3_plan_addon_replace_addon"))
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, addon)
+
+	addon, err = c.Addons.Publish(t.Context(), addon.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, addon)
+
+	createBody := validPlanAddonRequest(standardPhase.Key, addon.ID)
+	createBody.Labels = &map[string]string{"env": "prod"}
+
+	created, err := c.PlanAddons.Create(t.Context(), plan.ID, createBody)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, created)
+	require.NotEmpty(t, created.Labels)
+
+	updated, err := c.PlanAddons.Update(t.Context(), plan.ID, created.ID, v3sdk.UpsertPlanAddonRequest{
+		Name:          createBody.Name,
+		FromPlanPhase: standardPhase.Key,
+	})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, updated)
+
+	assert.Empty(t, updated.Labels, "omitted labels must be cleared, not carried over")
+
+	fetched, err := c.PlanAddons.Get(t.Context(), plan.ID, created.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, fetched)
+
+	assert.Empty(t, fetched.Labels)
+}

--- a/openmeter/productcatalog/planaddon/adapter/planaddon.go
+++ b/openmeter/productcatalog/planaddon/adapter/planaddon.go
@@ -172,6 +172,7 @@ func (a *adapter) CreatePlanAddon(ctx context.Context, params planaddon.CreatePl
 			SetNamespace(params.Namespace).
 			SetPlanID(params.PlanID).
 			SetAddonID(params.AddonID).
+			SetMetadata(params.Metadata).
 			SetAnnotations(params.Annotations).
 			SetFromPlanPhase(params.FromPlanPhase).
 			SetNillableMaxQuantity(params.MaxQuantity).
@@ -373,10 +374,10 @@ func (a *adapter) UpdatePlanAddon(ctx context.Context, params planaddon.UpdatePl
 				query = query.SetFromPlanPhase(*params.FromPlanPhase)
 			}
 
-			// Annotations are server-managed and are not part of the plan-addon
-			// representation, so they must survive an update that omits them.
 			query = query.SetOrClearMetadata((*map[string]string)(params.Metadata))
 
+			// Annotations are server-managed and are not part of the plan-addon
+			// representation, so they must survive an update that omits them.
 			if params.Annotations != nil {
 				query = query.SetAnnotations(*params.Annotations)
 			}

--- a/openmeter/productcatalog/planaddon/adapter/planaddon.go
+++ b/openmeter/productcatalog/planaddon/adapter/planaddon.go
@@ -373,12 +373,12 @@ func (a *adapter) UpdatePlanAddon(ctx context.Context, params planaddon.UpdatePl
 				query = query.SetFromPlanPhase(*params.FromPlanPhase)
 			}
 
+			// Annotations are server-managed and are not part of the plan-addon
+			// representation, so they must survive an update that omits them.
+			query = query.SetOrClearMetadata((*map[string]string)(params.Metadata))
+
 			if params.Annotations != nil {
 				query = query.SetAnnotations(*params.Annotations)
-			}
-
-			if params.Metadata != nil {
-				query = query.SetMetadata(*params.Metadata)
 			}
 
 			err = query.Exec(ctx)

--- a/openmeter/productcatalog/planaddon/service.go
+++ b/openmeter/productcatalog/planaddon/service.go
@@ -198,12 +198,10 @@ func (i UpdatePlanAddonInput) Equal(p PlanAddon) bool {
 		return false
 	}
 
-	// FIXME: annotations
-
-	if i.Metadata != nil {
-		if !i.Metadata.Equal(p.Metadata) {
-			return false
-		}
+	// Compared unguarded, unlike the fields above: nil means the update omitted labels and they
+	// are about to be cleared, so nil only equals an already-empty stored value.
+	if !lo.FromPtr(i.Metadata).Equal(p.Metadata) {
+		return false
 	}
 
 	return true

--- a/openmeter/productcatalog/planaddon/service/service_test.go
+++ b/openmeter/productcatalog/planaddon/service/service_test.go
@@ -263,6 +263,7 @@ func TestPlanAddonService(t *testing.T) {
 				NamespacedModel: models.NamespacedModel{
 					Namespace: namespace,
 				},
+				Metadata: models.Metadata{"env": "prod"},
 				Annotations: map[string]interface{}{
 					"openmeter.key": "openmeter.value",
 				},


### PR DESCRIPTION
## Overview

Omitting `labels` on a plan-addon update kept the stored labels. Two layers each independently treated nil as "no change", so fixing either one alone would not have been enough:

- the v3 handler only set `req.Metadata` when `body.Labels != nil`;
- the adapter only called `SetMetadata` when `params.Metadata != nil`.

Now the handler always hands the service a metadata value (empty included), and the adapter uses the generated `SetOrClear` helper. `Equal()` compares an omitted field against the stored value so the no-op short-circuit does not skip a legitimate clear.

## Notes for reviewer

**Annotations are deliberately excluded from the replace.** They are server-managed and are not part of the plan-addon representation at all — `ToAPIPlanAddon` returns only `labels` — so a client has no way to send them and a PUT has no business clearing them.

**One thing this PR does not fix, on purpose.** `UpsertPlanAddonRequest` carries `name` and `description`, but the plan-addon entity stores neither (`PlanAddonMeta` is metadata + annotations + `from_plan_phase` + `max_quantity`) and `PlanAddon` returns neither. They are inert write-only fields today, and they were inert before this change too. Making the request body honest about that is a separate API-shape question from the replace semantics here, so I left it alone rather than quietly widening the scope — flagging it in case you want it tracked.

**This affects v1 as well** — `PUT /api/v1/plans/{planId}/addons/{planAddonId}` shares this adapter.

Tests: `go test ./openmeter/productcatalog/planaddon/... ./api/v3/handlers/plans/...` against Postgres. E2E `TestV3PlanAddonUpdateClearsOmittedLabels` covers create → PUT-omitting → GET-cleared over HTTP (compiles and vets; not run here — needs a live server).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a plan add-on without labels now clears existing labels instead of preserving them.
  * Label removal is consistently saved and reflected in subsequent requests.
  * Metadata updates are now applied consistently, including when metadata is omitted.
  * Creating a plan add-on now correctly persists its metadata.
  * Annotations remain unchanged unless explicitly updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns plan-add-on label handling with PUT replacement semantics while preserving server-managed annotations.
- Always maps omitted v3 labels to an explicit empty metadata target.
- Persists metadata during plan-add-on creation and sets or clears it during updates.
- Updates equality behavior so legitimate label clears are not skipped.
- Adds service and end-to-end coverage for metadata persistence and omitted-label clearing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/plans/planaddons/update.go | Converts omitted labels into an explicit empty metadata value before invoking the service. |
| openmeter/productcatalog/planaddon/adapter/planaddon.go | Persists metadata on creation and applies replacement semantics during updates while preserving annotations. |
| openmeter/productcatalog/planaddon/service.go | Treats omitted update metadata as an empty target when evaluating whether an update is a no-op. |
| openmeter/productcatalog/planaddon/service/service_test.go | Extends service coverage to verify plan-add-on metadata persistence. |
| e2e/planaddons_v3_test.go | Adds HTTP-level coverage showing that a PUT omitting labels clears previously stored labels. |

<sub>Reviews (3): Last reviewed commit: ["fix(productcatalog): persist plan add-on..."](https://github.com/openmeterio/openmeter/commit/2a0cf04f4b9225c7b1bf6f02be3ff4548579d3c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874649)</sub>

<!-- /greptile_comment -->

## Update (review round 1)

- **Create dropped labels entirely**: the adapter's `CreatePlanAddon` never wrote the metadata column, which is why the e2e test failed in CI at the `require.NotEmpty(created.Labels)` precondition. Create now persists metadata, and the existing create-input assertion exercises the round-trip (the service test input now carries metadata).
- E2E `TestV3PlanAddon*` (all of them, including the new clear test) verified against a live local stack built from this branch.
