### PR TITLE
feat(charges): persist usage-based run immutability

### DIFF
--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -4149,6 +4149,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
+		s.True(finalRun.Immutable)
 		s.Equal(float64(125), finalRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)
@@ -4403,6 +4404,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
+		s.True(finalRun.Immutable)
 		s.Equal(float64(100), finalRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -507,6 +507,40 @@ func (s *DetailedLineAdapterSuite) TestExpandRealizationsExcludesDeletedRuns() {
 	s.Equal(runBase.ID, fetchedCharge.Realizations[0].ID)
 }
 
+func (s *DetailedLineAdapterSuite) TestRealizationRunImmutableFlag() {
+	ctx := s.T().Context()
+	charge, _, servicePeriod := s.createChargeWithRun("usagebased-run-immutable")
+
+	createdRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:       charge.State.FeatureID,
+		Type:            usagebased.RealizationRunTypePartialInvoice,
+		StoredAtLT:      servicePeriod.To,
+		ServicePeriodTo: servicePeriod.To,
+		MeteredQuantity: alpacadecimal.Zero,
+		Totals:          totals.Totals{},
+	})
+	s.Require().NoError(err)
+	s.False(createdRun.Immutable)
+
+	updatedRun, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        createdRun.ID,
+		Immutable: mo.Some(true),
+	})
+	s.Require().NoError(err)
+	s.True(updatedRun.Immutable)
+
+	fetchedCharge, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands:  chargesmeta.Expands{chargesmeta.ExpandRealizations},
+	})
+	s.Require().NoError(err)
+	fetchedRun, ok := lo.Find(fetchedCharge.Realizations, func(run usagebased.RealizationRun) bool {
+		return run.ID == createdRun.ID
+	})
+	s.Require().True(ok)
+	s.True(fetchedRun.Immutable)
+}
+
 func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usagebased.Charge, usagebased.RealizationRunBase, timeutil.ClosedPeriod) {
 	s.T().Helper()
 

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -170,6 +170,7 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunB
 		MeteredQuantity:                       dbRun.MeteredQuantity,
 		Totals:                                totals.FromDB(dbRun),
 		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
+		Immutable:                             dbRun.Immutable,
 		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
 	}
 }

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -86,6 +86,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 			update = update.SetNoFiatTransactionRequired(input.NoFiatTransactionRequired.OrEmpty())
 		}
 
+		if input.Immutable.IsPresent() {
+			update = update.SetImmutable(input.Immutable.OrEmpty())
+		}
+
 		dbRun, err := update.Save(ctx)
 		if err != nil {
 			return usagebased.RealizationRunBase{}, err

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -139,6 +139,7 @@ type UpdateRealizationRunInput struct {
 	MeteredQuantity           mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
 	Totals                    mo.Option[totals.Totals]         `json:"totals"`
 	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	Immutable                 mo.Option[bool]                  `json:"immutable"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -212,6 +213,8 @@ type RealizationRunBase struct {
 	// Totals includes credit allocations and excludes taxes.
 	Totals                    totals.Totals `json:"totals"`
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
+	// Immutable means the backing invoice crossed the external issuance boundary.
+	Immutable bool `json:"immutable"`
 	// DetailedLinesIncludeCreditAllocations describes if credit allocation is applied to the detailed lines.
 	// Credits-only: always false
 	// Credit-then-invoice:

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -1120,6 +1120,14 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 		return fmt.Errorf("accrue invoice usage: %w", err)
 	}
 	currentRun = accrueResult.Run
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        currentRun.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
+	}
+	currentRun.RealizationRunBase = runBase
 
 	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
 		return fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -731,6 +731,9 @@ func (a *creditThenInvoiceStateMachineAdapter) UpdateRealizationRun(_ context.Co
 	if input.Type.IsPresent() {
 		run.Type = input.Type.OrEmpty()
 	}
+	if input.Immutable.IsPresent() {
+		run.Immutable = input.Immutable.OrEmpty()
+	}
 
 	a.runs[input.ID.ID] = run
 	return run, nil

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -73,6 +73,8 @@ type ChargeUsageBasedRuns struct {
 	MeteredQuantity alpacadecimal.Decimal `json:"metered_quantity,omitempty"`
 	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
+	// Immutable holds the value of the "immutable" field.
+	Immutable bool `json:"immutable,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunsQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunsEdges `json:"edges"`
@@ -215,7 +217,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -389,6 +391,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.NoFiatTransactionRequired = value.Bool
 			}
+		case chargeusagebasedruns.FieldImmutable:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field immutable", values[i])
+			} else if value.Valid {
+				_m.Immutable = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -552,6 +560,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("no_fiat_transaction_required=")
 	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
+	builder.WriteString(", ")
+	builder.WriteString("immutable=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -64,6 +64,8 @@ const (
 	FieldMeteredQuantity = "metered_quantity"
 	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
+	// FieldImmutable holds the string denoting the immutable field in the database.
+	FieldImmutable = "immutable"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeFeature holds the string denoting the feature edge name in mutations.
@@ -185,6 +187,7 @@ var Columns = []string{
 	FieldInvoiceID,
 	FieldMeteredQuantity,
 	FieldNoFiatTransactionRequired,
+	FieldImmutable,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -214,6 +217,8 @@ var (
 	LineIDValidator func(string) error
 	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	InvoiceIDValidator func(string) error
+	// DefaultImmutable holds the default value on creation for the "immutable" field.
+	DefaultImmutable bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -364,6 +369,11 @@ func ByMeteredQuantity(opts ...sql.OrderTermOption) OrderOption {
 // ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
 func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
+}
+
+// ByImmutable orders the results by the immutable field.
+func ByImmutable(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldImmutable, opts...).ToFunc()
 }
 
 // ByUsageBasedField orders the results by usage_based field.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -177,6 +177,11 @@ func NoFiatTransactionRequired(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
 }
 
+// Immutable applies equality check predicate on the "immutable" field. It's identical to ImmutableEQ.
+func Immutable(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNamespace, v))
@@ -1180,6 +1185,16 @@ func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeUsageBasedRuns {
 // NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
 func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// ImmutableEQ applies the EQ predicate on the "immutable" field.
+func ImmutableEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
+}
+
+// ImmutableNEQ applies the NEQ predicate on the "immutable" field.
+func ImmutableNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldImmutable, v))
 }
 
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -226,6 +226,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetNoFiatTransactionRequired(v bool) *Char
 	return _c
 }
 
