### PR TITLE
fix: repair distributed locks after Ent adoption

### DIFF
--- a/tools/migrate/distributed_locks_repair_test.go
+++ b/tools/migrate/distributed_locks_repair_test.go
@@ -1,0 +1,78 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepairDistributedLocksMigration(t *testing.T) {
+	t.Run("repairs missing objects", func(t *testing.T) {
+		// given:
+		// - a database at the previous migration head without the raw-SQL lock objects
+		// when:
+		// - the distributed lock repair migration runs
+		// then:
+		// - the lock table and its record-version sequence are usable
+		runner{
+			stops: stops{
+				{
+					version:   20260818090123,
+					direction: directionUp,
+					action: func(t *testing.T, db *sql.DB) {
+						_, err := db.ExecContext(t.Context(), `DROP TABLE distributed_locks`)
+						require.NoError(t, err)
+					},
+				},
+				{
+					version:   20260824141945,
+					direction: directionUp,
+					action: func(t *testing.T, db *sql.DB) {
+						_, err := db.ExecContext(t.Context(), `
+							INSERT INTO distributed_locks (name, record_version_number)
+							VALUES ('repair-test', nextval('distributed_locks_rvn'))
+						`)
+						require.NoError(t, err)
+					},
+				},
+			},
+		}.Test(t)
+	})
+
+	t.Run("preserves existing objects", func(t *testing.T) {
+		// given:
+		// - a normally migrated database with an existing distributed lock row
+		// when:
+		// - the idempotent repair migration runs
+		// then:
+		// - the existing lock row remains unchanged
+		runner{
+			stops: stops{
+				{
+					version:   20260818090123,
+					direction: directionUp,
+					action: func(t *testing.T, db *sql.DB) {
+						_, err := db.ExecContext(t.Context(), `
+							INSERT INTO distributed_locks (name, record_version_number, owner)
+							VALUES ('existing-lock', nextval('distributed_locks_rvn'), 'existing-owner')
+						`)
+						require.NoError(t, err)
+					},
+				},
+				{
+					version:   20260824141945,
+					direction: directionUp,
+					action: func(t *testing.T, db *sql.DB) {
+						var owner string
+						err := db.QueryRowContext(t.Context(), `
+							SELECT owner FROM distributed_locks WHERE name = 'existing-lock'
+						`).Scan(&owner)
+						require.NoError(t, err)
+						require.Equal(t, "existing-owner", owner)
+					},
+				},
+			},
+		}.Test(t)
+	})
+}

