### PR TITLE
fix(billing): drop the customer's profile override when PUT omits billing_profile

### DIFF
--- a/api/v3/handlers/customers/billing/update_billing.go
+++ b/api/v3/handlers/customers/billing/update_billing.go
@@ -178,7 +178,6 @@ func (h *handler) UpdateCustomerBilling() UpdateCustomerBillingHandler {
 				return resp, fmt.Errorf("failed to update customer data: %w", err)
 			}
 
-			// Override the billing profile if an ID was provided
 			if request.ProfileID != nil {
 				_, err = h.billingService.UpsertCustomerOverride(ctx, billing.UpsertCustomerOverrideInput{
 					Namespace:  request.CustomerID.Namespace,
@@ -187,6 +186,16 @@ func (h *handler) UpdateCustomerBilling() UpdateCustomerBillingHandler {
 				})
 				if err != nil {
 					return resp, fmt.Errorf("failed to update billing profile: %w", err)
+				}
+			} else {
+				err = h.billingService.DeleteCustomerOverride(ctx, billing.DeleteCustomerOverrideInput{
+					Customer: request.CustomerID,
+				})
+				// A customer that was never pinned has nothing to drop, which is the state the
+				// request is asking for rather than an error.
+				if err != nil && !errors.Is(err, billing.ErrCustomerOverrideNotFound) &&
+					!errors.Is(err, billing.ErrCustomerOverrideAlreadyDeleted) {
+					return resp, fmt.Errorf("failed to clear billing profile: %w", err)
 				}
 			}
 

--- a/e2e/customerbilling_v3_test.go
+++ b/e2e/customerbilling_v3_test.go
@@ -1,0 +1,80 @@
+package e2e
+
+import (
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v3sdk "github.com/openmeterio/openmeter/api/v3/client"
+)
+
+func TestV3CustomerBillingUpdateDropsOmittedProfileOverride(t *testing.T) {
+	c := newV3Client(t)
+
+	prefix := uniqueKey("customer_billing_replace")
+
+	customer, err := c.Customers.Create(t.Context(), v3sdk.CreateCustomerRequest{
+		Key:  prefix + "_customer",
+		Name: "Customer Billing Replace Test Customer",
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, customer)
+
+	profiles, err := c.Billing.ListProfiles(t.Context(), v3sdk.ProfileListParams{
+		Page: &v3sdk.PageParams{Size: lo.ToPtr(100)},
+	})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, profiles)
+
+	defaultIdx := slices.IndexFunc(profiles.Data, func(profile v3sdk.Profile) bool {
+		return profile.Default
+	})
+	require.NotEqual(t, -1, defaultIdx, "default billing profile is required")
+	defaultProfileID := profiles.Data[defaultIdx].ID
+
+	pinned := createNewBillingProfileFromDefault(t, c, prefix, nil)
+	require.NotEqual(t, defaultProfileID, pinned.ID)
+
+	t.Run("Should pin the customer to a named profile", func(t *testing.T) {
+		updated, err := c.Customers.Billing.Update(t.Context(), customer.ID, v3sdk.UpsertCustomerBillingDataRequest{
+			BillingProfile: &v3sdk.ProfileReference{ID: pinned.ID},
+		})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, updated)
+		require.NotNil(t, updated.BillingProfile)
+		assert.Equal(t, pinned.ID, updated.BillingProfile.ID)
+
+		fetched, err := c.Customers.Billing.Get(t.Context(), customer.ID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, fetched)
+		require.NotNil(t, fetched.BillingProfile)
+		assert.Equal(t, pinned.ID, fetched.BillingProfile.ID)
+	})
+
+	t.Run("Should drop the pin when billing_profile is omitted", func(t *testing.T) {
+		updated, err := c.Customers.Billing.Update(t.Context(), customer.ID, v3sdk.UpsertCustomerBillingDataRequest{})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, updated)
+		require.NotNil(t, updated.BillingProfile)
+		assert.Equal(t, defaultProfileID, updated.BillingProfile.ID)
+
+		fetched, err := c.Customers.Billing.Get(t.Context(), customer.ID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, fetched)
+		require.NotNil(t, fetched.BillingProfile)
+		assert.Equal(t, defaultProfileID, fetched.BillingProfile.ID,
+			"an omitted billing_profile must unpin the customer, not merely answer with the default")
+	})
+
+	t.Run("Should tolerate a repeated omission once unpinned", func(t *testing.T) {
+		updated, err := c.Customers.Billing.Update(t.Context(), customer.ID, v3sdk.UpsertCustomerBillingDataRequest{})
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, updated)
+		require.NotNil(t, updated.BillingProfile)
+		assert.Equal(t, defaultProfileID, updated.BillingProfile.ID)
+	})
+}