+// SetImmutable sets the "immutable" field.
+func (_c *ChargeUsageBasedRunsCreate) SetImmutable(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetImmutable(v)
+	return _c
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetImmutable(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetID(v)
@@ -439,6 +453,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations
 		_c.mutation.SetDetailedLinesIncludeCreditAllocations(v)
 	}
+	if _, ok := _c.mutation.Immutable(); !ok {
+		v := chargeusagebasedruns.DefaultImmutable
+		_c.mutation.SetImmutable(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeusagebasedruns.DefaultID()
 		_c.mutation.SetID(v)
@@ -539,6 +557,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
 		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.no_fiat_transaction_required"`)}
+	}
+	if _, ok := _c.mutation.Immutable(); !ok {
+		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.immutable"`)}
 	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedRuns.usage_based"`)}
@@ -661,6 +682,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
 		_node.NoFiatTransactionRequired = value
+	}
+	if value, ok := _c.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+		_node.Immutable = value
 	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1094,6 +1119,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateNoFiatTransactionRequired() *ChargeUs
 	return u
 }
 
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsert) SetImmutable(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldImmutable, v)
+	return u
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateImmutable() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldImmutable)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1412,6 +1449,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetNoFiatTransactionRequired(v bool) *Ch
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetImmutable(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetImmutable(v)
+	})
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateImmutable() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateImmutable()
 	})
 }
 
@@ -1900,6 +1951,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetNoFiatTransactionRequired(v bool) *C
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetImmutable sets the "immutable" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetImmutable(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetImmutable(v)
+	})
+}
+
+// UpdateImmutable sets the "immutable" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateImmutable() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateImmutable()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -278,6 +278,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableNoFiatTransactionRequired(v *bo
 	return _u
 }
 
+// SetImmutable sets the "immutable" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetImmutable(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetImmutable(v)
+	return _u
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetImmutable(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -621,6 +635,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1151,6 +1168,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableNoFiatTransactionRequired(v 
 	return _u
 }
 
+// SetImmutable sets the "immutable" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetImmutable(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetImmutable(v)
+	return _u
+}
+
+// SetNillableImmutable sets the "immutable" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableImmutable(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetImmutable(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -1524,6 +1555,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Immutable(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3518,6 +3518,7 @@ var (
 		{Name: "detailed_lines_include_credit_allocations", Type: field.TypeBool, Default: false},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
