### PR TITLE
fix(api): surface rate card price errors as user-serviceable

### DIFF
--- a/.agents/skills/api/SKILL.md
+++ b/.agents/skills/api/SKILL.md
@@ -250,6 +250,20 @@ type (
 
 Reference: `api/v3/handlers/llmcost/list_prices.go`
 
+#### Converters (`convert.go`)
+
+Converters translate API request bodies into service/domain types faithfully —
+they must not enforce domain rules (valid type combinations, required-field
+semantics, cross-field constraints). Map invalid combinations onto the domain
+type as-is (zero values where needed) and let the domain `Validate()` report
+the issue; that path produces user-serviceable errors with codes, field paths,
+and severity, and keeps draft-with-issues semantics working (warning-severity
+issues are surfaced on the draft and block publish instead of failing create).
+
+A converter may only error when the body cannot be mapped at all — unknown
+union discriminator, unparsable amount or duration. Wrap such errors in
+`models.NewGenericValidationError` so they surface as 400, not 500.
+
 #### Error Mapping
 
 Domain errors auto-map to HTTP status codes via the error encoder:

--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -883,14 +883,11 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 	}
 
 	if rc.BillingCadence == nil {
-		// FlatFeeRateCard
-		flatRC := &productcatalog.FlatFeeRateCard{
-			RateCardMeta: meta,
-		}
-
 		switch priceDiscriminator {
 		case string(apiv3.BillingPriceFreeTypeFree):
-			// nil price
+			return &productcatalog.FlatFeeRateCard{
+				RateCardMeta: meta,
+			}, nil
 		case string(apiv3.BillingPriceFlatTypeFlat):
 			flatAPI, err := rc.Price.AsBillingPriceFlat()
 			if err != nil {
@@ -901,18 +898,19 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 				return nil, err
 			}
 			flatPrice.PaymentTerm = paymentTerm
-			flatRC.Price = productcatalog.NewPriceFrom(flatPrice)
-		default:
-			return nil, fmt.Errorf("unsupported price type %q for flat fee rate card (billing_cadence must be set for non-flat prices)", priceDiscriminator)
-		}
 
-		return flatRC, nil
+			flatRC := &productcatalog.FlatFeeRateCard{
+				RateCardMeta: meta,
+			}
+			flatRC.Price = productcatalog.NewPriceFrom(flatPrice)
+
+			return flatRC, nil
+		}
 	}
 
-	// UsageBasedRateCard
 	usageRC := &productcatalog.UsageBasedRateCard{
 		RateCardMeta:   meta,
-		BillingCadence: *parsedBillingCadence,
+		BillingCadence: lo.FromPtr(parsedBillingCadence),
 	}
 
 	switch priceDiscriminator {
@@ -965,7 +963,7 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 		usageRC.Price = productcatalog.NewPriceFrom(tieredPrice)
 
 	default:
-		return nil, fmt.Errorf("unsupported price type for v3: %s", priceDiscriminator)
+		return nil, models.NewGenericValidationError(fmt.Errorf("unsupported price type: %s", priceDiscriminator))
 	}
 
 	return usageRC, nil

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -532,3 +532,20 @@ func TestUnitConfigMapping(t *testing.T) {
 		assert.Equal(t, lo.ToPtr("GB"), uc.DisplayUnit)
 	})
 }
+
+func TestFromAPIBillingRateCardPriceTypeErrors(t *testing.T) {
+	t.Run("unknown price type is a validation error", func(t *testing.T) {
+		var price apiv3.BillingPrice
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"bogus"}`), &price))
+
+		bc := apiv3.ISO8601Duration("P1M")
+		_, err := FromAPIBillingRateCard(apiv3.BillingRateCard{
+			Key:            "storage",
+			Name:           "Storage",
+			Price:          price,
+			BillingCadence: &bc,
+		})
+		require.Error(t, err)
+		assert.True(t, models.IsGenericValidationError(err))
+	})
+}

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -797,7 +797,7 @@ func FromAPIBillingRateCard(rc api.BillingRateCard) (productcatalog.RateCard, er
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported price type: %s", priceType)
+		return nil, models.NewGenericValidationError(fmt.Errorf("unsupported price type: %s", priceType))
 	}
 }
 

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -310,6 +310,19 @@ func TestFromPlanWithPhases(t *testing.T) {
 }
 
 func TestFromRateCard(t *testing.T) {
+	t.Run("unknown price type is a validation error", func(t *testing.T) {
+		var price api.BillingPrice
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"bogus"}`), &price))
+
+		_, err := FromAPIBillingRateCard(api.BillingRateCard{
+			Key:   "storage",
+			Name:  "Storage",
+			Price: price,
+		})
+		require.Error(t, err)
+		assert.True(t, models.IsGenericValidationError(err))
+	})
+
 	t.Run("custom currency override round trips", func(t *testing.T) {
 		custom := currencyx.Code("CREDITS")
 		reference := currencies.NewCurrencyReference(custom)

--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -394,3 +394,134 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 		})
 	}
 }
