### PR TITLE
fix(entitlement): validate namespace ownership on writes

### DIFF
--- a/openmeter/credit/adapter/balance_snapshot.go
+++ b/openmeter/credit/adapter/balance_snapshot.go
@@ -66,6 +66,10 @@ func (b *balanceSnapshotRepo) GetLatestValidAt(ctx context.Context, owner models
 
 func (b *balanceSnapshotRepo) Save(ctx context.Context, owner models.NamespacedID, balances []balance.Snapshot) error {
 	return entutils.TransactingRepoWithNoValue(ctx, b, func(ctx context.Context, rep *balanceSnapshotRepo) error {
+		if len(balances) == 0 {
+			return nil
+		}
+
 		commands := make([]*db.BalanceSnapshotCreate, 0, len(balances))
 		for _, snapshot := range balances {
 			if snapshot.UsageSnapshot == nil {
@@ -91,6 +95,11 @@ func (b *balanceSnapshotRepo) Save(ctx context.Context, owner models.NamespacedI
 			}
 			commands = append(commands, command)
 		}
+
+		if err := ensureEntitlementOwnerExists(ctx, rep.db, owner); err != nil {
+			return err
+		}
+
 		_, err := rep.db.BalanceSnapshot.CreateBulk(commands...).Save(ctx)
 		return err
 	})

--- a/openmeter/credit/adapter/grant.go
+++ b/openmeter/credit/adapter/grant.go
@@ -34,6 +34,13 @@ func NewPostgresGrantRepo(db *db.Client) grant.Repo {
 
 func (g *grantDBADapter) CreateGrant(ctx context.Context, grant grant.RepoCreateInput) (*grant.Grant, error) {
 	// TODO: transaction and locking
+	if err := ensureEntitlementOwnerExists(ctx, g.db, models.NamespacedID{
+		Namespace: grant.Namespace,
+		ID:        grant.OwnerID,
+	}); err != nil {
+		return nil, err
+	}
+
 	command := g.db.Grant.Create().
 		SetNamespace(grant.Namespace).
 		SetOwnerID(grant.OwnerID).

--- a/openmeter/credit/adapter/owner.go
+++ b/openmeter/credit/adapter/owner.go
@@ -1,0 +1,32 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	db_entitlement "github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// ensureEntitlementOwnerExists prevents credit state from being attached to an
+// entitlement in another namespace. Credit's owner model is generic, while its
+// persisted owner foreign key currently targets entitlements.
+func ensureEntitlementOwnerExists(ctx context.Context, dbClient *db.Client, owner models.NamespacedID) error {
+	exists, err := dbClient.Entitlement.Query().
+		Where(
+			db_entitlement.ID(owner.ID),
+			db_entitlement.Namespace(owner.Namespace),
+		).
+		Exist(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve credit owner: %w", err)
+	}
+
+	if !exists {
+		return grant.NewOwnerNotFoundError(owner, "entitlement")
+	}
+
+	return nil
+}

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -119,6 +119,23 @@ func (a *entitlementDBAdapter) CreateEntitlement(ctx context.Context, ent entitl
 		func(ctx context.Context, repo *entitlementDBAdapter) (*entitlement.Entitlement, error) {
 			now := clock.Now().UTC()
 
+			featureExists, err := repo.db.Feature.Query().
+				Where(
+					db_feature.Namespace(ent.Namespace),
+					db_feature.ID(ent.FeatureID),
+					db_feature.Key(ent.FeatureKey),
+				).
+				Exist(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve feature: %w", err)
+			}
+
+			if !featureExists {
+				return nil, models.NewGenericNotFoundError(
+					fmt.Errorf("feature with id %s and key %s not found in %s namespace", ent.FeatureID, ent.FeatureKey, ent.Namespace),
+				)
+			}
+
 			query := repo.db.Customer.Query().Where(
 				customerdb.Namespace(ent.Namespace),
 				customerdb.ID(ent.UsageAttribution.ID),
@@ -184,7 +201,10 @@ func (a *entitlementDBAdapter) CreateEntitlement(ctx context.Context, ent entitl
 
 			// Query the created entitlement back with customer and subject edges loaded
 			entWithEdges, err := repo.db.Entitlement.Query().
-				Where(db_entitlement.ID(res.ID)).
+				Where(
+					db_entitlement.ID(res.ID),
+					db_entitlement.Namespace(res.Namespace),
+				).
 				Only(ctx)
 			if err != nil {
 				if db.IsNotFound(err) {
@@ -701,11 +721,9 @@ func (a *entitlementDBAdapter) UpsertEntitlementCurrentPeriods(ctx context.Conte
 
 			// We will check that all provided entitlements exist as we don't want to create any, just update the current usage period
 			entitlements, err := repo.db.Entitlement.Query().
-				// We're ignoring namespace here but as IDs are globally unique this should be fine
 				Where(db_entitlement.IDIn(slicesx.Map(updates, func(u entitlement.UpsertEntitlementCurrentPeriodElement) string {
 					return u.ID
-				})...),
-				).
+				})...)).
 				All(ctx)
 			if err != nil {
 				return err
@@ -725,8 +743,8 @@ func (a *entitlementDBAdapter) UpsertEntitlementCurrentPeriods(ctx context.Conte
 			dbUpdates := make([]*db.EntitlementCreate, 0, len(updates))
 			for _, update := range updates {
 				ent, ok := entMap[update.ID]
-				if !ok {
-					return fmt.Errorf("inconsistency error: entitlement %s not found", update.ID)
+				if !ok || ent.Namespace != update.Namespace {
+					return &entitlement.NotFoundError{EntitlementID: update.NamespacedID}
 				}
 
 				create := repo.db.Entitlement.Create().

--- a/openmeter/entitlement/adapter/namespace_test.go
+++ b/openmeter/entitlement/adapter/namespace_test.go
@@ -1,0 +1,214 @@
+package adapter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	creditadapter "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	db_entitlement "github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	entitlementadapter "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type namespaceTestEnv struct {
+	db                  *db.Client
+	entitlementRepo     entitlement.EntitlementRepo
+	grantRepo           grant.Repo
+	usageResetRepo      meteredentitlement.UsageResetRepo
+	balanceSnapshotRepo balance.SnapshotRepo
+}
+
+func newNamespaceTestEnv(t *testing.T) namespaceTestEnv {
+	t.Helper()
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
+	dbClient := testDB.EntDriver.Client()
+
+	t.Cleanup(func() {
+		_ = dbClient.Close()
+		testDB.Close(t)
+	})
+
+	return namespaceTestEnv{
+		db:                  dbClient,
+		entitlementRepo:     entitlementadapter.NewPostgresEntitlementRepo(dbClient),
+		grantRepo:           creditadapter.NewPostgresGrantRepo(dbClient),
+		usageResetRepo:      entitlementadapter.NewPostgresUsageResetRepo(dbClient),
+		balanceSnapshotRepo: creditadapter.NewPostgresBalanceSnapshotRepo(dbClient),
+	}
+}
+
+func (e namespaceTestEnv) createCustomer(t *testing.T, namespace string) *db.Customer {
+	t.Helper()
+
+	key := "customer-" + ulid.Make().String()
+	entity, err := e.db.Customer.Create().
+		SetNamespace(namespace).
+		SetName(key).
+		SetKey(key).
+		Save(t.Context())
+	require.NoError(t, err)
+
+	return entity
+}
+
+func (e namespaceTestEnv) createFeature(t *testing.T, namespace string) *db.Feature {
+	t.Helper()
+
+	key := "feature-" + ulid.Make().String()
+	entity, err := e.db.Feature.Create().
+		SetNamespace(namespace).
+		SetName(key).
+		SetKey(key).
+		Save(t.Context())
+	require.NoError(t, err)
+
+	return entity
+}
+
+func createEntitlementInput(namespace string, customer *db.Customer, feature *db.Feature) entitlement.CreateEntitlementRepoInputs {
+	return entitlement.CreateEntitlementRepoInputs{
+		Namespace:  namespace,
+		FeatureID:  feature.ID,
+		FeatureKey: feature.Key,
+		UsageAttribution: streaming.CustomerUsageAttribution{
+			ID:  customer.ID,
+			Key: &customer.Key,
+		},
+		EntitlementType: entitlement.EntitlementTypeMetered,
+	}
+}
+
+func TestEntitlementWritesResolveReferencesInNamespace(t *testing.T) {
+	// given:
+	// - customer, feature, and entitlement rows in target and foreign namespaces
+	// when:
+	// - repositories receive existing foreign IDs wrapped in the target namespace
+	// then:
+	// - no entitlement-owned row is persisted with a cross-namespace reference
+	env := newNamespaceTestEnv(t)
+	targetNamespace := ulid.Make().String()
+	foreignNamespace := ulid.Make().String()
+	targetCustomer := env.createCustomer(t, targetNamespace)
+	targetFeature := env.createFeature(t, targetNamespace)
+	foreignCustomer := env.createCustomer(t, foreignNamespace)
+	foreignFeature := env.createFeature(t, foreignNamespace)
+	mismatchedFeatureKeyInput := createEntitlementInput(targetNamespace, targetCustomer, targetFeature)
+	mismatchedFeatureKeyInput.FeatureKey = foreignFeature.Key
+
+	for _, testCase := range []struct {
+		name  string
+		input entitlement.CreateEntitlementRepoInputs
+	}{
+		{
+			name:  "foreign customer",
+			input: createEntitlementInput(targetNamespace, foreignCustomer, targetFeature),
+		},
+		{
+			name:  "foreign feature",
+			input: createEntitlementInput(targetNamespace, targetCustomer, foreignFeature),
+		},
+		{
+			name:  "feature key does not match id",
+			input: mismatchedFeatureKeyInput,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := env.entitlementRepo.CreateEntitlement(t.Context(), testCase.input)
+			require.Error(t, err)
+			require.True(t, models.IsGenericNotFoundError(err))
+		})
+	}
+
+	count, err := env.db.Entitlement.Query().
+		Where(db_entitlement.Namespace(targetNamespace)).
+		Count(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, count)
+
+	targetEntitlement, err := env.entitlementRepo.CreateEntitlement(
+		t.Context(),
+		createEntitlementInput(targetNamespace, targetCustomer, targetFeature),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, targetEntitlement)
+
+	foreignEntitlement, err := env.entitlementRepo.CreateEntitlement(
+		t.Context(),
+		createEntitlementInput(foreignNamespace, foreignCustomer, foreignFeature),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, foreignEntitlement)
+
+	foreignOwner := models.NamespacedID{
+		Namespace: targetNamespace,
+		ID:        foreignEntitlement.ID,
+	}
+	now := time.Now().UTC().Truncate(time.Minute)
+
+	err = env.entitlementRepo.UpsertEntitlementCurrentPeriods(t.Context(), []entitlement.UpsertEntitlementCurrentPeriodElement{
+		{
+			NamespacedID: foreignOwner,
+			CurrentUsagePeriod: timeutil.ClosedPeriod{
+				From: now,
+				To:   now.AddDate(0, 1, 0),
+			},
+		},
+	})
+	var entitlementNotFound *entitlement.NotFoundError
+	require.ErrorAs(t, err, &entitlementNotFound)
+
+	foreignEntitlementRow, err := env.db.Entitlement.Get(t.Context(), foreignEntitlement.ID)
+	require.NoError(t, err)
+	require.Nil(t, foreignEntitlementRow.CurrentUsagePeriodStart)
+	require.Nil(t, foreignEntitlementRow.CurrentUsagePeriodEnd)
+
+	_, err = env.grantRepo.CreateGrant(t.Context(), grant.RepoCreateInput{
+		Namespace:   foreignOwner.Namespace,
+		OwnerID:     foreignOwner.ID,
+		Amount:      100,
+		EffectiveAt: now,
+	})
+	require.Error(t, err)
+	require.True(t, models.IsGenericNotFoundError(err))
+
+	err = env.usageResetRepo.Save(t.Context(), meteredentitlement.UsageResetUpdate{
+		NamespacedModel:     models.NamespacedModel{Namespace: foreignOwner.Namespace},
+		EntitlementID:       foreignOwner.ID,
+		ResetTime:           now,
+		Anchor:              now,
+		UsagePeriodInterval: datetime.ISODurationString("P1M"),
+	})
+	entitlementNotFound = nil
+	require.ErrorAs(t, err, &entitlementNotFound)
+
+	err = env.balanceSnapshotRepo.Save(t.Context(), foreignOwner, []balance.Snapshot{
+		balance.NewStartingSnapshot(nil, now),
+	})
+	require.Error(t, err)
+	require.True(t, models.IsGenericNotFoundError(err))
+
+	grantCount, err := env.db.Grant.Query().Count(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, grantCount)
+
+	usageResetCount, err := env.db.UsageReset.Query().Count(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, usageResetCount)
+
+	balanceSnapshotCount, err := env.db.BalanceSnapshot.Query().Count(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, balanceSnapshotCount)
+}

--- a/openmeter/entitlement/adapter/usage_reset.go
+++ b/openmeter/entitlement/adapter/usage_reset.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	db_entitlement "github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type usageResetDBAdapter struct {
@@ -36,7 +39,25 @@ func (a *usageResetDBAdapter) Save(ctx context.Context, usageResetTime metereden
 				return nil, err
 			}
 
-			_, err := repo.db.UsageReset.Create().
+			entitlementID := models.NamespacedID{
+				Namespace: usageResetTime.Namespace,
+				ID:        usageResetTime.EntitlementID,
+			}
+			entitlementExists, err := repo.db.Entitlement.Query().
+				Where(
+					db_entitlement.ID(entitlementID.ID),
+					db_entitlement.Namespace(entitlementID.Namespace),
+				).
+				Exist(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			if !entitlementExists {
+				return nil, &entitlement.NotFoundError{EntitlementID: entitlementID}
+			}
+
+			_, err = repo.db.UsageReset.Create().
 				SetEntitlementID(usageResetTime.EntitlementID).
 				SetNamespace(usageResetTime.Namespace).
 				SetResetTime(usageResetTime.ResetTime).


### PR DESCRIPTION
## Summary

- validate feature identity within the entitlement namespace during creation
- reject cross-namespace entitlement owners when writing grants, usage resets, and balance snapshots
- prevent current-period upserts from updating an entitlement outside the requested namespace
- keep the hardening scoped to write paths

## Testing

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/entitlement/... ./openmeter/credit/...`
- `go vet -tags=dynamic ./openmeter/entitlement/... ./openmeter/credit/...`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens entitlement and credit write paths so referenced features and entitlement owners must belong to the requested namespace.
- Validates feature namespace, ID, and key before entitlement creation.
- Validates entitlement ownership before grants, usage resets, and balance snapshots are persisted.
- Prevents current-period upserts from modifying an entitlement in another namespace.
- Adds database-backed coverage for cross-namespace write attempts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the namespace checks consistently reject mismatched references before persistence and no actionable regression was identified.

The changed write paths preserve namespace ownership for feature references, entitlement period updates, grants, usage resets, and balance snapshots, with database-backed tests covering the rejected cross-namespace cases.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/entitlement/adapter/entitlement.go | Validates feature identity during creation and checks namespace ownership before current-period upserts. |
| openmeter/credit/adapter/owner.go | Introduces the shared namespace-aware entitlement-owner existence check used by credit repositories. |
| openmeter/credit/adapter/grant.go | Rejects grant creation when the entitlement owner does not exist in the supplied namespace. |
| openmeter/credit/adapter/balance_snapshot.go | Skips empty snapshot batches and validates the namespaced entitlement owner before bulk persistence. |
| openmeter/entitlement/adapter/usage_reset.go | Validates the namespaced entitlement reference before persisting a usage reset. |
| openmeter/entitlement/adapter/namespace_test.go | Covers foreign customers, features, owners, mismatched feature identity, and protected write paths. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Write[Entitlement or credit write] --> Resolve[Resolve referenced resource by namespace and ID]
  Resolve -->|Not found or mismatched| Reject[Return not-found error]
  Resolve -->|Valid owner| Persist[Persist namespace-scoped write]
  Persist --> Protected[Cross-namespace state remains unchanged]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(entitlement): validate namespace own..."](https://github.com/openmeterio/openmeter/commit/61732494fd30b1a563b7e0cc50840ef7759f2e3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56257873)</sub>

<!-- /greptile_comment -->