+		{Name: "immutable", Type: field.TypeBool, Default: false},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -3531,25 +3532,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3568,7 +3569,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[23]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[24]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -77904,6 +77904,7 @@ type ChargeUsageBasedRunsMutation struct {
 	detailed_lines_include_credit_allocations *bool
 	metered_quantity                          *alpacadecimal.Decimal
 	no_fiat_transaction_required              *bool
+	immutable                                 *bool
 	clearedFields                             map[string]struct{}
 	usage_based                               *string
 	clearedusage_based                        bool
@@ -78941,6 +78942,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetNoFiatTransactionRequired() {
 	m.no_fiat_transaction_required = nil
 }
 
+// SetImmutable sets the "immutable" field.
+func (m *ChargeUsageBasedRunsMutation) SetImmutable(b bool) {
+	m.immutable = &b
+}
+
+// Immutable returns the value of the "immutable" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) Immutable() (r bool, exists bool) {
+	v := m.immutable
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldImmutable returns the old "immutable" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldImmutable(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldImmutable is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldImmutable requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldImmutable: %w", err)
+	}
+	return oldValue.Immutable, nil
+}
+
+// ResetImmutable resets all changes to the "immutable" field.
+func (m *ChargeUsageBasedRunsMutation) ResetImmutable() {
+	m.immutable = nil
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -79416,7 +79453,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 24)
+	fields := make([]string, 0, 25)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -79489,6 +79526,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.no_fiat_transaction_required != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNoFiatTransactionRequired)
 	}
+	if m.immutable != nil {
+		fields = append(fields, chargeusagebasedruns.FieldImmutable)
+	}
 	return fields
 }
 
@@ -79545,6 +79585,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.MeteredQuantity()
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		return m.NoFiatTransactionRequired()
+	case chargeusagebasedruns.FieldImmutable:
+		return m.Immutable()
 	}
 	return nil, false
 }