+
+// Non-flat prices require billing_cadence. The converter accepts the body
+// as-is (zero-cadence usage-based rate card); the defect surfaces as
+// billing_cadence_invalid_value on the draft and blocks publish.
+func TestV3AddonUnitPriceWithoutBillingCadence(t *testing.T) {
+	c := newV3Client(t)
+
+	meterKey := uniqueKey("no_cadence")
+
+	m, err := c.Meters.Create(t.Context(), v3sdk.CreateMeterRequest{
+		Key:           meterKey,
+		Name:          "Test Meter " + meterKey,
+		Aggregation:   v3sdk.MeterAggregationSum,
+		EventType:     uniqueKey("no_cadence_event"),
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, m)
+
+	featureKey := uniqueKey("no_cadence")
+
+	f, err := c.Features.Create(t.Context(), v3sdk.CreateFeatureRequest{
+		Key:  featureKey,
+		Name: "Test Feature " + featureKey,
+		Meter: &v3sdk.FeatureMeterReferenceInput{
+			ID: m.ID,
+		},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, f)
+
+	rc := validUnitRateCard(*f)
+	rc.BillingCadence = nil
+
+	body := validAddonRequest("unit_no_cadence")
+	body.RateCards = []v3sdk.RateCardInput{rc}
+
+	var addonID string
+
+	t.Run("create accepts the invalid draft", func(t *testing.T) {
+		addon, err := c.Addons.Create(t.Context(), body)
+		c.requireStatus(http.StatusCreated, err)
+		require.NotNil(t, addon)
+		assert.Equal(t, v3sdk.AddonStatusDraft, addon.Status)
+		addonID = addon.ID
+	})
+
+	t.Run("validation_errors surfaces on GET", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+		got, err := c.Addons.Get(t.Context(), addonID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, got)
+		require.NotEmpty(t, got.ValidationErrors, "expected validation_errors on the draft")
+
+		var codes []string
+		for _, e := range got.ValidationErrors {
+			codes = append(codes, e.Code)
+		}
+		assert.Contains(t, codes, "billing_cadence_invalid_value")
+	})
+
+	t.Run("publish rejects with the same code", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+		_, err := c.Addons.Publish(t.Context(), addonID)
+		problem := requireProblem(t, err, http.StatusBadRequest)
+		assertValidationCode(t, problem, "billing_cadence_invalid_value")
+	})
+
+	t.Run("fix by setting billing_cadence", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+		update := v3sdk.UpsertAddonRequest{
+			Name:         body.Name,
+			InstanceType: body.InstanceType,
+			RateCards:    []v3sdk.RateCardInput{validUnitRateCard(*f)},
+		}
+		_, err := c.Addons.Update(t.Context(), addonID, update)
+		c.requireStatus(http.StatusOK, err)
+	})
+
+	t.Run("publish succeeds after fix", func(t *testing.T) {
+		require.NotEmpty(t, addonID)
+		addon, err := c.Addons.Publish(t.Context(), addonID)
+		c.requireStatus(http.StatusOK, err)
+		assert.Equal(t, v3sdk.AddonStatusActive, addon.Status)
+	})
+}
+
+// An unrecognized price type discriminator has no domain price to map to; the
+// server must reject the body with a 400 rather than a 500. The typed SDK
+// cannot express an unknown discriminator, so this goes through the raw HTTP
+// escape hatch.
+func TestV3RateCardUnknownPriceType(t *testing.T) {
+	bogusRateCard := func() map[string]any {
+		return map[string]any{
+			"key":             uniqueKey("bogus_rc"),
+			"name":            "Bogus Price Rate Card",
+			"billing_cadence": "P1M",
+			"price":           map[string]any{"type": "bogus", "amount": "1"},
+		}
+	}
+
+	t.Run("addon create", func(t *testing.T) {
+		c := newV3Client(t)
+
+		status, raw, _ := c.doMalformedRequest(http.MethodPost, "/addons", map[string]any{
+			"key":           uniqueKey("bogus_price_addon"),
+			"name":          "Bogus Price Addon",
+			"currency":      "USD",
+			"instance_type": "single",
+			"rate_cards":    []map[string]any{bogusRateCard()},
+		})
+		assert.Equal(t, http.StatusBadRequest, status, "raw: %s", raw)
+	})
+
+	t.Run("plan create", func(t *testing.T) {
+		c := newV3Client(t)
+
+		status, raw, _ := c.doMalformedRequest(http.MethodPost, "/plans", map[string]any{
+			"key":             uniqueKey("bogus_price_plan"),
+			"name":            "Bogus Price Plan",
+			"currency":        "USD",
+			"billing_cadence": "P1M",
+			"phases": []map[string]any{{
+				"key":        uniqueKey("bogus_phase"),
+				"name":       "Bogus Phase",
+				"rate_cards": []map[string]any{bogusRateCard()},
+			}},
+		})
+		assert.Equal(t, http.StatusBadRequest, status, "raw: %s", raw)
+	})
+}

