### PR TITLE
fix(sink): handling partition assignment updates

### DIFF
--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -820,12 +820,6 @@ func (s *Sink) rebalance(c *kafka.Consumer, event kafka.Event) error {
 
 	switch e := event.(type) {
 	case kafka.AssignedPartitions:
-		// We resume the consumer after the partitions are assigned to start processing new messages.
-		err := s.resume()
-		if err != nil {
-			return fmt.Errorf("failed to resume after assigned partitions: %w", err)
-		}
-
 		// Logs newly assigned partitions only (doesn't log already assigned partitions)
 		logger.Info("kafka partition assignment", "partitions", prettyPartitions(e.Partitions))
 
@@ -842,9 +836,15 @@ func (s *Sink) rebalance(c *kafka.Consumer, event kafka.Event) error {
 		}
 
 		// IncrementalAssign adds the specified partitions to the current set of partitions to consume.
-		err = s.config.Consumer.IncrementalAssign(e.Partitions)
+		err := s.config.Consumer.IncrementalAssign(e.Partitions)
 		if err != nil {
 			return fmt.Errorf("failed to assign partitions: %w", err)
+		}
+
+		// We resume the consumer after the partitions are assigned to start processing new messages.
+		err = s.config.Consumer.Resume(e.Partitions)
+		if err != nil {
+			return fmt.Errorf("failed to resume after assigned partitions: %w", err)
 		}
 
 	case kafka.RevokedPartitions:

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -823,10 +823,6 @@ func (s *Sink) rebalance(c *kafka.Consumer, event kafka.Event) error {
 		// Logs newly assigned partitions only (doesn't log already assigned partitions)
 		logger.Info("kafka partition assignment", "partitions", prettyPartitions(e.Partitions))
 
-		if len(e.Partitions) == 0 {
-			return nil
-		}
-
 		// Consumer to use the committed offset as a start position,
 		// with a fallback to `auto.offset.reset` if there is no committed offset.
 		// Auto offset reset is typically should be set to latest, so we will only consume new messages.

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -841,8 +841,8 @@ func (s *Sink) rebalance(c *kafka.Consumer, event kafka.Event) error {
 			return fmt.Errorf("failed to assign partitions: %w", err)
 		}
 
-		// We resume the consumer after the partitions are assigned to start processing new messages.
-		err = s.config.Consumer.Resume(e.Partitions)
+		// Resume the full post-rebalance assignment, including partitions retained during a cooperative rebalance.
+		err = s.resume()
 		if err != nil {
 			return fmt.Errorf("failed to resume after assigned partitions: %w", err)
 		}


### PR DESCRIPTION
## What

Fixes the sink worker becoming permanently paused after losing and regaining its Kafka partition assignment.

## Why

The rebalance handler attempted to resume consumption before assigning the new partitions. At that point the consumer had no assignment, so nothing was resumed and the partitions could remain paused indefinitely.

## How

Assigns the new partitions first, then explicitly resumes those same partitions so consumption continues after the rebalance.

Fixes: https://github.com/openmeterio/openmeter/issues/4987


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consumer partition rebalancing by assigning newly available partitions before resuming consumption.
  * Ensured retained partitions remain included after cooperative rebalancing, helping maintain uninterrupted processing.
  * Removed an edge case that could skip partition assignment when no new partitions were reported.
  * Added clearer handling of assignment and resumption failures, improving reliability during rebalance events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes sink consumption after Kafka cooperative rebalances by assigning incoming partitions before resuming the consumer.
- Removes the early return for empty assignment events so retained partitions are still resumed.
- Resumes the consumer’s full post-rebalance assignment, covering both retained and newly assigned partitions.
- Returns contextual errors when assignment or resumption fails.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/sink/sink.go | Reorders partition assignment and resumption and ensures retained partitions are resumed even when the assignment event contains no new partitions. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  R[Partitions revoked] --> P[Pause current assignment]
  P --> U[Incrementally unassign revoked partitions]
  U --> A[AssignedPartitions event]
  A --> I[Incrementally assign new partitions]
  I --> F[Read full post-rebalance assignment]
  F --> C[Resume retained and new partitions]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(sink): handle empty partition assign..."](https://github.com/openmeterio/openmeter/commit/e176b1e2438302ea5235d90e5e103b153606f217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56245299)</sub>

<!-- /greptile_comment -->