@@ -79602,6 +79644,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldMeteredQuantity(ctx)
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		return m.OldNoFiatTransactionRequired(ctx)
+	case chargeusagebasedruns.FieldImmutable:
+		return m.OldImmutable(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79779,6 +79823,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetNoFiatTransactionRequired(v)
 		return nil
+	case chargeusagebasedruns.FieldImmutable:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetImmutable(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -79920,6 +79971,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
 		m.ResetNoFiatTransactionRequired()
+		return nil
+	case chargeusagebasedruns.FieldImmutable:
+		m.ResetImmutable()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1841,6 +1841,10 @@ func init() {
 	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[9].Descriptor()
 	// chargeusagebasedruns.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeusagebasedruns.InvoiceIDValidator = chargeusagebasedrunsDescInvoiceID.Validators[0].(func(string) error)
+	// chargeusagebasedrunsDescImmutable is the schema descriptor for immutable field.
+	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[12].Descriptor()
+	// chargeusagebasedruns.DefaultImmutable holds the default value on creation for the immutable field.
+	chargeusagebasedruns.DefaultImmutable = chargeusagebasedrunsDescImmutable.Default.(bool)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.
 	chargeusagebasedrunsDescID := chargeusagebasedrunsMixinFields1[0].Descriptor()
 	// chargeusagebasedruns.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -388,6 +388,9 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 			}),
 
 		field.Bool("no_fiat_transaction_required"),
+
+		field.Bool("immutable").
+			Default(false),
 	}
 }
 

--- a/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.down.sql
+++ b/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "immutable";

--- a/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.up.sql
+++ b/tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.up.sql
@@ -1,0 +1,2 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "immutable" boolean NOT NULL DEFAULT false;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4XSY59ElhpfWLOW+jQLPXMcNy9wMb/SqecP+nM+G3MM=
+h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -269,3 +269,4 @@ h1:4XSY59ElhpfWLOW+jQLPXMcNy9wMb/SqecP+nM+G3MM=
 20260814114215_charges-search-feature-filters.up.sql h1:ttOzcueUboyfQKgIV2Pv7lRzUXus2AknzqeD40VQvSE=
 20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=
 20260824141945_repair_distributed_locks.up.sql h1:2yMrvYEgMu69u2VehzaZMyESZmD/HrwOZaOU1xQsTDY=
+20260825073524_add_usage_based_run_immutable.up.sql h1:gtNDCpb60imuRqnncnjB/xHjAWKUa44SrnJbFl152wo=


### PR DESCRIPTION
## Overview

Usage-based realization runs need a durable way to distinguish invoice preparation from invoice history that has crossed the external issuance boundary. Charge status alone is not sufficient for later cleanup and reversal paths that must decide whether accrued invoice effects may still be corrected.

This change adds an `immutable` flag to usage-based realization runs. New runs start with `false`. The credit-then-invoice state machine changes the flag to `true` from the invoice-issued transition, after invoice usage has been booked successfully. Zero-fiat runs that complete without invoice issuance remain mutable.

The flag is persisted through the usage-based adapter and Ent schema. The generated migration adds the column with a default of `false`. Historical issuance state is intentionally not backfilled in this change.

## Notes for reviewer

`Immutable` represents the external invoice issuance boundary. It does not mean that invoice preparation has started; prepared invoice usage and issued invoice history remain distinct facts.

The lifecycle tests verify that invoiced usage-based runs become immutable, while the adapter test verifies the default and update persistence behavior.

## Verification

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/usagebased/...`
- focused usage-based invoice lifecycle integration tests
- `make lint-go-fast` for the touched charge and Ent packages
- Atlas migration lint and validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable status tracking for usage-based realization runs.
  * Realization runs can be marked immutable once invoice usage is issued.
  * Immutable status is retained when runs are updated or retrieved.

* **Bug Fixes**
  * Finalized usage-based invoice runs now consistently preserve their immutable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a persisted immutable flag to usage-based realization runs and sets it after externally issued invoice usage is booked.

- Adds the domain, adapter, Ent schema, generated persistence code, and migration for the flag.
- Updates the credit-then-invoice issuance transition and lifecycle tests.
- The new post-booking write introduces a partial-failure state that the existing retry path cannot recover from.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until issuance retries can recover when immutable persistence fails after invoice usage has committed.

The new write creates a durable partial state in which usage is booked but immutability is not; the documented retry replays a booking operation that rejects the already-persisted usage, so the invoice cannot leave charge-booking failure.

**Files Needing Attention:** openmeter/billing/charges/usagebased/service/creditheninvoice.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Marks issued runs immutable, but does so after a separately committed, non-retryable usage-booking operation. |
| openmeter/billing/charges/usagebased/adapter/realizationrun.go | Correctly maps an optional immutable update into Ent persistence. |
| openmeter/billing/charges/usagebased/realizationrun.go | Adds the immutable field to the realization-run domain and update contracts. |
| openmeter/ent/schema/chargesusagebased.go | Adds the non-null immutable field with a false default. |
| tools/migrate/migrations/20260825073524_add_usage_based_run_immutable.up.sql | Adds the persisted boolean with a compatible false default for existing rows. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Invoice state machine
    participant R as Usage run service
    participant DB as Database
    S->>R: FinalizeInvoiceRun
    R->>DB: Book invoice usage
    DB-->>R: Committed
    R->>DB: "Set immutable=true"
    DB-->>R: Transient failure
    R-->>S: Error
    S->>S: Enter charge-booking failure
    S->>R: Retry FinalizeInvoiceRun
    R->>R: Reject existing InvoiceUsage
    R-->>S: Retry fails again
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%234998%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=4998&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Fservice%2Fcreditheninvoice.go%3A1123-1127%0A**Retry%20traps%20partially%20finalized%20runs**%0A%0AWhen%20%60UpdateRealizationRun%60%20fails%20after%20%60BookAccruedInvoiceUsage%60%20commits%2C%20the%20charge-booking%20retry%20calls%20the%20booking%20operation%20again%2C%20which%20rejects%20the%20existing%20%60InvoiceUsage%60%3B%20this%20leaves%20the%20externally%20finalized%20invoice%20stuck%20in%20charge-booking%20failure%20and%20the%20realization%20run%20mutable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4998&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fusagebased-run-immutable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fusagebased-run-immutable%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Fservice%2Fcreditheninvoice.go%3A1123-1127%0A**Retry%20traps%20partially%20finalized%20runs**%0A%0AWhen%20%60UpdateRealizationRun%60%20fails%20after%20%60BookAccruedInvoiceUsage%60%20commits%2C%20the%20charge-booking%20retry%20calls%20the%20booking%20operation%20again%2C%20which%20rejects%20the%20existing%20%60InvoiceUsage%60%3B%20this%20leaves%20the%20externally%20finalized%20invoice%20stuck%20in%20charge-booking%20failure%20and%20the%20realization%20run%20mutable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=4998&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/billing/charges/usagebased/service/creditheninvoice.go:1123-1127
**Retry traps partially finalized runs**

When `UpdateRealizationRun` fails after `BookAccruedInvoiceUsage` commits, the charge-booking retry calls the booking operation again, which rejects the existing `InvoiceUsage`; this leaves the externally finalized invoice stuck in charge-booking failure and the realization run mutable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(charges): persist usage-based run i..."](https://github.com/openmeterio/openmeter/commit/9d1b86f8e449d39e584083d4353c277df6ae20f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56568594)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->