--- a/tools/migrate/legacy_ent_parity_test.go
+++ b/tools/migrate/legacy_ent_parity_test.go
@@ -8,7 +8,6 @@ import (
 
 	"ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/postgres"
-	"ariga.io/atlas/sql/schema"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/testutils"
@@ -69,10 +68,9 @@ func TestLegacyEntAdoptionSchemaParity(t *testing.T) {
 	adoptedSchemaName := currentSchema(t, adoptedDB.PGDriver.DB())
 	require.Equal(t, canonicalSchemaName, adoptedSchemaName)
 
-	inspectOptions := &schema.InspectOptions{Exclude: []string{"distributed_locks"}}
-	canonicalSchema, err := canonicalAtlas.InspectSchema(t.Context(), canonicalSchemaName, inspectOptions)
+	canonicalSchema, err := canonicalAtlas.InspectSchema(t.Context(), canonicalSchemaName, nil)
 	require.NoError(t, err)
-	adoptedSchema, err := adoptedAtlas.InspectSchema(t.Context(), adoptedSchemaName, inspectOptions)
+	adoptedSchema, err := adoptedAtlas.InspectSchema(t.Context(), adoptedSchemaName, nil)
 	require.NoError(t, err)
 
 	changes, err := adoptedAtlas.SchemaDiff(adoptedSchema, canonicalSchema)

--- a/tools/migrate/migrations/20260824141945_repair_distributed_locks.down.sql
+++ b/tools/migrate/migrations/20260824141945_repair_distributed_locks.down.sql
@@ -1,0 +1,4 @@
+-- Intentionally no-op.
+--
+-- Healthy databases created these objects in migration 20260502093117. Dropping
+-- them when rolling back this repair would break those databases.

--- a/tools/migrate/migrations/20260824141945_repair_distributed_locks.up.sql
+++ b/tools/migrate/migrations/20260824141945_repair_distributed_locks.up.sql
@@ -1,0 +1,11 @@
+-- Repair databases adopted from the frozen Ent baseline, which does not include
+-- raw-SQL-only objects created by migrations before the recorded baseline.
+CREATE TABLE IF NOT EXISTS distributed_locks (
+    "name" varchar(255) NOT NULL,
+    "record_version_number" int8 NULL,
+    "data" bytea NULL,
+    "owner" varchar(255) NULL,
+    CONSTRAINT distributed_locks_pkey PRIMARY KEY ("name")
+);
+
+CREATE SEQUENCE IF NOT EXISTS distributed_locks_rvn CYCLE OWNED BY distributed_locks.record_version_number;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qQ6gNLxEMsePP997hF7MrK17QRL1WuILBaeC3jbc79M=
+h1:4XSY59ElhpfWLOW+jQLPXMcNy9wMb/SqecP+nM+G3MM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -268,3 +268,4 @@ h1:qQ6gNLxEMsePP997hF7MrK17QRL1WuILBaeC3jbc79M=
 20260814113139_backfill_rate_card_feature_references.up.sql h1:iA5yWo3AC0sXJIt10Lr7/Wic6cLbQDpPkW51upFJK10=
 20260814114215_charges-search-feature-filters.up.sql h1:ttOzcueUboyfQKgIV2Pv7lRzUXus2AknzqeD40VQvSE=
 20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=
+20260824141945_repair_distributed_locks.up.sql h1:2yMrvYEgMu69u2VehzaZMyESZmD/HrwOZaOU1xQsTDY=


### PR DESCRIPTION
## Summary

- add an idempotent forward migration that restores the distributed lock table and sequence missing after legacy Ent adoption
- keep rollback non-destructive for databases where the original migration already created the objects
- cover missing and existing lock state, and require full legacy adoption schema parity

Fixes #4952

## Verification

- POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./tools/migrate/... -count=1
- make migrate-check-lint migrate-check-validate in the Nix CI shell
- make lint-go in the Nix CI shell

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an idempotent forward migration that restores the distributed-lock table and sequence omitted by legacy Ent adoption while preserving existing installations during rollback.

- Recreates the original `distributed_locks` table and `distributed_locks_rvn` sequence when absent.
- Adds migration tests for missing and existing lock state.
- Expands legacy Ent schema parity checks to include distributed-lock objects.
- Updates the Atlas migration checksum.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the repaired schema matching the original distributed-lock definition and tests covering the intended missing and existing database states.

The forward migration reconstructs the original lock objects idempotently, the no-op rollback avoids destructive behavior on healthy databases, and no concrete changed-code failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260824141945_repair_distributed_locks.up.sql | Idempotently restores the same distributed-lock table and sequence definitions introduced by the original migration. |
| tools/migrate/migrations/20260824141945_repair_distributed_locks.down.sql | Intentionally retains lock objects during rollback to avoid removing objects owned by the earlier migration on healthy databases. |
| tools/migrate/distributed_locks_repair_test.go | Verifies repair of missing objects and preservation of existing lock data. |
| tools/migrate/legacy_ent_parity_test.go | Extends canonical-versus-adopted schema comparison to cover distributed-lock objects. |
| tools/migrate/migrations/atlas.sum | Registers the new forward migration in the Atlas checksum manifest. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Database reaches repair migration] --> B{Lock table exists?}
    B -- No --> C[Create distributed_locks table]
    B -- Yes --> D[Preserve existing table and rows]
    C --> E{RVN sequence exists?}
    D --> E
    E -- No --> F[Create cyclic owned sequence]
    E -- Yes --> G[Preserve existing sequence]
    F --> H[Distributed locks usable]
    G --> H
    H --> I[Rollback repair]
    I --> J[No-op: retain lock objects]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: repair distributed locks after Ent ..."](https://github.com/openmeterio/openmeter/commit/7e967da7ee896023104d08ddcd9b2d5fae03916a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56267474)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a migration to restore missing distributed-lock storage and its supporting sequence.
  * Preserved existing lock ownership and data during repair.
  * Ensured repaired lock storage remains usable for normal table and sequence operations.
  * Made rollback behavior non-destructive so restored lock objects are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->