### PR DESCRIPTION
## Overview

On `PUT /openmeter/customers/{customerId}/billing`, omitting `billing_profile` left any existing customer override in place. The handler fell back to the organization default *for the response*, but never removed the override — so the endpoint answered with a profile the customer was not actually on, while the customer stayed pinned to whatever a previous request had set.

The second-order effect is worse than the stale response: there was no way to unpin a customer through this API at all. Once pinned, always pinned.

Now an absent `billing_profile` deletes the override, so the customer falls back to the organization default and the response matches the stored state.

## Notes for reviewer

A customer that was never pinned has nothing to drop — that is the state the request is asking for, not an error — so `ErrCustomerOverrideNotFound` and `ErrCustomerOverrideAlreadyDeleted` are tolerated and everything else propagates. I verified `errors.Is` actually matches through `billing.NotFoundError`'s `Unwrap` for both sentinels rather than assuming it.

Scope note: this changes only the *profile pin*. App data on the same endpoint is already written unconditionally via `UpsertCustomerData` and is untouched here.

Behaviour change for callers that sent this endpoint without `billing_profile` expecting the pin to persist — they now need to name the profile explicitly on every call, which is what replace semantics require.

Tests: `go test ./api/v3/handlers/customers/... ./openmeter/billing/...` against Postgres.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7aYus5cbiqf48bnJkrQDv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Billing profile overrides now correctly replace existing customer billing settings when a new profile is selected.
  - Omitting a billing profile now clears the existing override and restores the default billing profile.
  - Repeated requests to clear an already-removed override now complete successfully without changing the result.
  - Unexpected errors encountered while clearing billing settings are now reported appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes PUT customer-billing replacement semantics so omitting `billing_profile` removes an existing customer override and returns the effective default profile.
- Adds idempotent override deletion when the profile is omitted.
- Adds an end-to-end test covering pinning, unpinning, and repeated omission.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a failed override deletion can leave app data committed while the previous profile override remains active.

The handler persists app data before attempting override deletion, and those operations use separate transactions, so a non-tolerated deletion failure returns an error after only the app-data portion of the requested replacement has committed.

**Files Needing Attention:** api/v3/handlers/customers/billing/update_billing.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/customers/billing/update_billing.go | Adds the omitted-profile deletion path while retaining the existing sequence of app-data persistence followed by profile mutation. |
| e2e/customerbilling_v3_test.go | Adds end-to-end coverage for pinning a customer, reverting to the default profile, and idempotently repeating the omission. |

<sub>Reviews (3): Last reviewed commit: ["test(billing): cover dropping the custom..."](https://github.com/openmeterio/openmeter/commit/0258f5222fbbe7b7aca89315d371a4fa7b7c6a9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55874718)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)

<!-- /greptile_comment -->

## Update (review round 1)

- Added e2e `TestV3CustomerBillingUpdateDropsOmittedProfileOverride`: pin to a cloned profile → PUT omitting `billing_profile` → the response answers the org default **and** a follow-up GET confirms the override is gone → a repeated omission stays a no-op success (exercising the tolerated not-found/already-deleted path). Verified against a live local stack built from this branch.
- On the atomicity findings: app data and the override were already two sequential writes with no shared transaction before this PR, on both the pin and unpin paths; replied in-thread proposing a follow-up rather than widening this fix.
