### PR TITLE
fix(charges): restore sync-failed overage deletion

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -107,8 +107,9 @@ finalization callback. Engines return fully calculated lines with unchanged
 line IDs; billing replaces those lines, sums their totals, and persists the
 invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
-engine-owned effects. Once line finalization starts, issuing is retry-only;
-invoice deletion requires correction support for any durable preparation.
+engine-owned effects. Line-finalization failures are retry-only. If invoicing
+app synchronization fails after durable preparation succeeds, charge-owned
+cleanup must correct that preparation before the invoice can be deleted.
 
 A deleted app keeps its historical identity and can still be expanded on
 invoices. Its generic app operations return `app.ErrAppDeleted`, while its

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -280,9 +280,13 @@ Charge-currency and settlement-fiat allocations are separate realization and
 lineage domains. Rating and mutable rerating reconcile charge-currency facts;
 invoice finalization first persists the gross converted overage, then allocates
 settlement-fiat credits once against it. Invoice-issued callbacks only advance
-the prepared custom-currency run. Once preparation starts, invoice issuing is
-retry-only; generic correction of prepared accounting is not part of this
-lifecycle.
+the prepared custom-currency run. A line-finalization failure remains
+retry-only. If synchronization with the invoicing app fails after preparation,
+invoice deletion corrects settlement-fiat allocations, the gross overage, and
+charge-currency allocations before deleting the prepared run. Cleanup and its
+ledger effects share the billing transaction. Failed cleanup rolls back and
+leaves preparation attached for retry from `delete.failed`; committed cleanup
+sets `DeletedAt`, so later invoice-delete sync retries do not dispatch it again.
 
 The converted post-allocation overage and the required fiat transaction are
 separate settlement facts. A zero converted overage controls line omission and

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -146,6 +146,10 @@ type OnCustomCurrencyOverageAccruedResult struct {
 	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
+
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
 
@@ -344,6 +348,12 @@ type Handler interface {
 	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
 	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
+
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
 	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -376,36 +377,30 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		}
 
 		if charge.Intent.GetCurrency().IsCustom() {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf(
-				"custom-currency flat fee line[%s] cannot be deleted: %w",
-				line.GetID(),
-				billing.ErrCannotUpdateChargeManagedLine,
-			)
+			err := transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+				if err := validatePreparedCustomCurrencyInvoiceDelete(input.Invoice, charge, line); err != nil {
+					return err
+				}
+
+				charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge)
+				if err != nil {
+					return fmt.Errorf("canceling prepared flat fee run for line[%s]: %w", line.GetID(), err)
+				}
+
+				return e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID)
+			})
+			if err != nil {
+				return billing.OnMutableInvoiceUpdateResult{}, err
+			}
+
+			continue
 		}
 
 		if err := validateManualDeleteLine(charge, line); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 
-		stateMachine, err := e.service.newStateMachineForCharge(charge)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
-		}
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceAPIRequest,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
-		})
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
-		}
-
-		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
-		}
-
-		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, patches); err != nil {
+		if err := e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -414,6 +409,34 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		CreatedLines: createdLines,
 		UpdatedLines: updatedLines,
 	}, nil
+}
+
+func (e *LineEngine) deleteLineViaAPI(
+	ctx context.Context,
+	invoice billing.GenericInvoiceReader,
+	charge flatfee.Charge,
+	line billing.GenericInvoiceLine,
+	chargeID string,
+) error {
+	stateMachine, err := e.service.newStateMachineForCharge(charge)
+	if err != nil {
+		return fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
+	}
+
+	deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		Policy:       meta.RefundAsCreditsDeletePolicy,
+	})
+	if err != nil {
+		return fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
+	}
+
+	patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
+	if err != nil {
+		return fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
+	}
+
+	return e.handleManualDeleteInvoicePatches(ctx, invoice, line, chargeID, patches)
 }
 
 func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) error {
@@ -438,7 +461,7 @@ func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, i
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.validateManualDeleteLineViaAPI(ctx, line); err != nil {
+		if err := e.validateManualDeleteLineViaAPI(ctx, input.Invoice, line); err != nil {
 			return err
 		}
 	}
@@ -495,7 +518,7 @@ func (e *LineEngine) validateManualUpdateLineViaAPI(ctx context.Context, overrid
 	return nil
 }
 
-func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line billing.GenericInvoiceLine) error {
+func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
 	chargeID := line.GetChargeID()
 	if chargeID == nil || *chargeID == "" {
 		return fmt.Errorf("flat fee line[%s]: charge id is required", line.GetID())
@@ -523,14 +546,76 @@ func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line bi
 	}
 
 	if charge.Intent.GetCurrency().IsCustom() {
-		return fmt.Errorf(
-			"custom-currency flat fee line[%s] cannot be deleted: %w",
-			line.GetID(),
-			billing.ErrCannotUpdateChargeManagedLine,
-		)
+		return validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, line)
 	}
 
 	return validateManualDeleteLine(charge, line)