--- a/e2e/plans_v3_test.go
+++ b/e2e/plans_v3_test.go
@@ -258,6 +258,100 @@ func TestV3PlanInvalidDraftLifecycle(t *testing.T) {
 	})
 }
 
+// Non-flat prices require billing_cadence (the plan analog of
+// TestV3AddonUnitPriceWithoutBillingCadence): the body is accepted as a
+// zero-cadence draft, flagged as billing_cadence_invalid_value on GET, and
+// rejected at publish.
+func TestV3PlanUnitPriceWithoutBillingCadence(t *testing.T) {
+	c := newV3Client(t)
+
+	meterKey := uniqueKey("plan_no_cadence")
+
+	m, err := c.Meters.Create(t.Context(), v3sdk.CreateMeterRequest{
+		Key:           meterKey,
+		Name:          "Test Meter " + meterKey,
+		Aggregation:   v3sdk.MeterAggregationSum,
+		EventType:     uniqueKey("plan_no_cadence_event"),
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, m)
+
+	featureKey := uniqueKey("plan_no_cadence")
+
+	f, err := c.Features.Create(t.Context(), v3sdk.CreateFeatureRequest{
+		Key:  featureKey,
+		Name: "Test Feature " + featureKey,
+		Meter: &v3sdk.FeatureMeterReferenceInput{
+			ID: m.ID,
+		},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, f)
+
+	rc := validUnitRateCard(*f)
+	rc.BillingCadence = nil
+
+	phase := validPlanPhase("no_cadence_phase", true /* isLast */)
+	phase.RateCards = []v3sdk.RateCardInput{rc}
+
+	body := validPlanRequest("unit_no_cadence")
+	body.Phases = []v3sdk.PlanPhaseInput{phase}
+
+	var planID string
+
+	t.Run("create accepts the invalid draft", func(t *testing.T) {
+		plan, err := c.Plans.Create(t.Context(), body)
+		c.requireStatus(http.StatusCreated, err)
+		require.NotNil(t, plan)
+		assert.Equal(t, v3sdk.PlanStatusDraft, plan.Status)
+		planID = plan.ID
+	})
+
+	t.Run("validation_errors surfaces on GET", func(t *testing.T) {
+		require.NotEmpty(t, planID)
+		got, err := c.Plans.Get(t.Context(), planID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, got)
+		require.NotEmpty(t, got.ValidationErrors, "expected validation_errors on the draft")
+
+		var codes []string
+		for _, e := range got.ValidationErrors {
+			codes = append(codes, e.Code)
+		}
+		assert.Contains(t, codes, "billing_cadence_invalid_value")
+	})
+
+	t.Run("publish rejects with the same code", func(t *testing.T) {
+		require.NotEmpty(t, planID)
+		_, err := c.Plans.Publish(t.Context(), planID)
+		problem := requireProblem(t, err, http.StatusBadRequest)
+		assertValidationCode(t, problem, "billing_cadence_invalid_value")
+	})
+
+	t.Run("fix by setting billing_cadence", func(t *testing.T) {
+		require.NotEmpty(t, planID)
+		update := v3sdk.UpsertPlanRequest{
+			Name: body.Name,
+			Phases: []v3sdk.PlanPhaseInput{{
+				Key:       phase.Key,
+				Name:      phase.Name,
+				RateCards: []v3sdk.RateCardInput{validUnitRateCard(*f)},
+			}},
+		}
+		_, err := c.Plans.Update(t.Context(), planID, update)
+		c.requireStatus(http.StatusOK, err)
+	})
+
+	t.Run("publish succeeds after fix", func(t *testing.T) {
+		require.NotEmpty(t, planID)
+		published, err := c.Plans.Publish(t.Context(), planID)
+		c.requireStatus(http.StatusOK, err)
+		require.NotNil(t, published)
+		assert.Equal(t, v3sdk.PlanStatusActive, published.Status)
+	})
+}
+
 // A second draft with the same key while v1 is still draft is rejected.
 // Only one draft per key may exist at a time.
 func TestV3PlanDuplicateDraftKeyRejected(t *testing.T) {


### PR DESCRIPTION
## Summary

Creating an addon with a non-flat price (e.g. `unit`) and no `billing_cadence` failed with a 500 (`unsupported price type "unit" for flat fee rate card`) instead of a user-serviceable error.

The v3 addon rate card converter enforced this price-type restriction itself with a bare error. Converters should map the body to the service type faithfully and leave validation to the service: such rate cards now map to a zero-cadence usage-based rate card, and domain validation reports `billing_cadence_invalid_value` (field `billingCadence`, HTTP 400 attributed) — surfaced on the draft's `validation_errors` and blocking publish, matching the existing plans behavior.

Unknown price type discriminators cannot be mapped at all; those converter errors are now wrapped as validation errors so they return 400 instead of 500 (addons + plans).

Also records the converter rule in the `api` skill.

## Behavior change

`POST /addons` with a non-flat price and no `billing_cadence`: previously 500; now 201 draft carrying the `billing_cadence_invalid_value` validation error, publish rejected with 400.

## Test plan

- Unit tests on the converters (addons + plans).
- New e2e tests, run against the local stack built from this branch:
  - `TestV3AddonUnitPriceWithoutBillingCadence` — create draft → GET shows error → publish 400 → fix → publish OK
  - `TestV3PlanUnitPriceWithoutBillingCadence` — same flow for plans
  - `TestV3RateCardUnknownPriceType` — `{"type":"bogus"}` price → 400 on addon and plan create

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S93A9RigLLfBnXoauNNt7w

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes v3 rate-card conversion preserve non-flat prices without billing cadence as invalid drafts and classifies unknown price discriminators as client validation errors.

- Maps cadence-less non-flat addon rate cards to zero-cadence usage-based domain objects for structured validation.
- Wraps unsupported addon and plan price discriminators as generic validation errors so API responses use HTTP 400.
- Adds converter unit tests, draft lifecycle e2e coverage, and converter guidance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the intended invalid-draft and HTTP 400 behavior covered end to end.

The changed converters preserve cadence validation for the domain layer, prevent invalid drafts from being published, and correctly classify unknown price discriminators without introducing a reachable blocking failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/addons/convert.go | Converts cadence-less non-flat prices into zero-cadence usage rate cards and classifies unknown price types as validation errors. |
| api/v3/handlers/plans/convert.go | Wraps unsupported plan price discriminators as generic validation errors for HTTP 400 handling. |
| api/v3/handlers/addons/convert_test.go | Adds unit coverage confirming unknown addon price types produce validation errors. |
| api/v3/handlers/plans/convert_test.go | Adds equivalent unknown-price validation coverage for plans. |
| e2e/addons_v3_test.go | Covers addon invalid-draft validation, publish blocking and recovery, plus unknown discriminator handling. |
| e2e/plans_v3_test.go | Covers the plan lifecycle for a non-flat rate card lacking billing cadence. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Rate card request] --> B{Price discriminator known?}
  B -- No --> C[Generic validation error]
  C --> D[HTTP 400]
  B -- Yes --> E{Non-flat price without cadence?}
  E -- Yes --> F[Zero-cadence usage rate card]
  F --> G[Persist invalid draft]
  G --> H[Expose validation error]
  H --> I[Block publish]
  E -- No --> J[Normal rate-card conversion]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skills): add converter rule to the ..."](https://github.com/openmeterio/openmeter/commit/28a74f5b74de8892442a3bf59e40708b758798f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56005716)</sub>

<!-- /greptile_comment -->