### PR TITLE
fix(api): let domain validation own the metered entitlement usage period

### DIFF
--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -732,13 +732,9 @@ func FromAPIBillingRateCardEntitlement(e apiv3.BillingRateCardEntitlement, billi
 			}
 		}
 
-		if usagePeriod.IsZero() {
-			if billingCadence == nil || billingCadence.IsZero() {
-				return nil, models.NewGenericValidationError(
-					fmt.Errorf("metered entitlement requires usage_period when it cannot be inferred from billing_cadence"),
-				)
-			}
-
+		// When neither is set the usage period stays zero and the domain
+		// validation reports it on the entitlement template.
+		if usagePeriod.IsZero() && billingCadence != nil {
 			usagePeriod = *billingCadence
 		}
 

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -176,15 +176,24 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		assert.Equal(t, "P3M", metered.UsagePeriod.ISOString().String())
 	})
 
-	t.Run("metered — missing usage period with no billing cadence is a validation error", func(t *testing.T) {
+	t.Run("metered — missing usage period with no billing cadence converts and fails domain validation", func(t *testing.T) {
 		var apiEnt apiv3.BillingRateCardEntitlement
 		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
 			Type: "metered",
 		}))
 
 		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
-		require.Error(t, err)
-		assert.Nil(t, domain)
+		require.NoError(t, err)
+
+		metered, err := domain.AsMetered()
+		require.NoError(t, err)
+		assert.True(t, metered.UsagePeriod.IsZero())
+
+		issues, err := models.AsValidationIssues(metered.Validate())
+		require.NoError(t, err)
+		assert.True(t, lo.ContainsBy(issues, func(issue models.ValidationIssue) bool {
+			return issue.Code() == productcatalog.ErrCodeEntitlementTemplateNegativeUsagePeriod
+		}))
 	})
 
 	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -176,26 +176,6 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		assert.Equal(t, "P3M", metered.UsagePeriod.ISOString().String())
 	})
 
-	t.Run("metered — missing usage period with no billing cadence converts and fails domain validation", func(t *testing.T) {
-		var apiEnt apiv3.BillingRateCardEntitlement
-		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
-			Type: "metered",
-		}))
-
-		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
-		require.NoError(t, err)
-
-		metered, err := domain.AsMetered()
-		require.NoError(t, err)
-		assert.True(t, metered.UsagePeriod.IsZero())
-
-		issues, err := models.AsValidationIssues(metered.Validate())
-		require.NoError(t, err)
-		assert.True(t, lo.ContainsBy(issues, func(issue models.ValidationIssue) bool {
-			return issue.Code() == productcatalog.ErrCodeEntitlementTemplateNegativeUsagePeriod
-		}))
-	})
-
 	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {
 		bad := apiv3.ISO8601Duration("not-a-duration")
 		var apiEnt apiv3.BillingRateCardEntitlement

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -823,13 +823,9 @@ func FromAPIBillingRateCardEntitlement(e api.BillingRateCardEntitlement, billing
 			}
 		}
 
-		if usagePeriod.IsZero() {
-			if billingCadence == nil || billingCadence.IsZero() {
-				return nil, models.NewGenericValidationError(
-					fmt.Errorf("metered entitlement requires usage_period when it cannot be inferred from billing_cadence"),
-				)
-			}
-
+		// When neither is set the usage period stays zero and the domain
+		// validation reports it on the entitlement template.
+		if usagePeriod.IsZero() && billingCadence != nil {
 			usagePeriod = *billingCadence
 		}
 

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1775,27 +1775,6 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		assert.Equal(t, "P3M", metered.UsagePeriod.ISOString().String())
 	})
 
-	t.Run("metered — missing usage period with no billing cadence converts and fails domain validation", func(t *testing.T) {
-		var apiEnt api.BillingRateCardEntitlement
-		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(api.BillingRateCardMeteredEntitlement{
-			Type: "metered",
-		}))
-
-		// No usage_period on the entitlement and no billing cadence to default from.
-		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
-		require.NoError(t, err)
-
-		metered, err := domain.AsMetered()
-		require.NoError(t, err)
-		assert.True(t, metered.UsagePeriod.IsZero())
-
-		issues, err := models.AsValidationIssues(metered.Validate())
-		require.NoError(t, err)
-		assert.True(t, lo.ContainsBy(issues, func(issue models.ValidationIssue) bool {
-			return issue.Code() == productcatalog.ErrCodeEntitlementTemplateNegativeUsagePeriod
-		}))
-	})
-
 	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {
 		bad := api.ISO8601Duration("not-a-duration")
 		var apiEnt api.BillingRateCardEntitlement

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1775,7 +1775,7 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		assert.Equal(t, "P3M", metered.UsagePeriod.ISOString().String())
 	})
 
