### PR TITLE
ci: improve golangci caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,14 +50,20 @@ jobs:
           primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{ hashFiles('flake.*') }}
           save: "true"
 
-      - name: Populate go caches - go mod download
-        run: nix develop --impure .#ci -c go mod download
+      - name: Populate Go module cache
+        run: |
+          nix develop --impure .#ci -c sh -eu -c '
+            go mod download
+            go -C collector mod download
+            go -C api/v3/client mod download
+            go -C e2e mod download
+          '
 
-      - name: Save go caches - go mod
+      - name: Save Go module cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
 
   build:
     name: Build
@@ -94,16 +100,16 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Validate Nix flake
@@ -175,16 +181,16 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Ensure code generators are run
@@ -294,16 +300,16 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Ensure code generators are run
@@ -408,17 +414,16 @@ jobs:
       - name: Upsert Nix store
         run: nix develop --impure .#ci
 
-      # This shaves off 5s or so
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Wait for dependencies to be ready
@@ -486,15 +491,15 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Run migration checks
@@ -538,44 +543,30 @@ jobs:
       - name: Upsert Nix store
         run: nix develop --impure .#ci
 
-      # This shaves off 5s or so
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
-      - name: Get main fork point
-        id: base-commit
-        run: |
-          git fetch origin main
-
-          echo "base candidate:"
-          git log -1 --reverse --boundary HEAD ^origin/main
-
-          BASE_COMMIT=$(git log -1 --reverse --boundary --format=%h HEAD ^origin/main)
-          if [ -z "$BASE_COMMIT" ]; then
-            BASE_COMMIT=$(git log -1 --format=%h)
-          fi
-          echo "sha=${BASE_COMMIT}" >> "$GITHUB_OUTPUT"
-
-          echo "sha=${BASE_COMMIT}"
-
-      - name: Lint cache
+      # PR merge commits change on every update, so use the target commit to
+      # keep unchanged package analysis reusable across the pull request.
+      - name: Go lint caches
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/golangci-lint-cache
-          key: ${{ runner.os }}-openmeter-golangci-lint-cache-${{ steps.base-commit.outputs.sha }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: |
+            .devenv/golangci-lint-cache
+            .devenv/state/go/build-cache
+          key: ${{ runner.os }}-openmeter-go-lint-${{ github.event.pull_request.base.sha || github.sha }}-${{ hashFiles('flake.*', '.golangci*.yaml', 'go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-golangci-lint-cache-${{ steps.base-commit.outputs.sha }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
-            ${{ runner.os }}-openmeter-golangci-lint-cache-${{ steps.base-commit.outputs.sha }}-
-            ${{ runner.os }}-openmeter-golangci-lint-cache-
+            ${{ runner.os }}-openmeter-go-lint-${{ github.event.pull_request.base.sha || github.sha }}-
+            ${{ runner.os }}-openmeter-go-lint-
 
       - name: Run linters - go
         env:
@@ -783,15 +774,15 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Check container health
@@ -907,15 +898,15 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           # Prefer to restore the branch cache over the main cache
           restore-keys: |
             ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
             ${{ runner.os }}-openmeter-go-modules-main
 
       - name: Check container health


### PR DESCRIPTION
## What

- Updated GitHub Actions to cache Go modules from the actual `GOMODCACHE` directory.
- Added cache warming for the root, collector, v3 Go SDK, and e2e modules.
- Persisted golangci-lint analysis and Go build caches.
- Replaced the unstable lint-cache key with one based on the pull request target commit.

## Why

The previous module cache stored `.devenv/state/go`, while Go downloads modules into `$HOME/go/pkg/mod`. The lint-cache fork-point calculation also resolved to the changing PR merge commit on shallow checkouts, frequently preventing effective cache reuse and causing long lint runs.

## How

- Save and restore `~/go/pkg/mod`, keyed by every module’s `go.mod` and `go.sum`.
- Run `go mod download` for all four modules when rebuilding caches.
- Key lint caches with `github.event.pull_request.base.sha`, falling back to `github.sha`.
- Cache `.devenv/golangci-lint-cache` and `.devenv/state/go/build-cache` together.
- Validate the workflow with actionlint, YAML parsing, the exact module-download command, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI build performance by caching Go modules and build artifacts.
  * Updated caching across build, generation, testing, migration, linting, quickstart, and end-to-end workflows.
  * Added more reliable cache keys based on the target commit or current revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns GitHub Actions caching with the repository’s configured Go cache directories and makes lint cache keys more stable across pull-request updates.
- Warms and caches dependencies for the root, collector, Go SDK, and end-to-end modules.
- Restores the shared module cache across Go-related CI jobs.
- Persists golangci-lint analysis and Go build caches using the pull request’s target commit.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no blocking or non-blocking issues identified.

The configured module-cache path matches the Nix development environment, the warmed module set matches the repository layout, and the lint cache inputs cover the modules processed by the lint job.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Updates Go module and lint cache paths, warming, keys, and restoration consistently; no actionable defect was identified. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Push[Push to main] --> Warm[Download dependencies for four Go modules]
  Warm --> ModuleCache[Save shared module cache]
  ModuleCache --> Jobs[Restore in build, generation, test, lint, and E2E jobs]
  PR[Pull request] --> LintKey[Key by target commit and lint inputs]
  LintKey --> LintCaches[Restore and save golangci-lint and Go build caches]
  LintCaches --> Lint[Run Go linters]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: improve golangci caching"](https://github.com/openmeterio/openmeter/commit/ab1b735385b8bf87d3ceb724a66ca054fc092774) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56220918)</sub>

<!-- /greptile_comment -->