### PR TITLE
fix(customer): make PUT /customers/{customerId} replace omitted fields

### DIFF
--- a/e2e/customers_v3_test.go
+++ b/e2e/customers_v3_test.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v3sdk "github.com/openmeterio/openmeter/api/v3/client"
+)
+
+func TestV3CustomerUpdateClearsOmittedFields(t *testing.T) {
+	c := newV3Client(t)
+
+	created, err := c.Customers.Create(t.Context(), v3sdk.CreateCustomerRequest{
+		Key:          uniqueKey("test_v3_customer_replace"),
+		Name:         "Customer replace",
+		Description:  lo.ToPtr("Original description"),
+		PrimaryEmail: lo.ToPtr("original@example.com"),
+		Currency:     lo.ToPtr("USD"),
+		BillingAddress: &v3sdk.Address{
+			City:       lo.ToPtr("Budapest"),
+			Country:    lo.ToPtr("HU"),
+			Line1:      lo.ToPtr("Fő utca 1."),
+			PostalCode: lo.ToPtr("1011"),
+			State:      lo.ToPtr("Budapest"),
+		},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, created)
+	require.NotNil(t, created.PrimaryEmail)
+	require.NotNil(t, created.Currency)
+	require.NotNil(t, created.BillingAddress)
+
+	t.Run("Should replace a supplied billing address as a whole", func(t *testing.T) {
+		updated, err := c.Customers.Upsert(t.Context(), created.ID, v3sdk.UpsertCustomerRequest{
+			Name: created.Name,
+			BillingAddress: &v3sdk.Address{
+				City: lo.ToPtr("Berlin"),
+			},
+		})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, updated)
+
+		require.NotNil(t, updated.BillingAddress)
+		assert.Equal(t, lo.ToPtr("Berlin"), updated.BillingAddress.City)
+		assert.Nil(t, updated.BillingAddress.Country, "address lines omitted from a supplied address must be cleared")
+		assert.Nil(t, updated.BillingAddress.Line1)
+		assert.Nil(t, updated.BillingAddress.PostalCode)
+		assert.Nil(t, updated.BillingAddress.State)
+	})
+
+	t.Run("Should clear omitted top-level fields", func(t *testing.T) {
+		updated, err := c.Customers.Upsert(t.Context(), created.ID, v3sdk.UpsertCustomerRequest{
+			Name: created.Name,
+		})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, updated)
+
+		assert.Nil(t, updated.Description, "omitted description must be cleared, not carried over")
+		assert.Nil(t, updated.PrimaryEmail, "omitted primary email must be cleared, not carried over")
+		assert.Nil(t, updated.Currency, "omitted currency must be cleared, not carried over")
+		assert.Nil(t, updated.BillingAddress, "omitted billing address must be cleared, not carried over")
+
+		fetched, err := c.Customers.Get(t.Context(), created.ID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, fetched)
+
+		assert.Nil(t, fetched.Description)
+		assert.Nil(t, fetched.PrimaryEmail)
+		assert.Nil(t, fetched.Currency)
+		assert.Nil(t, fetched.BillingAddress)
+		assert.Equal(t, created.Key, fetched.Key, "the key is not part of the update body and must survive the replace")
+	})
+}

--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -691,11 +691,10 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 			SetUpdatedAt(clock.Now().UTC()).
 			SetName(input.Name).
 			SetOrClearDescription(input.Description).
-			SetNillablePrimaryEmail(input.PrimaryEmail).
-			SetNillableCurrency(input.Currency).
+			SetOrClearPrimaryEmail(input.PrimaryEmail).
+			SetOrClearCurrency(input.Currency).
 			SetOrClearKey(input.Key)
 