+}
+
+func validatePreparedCustomCurrencyInvoiceDelete(invoice billing.GenericInvoiceReader, charge flatfee.Charge, line billing.GenericInvoiceLine) error {
+	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
+		return fmt.Errorf("custom-currency flat fee line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("flat fee line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	switch standardInvoice.Status {
+	case billing.StandardInvoiceStatusIssuingSyncFailed,
+		billing.StandardInvoiceStatusDeleteInProgress,
+		billing.StandardInvoiceStatusDeleteFailed:
+	default:
+		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	run := charge.Realizations.CurrentRun
+	if run == nil || run.LineID == nil || *run.LineID != line.GetID() || run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.AccruedUsage == nil || !run.FiatOverageCreditAllocationCompleted || !run.Immutable {
+		return fmt.Errorf("custom-currency flat fee line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.Payment != nil {
+		return fmt.Errorf("custom-currency flat fee line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) cancelPreparedCustomCurrencyRun(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
+	run := *charge.Realizations.CurrentRun
+	if err := e.service.realizations.CorrectAllCreditRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
+		Charge:     charge,
+		Run:        run,
+		AllocateAt: flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
+	}); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	if err := e.service.adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	deletedAt := clock.Now()
+	runBase, err := e.service.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:        run.ID,
+		DeletedAt: mo.Some(lo.ToPtr(deletedAt)),
+	})
+	if err != nil {
+		return flatfee.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+	run.RealizationRunBase = runBase
+
+	if err := e.service.adapter.DetachCurrentRun(ctx, charge.GetChargeID()); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	charge.Realizations.PriorRuns = append(charge.Realizations.PriorRuns, run)
+	charge.Realizations.CurrentRun = nil
+
+	return charge, nil
 }
 
 type manualCreatedInvoiceLine struct {

--- a/openmeter/billing/charges/flatfee/service/realizations/credits.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credits.go
@@ -402,6 +402,19 @@ func (s *Service) CorrectAllCreditRealizations(
 		}); err != nil {
 			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
 		}
+
+		if input.Run.AccruedUsage != nil {
+			correctionInput := flatfee.OnCustomCurrencyOverageAccruedCorrectionInput{
+				Charge: input.Charge,
+				Run:    input.Run,
+			}
+			if err := correctionInput.Validate(); err != nil {
+				return fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+			}
+			if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+				return fmt.Errorf("correct custom-currency overage accrual: %w", err)
+			}
+		}
 	}
 
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -37,15 +37,16 @@ func (m *mockLineageService) BackfillAdvanceLineageSegments(ctx context.Context,
 var _ flatfee.Handler = (*flatFeeTestHandler)(nil)
 
 type flatFeeTestHandler struct {
-	onAllocateCredits                     func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onInvoiceUsageAccrued                 func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
-	onCorrectCreditAllocations            func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onPaymentAuthorized                   func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onPaymentUncollectible                func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
+	onAllocateCredits                        func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onCorrectCreditAllocations               func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onPaymentAuthorized                      func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onPaymentUncollectible                   func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
 }
 
 func newFlatFeeTestHandler() *flatFeeTestHandler {
@@ -74,6 +75,14 @@ func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Context,
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
@@ -180,14 +189,15 @@ func (h *creditPurchaseTestHandler) Reset() {
 var _ usagebased.Handler = (*usageBasedTestHandler)(nil)
 
 type usageBasedTestHandler struct {
-	onInvoiceUsageAccrued                 func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
-	onPaymentAuthorized                   func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onCreditsOnlyUsageAccrued             func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
-	onCreditsOnlyUsageAccruedCorrection   func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onPaymentAuthorized                      func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onCreditsOnlyUsageAccrued                func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
+	onCreditsOnlyUsageAccruedCorrection      func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 }
 
 func newUsageBasedTestHandler() *usageBasedTestHandler {
@@ -208,6 +218,14 @@ func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Conte
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *usageBasedTestHandler) OnPaymentAuthorized(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -586,7 +586,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				}
 
 				if test.expectPaymentSettled {
-
 					authorizedCallback = newCountedLedgerTransactionCallback[flatfee.OnPaymentAuthorizedInput]()
 					s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input flatfee.OnPaymentAuthorizedInput) {
 						assert.Equal(t, chargeID.ID, input.Charge.ID)
@@ -749,6 +748,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a custom-currency flat-fee run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -810,9 +817,17 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 	}
 	s.FlatFeeTestHandler.onAllocateCredits = func(
 		_ context.Context,
-		_ flatfee.OnAllocateCreditsInput,
+		input flatfee.OnAllocateCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
-		return nil, nil
+		return creditrealization.CreateAllocationInputs{
+			{
+				ServicePeriod: input.ServicePeriod,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+				Amount: alpacadecimal.NewFromInt(2),
+			},
+		}, nil
 	}
 	fiatOverageAllocationInvocations := 0
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = func(
@@ -824,7 +839,34 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
+	correctionEvents := make([]string, 0, 6)
+	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input flatfee.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ flatfee.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.FlatFeeTestHandler.onCorrectCreditAllocations = func(
+		_ context.Context,
+		input flatfee.CorrectCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -859,7 +901,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 						},
 						InvoiceAt:             invoiceAt,
 						PaymentTerm:           productcatalog.InArrearsPaymentTerm,
-						AmountBeforeProration: alpacadecimal.NewFromInt(10),
+						AmountBeforeProration: alpacadecimal.NewFromInt(12),
 					},
 					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 					CostBasis:      &costBasisIntent,
@@ -898,7 +940,11 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
 	s.Run("when invoice sync fails after fiat allocation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
@@ -923,11 +969,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(5), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
 
-		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
-			Invoice:        invoice.GetInvoiceID(),
-			DeletionSource: billing.ChangeSourceSystem,
-		})
-		s.ErrorContains(err, "invoice action not available")
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceSystem,
@@ -949,6 +991,94 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Require().NotNil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.CurrentRun.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.CreditRealizations[0].Type)
+			s.Nil(charge.Realizations.CurrentRun.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Equal(flatfee.StatusDeleted, charge.Status)
+			s.Nil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.PriorRuns, 1)
+			run := charge.Realizations.PriorRuns[0]
+			s.Require().NotNil(run.DeletedAt)
+			s.Require().Len(run.FiatOverageCreditRealizations, 2)
+			s.Zero(run.FiatOverageCreditRealizations.Sum().InexactFloat64())
+			s.Require().Len(run.CreditRealizations, 2)
+			s.Zero(run.CreditRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -325,6 +325,14 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyCreditThenInvoi
 }
 
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a collected custom-currency usage run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -406,8 +414,35 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
-	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(0)
+	correctionEvents := make([]string, 0, 6)
+	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input usagebased.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.UsageBasedTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ usagebased.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(2)
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccruedCorrection = func(
+		_ context.Context,
+		input usagebased.CreditsOnlyUsageAccruedCorrectionInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -419,6 +454,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 	var (
 		chargeID meta.ChargeID
+		runID    usagebased.RealizationRunID
 		invoice  billing.StandardInvoice
 	)
 
@@ -460,7 +496,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		s.MockStreamingConnector.AddSimpleEvent(
 			feature.Feature.Key,
-			5,
+			6,
 			usageAt,
 			streamingtestutils.WithStoredAt(usageAt),
 		)
@@ -496,7 +532,11 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
 	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
@@ -549,6 +589,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		charge := s.mustGetUsageBasedChargeByID(chargeID)
 		run, err := charge.GetCurrentRealizationRun()
 		s.Require().NoError(err)
+		runID = run.ID
 		s.Require().NotNil(run.InvoiceUsage)
 		s.Require().NotNil(run.InvoiceUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
@@ -560,11 +601,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 			"fiat overage",
 		)
 
-		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
-			Invoice:        invoice.GetInvoiceID(),
-			DeletionSource: billing.ChangeSourceSystem,
-		})
-		s.ErrorContains(err, "invoice action not available")
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceSystem,
@@ -586,6 +623,101 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			run, err := charge.GetCurrentRealizationRun()
+			s.Require().NoError(err)
+			s.Require().Len(run.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(run.CreditsAllocated, 1)
+			s.Equal(creditrealization.TypeAllocation, run.CreditsAllocated[0].Type)
+			s.Nil(run.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			s.Equal(usagebased.StatusDeleted, charge.Status)
+			s.Nil(charge.State.CurrentRealizationRunID)
+			dbRun, err := s.DBClient.ChargeUsageBasedRuns.Get(ctx, runID.ID)
+			s.Require().NoError(err)
+			s.Require().NotNil(dbRun.DeletedAt)
+			dbFiatRealizations, err := dbRun.QueryFiatOverageCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			fiatRealizations := creditrealization.FromDBRealizations(dbFiatRealizations)
+			s.Require().Len(fiatRealizations, 2)
+			s.Zero(fiatRealizations.Sum().InexactFloat64())
+			dbChargeRealizations, err := dbRun.QueryCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			chargeRealizations := creditrealization.FromDBRealizations(dbChargeRealizations)
+			s.Require().Len(chargeRealizations, 2)
+			s.Zero(chargeRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
@@ -1501,7 +1633,6 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 				}
 
 				if test.expectPaymentSettled {
-
 					authorizedCallback = newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
 					s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(_ *testing.T, input usagebased.OnPaymentAuthorizedInput) {
 						s.Equal(chargeID.ID, input.Charge.ID)

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -66,6 +66,10 @@ func (mockFlatFeeHandler) OnCustomCurrencyOverageAccrued(_ context.Context, inpu
 	}, nil
 }
 
+func (mockFlatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
+}
+
 func (mockFlatFeeHandler) OnCorrectCreditAllocations(_ context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
 	return lo.Map(input.Corrections, func(correction creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
 		return creditrealization.CreateCorrectionInput{
@@ -151,6 +155,10 @@ func (mockUsageBasedHandler) OnCustomCurrencyOverageAccrued(_ context.Context, i
 		TransactionGroup: newMockLedgerTransactionGroupReference(),
 		TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
 	}, nil
+}
+
+func (mockUsageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
 }
 
 func (mockUsageBasedHandler) OnPaymentAuthorized(context.Context, usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -298,6 +298,10 @@ type OnCustomCurrencyOverageAccruedResult struct {
 	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
 
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
+
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
 
@@ -360,6 +364,12 @@ type Handler interface {
 	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
 
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
+
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.
 	OnCreditsOnlyUsageAccrued(ctx context.Context, input CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
 
@@ -384,6 +394,10 @@ func (h UnimplementedHandler) OnInvoiceUsageAccrued(ctx context.Context, input O
 
 func (h UnimplementedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error) {
 	return OnCustomCurrencyOverageAccruedResult{}, errors.New("not implemented")
+}
+
+func (h UnimplementedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return errors.New("not implemented")
 }
 
 func (h UnimplementedHandler) OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
@@ -357,7 +358,10 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line); err != nil {
+		err := transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+			return e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line)
+		})
+		if err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -600,6 +604,16 @@ func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoic
 			// This is an internal consistency error, we are not supposed to surface this to the user, so no typed error wrapping.
 			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
 		}
+
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return usagebased.Charge{}, fmt.Errorf("getting usage based realization run for line[%s]: %w", line.GetID(), err)
+		}
+		if charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil {
+			if err := validatePreparedCustomCurrencyInvoiceDelete(invoice, charge, run, line); err != nil {
+				return usagebased.Charge{}, err
+			}
+		}
 	default:
 		return usagebased.Charge{}, fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
 	}
@@ -665,6 +679,17 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		return nil
 	case billing.InvoiceLineTypeStandard:
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: getting realization run: %w", line.GetID(), err)
+		}
+		preparedRunCanceled := charge.Intent.GetEffectiveIntent().Currency.IsCustom() && run.InvoiceUsage != nil
+		if preparedRunCanceled {
+			charge, err = e.cancelPreparedCustomCurrencyRun(ctx, charge, &run)
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: canceling prepared realization run: %w", line.GetID(), err)
+			}
+		}
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,
@@ -689,27 +714,33 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		if len(stdInvoicePatches) != 1 {
-			return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
-		}
+		if preparedRunCanceled {
+			if len(stdInvoicePatches) != 0 {
+				return fmt.Errorf("usage based line[%s]: prepared cancellation emitted unexpected standard invoice patches: %v", line.GetID(), stdInvoicePatches)
+			}
+		} else {
+			if len(stdInvoicePatches) != 1 {
+				return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
+			}
 
-		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		if err := stdInvoicePatch.RequireTarget(line); err != nil {
-			return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			if err := stdInvoicePatch.RequireTarget(line); err != nil {
+				return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		standardLine, err := line.AsInvoiceLine().AsStandardLine()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			standardLine, err := line.AsInvoiceLine().AsStandardLine()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 		}
 
 		// Handle the remaining gathering line patches
@@ -728,6 +759,66 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 	default:
 		return fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
 	}
+}
+
+func validatePreparedCustomCurrencyInvoiceDelete(
+	invoice billing.GenericInvoiceReader,
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	line billing.GenericInvoiceLine,
+) error {
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("usage based line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	switch standardInvoice.Status {
+	case billing.StandardInvoiceStatusIssuingSyncFailed,
+		billing.StandardInvoiceStatusDeleteInProgress,
+		billing.StandardInvoiceStatusDeleteFailed:
+	default:
+		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted before invoice synchronization: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	intent := charge.Intent.GetEffectiveIntent()
+	if !intent.Currency.IsCustom() || intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return fmt.Errorf("usage based line[%s] is not a custom-currency credit-then-invoice line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if charge.State.CurrentRealizationRunID == nil || *charge.State.CurrentRealizationRunID != run.ID.ID {
+		return fmt.Errorf("custom-currency usage based line[%s] must reference the current realization run: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID || run.LineID == nil || *run.LineID != line.GetID() {
+		return fmt.Errorf("custom-currency usage based line[%s] has mismatched invoice preparation references: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if !run.FiatOverageCreditAllocationCompleted {
+		return fmt.Errorf("custom-currency usage based line[%s] does not have completed invoice issuance preparation: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if run.Payment != nil {
+		return fmt.Errorf("custom-currency usage based line[%s] cannot be deleted after payment booking: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) cancelPreparedCustomCurrencyRun(
+	ctx context.Context,
+	charge usagebased.Charge,
+	run *usagebased.RealizationRun,
+) (usagebased.Charge, error) {
+	if err := e.service.runs.CorrectAllCreditRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
+		Charge:     charge,
+		Run:        *run,
+		AllocateAt: run.ServicePeriodTo,
+	}); err != nil {
+		return usagebased.Charge{}, fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+	}
+
+	charge, err := e.markMutableStandardLineRunDeleted(ctx, charge, *run, clock.Now())
+	if err != nil {
+		return usagebased.Charge{}, fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+	}
+
+	return charge, nil
 }
 
 func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Context, charge usagebased.Charge, patch meta.Patch) (usagebased.Charge, invoiceupdater.Patches, error) {

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -436,6 +436,19 @@ func (s *Service) CorrectAllCreditRealizations(
 		}); err != nil {
 			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
 		}
+
+		if input.Run.InvoiceUsage != nil {
+			correctionInput := usagebased.OnCustomCurrencyOverageAccruedCorrectionInput{
+				Charge: input.Charge,
+				Run:    input.Run,
+			}
+			if err := correctionInput.Validate(); err != nil {
+				return fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+			}
+			if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+				return fmt.Errorf("correct custom-currency overage accrual: %w", err)
+			}
+		}
 	}
 
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -766,6 +766,11 @@ func (s *Service) DeleteInvoice(ctx context.Context, input billing.DeleteInvoice
 			if input.DeletionSource != billing.ChangeSourceAPIRequest {
 				return nil
 			}
+			// Charge cleanup committed before invoice-app synchronization. A retry
+			// must not validate or dispatch those already-applied line deletions.
+			if sm.Invoice.DeletedAt != nil {
+				return nil
+			}
 
 			if err := s.validateAPIStandardLineDeletions(
 				ctx,

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -222,8 +222,8 @@ func allocateStateMachine() *InvoiceStateMachine {
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleted)
 
 	// Issuing state. Line finalization handlers can persist durable preparation
-	// before returning, so failed and later issuing states are retry-only until
-	// correction support can make deletion safe.
+	// before returning. Preparation failures remain retry-only, while invoice-app
+	// synchronization can be abandoned through the charge-owned correction path.
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalization).
 		Permit(
@@ -250,6 +250,7 @@ func allocateStateMachine() *InvoiceStateMachine {
 		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingSyncFailed).
+		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingSyncing)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBooking).

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -165,6 +165,14 @@ func (h *flatFeeHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, inp
 	return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *flatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *flatFeeHandler) OnAllocateFiatOverageCredits(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -179,6 +179,14 @@ func (h *usageBasedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, 
 	return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *usageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *usageBasedHandler) OnAllocateFiatOverageCredits(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- restore invoice deletion from `issuing.sync.failed` after custom-currency overage preparation
- cancel prepared FF and UBP runs in accounting order: settlement-FIAT credit allocations, gross overage correction, then charge-currency allocations
- keep direct charge deletion guarded after preparation; cancellation is owned by the invoice delete lifecycle
- run charge cleanup and ledger callbacks in the caller transaction, so failed cleanup rolls back before retry
- persist invoice deletion before invoicing-app delete sync, so sync retries do not repeat committed charge cleanup

## Scope

This PR is stacked on #4959. It defines the billing/charge correction contract and orchestration only. Production custom-currency ledger adapters remain explicitly unsupported; real gross-overage and FIAT ledger correction behavior is not implemented here.

## Tests

- FF and UBP service-backed invoice sync failure deletion
- correction call ordering across FIAT, gross overage, and charge currency
- later-step correction failure rolls back earlier cleanup and remains retryable from `delete.failed`
- invoicing-app delete failure retries sync without repeating committed cleanup
- persisted allocation/run audit history after cancellation
- existing invoice sync retry remains idempotent
- direct charge deletion remains rejected after preparation

Focused lifecycle tests and the full billing and charge service package tests pass.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores deletion of invoices whose external synchronization failed after custom-currency overage preparation.
- Cancels prepared flat-fee and usage-based runs in accounting order within the caller transaction.
- Persists invoice deletion before retrying invoicing-app synchronization, preventing committed cleanup from being replayed.
- Adds lifecycle tests covering rollback, retry, correction ordering, and retained audit history.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/service/invoice.go | Reorders invoice persistence and external delete synchronization to make retries avoid replaying committed charge cleanup. |
| openmeter/billing/service/stdinvoicestate.go | Restores deletion as an available transition after issuing synchronization fails. |
| openmeter/billing/charges/flatfee/service/lineengine.go | Adds transactional validation and cancellation of prepared custom-currency flat-fee realization runs. |
| openmeter/billing/charges/usagebased/service/lineengine.go | Adds transactional cancellation and deletion handling for prepared custom-currency usage-based runs. |
| openmeter/billing/charges/service/invoicable_test.go | Covers flat-fee correction ordering, rollback, audit history, and external deletion retry behavior. |
| openmeter/billing/charges/service/usagebased_test.go | Covers equivalent usage-based cancellation and retry behavior with explicit lifecycle intent comments. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Billing service
    participant C as Charge engine
    participant L as Ledger callbacks
    participant DB as Billing database
    participant A as Invoicing app
    B->>C: Delete prepared invoice line
    C->>L: Correct FIAT allocations
    C->>L: Correct gross overage
    C->>L: Correct charge-currency allocations
    alt Cleanup fails
        C-->>B: Error
        B->>DB: Roll back cleanup
    else Cleanup succeeds
        C->>DB: Delete run and detach it
        B->>DB: Persist invoice deletion
        B->>A: Delete external invoice
        alt App deletion fails
            A-->>B: Error
            Note over B,DB: Retry external sync without replaying cleanup
        end
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(charges): restore sync-failed overag..."](https://github.com/openmeterio/openmeter/commit/7ed9d7602725034ef031e068cdb285263603e9f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56206385)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice synchronization failures can now be retried safely without losing prepared billing data.
  * Invoices can be deleted after synchronization failures, with associated allocations and overage records cleaned up transactionally.
  * Repeated deletion retries no longer repeat completed cleanup or redispatch unnecessary operations.
  * Custom-currency overage corrections now run during invoice deletion and rollback flows.

* **Tests**
  * Expanded coverage for synchronization retries, deletion cleanup, correction callbacks, and transactional rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->