### PR TITLE
fix(taxcode): make PUT /tax-codes/{taxCodeId} clear an omitted description

### DIFF
--- a/e2e/taxcodes_v3_test.go
+++ b/e2e/taxcodes_v3_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v3sdk "github.com/openmeterio/openmeter/api/v3/client"
+)
+
+func TestV3TaxCodeUpdateClearsOmittedFields(t *testing.T) {
+	c := newV3Client(t)
+
+	created, err := c.Tax.CreateCode(t.Context(), v3sdk.CreateTaxCodeRequest{
+		Key:         uniqueKey("test_v3_tax_code_replace"),
+		Name:        "Tax code replace",
+		Description: lo.ToPtr("Original description"),
+		Labels:      &map[string]string{"env": "prod"},
+		AppMappings: []v3sdk.TaxCodeAppMapping{},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, created)
+	require.NotNil(t, created.Description)
+	require.NotEmpty(t, created.Labels)
+
+	updated, err := c.Tax.UpsertCode(t.Context(), created.ID, v3sdk.UpsertTaxCodeRequest{
+		Name:        created.Name,
+		AppMappings: []v3sdk.TaxCodeAppMapping{},
+	})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, updated)
+
+	assert.Nil(t, updated.Description, "omitted description must be cleared, not carried over")
+	assert.Empty(t, updated.Labels, "omitted labels must be cleared, not carried over")
+
+	fetched, err := c.Tax.GetCode(t.Context(), created.ID)
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, fetched)
+
+	assert.Nil(t, fetched.Description)
+	assert.Empty(t, fetched.Labels)
+}

--- a/openmeter/taxcode/adapter/taxcode.go
+++ b/openmeter/taxcode/adapter/taxcode.go
@@ -59,7 +59,7 @@ func (a *adapter) UpdateTaxCode(ctx context.Context, input taxcode.UpdateTaxCode
 			Where(taxcodedb.NamespaceEQ(input.Namespace)).
 			Where(taxcodedb.DeletedAtIsNil()).
 			SetName(input.Name).
-			SetNillableDescription(input.Description).
+			SetOrClearDescription(input.Description).
 			SetMetadata(input.Metadata).
 			SetAnnotations(input.Annotations)
 

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -164,6 +165,35 @@ func TestTaxCodeService(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.Equal(t, "updated name", updated.Name)
+		})
+
+		t.Run("UpdateClearsOmittedDescription", func(t *testing.T) {
+			// given a tax code that carries a description
+			name := testutils.NameGenerator.Generate()
+			created, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+				Namespace:   ns,
+				Key:         name.Key,
+				Name:        name.Name,
+				Description: lo.ToPtr("original description"),
+			})
+			require.NoError(t, err)
+			require.NotNil(t, created.Description)
+
+			// when an update arrives that does not name it
+			updated, err := env.Service.UpdateTaxCode(t.Context(), taxcode.UpdateTaxCodeInput{
+				NamespacedID: models.NamespacedID{Namespace: ns, ID: created.ID},
+				Name:         created.Name,
+			})
+			require.NoError(t, err)
+
+			// then the description is cleared and the clear is persisted
+			assert.Nil(t, updated.Description)
+
+			fetched, err := env.Service.GetTaxCode(t.Context(), taxcode.GetTaxCodeInput{
+				NamespacedID: models.NamespacedID{Namespace: ns, ID: created.ID},
+			})
+			require.NoError(t, err)
+			assert.Nil(t, fetched.Description)
 		})
 
 		t.Run("UpdateAnnotationsSucceeds", func(t *testing.T) {


### PR DESCRIPTION
## Overview

One-line semantics fix. `UpdateTaxCode` replaced metadata, annotations and app mappings on every write, but used Ent's `SetNillableDescription` for the description — where nil means "no change", not "clear". So within a single request body, `description` was the only field that survived being omitted.

Switched to the generated `SetOrClear` helper.

## Notes for reviewer

Smallest of the v3 PUT replace-semantics PRs — a single call site in `openmeter/taxcode/adapter/taxcode.go`, no spec change, no generated output.

No handler change was needed: the goverter-generated `FromAPIUpsertTaxCodeRequest` already passes `Description` straight through as a nil-able pointer, so the boundary was already expressing "the client omitted this". Only the adapter was mistranslating it.

Tests: `go test ./openmeter/taxcode/... ./api/v3/handlers/taxcodes/...` against Postgres.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a tax code without a description now correctly clears any existing description during full replacement updates.
  * Updating a tax code without labels now correctly clears any existing labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects PUT replacement semantics so omitting a tax-code description clears the persisted value.
- Uses Ent’s generated set-or-clear helper for description updates.
- Adds service-level persistence coverage and an end-to-end API regression test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/taxcode/adapter/taxcode.go | Changes description persistence from nil-as-no-op to nil-as-clear, matching full-replacement update semantics. |
| openmeter/taxcode/service/taxcode_test.go | Adds a database-backed regression test confirming an omitted description is cleared and remains cleared after re-fetching. |
| e2e/taxcodes_v3_test.go | Adds API-level coverage confirming omitted replaceable fields are cleared in both update and subsequent fetch responses. |

<sub>Reviews (3): Last reviewed commit: ["test(taxcode): cover clearing an omitted..."](https://github.com/openmeterio/openmeter/commit/e1475299ffc920a8b1903368834a4d7842a916bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874668)</sub>

<!-- /greptile_comment -->

## Update (review round 1)

- Added the review-requested regression: `UpdateClearsOmittedDescription` creates a tax code with a description, updates without one, and asserts the clear persists through a fresh GET.
- Added e2e `TestV3TaxCodeUpdateClearsOmittedFields` (create with description + labels → PUT omitting both → cleared on the response and on GET), verified against a live local stack built from this branch.