-		// Replace metadata
 		if input.Metadata != nil {
 			query = query.SetMetadata(input.Metadata.ToMap())
 		} else {
@@ -710,13 +709,13 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 
 		if input.BillingAddress != nil {
 			query = query.
-				SetNillableBillingAddressCity(input.BillingAddress.City).
-				SetNillableBillingAddressCountry(input.BillingAddress.Country).
-				SetNillableBillingAddressLine1(input.BillingAddress.Line1).
-				SetNillableBillingAddressLine2(input.BillingAddress.Line2).
-				SetNillableBillingAddressPhoneNumber(input.BillingAddress.PhoneNumber).
-				SetNillableBillingAddressPostalCode(input.BillingAddress.PostalCode).
-				SetNillableBillingAddressState(input.BillingAddress.State)
+				SetOrClearBillingAddressCity(input.BillingAddress.City).
+				SetOrClearBillingAddressCountry(input.BillingAddress.Country).
+				SetOrClearBillingAddressLine1(input.BillingAddress.Line1).
+				SetOrClearBillingAddressLine2(input.BillingAddress.Line2).
+				SetOrClearBillingAddressPhoneNumber(input.BillingAddress.PhoneNumber).
+				SetOrClearBillingAddressPostalCode(input.BillingAddress.PostalCode).
+				SetOrClearBillingAddressState(input.BillingAddress.State)
 		} else {
 			query = query.
 				ClearBillingAddressCity().


### PR DESCRIPTION
## Overview

The customer adapter was mostly a correct replace already — it cleared description, key, metadata, annotations, and the entire billing address when they were absent, with an explicit `// Replace metadata` comment saying so. Three fields did not follow the rule:

- **`primary_email`** and **`currency`** used Ent's `SetNillable`, where nil is a no-op, so omitting them kept the stored values.
- **A supplied billing address** set its lines with `SetNillable` too. So `billing_address: {city: "Berlin"}` silently kept the previous postcode, state and street lines alongside the new city — a partially-replaced address that matched neither what was sent nor what was stored.

All three switch to the generated `SetOrClear` helpers. The address is now replaced as a whole: supplying one clears the lines it leaves out, exactly as an absent address already cleared all of them.

## Notes for reviewer

The nested-address case is the one I'd look at hardest — it is the only place in this series where a *provided* object was being merged field-by-field, and it is the easiest for a caller to have accidentally depended on.

**This affects v1 as well** — `PUT /api/v1/customers/{customerIdOrKey}` shares this adapter. Not a v3-only change.

Note the pre-existing `// FIXME` in `api/v3/handlers/customers/upsert.go`: the v3 handler already round-trips the customer to backfill `key`, precisely because `UpdateCustomer` wipes what the input does not carry. That FIXME is evidence the replace behaviour here is intended, not accidental — this PR extends it to the three fields that were missing it. I have not touched the FIXME itself; it is a separate cleanup.

Tests: `go test ./openmeter/customer/... ./api/v3/handlers/customers/...` against Postgres, plus the full root suite on the combined change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Full customer replacements now correctly clear omitted primary email and currency values.
  - Billing address fields are cleared when omitted from an update.
  - Removing an address continues to clear all associated address details, ensuring outdated contact and billing information is not retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns customer PUT persistence with replacement semantics by clearing omitted primary email, currency, and supplied-address fields.
- Replaces nillable Ent setters with set-or-clear helpers for affected customer fields.
- Adds v3 end-to-end coverage for replacing billing addresses and clearing omitted values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/customer/adapter/customer.go | Updates optional customer fields to use generated nil-to-clear setters, consistently implementing the documented replacement behavior. |
| e2e/customers_v3_test.go | Adds end-to-end coverage for the customer replacement behavior without introducing an eligible blocking finding. |

<sub>Reviews (3): Last reviewed commit: ["test(customer): cover PUT replace of omi..."](https://github.com/openmeterio/openmeter/commit/b43a36afe9d11c389709ceef19bceb5064874daf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874694)</sub>

**Context used:**

- Knowledge Base — [Customer, namespace, and portal services](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/customer-namespace-and-portal.md)

<!-- /greptile_comment -->

## Update (review round 1)

- Added e2e `TestV3CustomerUpdateClearsOmittedFields`: covers the three flipped fields (primary email, currency, supplied-address lines), the whole-address clear, and pins that the key — which the v3 body cannot carry — survives the replace. Verified against a live local stack built from this branch.
- Audited every internal `UpdateCustomer` caller (subscription currency backfill, subject-customer provisioning hooks): all do a full read-modify-write from the stored customer, so the nil-clears flip cannot wipe fields through them.