-	t.Run("metered — missing usage period with no billing cadence is a validation error", func(t *testing.T) {
+	t.Run("metered — missing usage period with no billing cadence converts and fails domain validation", func(t *testing.T) {
 		var apiEnt api.BillingRateCardEntitlement
 		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(api.BillingRateCardMeteredEntitlement{
 			Type: "metered",
@@ -1783,8 +1783,17 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 
 		// No usage_period on the entitlement and no billing cadence to default from.
 		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
-		require.Error(t, err)
-		assert.Nil(t, domain)
+		require.NoError(t, err)
+
+		metered, err := domain.AsMetered()
+		require.NoError(t, err)
+		assert.True(t, metered.UsagePeriod.IsZero())
+
+		issues, err := models.AsValidationIssues(metered.Validate())
+		require.NoError(t, err)
+		assert.True(t, lo.ContainsBy(issues, func(issue models.ValidationIssue) bool {
+			return issue.Code() == productcatalog.ErrCodeEntitlementTemplateNegativeUsagePeriod
+		}))
 	})
 
 	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {

--- a/e2e/entitlement_usage_period_v3_test.go
+++ b/e2e/entitlement_usage_period_v3_test.go
@@ -1,0 +1,100 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	v3sdk "github.com/openmeterio/openmeter/api/v3/client"
+)
+
+// A metered entitlement with no usage_period and no billing_cadence to default
+// it from converts as-is; the domain validation rejects the zero usage period
+// with entitlement_template_negative_usage_period. The rejection currently
+// fires at create: the entitlement_template ent field validator runs
+// EntitlementTemplate.Validate severity-blind at insert, so the draft is never
+// stored (unlike rate-card-level warnings, which surface on the draft).
+// Covers the plan and addon converters separately — they map entitlements
+// independently.
+func TestV3PlanMeteredEntitlementWithoutUsagePeriod(t *testing.T) {
+	c := newV3Client(t)
+
+	f := createMeteredFeature(t, c, "plan_ent_period")
+
+	phase := validPlanPhase("ent_period_phase", true /* isLast */)
+	phase.RateCards = []v3sdk.RateCardInput{meteredEntitlementRateCardWithoutPeriod(f)}
+
+	body := validPlanRequest("ent_period")
+	body.Phases = []v3sdk.PlanPhaseInput{phase}
+
+	_, err := c.Plans.Create(t.Context(), body)
+	problem := requireProblem(t, err, http.StatusBadRequest)
+	assertValidationCode(t, problem, "entitlement_template_negative_usage_period")
+}
+
+func TestV3AddonMeteredEntitlementWithoutUsagePeriod(t *testing.T) {
+	c := newV3Client(t)
+
+	f := createMeteredFeature(t, c, "addon_ent_period")
+
+	body := validAddonRequest("ent_period")
+	body.RateCards = []v3sdk.RateCardInput{meteredEntitlementRateCardWithoutPeriod(f)}
+
+	_, err := c.Addons.Create(t.Context(), body)
+	problem := requireProblem(t, err, http.StatusBadRequest)
+	assertValidationCode(t, problem, "entitlement_template_negative_usage_period")
+}
+
+// createMeteredFeature provisions a sum meter and a feature bound to it, the
+// prerequisite for metered entitlement templates.
+func createMeteredFeature(t *testing.T, c *v3Client, keyPrefix string) v3sdk.Feature {
+	t.Helper()
+
+	meterKey := uniqueKey(keyPrefix)
+
+	m, err := c.Meters.Create(t.Context(), v3sdk.CreateMeterRequest{
+		Key:           meterKey,
+		Name:          "Test Meter " + meterKey,
+		Aggregation:   v3sdk.MeterAggregationSum,
+		EventType:     uniqueKey(keyPrefix + "_event"),
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, m)
+
+	featureKey := uniqueKey(keyPrefix)
+
+	f, err := c.Features.Create(t.Context(), v3sdk.CreateFeatureRequest{
+		Key:  featureKey,
+		Name: "Test Feature " + featureKey,
+		Meter: &v3sdk.FeatureMeterReferenceInput{
+			ID: m.ID,
+		},
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, f)
+
+	return *f
+}
+
+// meteredEntitlementRateCardWithoutPeriod builds a flat rate card with no
+// billing cadence whose metered entitlement omits usage_period — the usage
+// period cannot be defaulted and stays zero.
+func meteredEntitlementRateCardWithoutPeriod(f v3sdk.Feature) v3sdk.RateCardInput {
+	term := v3sdk.PricePaymentTermInAdvance
+
+	entitlement := lo.Must(v3sdk.RateCardEntitlementFromRateCardMeteredEntitlement(v3sdk.RateCardMeteredEntitlement{
+		Limit: lo.ToPtr(float64(1000)),
+	}))
+
+	return v3sdk.RateCardInput{
+		Key:         f.Key,
+		Name:        "Test Entitlement Rate Card " + f.Key,
+		Price:       lo.Must(v3sdk.PriceFromPriceFlat(v3sdk.PriceFlat{Amount: "10"})),
+		PaymentTerm: &term,
+		Feature:     &v3sdk.FeatureReference{ID: f.ID},
+		Entitlement: &entitlement,
+	}
+}

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -349,6 +349,7 @@ var ErrEntitlementTemplateNegativeUsagePeriod = models.NewValidationIssue(
 	"usage period must be positive",
 	models.WithFieldString("usagePeriod"),
 	models.WithWarningSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
 const ErrCodeEntitlementTemplateUsagePeriodLessThenAnHour models.ErrorCode = "entitlement_template_usage_period_less_then_an_hour"


### PR DESCRIPTION
## Summary

The v3 plan and addon rate card converters hard-rejected (400 at create) a metered entitlement that has no `usage_period` and no `billing_cadence` to default it from. That duplicates the domain layer: `MeteredEntitlementTemplate.Validate` already rejects a non-positive usage period (`entitlement_template_negative_usage_period`).

The converters now keep the defaulting (`usage_period` ← rate card billing cadence) but map a zero usage period through, so the domain validation reports it.

Companion one-liner: `entitlement_template_negative_usage_period` was missing the HTTP 400 status attribute its sibling `..._less_then_an_hour` issue carries — added so its 400 mapping is deliberate rather than dependent on the sibling firing alongside.

Converters should translate bodies to service types faithfully and leave validation to the owning layer (same principle as #4979, sibling of #4980).

## Behavior change

Create with a metered entitlement lacking both `usage_period` and `billing_cadence` still returns 400 at create — but now with the structured domain code `entitlement_template_negative_usage_period` (field `$.entitlementTemplate.usagePeriod`) instead of the converter's free-text message.

Writing the e2e tests surfaced why it stays a create-time 400 rather than the draft-with-issues flow used by other rate card warnings: ent auto-runs `Validate()` on the `entitlement_template` field's Go type at insert (`ent/db/addonratecard_create.go` generated check), severity-blind. Entitlement warnings therefore block persistence while rate-card-level warnings (e.g. `billing_cadence_invalid_value`) are stored on the draft. That layering inconsistency predates this PR and is left as a follow-up.

## Test plan

- New e2e tests (`TestV3PlanMeteredEntitlementWithoutUsagePeriod`, `TestV3AddonMeteredEntitlementWithoutUsagePeriod`) assert both endpoints reject with 400 + `entitlement_template_negative_usage_period`; run green against a local stack built from this branch.
- `go test ./api/v3/handlers/addons/... ./api/v3/handlers/plans/... ./openmeter/productcatalog/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S93A9RigLLfBnXoauNNt7w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for metered entitlements with missing usage periods during plan and addon creation.
  * Usage periods continue to be inferred from billing cadence when available.
  * Missing usage periods now receive consistent domain validation instead of failing during conversion.
  * Invalid or missing usage periods return an HTTP 400 response with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves missing metered-entitlement usage-period handling from the v3 plan and add-on converters into product-catalog domain validation.
- Preserves billing-cadence defaulting while allowing an unresolved zero period to reach domain validation.
- Explicitly maps the negative-usage-period validation issue to HTTP 400.
- Adds end-to-end coverage confirming plan and add-on creation rejects the invalid entitlement with the domain validation code.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/addons/convert.go | Defers unresolved metered-entitlement usage periods to product-catalog validation while retaining cadence defaulting. |
| api/v3/handlers/plans/convert.go | Applies the same domain-validation ownership change to plan rate-card conversion. |
| openmeter/productcatalog/errors.go | Adds an explicit HTTP 400 attribute to the negative usage-period validation issue. |
| e2e/entitlement_usage_period_v3_test.go | Covers the plan and add-on create paths and verifies the domain validation code returned for an absent usage period. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant API as V3 Plan/Add-on API
  participant Converter
  participant Domain as Product Catalog Validation
  Client->>API: Create with metered entitlement
  API->>Converter: Convert request
  alt Billing cadence is available
    Converter->>Converter: Default usage period from cadence
  else No usage period or cadence
    Converter->>Domain: Pass zero usage period through
    Domain-->>API: negative_usage_period validation issue
    API-->>Client: HTTP 400
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(api): cover missing entitlement usa..."](https://github.com/openmeterio/openmeter/commit/3f6b14ac8a62006a64df388f69ed436c01232564) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56010282)</sub>

<!-- /greptile_comment -->