### PR TITLE
fix(charges): reconcile custom currency invoice preparation

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -107,13 +107,18 @@ finalization callback. Engines return fully calculated lines with unchanged
 line IDs; billing replaces those lines, sums their totals, and persists the
 invoice before sending it to the invoicing app. Line finalization has its own
 retryable failure state, so an external app retry does not repeat stable
-engine-owned effects.
+engine-owned effects. Flat-fee and usage-based accounting preparation complete
+at this boundary; the later external-issued callback validates and advances the
+already-prepared charge lifecycle. Line-finalization failures and subsequent
+issuing are retry-only. If invoicing app synchronization fails after durable
+preparation succeeds, charge-owned cleanup must correct that preparation before
+the invoice can be deleted.
 
 A deleted app keeps its historical identity and can still be expanded on
 invoices. Its generic app operations return `app.ErrAppDeleted`, while its
 invoicing operations return billing-owned validation issues. Critical issues
-move the invoice into the failed state for that step. Invoice deletion remains
-available and returns a warning when provider cleanup has to be skipped.
+move the invoice into the failed state for that step. Before issuing, invoice
+deletion returns a warning when provider cleanup has to be skipped.
 
 Retrying and deleting are separate domain actions. Use the billing service's
 retry operation for a retryable failure and its delete operation for the

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -242,9 +242,18 @@ one.
   run and monetary domain, preserving lineage to the facts previously billed
   or posted.
 - Settlement-fiat overage allocation for a custom-currency usage-based or
-  flat-fee run is a one-shot invoice-finalization effect. It requires an empty
-  settlement-fiat realization history; later cleanup corrects the persisted
-  facts instead of re-entering allocation.
+  flat-fee run is a one-shot invoice-finalization effect. A persisted
+  completion marker distinguishes pending allocation from a successful
+  zero-allocation result, so retries do not re-enter completed allocation.
+- Invoice line finalization makes flat-fee and usage-based lines authoritative
+  before billing synchronizes the external invoice. Custom-currency runs also
+  prepare their reversible gross overage and allocate settlement-fiat credits
+  at this boundary because those effects determine the final line. Any line
+  change is emitted as an explicit invoice update patch; no patch means the
+  existing line remains authoritative. Regular-fiat invoice usage is accrued
+  only after external issuance succeeds. The invoice-issued callback books that
+  non-reversible effect and marks the run immutable; custom-currency runs use it
+  to validate and seal their already-prepared accounting history.
 - Amount discounts on persisted detailed lines are signed realization facts.
   Their rounded amounts and rounding adjustments reconcile to the line's
   `DiscountsTotal`; correction lines can therefore carry negative discount
@@ -287,9 +296,22 @@ Within the charges domain, custom-currency `credit_then_invoice`:
 
 Charge-currency and settlement-fiat allocations are separate realization and
 lineage domains. Rating and mutable rerating reconcile charge-currency facts;
-invoice finalization allocates settlement-fiat credits once against the final
-converted overage. Cleanup reverses persisted settlement-fiat allocations
-before the charge-currency allocations from which the overage was derived.
+invoice finalization first persists the gross converted overage, then allocates
+settlement-fiat credits once against it. This preparation remains reversible
+until the invoice-issued callback marks its run immutable after successful
+external synchronization. Deleting a charge corrects settlement-fiat
+allocations, the gross overage, and charge-currency allocations while the run
+is still reversible. Successful correction deletes the transient accrued-usage
+preparation and resets its allocation-completion marker, leaving the realization
+run clean for rerating or preparation retry. The immutable ledger retains the
+original transaction and its correction; an immutable issued run remains durable
+billing history.
+A line-finalization failure remains retry-only. If synchronization with the
+invoicing app fails after preparation, invoice deletion enters the same charge
+deletion path. Cleanup and its ledger effects share the billing transaction.
+Failed cleanup rolls back and leaves preparation attached for retry from
+`delete.failed`. Committed cleanup removes the preparation and sets run
+`DeletedAt`, so later invoice-delete sync retries do not dispatch it again.
 
 The converted post-allocation overage and the required fiat transaction are
 separate settlement facts. A zero converted overage controls line omission and

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -53,6 +53,7 @@ type ChargeDetailedLineAdapter interface {
 
 type ChargeInvoicedUsageAdapter interface {
 	CreateInvoicedUsage(ctx context.Context, input CreateInvoicedUsageInput) (invoicedusage.AccruedUsage, error)
+	DeleteInvoicedUsage(ctx context.Context, id models.NamespacedID) error
 }
 
 type ChargeRunAdapter interface {

--- a/openmeter/billing/charges/flatfee/adapter/mapping.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapping.go
@@ -101,15 +101,16 @@ func fromDBRunBase(dbRun *entdb.ChargeFlatFeeRun) flatfee.RealizationRunBase {
 		},
 		ManagedModel: entutils.MapTimeMixinFromDB(dbRun),
 
-		LineID:                    dbRun.LineID,
-		InvoiceID:                 dbRun.InvoiceID,
-		Type:                      dbRun.Type,
-		InitialType:               dbRun.InitialType,
-		ServicePeriod:             timeutil.ClosedPeriod{From: dbRun.ServicePeriodFrom.UTC(), To: dbRun.ServicePeriodTo.UTC()},
-		AmountAfterProration:      dbRun.AmountAfterProration,
-		Totals:                    totals.FromDB(dbRun),
-		NoFiatTransactionRequired: dbRun.NoFiatTransactionRequired,
-		Immutable:                 dbRun.Immutable,
+		LineID:                               dbRun.LineID,
+		InvoiceID:                            dbRun.InvoiceID,
+		Type:                                 dbRun.Type,
+		InitialType:                          dbRun.InitialType,
+		ServicePeriod:                        timeutil.ClosedPeriod{From: dbRun.ServicePeriodFrom.UTC(), To: dbRun.ServicePeriodTo.UTC()},
+		AmountAfterProration:                 dbRun.AmountAfterProration,
+		Totals:                               totals.FromDB(dbRun),
+		NoFiatTransactionRequired:            dbRun.NoFiatTransactionRequired,
+		FiatOverageCreditAllocationCompleted: dbRun.FiatOverageCreditAllocationCompleted,
+		Immutable:                            dbRun.Immutable,
 	}
 }
 

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun.go
@@ -112,6 +112,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input flatfee.Update
 			update = update.SetNoFiatTransactionRequired(input.NoFiatTransactionRequired.OrEmpty())
 		}
 
+		if input.FiatOverageCreditAllocationCompleted.IsPresent() {
+			update = update.SetFiatOverageCreditAllocationCompleted(input.FiatOverageCreditAllocationCompleted.OrEmpty())
+		}
+
 		if input.Immutable.IsPresent() {
 			update = update.SetImmutable(input.Immutable.OrEmpty())
 		}

--- a/openmeter/billing/charges/flatfee/adapter/usage.go
+++ b/openmeter/billing/charges/flatfee/adapter/usage.go
@@ -7,7 +7,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
+	dbchargeflatfeeruninvoicedusage "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var _ flatfee.ChargeInvoicedUsageAdapter = (*adapter)(nil)
@@ -37,5 +39,21 @@ func (a *adapter) CreateInvoicedUsage(ctx context.Context, input flatfee.CreateI
 		}
 
 		return invoicedusage.MapAccruedUsageFromDB(entity), nil
+	})
+}
+
+func (a *adapter) DeleteInvoicedUsage(ctx context.Context, id models.NamespacedID) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
+
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		if err := tx.db.ChargeFlatFeeRunInvoicedUsage.DeleteOneID(id.ID).
+			Where(dbchargeflatfeeruninvoicedusage.NamespaceEQ(id.Namespace)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("deleting flat fee invoiced usage [id=%s]: %w", id.ID, err)
+		}
+
+		return nil
 	})
 }

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -141,8 +141,14 @@ func (i OnCustomCurrencyOverageAccruedInput) Validate() error {
 
 type OnCustomCurrencyOverageAccruedResult struct {
 	TransactionGroup ledgertransaction.GroupReference `json:"transactionGroup"`
-	TotalFiatAmount  alpacadecimal.Decimal            `json:"totalFiatAmount"`
+	// TotalFiatAmount is the authoritative rounded gross amount persisted for
+	// invoice projection and later settlement-credit allocation.
+	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
+
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
 
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
@@ -339,14 +345,21 @@ type Handler interface {
 	// OnFlatFeeStandardInvoiceUsageAccrued is called when the remaining usage is sent to the customer on a standard invoice.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency flat-fee value is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
+	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
+
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
 
 	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
 	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 
-	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against a custom-currency overage.
+	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against an
+	// already-prepared custom-currency overage.
 	OnAllocateFiatOverageCredits(ctx context.Context, input AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
 
 	// OnCorrectFiatOverageCreditAllocations corrects settlement-fiat allocations for a custom-currency overage.

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -53,15 +53,16 @@ func (i RealizationRunID) Validate() error {
 type UpdateRealizationRunInput struct {
 	ID RealizationRunID
 
-	Type                      mo.Option[RealizationRunType]    `json:"type"`
-	DeletedAt                 mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
-	LineID                    mo.Option[*string]               `json:"lineId,omitempty"`
-	InvoiceID                 mo.Option[*string]               `json:"invoiceId,omitempty"`
-	ServicePeriod             mo.Option[timeutil.ClosedPeriod] `json:"servicePeriod"`
-	AmountAfterProration      mo.Option[alpacadecimal.Decimal] `json:"amountAfterProration"`
-	Totals                    mo.Option[totals.Totals]         `json:"totals"`
-	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
-	Immutable                 mo.Option[bool]                  `json:"immutable"`
+	Type                                 mo.Option[RealizationRunType]    `json:"type"`
+	DeletedAt                            mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
+	LineID                               mo.Option[*string]               `json:"lineId,omitempty"`
+	InvoiceID                            mo.Option[*string]               `json:"invoiceId,omitempty"`
+	ServicePeriod                        mo.Option[timeutil.ClosedPeriod] `json:"servicePeriod"`
+	AmountAfterProration                 mo.Option[alpacadecimal.Decimal] `json:"amountAfterProration"`
+	Totals                               mo.Option[totals.Totals]         `json:"totals"`
+	NoFiatTransactionRequired            mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	FiatOverageCreditAllocationCompleted mo.Option[bool]                  `json:"fiatOverageCreditAllocationCompleted"`
+	Immutable                            mo.Option[bool]                  `json:"immutable"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -140,8 +141,12 @@ type RealizationRunBase struct {
 	// Totals includes credit allocations and excludes taxes.
 	Totals                    totals.Totals `json:"totals"`
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
-	// Immutable means the backing invoice line can no longer be updated in place.
-	// When true, deleting this run requires issuing a credit note instead of mutating the invoice line.
+	// FiatOverageCreditAllocationCompleted distinguishes a successful
+	// zero-allocation result from pending allocation.
+	FiatOverageCreditAllocationCompleted bool `json:"fiatOverageCreditAllocationCompleted"`
+	// Immutable means the backing invoice crossed the external issuance boundary.
+	// AccruedUsage records preparation before that boundary and can be reversed
+	// only through invoice-owned cancellation.
 	Immutable bool `json:"immutable"`
 }
 

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -140,7 +140,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			flatfee.StatusActiveRealizationZeroFiatAmountOverageCompleted,
 			statelessx.BoolFn(s.IsCurrentRunZeroFiatAmountOverage),
 		).
-		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationIssuing).
+		Permit(meta.TriggerInvoiceFinalizing, flatfee.StatusActiveRealizationIssuing).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
@@ -151,7 +151,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		OnEntryFrom(meta.TriggerAttachInvoiceLine, statelessx.WithParameters(s.AttachInvoiceLine))
 
 	s.Configure(flatfee.StatusActiveRealizationIssuing).
-		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationCompleted).
+		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationCompleted).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
@@ -159,7 +159,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.AccrueInvoiceUsage))
+		OnEntryFrom(meta.TriggerInvoiceFinalizing, statelessx.WithParameters(s.FinalizeInvoice))
 
 	// Zero-fiat-amount overages bypass invoice issuance. This state seals the
 	// persisted current run before the charge completes without payment
@@ -183,7 +183,8 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.UnsupportedLineManualEditOperation)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		Permit(meta.TriggerClearOverride, flatfee.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
-		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted)))
+		Permit(meta.TriggerClearOverride, flatfee.StatusActiveClearOverride, statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.InvoiceIssued))
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
@@ -361,6 +362,45 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun != nil && currentRun.AccruedUsage != nil && !currentRun.Immutable {
+		run := *currentRun
+		correctionInput := flatfeerealizations.CreditReconciliationHandlerInput{
+			Charge:     s.Charge,
+			Run:        run,
+			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
+		}
+		if s.Charge.Intent.GetCurrency().IsCustom() {
+			correctedRun, err := s.Realizations.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
+			if err != nil {
+				return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+			}
+			run = correctedRun
+		} else if err := s.Realizations.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
+			return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+		}
+
+		if err := s.Adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
+			return fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
+		}
+
+		runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+			ID:        run.ID,
+			DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+		})
+		if err != nil {
+			return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+		}
+		run.RealizationRunBase = runBase
+
+		if err := s.Adapter.DetachCurrentRun(ctx, s.Charge.GetChargeID()); err != nil {
+			return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+		}
+
+		s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, run)
+		s.Charge.Realizations.CurrentRun = nil
+	}
+
 	s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
 
 	if err := s.cancelCurrentRealization(ctx); err != nil {
@@ -437,7 +477,6 @@ func (s *CreditThenInvoiceStateMachine) LineManualEdit(ctx context.Context, patc
 		if currentRun.Immutable {
 			return fmt.Errorf("immutable current run [charge_id=%s,run_id=%s]: %w", s.Charge.ID, currentRun.ID.ID, billing.ErrCannotUpdateChargeManagedLine)
 		}
-
 		if currentRun.LineID == nil || *currentRun.LineID != editedLine.GetID() {
 			return fmt.Errorf("run line mismatch [charge_id=%s,run_id=%s,line_id=%s,run_line_id=%s]: %w",
 				s.Charge.ID,
@@ -685,22 +724,135 @@ func (s *CreditThenInvoiceStateMachine) AttachInvoiceLine(ctx context.Context, i
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) AccrueInvoiceUsage(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+// FinalizeInvoice makes the line authoritative and performs reversible custom-
+// currency accounting preparation before external invoice synchronization.
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoice(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
 
-	result, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
-		Charge:         s.Charge,
-		LineWithHeader: input,
-	})
-	if err != nil {
-		return fmt.Errorf("post invoice issued: %w", err)
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("realization run[%s] line does not match finalizing line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("realization run[%s] invoice does not match finalizing invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
 	}
 
-	// The state machine persists this clear through StatusFinal's ClearAdvanceAfter hook.
-	s.Charge.Realizations.CurrentRun = &result.Run
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		s.Charge.State.AdvanceAfter = nil
+
+		return nil
+	}
+
+	run := *currentRun
+	if run.AccruedUsage == nil && (len(run.FiatOverageCreditRealizations) > 0 || run.FiatOverageCreditAllocationCompleted) {
+		return fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", run.ID.ID)
+	}
+
+	line, err := input.Line.Clone()
+	if err != nil {
+		return fmt.Errorf("cloning finalizing line[%s]: %w", input.Line.ID, err)
+	}
+
+	if run.AccruedUsage == nil {
+		if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+			Charge: s.Charge,
+			Run:    run,
+			Stage:  standardLinePopulationStageInvoiceFinalizing,
+		}); err != nil {
+			return fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", line.ID, run.ID.ID, err)
+		}
+
+		prepared, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
+			Charge: s.Charge,
+			LineWithHeader: billing.StandardLineWithInvoiceHeader{
+				Line:    line,
+				Invoice: input.Invoice,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", line.ID, err)
+		}
+		run = prepared.Run
+		s.Charge.Realizations.CurrentRun = &run
+	}
+
+	if !run.FiatOverageCreditAllocationCompleted {
+		allocated, err := s.Realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
+			Charge: s.Charge,
+			Run:    run,
+		})
+		if err != nil {
+			return fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", line.ID, err)
+		}
+		run = allocated.Run
+		s.Charge.Realizations.CurrentRun = &run
+	}
+
+	if err := populateFlatFeeStandardLineFromRun(line, populateFlatFeeStandardLineFromRunInput{
+		Charge: s.Charge,
+		Run:    run,
+		Stage:  standardLinePopulationStageInvoiceFinalizing,
+	}); err != nil {
+		return fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", line.ID, run.ID.ID, err)
+	}
+
 	s.Charge.State.AdvanceAfter = nil
+	s.AddInvoicePatch(invoiceupdater.NewUpdateLinePatch(line.AsGenericLine()))
+
+	return nil
+}
+
+// InvoiceIssued accrues regular-fiat invoice usage or verifies custom-currency
+// preparation, then marks the externally issued invoice history immutable.
+func (s *CreditThenInvoiceStateMachine) InvoiceIssued(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+
+	run := *currentRun
+	if s.Charge.Intent.GetCurrency().IsCustom() {
+		if currentRun.AccruedUsage == nil {
+			return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+		}
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+		}
+	}
+
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		result, err := s.Realizations.AccrueInvoiceUsage(ctx, flatfeerealizations.AccrueInvoiceUsageInput{
+			Charge:         s.Charge,
+			LineWithHeader: input,
+		})
+		if err != nil {
+			return fmt.Errorf("accruing issued invoice usage: %w", err)
+		}
+		run = result.Run
+	}
+
+	run, err := s.Realizations.MarkInvoiceIssued(ctx, run)
+	if err != nil {
+		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
+	}
+
+	s.Charge.Realizations.CurrentRun = &run
 
 	return nil
 }
@@ -740,9 +892,9 @@ func (s *CreditThenInvoiceStateMachine) IsCurrentRunZeroFiatAmountOverage() bool
 	return fiatOverage.ShouldOmitInvoiceLine
 }
 
-// FinalizeZeroFiatAmountOverageRun seals the persisted current run while the
-// state machine is in zero-fiat-amount overage completion.
-func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx context.Context) error {
+// FinalizeZeroFiatAmountOverageRun completes a run without crossing the
+// external invoice issuance boundary.
+func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(_ context.Context) error {
 	currentRun := s.Charge.Realizations.CurrentRun
 	if currentRun == nil {
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
@@ -757,18 +909,6 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(ctx con
 		return fmt.Errorf("current realization run %s is not a zero fiat amount overage", currentRun.ID.ID)
 	}
 
-	// Mark the run immutable because its deleted line might already belong to an
-	// issued invoice. This is safe because a zero-fiat line cannot yield a credit note, where
-	// the deleted line would be an issue.
-	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:        currentRun.ID,
-		Immutable: mo.Some(true),
-	})
-	if err != nil {
-		return fmt.Errorf("mark zero-fiat-amount overage run immutable: %w", err)
-	}
-
-	currentRun.RealizationRunBase = runBase
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil
@@ -782,6 +922,9 @@ type reconcileInvoicingStateInput struct {
 }
 
 func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Context, input reconcileInvoicingStateInput) error {
+	if err := s.correctReversibleCurrentRun(ctx, input.Op); err != nil {
+		return err
+	}
 	currentRun := s.Charge.Realizations.CurrentRun
 
 	// TODO(credit-note support): this branch is a temporary fallback for
@@ -880,8 +1023,8 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		)
 	}
 
-	// If the run is not immutable, we can just update the invoice standard line.
-	if !currentRun.Immutable {
+	// A mutable, non-terminal run can update its draft invoice standard line in place.
+	if !currentRun.Immutable && !s.IsCurrentRunZeroFiatAmountOverage() {
 		// Case #1: If the new amount is zero we just need to delete the old line
 		if input.NewAmountAfterProration.IsZero() {
 			s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
@@ -944,7 +1087,8 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		return nil
 	}
 
-	// Final case: we have an immutable invoice, so we need to invoke the prorating path, unless the amount haven't changed
+	// Final case: externally issued and zero-fiat terminal history cannot be
+	// rerated in place, so invoke the replacement path unless the amount is unchanged.
 	if input.NewAmountAfterProration.Equal(input.OldAmountAfterProration) {
 		return nil
 	}
@@ -970,4 +1114,32 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 
 	s.Charge.Status = flatfee.StatusCreated
 	return s.AdvanceAfterInvoiceAt(ctx)
+}
+
+// correctReversibleCurrentRun removes invoice-finalization effects that would
+// otherwise make rerating a mutable custom-currency run reuse stale preparation.
+func (s *CreditThenInvoiceStateMachine) correctReversibleCurrentRun(ctx context.Context, op meta.PatchType) error {
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil || currentRun.Immutable || currentRun.AccruedUsage == nil {
+		return nil
+	}
+
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		return fmt.Errorf("cannot %s flat-fee charge %s: mutable realization run %s has unexpected regular-fiat invoice usage", op, s.Charge.ID, currentRun.ID.ID)
+	}
+
+	_, err := s.Realizations.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
+		Charge:     s.Charge,
+		Run:        *currentRun,
+		AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), currentRun.ServicePeriod),
+	})
+	if err != nil {
+		return fmt.Errorf("correct reversible realization run[%s] before %s: %w", currentRun.ID.ID, op, err)
+	}
+
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("refetch flat-fee charge[%s] after correcting realization run[%s]: %w", s.Charge.ID, currentRun.ID.ID, err)
+	}
+
+	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -286,16 +286,67 @@ func (s *CreditThenInvoiceStateMachine) ActiveClearOverride(ctx context.Context)
 	return nil
 }
 
+// cancelCurrentRealization owns charge-side cleanup for removing the current
+// invoice run. Reversible runs are corrected and marked deleted before their
+// invoice patch is emitted; immutable and zero-fiat history is only detached.
 func (s *CreditThenInvoiceStateMachine) cancelCurrentRealization(ctx context.Context) error {
 	currentRun := s.Charge.Realizations.CurrentRun
 	if currentRun == nil {
 		return nil
 	}
+	run := *currentRun
 
-	if currentRun.LineID != nil && currentRun.InvoiceID != nil {
+	shouldCorrect := false
+	if !run.Immutable {
+		if run.Payment != nil {
+			return fmt.Errorf("cannot cancel realization run[%s] with payment allocation", run.ID.ID)
+		}
+
+		fiatOverage, err := calculateFiatOverageForRun(s.Charge, run)
+		if err != nil {
+			return fmt.Errorf("calculating fiat overage for realization run[%s]: %w", run.ID.ID, err)
+		}
+		shouldCorrect = !fiatOverage.ShouldOmitInvoiceLine
+	}
+
+	if shouldCorrect {
+		correctionInput := flatfeerealizations.CreditReconciliationHandlerInput{
+			Charge:     s.Charge,
+			Run:        run,
+			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
+		}
+		if run.AccruedUsage != nil {
+			if !s.Charge.Intent.GetCurrency().IsCustom() {
+				return fmt.Errorf("cannot cancel mutable regular-fiat realization run[%s] with invoice usage", run.ID.ID)
+			}
+
+			correctedRun, err := s.Realizations.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
+			if err != nil {
+				return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+			}
+			run = correctedRun
+		} else if err := s.Realizations.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
+			return fmt.Errorf("correcting realization run[%s]: %w", run.ID.ID, err)
+		}
+
+		if err := s.Adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
+			return fmt.Errorf("deleting detailed lines for realization run[%s]: %w", run.ID.ID, err)
+		}
+
+		runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+			ID:        run.ID,
+			DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+		})
+		if err != nil {
+			return fmt.Errorf("marking realization run[%s] deleted: %w", run.ID.ID, err)
+		}
+		run.RealizationRunBase = runBase
+	}
+
+	if run.LineID != nil && run.InvoiceID != nil {
 		s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
-			billing.LineID{Namespace: s.Charge.Namespace, ID: *currentRun.LineID},
-			*currentRun.InvoiceID,
+			billing.LineID{Namespace: s.Charge.Namespace, ID: *run.LineID},
+			*run.InvoiceID,
 		))
 	}
 
@@ -303,7 +354,7 @@ func (s *CreditThenInvoiceStateMachine) cancelCurrentRealization(ctx context.Con
 		return fmt.Errorf("detach current realization: %w", err)
 	}
 
-	s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, *currentRun)
+	s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, run)
 	s.Charge.Realizations.CurrentRun = nil
 
 	return nil
@@ -362,45 +413,6 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
-	currentRun := s.Charge.Realizations.CurrentRun
-	if currentRun != nil && currentRun.AccruedUsage != nil && !currentRun.Immutable {
-		run := *currentRun
-		correctionInput := flatfeerealizations.CreditReconciliationHandlerInput{
-			Charge:     s.Charge,
-			Run:        run,
-			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
-		}
-		if s.Charge.Intent.GetCurrency().IsCustom() {
-			correctedRun, err := s.Realizations.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
-			if err != nil {
-				return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
-			}
-			run = correctedRun
-		} else if err := s.Realizations.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
-			return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
-		}
-
-		if err := s.Adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
-			return fmt.Errorf("deleting detailed lines for prepared realization run[%s]: %w", run.ID.ID, err)
-		}
-
-		runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-			ID:        run.ID,
-			DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
-		})
-		if err != nil {
-			return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
-		}
-		run.RealizationRunBase = runBase
-
-		if err := s.Adapter.DetachCurrentRun(ctx, s.Charge.GetChargeID()); err != nil {
-			return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
-		}
-
-		s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, run)
-		s.Charge.Realizations.CurrentRun = nil
-	}
-
 	s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
 
 	if err := s.cancelCurrentRealization(ctx); err != nil {
@@ -1027,24 +1039,12 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 	if !currentRun.Immutable && !s.IsCurrentRunZeroFiatAmountOverage() {
 		// Case #1: If the new amount is zero we just need to delete the old line
 		if input.NewAmountAfterProration.IsZero() {
-			s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
-				billing.LineID{
-					Namespace: s.Charge.Namespace,
-					ID:        *currentRun.LineID,
-				},
-				*currentRun.InvoiceID,
-			))
-
-			if err := s.Adapter.DetachCurrentRun(ctx, s.Charge.GetChargeID()); err != nil {
-				return fmt.Errorf("detach zero-amount current run: %w", err)
+			if err := s.cancelCurrentRealization(ctx); err != nil {
+				return fmt.Errorf("canceling zero-amount current run: %w", err)
 			}
 
-			s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, *currentRun)
-			s.Charge.Realizations.CurrentRun = nil
-
-			// The mutable standard-line deletion hook owns credit correction
-			// for the detached run. After the line is removed, a zero-amount
-			// charge has no remaining invoice lifecycle to wait for.
+			// After the line is removed, a zero-amount charge has no remaining
+			// invoice lifecycle to wait for.
 			s.Charge.Status = flatfee.StatusFinal
 			s.Charge.State.AdvanceAfter = nil
 
@@ -1095,22 +1095,11 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 
 	// We need to trigger a prorating for the new amount
 
-	s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
-		billing.LineID{
-			Namespace: s.Charge.Namespace,
-			ID:        *currentRun.LineID,
-		},
-		*currentRun.InvoiceID,
-	))
-
-	if err := s.Adapter.DetachCurrentRun(ctx, s.Charge.GetChargeID()); err != nil {
-		return fmt.Errorf("detach immutable current run: %w", err)
+	if err := s.cancelCurrentRealization(ctx); err != nil {
+		return fmt.Errorf("canceling current run before replacement: %w", err)
 	}
 
 	s.AddInvoicePatch(invoiceupdater.NewCreateLinePatch(updatedGatheringLine))
-
-	s.Charge.Realizations.PriorRuns = append(s.Charge.Realizations.PriorRuns, *currentRun)
-	s.Charge.Realizations.CurrentRun = nil
 
 	s.Charge.Status = flatfee.StatusCreated
 	return s.AdvanceAfterInvoiceAt(ctx)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -759,11 +759,11 @@ func (e *LineEngine) handleManualDeleteInvoicePatches(ctx context.Context, invoi
 				return fmt.Errorf("line[%s]: getting standard line for manual delete cleanup: %w", line.GetID(), err)
 			}
 
-			if err := e.cleanupDeletedStandardLines(ctx, billing.StandardLineEventInput{
+			if err := e.validateDeletedStandardLines(ctx, billing.StandardLineEventInput{
 				Invoice: standardInvoice,
 				Lines:   billing.StandardLines{&standardLine},
 			}); err != nil {
-				return fmt.Errorf("line[%s]: cleaning up manual delete line patch: %w", line.GetID(), err)
+				return fmt.Errorf("line[%s]: validating manual delete line patch result: %w", line.GetID(), err)
 			}
 		default:
 			return fmt.Errorf("line[%s]: unexpected manual delete invoice patch %s", line.GetID(), patch.Op())
@@ -778,10 +778,13 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		return fmt.Errorf("validating input: %w", err)
 	}
 
-	return e.cleanupDeletedStandardLines(ctx, input)
+	return e.validateDeletedStandardLines(ctx, input)
 }
 
-func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input billing.StandardLineEventInput) error {
+// validateDeletedStandardLines confirms that charge lifecycle handling ran
+// before billing persisted a standard-line deletion. It never changes charge
+// accounting or realization state.
+func (e *LineEngine) validateDeletedStandardLines(ctx context.Context, input billing.StandardLineEventInput) error {
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
 	})
@@ -800,30 +803,20 @@ func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input bill
 			return err
 		}
 
-		if run.DeletedAt != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
-		}
-
 		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
 			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
 		}
 
-		// Issued runs remain durable billing history when their presentation
-		// line is deleted; only reversible runs enter correction cleanup.
-		if run.Immutable {
+		// A deleted run proves that its state machine completed reversible
+		// cleanup before handing the invoice effect to billing.
+		if run.DeletedAt != nil {
 			continue
 		}
 
-		if run.AccruedUsage != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
-		}
-
-		if run.Payment != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
-		}
-
-		if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.ID.ID == run.ID.ID {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is still current for charge[%s]", stdLine.ID, run.ID.ID, charge.ID)
+		// Immutable runs retain their accounting when billing can only record
+		// unsupported invoice drift.
+		if run.Immutable {
+			continue
 		}
 
 		// Collection deletes only the presentation line for a zero-fiat-amount
@@ -837,24 +830,7 @@ func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input bill
 			continue
 		}
 
-		if err := e.service.realizations.CorrectAllCreditRealizations(ctx, flatfeerealizations.CreditReconciliationHandlerInput{
-			Charge:     charge,
-			Run:        run,
-			AllocateAt: flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
-		}); err != nil {
-			return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if err := e.service.adapter.UpsertDetailedLines(ctx, run.ID, nil); err != nil {
-			return fmt.Errorf("deleting detailed lines for deleted flat fee standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if _, err := e.service.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-			ID:        run.ID,
-			DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
-		}); err != nil {
-			return fmt.Errorf("marking realization run[%s] deleted for flat fee standard line[%s]: %w", run.ID.ID, stdLine.ID, err)
-		}
+		return fmt.Errorf("flat fee standard line[%s] cannot be deleted because mutable realization run[%s] was not canceled by the charge state machine", stdLine.ID, run.ID.ID)
 	}
 
 	return nil
@@ -890,8 +866,11 @@ func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.
 			return fmt.Errorf("flat fee standard line[%s] cannot be marked unsupported credit note because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
 		}
 
+		// Charge deletion can reconcile the run before its patch reaches an
+		// immutable invoice. Billing still records the validation issue, but the
+		// completed charge cleanup must remain authoritative.
 		if run.DeletedAt != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be marked unsupported credit note because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
+			continue
 		}
 
 		if run.Type == flatfee.RealizationRunTypeInvalidDueToUnsupportedCreditNote {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -376,36 +377,19 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		}
 
 		if charge.Intent.GetCurrency().IsCustom() {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf(
-				"custom-currency flat fee line[%s] cannot be deleted: %w",
-				line.GetID(),
-				billing.ErrCannotUpdateChargeManagedLine,
-			)
+			if err := validateCustomCurrencyInvoiceLineDelete(input.Invoice, line, charge); err != nil {
+				return billing.OnMutableInvoiceUpdateResult{}, err
+			}
+		} else {
+			if err := validateManualDeleteLine(charge, line); err != nil {
+				return billing.OnMutableInvoiceUpdateResult{}, err
+			}
 		}
 
-		if err := validateManualDeleteLine(charge, line); err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, err
-		}
-
-		stateMachine, err := e.service.newStateMachineForCharge(charge)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
-		}
-
-		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
-			ChangeSource: billing.ChangeSourceAPIRequest,
-			Policy:       meta.RefundAsCreditsDeletePolicy,
+		err = transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+			return e.deleteLineViaAPI(ctx, input.Invoice, charge, line, *chargeID)
 		})
 		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
-		}
-
-		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
-		if err != nil {
-			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
-		}
-
-		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, patches); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -414,6 +398,34 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		CreatedLines: createdLines,
 		UpdatedLines: updatedLines,
 	}, nil
+}
+
+func (e *LineEngine) deleteLineViaAPI(
+	ctx context.Context,
+	invoice billing.GenericInvoiceReader,
+	charge flatfee.Charge,
+	line billing.GenericInvoiceLine,
+	chargeID string,
+) error {
+	stateMachine, err := e.service.newStateMachineForCharge(charge)
+	if err != nil {
+		return fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
+	}
+
+	deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		Policy:       meta.RefundAsCreditsDeletePolicy,
+	})
+	if err != nil {
+		return fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
+	}
+
+	patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerDelete, deletePatch)
+	if err != nil {
+		return fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
+	}
+
+	return e.handleManualDeleteInvoicePatches(ctx, invoice, line, chargeID, patches)
 }
 
 func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) error {
@@ -438,7 +450,7 @@ func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, i
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.validateManualDeleteLineViaAPI(ctx, line); err != nil {
+		if err := e.validateManualDeleteLineViaAPI(ctx, input.Invoice, line); err != nil {
 			return err
 		}
 	}
@@ -495,7 +507,7 @@ func (e *LineEngine) validateManualUpdateLineViaAPI(ctx context.Context, overrid
 	return nil
 }
 
-func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line billing.GenericInvoiceLine) error {
+func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
 	chargeID := line.GetChargeID()
 	if chargeID == nil || *chargeID == "" {
 		return fmt.Errorf("flat fee line[%s]: charge id is required", line.GetID())
@@ -523,14 +535,37 @@ func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line bi
 	}
 
 	if charge.Intent.GetCurrency().IsCustom() {
-		return fmt.Errorf(
-			"custom-currency flat fee line[%s] cannot be deleted: %w",
-			line.GetID(),
-			billing.ErrCannotUpdateChargeManagedLine,
-		)
+		return validateCustomCurrencyInvoiceLineDelete(invoice, line, charge)
 	}
 
 	return validateManualDeleteLine(charge, line)
+}
+
+// validateCustomCurrencyInvoiceLineDelete verifies the invoice and charge
+// association required to delete a custom-currency line.
+func validateCustomCurrencyInvoiceLineDelete(invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine, charge flatfee.Charge) error {
+	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
+		return fmt.Errorf("custom-currency flat fee line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("flat fee line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	if standardInvoice.Namespace != charge.Namespace || line.GetLineID().Namespace != charge.Namespace {
+		return fmt.Errorf("custom-currency flat fee line[%s] namespace does not match charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
+	}
+	if line.GetChargeID() == nil || *line.GetChargeID() != charge.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] does not match charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	currentRun := charge.Realizations.CurrentRun
+	if currentRun == nil || currentRun.LineID == nil || *currentRun.LineID != line.GetID() || currentRun.InvoiceID == nil || *currentRun.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency flat fee line[%s] must reference the current realization run of charge[%s]: %w", line.GetID(), charge.ID, billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
 }
 
 type manualCreatedInvoiceLine struct {
@@ -773,6 +808,12 @@ func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input bill
 			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
 		}
 
+		// Issued runs remain durable billing history when their presentation
+		// line is deleted; only reversible runs enter correction cleanup.
+		if run.Immutable {
+			continue
+		}
+
 		if run.AccruedUsage != nil {
 			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
 		}
@@ -947,62 +988,30 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
-		meta.ExpandRealizations,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	return slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
-		charge, ok := chargesByID[*stdLine.ChargeID]
-		if !ok {
-			return nil, fmt.Errorf("flat fee charge[%s] not found for finalizing line[%s]", *stdLine.ChargeID, stdLine.ID)
-		}
-
-		if stdLine.IsDeleted() ||
-			charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
-			!charge.Intent.GetCurrency().IsCustom() {
+		if stdLine.IsDeleted() {
 			return stdLine, nil
 		}
 
-		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, fmt.Errorf("getting realization run for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, err
 		}
 
-		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
-			return nil, fmt.Errorf(
-				"realization run[%s] for finalizing line[%s] is not associated with invoice[%s]",
-				run.ID.ID,
-				stdLine.ID,
-				input.Invoice.ID,
-			)
-		}
-
-		allocated, err := e.service.realizations.AllocateFiatOverageCredits(ctx, flatfeerealizations.AllocateFiatOverageCreditsInput{
-			Charge: charge,
-			Run:    run,
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerInvoiceFinalizing, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("finalizing invoice line for charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		updatedLine, err := stdLine.Clone()
+		updatedLine, err := patches.RequireSingularStandardLineUpdateOrEmpty(stdLine.GetLineID(), input.Invoice.ID)
 		if err != nil {
-			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("validating finalizing update for line[%s]: %w", stdLine.ID, err)
 		}
-
-		if err := populateFlatFeeStandardLineFromRun(updatedLine, populateFlatFeeStandardLineFromRunInput{
-			Charge: allocated.Charge,
-			Run:    allocated.Run,
-			Stage:  standardLinePopulationStageInvoiceFinalizing,
-		}); err != nil {
-			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if err := updatedLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating finalizing line[%s]: %w", stdLine.ID, err)
+		if updatedLine == nil {
+			return stdLine, nil
 		}
 
 		return updatedLine, nil

--- a/openmeter/billing/charges/flatfee/service/lineengine_test.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newFlatFeeStandardLineForTest(servicePeriod)
+	charge := newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+	run := newFlatFeeCustomCurrencyRunForTest(servicePeriod, line.Totals, false)
+	run.LineID = lo.ToPtr(line.ID)
+	run.InvoiceID = lo.ToPtr(line.InvoiceID)
+	charge.Realizations.CurrentRun = &run
+
+	invoice := &billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			Namespace: line.Namespace,
+			ID:        line.InvoiceID,
+			Status:    billing.StandardInvoiceStatusDraftCreated,
+		},
+	}
+
+	require.NoError(t, validateCustomCurrencyInvoiceLineDelete(invoice, line.AsGenericLine(), charge))
+}

--- a/openmeter/billing/charges/flatfee/service/linemapper.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper.go
@@ -76,6 +76,37 @@ func calculateFiatOverageForRun(charge flatfee.Charge, run flatfee.RealizationRu
 	}, nil
 }
 
+// resolveFiatOverageForLinePopulation reuses the gross FIAT amount persisted
+// by invoice preparation. This keeps retries from repeating conversion after
+// the durable accounting boundary has been crossed.
+func resolveFiatOverageForLinePopulation(
+	charge flatfee.Charge,
+	run flatfee.RealizationRun,
+	stage standardLinePopulationStage,
+) (calculateFiatOverageForRunResult, error) {
+	if stage != standardLinePopulationStageInvoiceFinalizing || run.AccruedUsage == nil {
+		return calculateFiatOverageForRun(charge, run)
+	}
+
+	costBasisIntent := charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return calculateFiatOverageForRunResult{}, errors.New("cost basis intent is required for a custom-currency invoice")
+	}
+
+	fiatCurrency, err := costBasisIntent.GetFiatCurrency()
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	grossFiatAmount := run.AccruedUsage.Totals.Total
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatCurrency,
+		FiatOverage:           grossFiatAmount,
+		ShouldOmitInvoiceLine: grossFiatAmount.IsZero(),
+	}, nil
+}
+
 func (i populateFlatFeeStandardLineFromRunInput) Validate() error {
 	var errs []error
 
@@ -168,7 +199,7 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := calculateFiatOverageForRun(charge, run)
+	fiatOverage, err := resolveFiatOverageForLinePopulation(charge, run, input.Stage)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}

--- a/openmeter/billing/charges/flatfee/service/linemapper_test.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -89,6 +90,36 @@ func TestCalculateFiatOverageForRun(t *testing.T) {
 			require.Equal(t, test.expectOmitInvoiceLine, fiatOverage.ShouldOmitInvoiceLine)
 		})
 	}
+}
+
+func TestResolveFlatFeeCustomCurrencyFinalizationOverageReusesPreparedGrossAmount(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge := newFlatFeeCustomCurrencyCreditThenInvoiceChargeForTest(t, servicePeriod)
+	run := newFlatFeeCustomCurrencyRunForTest(
+		servicePeriod,
+		totals.Totals{Amount: alpacadecimal.NewFromInt(3), Total: alpacadecimal.NewFromInt(3)},
+		false,
+	)
+	run.AccruedUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: servicePeriod,
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
+		},
+	}
+
+	// The current cost basis would convert the run to 6 USD. Finalization must
+	// reuse the persisted 5 USD result instead of converting again.
+	fiatOverage, err := resolveFiatOverageForLinePopulation(
+		charge,
+		run,
+		standardLinePopulationStageInvoiceFinalizing,
+	)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), fiatOverage.FiatOverage.InexactFloat64())
 }
 
 func TestPopulateFlatFeeCustomCurrencyOverageLineDeletionUsesConvertedOverage(t *testing.T) {

--- a/openmeter/billing/charges/flatfee/service/realizations/credits.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credits.go
@@ -304,12 +304,12 @@ func (i AllocateFiatOverageCreditsInput) Validate() error {
 		))
 	}
 
-	if i.Run.AccruedUsage != nil {
-		errs = append(errs, errors.New("run already has accrued invoice usage"))
+	if i.Run.AccruedUsage == nil {
+		errs = append(errs, errors.New("run must have prepared invoice usage before fiat allocation"))
 	}
 
-	if len(i.Run.FiatOverageCreditRealizations) > 0 {
-		errs = append(errs, errors.New("run already has fiat overage credit realizations"))
+	if i.Run.FiatOverageCreditAllocationCompleted {
+		errs = append(errs, errors.New("fiat overage credit allocation already completed"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -331,33 +331,44 @@ func (s *Service) AllocateFiatOverageCredits(
 		return AllocateFiatOverageCreditsResult{}, err
 	}
 
-	fiatOverage, err := in.Charge.ConvertCustomCurrencyOverageToFiat(in.Run.Totals)
+	fiatCurrency, err := in.Charge.GetInvoiceCurrency()
 	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("get invoice currency: %w", err)
 	}
+	grossFiatAmount := in.Run.AccruedUsage.Totals.Total
 
 	run := in.Run
-	allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
-		Amount: fiatOverage.Amount,
-		Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
-			Charge: in.Charge,
-			Run:    run,
-			// Fiat overage allocation is an invoice-finalization effect. Current
-			// time makes the outstanding settlement-fiat balance eligible then.
-			AllocateAt: clock.Now(),
-		}),
-	})
-	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+	if len(run.FiatOverageCreditRealizations) == 0 {
+		allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
+			Amount: grossFiatAmount,
+			Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
+				Charge: in.Charge,
+				Run:    run,
+				// Fiat overage allocation is an invoice-finalization effect. Current
+				// time makes the outstanding settlement-fiat balance eligible then.
+				AllocateAt: clock.Now(),
+			}),
+		})
+		if err != nil {
+			return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+		}
+
+		run.FiatOverageCreditRealizations = allocationResult.Realizations
 	}
 
-	run.FiatOverageCreditRealizations = allocationResult.Realizations
-
-	allocated := fiatOverage.Currency.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
-	remainingFiatOverage := fiatOverage.Currency.RoundToPrecision(fiatOverage.Amount.Sub(allocated))
+	fiatCurrencyCalculator, err := currencyx.NewFiatCurrency(fiatCurrency)
+	if err != nil {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("create invoice currency calculator: %w", err)
+	}
+	allocated := fiatCurrencyCalculator.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
+	if allocated.GreaterThan(grossFiatAmount) {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("fiat overage credit allocations exceed prepared gross amount: %s > %s", allocated, grossFiatAmount)
+	}
+	remainingFiatOverage := fiatCurrencyCalculator.RoundToPrecision(grossFiatAmount.Sub(allocated))
 	runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-		ID:                        run.ID,
-		NoFiatTransactionRequired: mo.Some(remainingFiatOverage.IsZero()),
+		ID:                                   run.ID,
+		NoFiatTransactionRequired:            mo.Some(remainingFiatOverage.IsZero()),
+		FiatOverageCreditAllocationCompleted: mo.Some(true),
 	})
 	if err != nil {
 		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("update realization run after fiat overage allocation: %w", err)
@@ -374,8 +385,7 @@ func (s *Service) AllocateFiatOverageCredits(
 }
 
 // CorrectAllCreditRealizations reverses every active credit allocation for a
-// flat-fee run. Custom-currency credit-then-invoice runs unwind settlement
-// fiat before the charge currency from which that overage was derived.
+// flat-fee run without changing its accrued invoice usage.
 func (s *Service) CorrectAllCreditRealizations(
 	ctx context.Context,
 	input CreditReconciliationHandlerInput,
@@ -384,15 +394,74 @@ func (s *Service) CorrectAllCreditRealizations(
 		return err
 	}
 
-	if input.Charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode &&
-		input.Charge.Intent.GetCurrency().IsCustom() {
-		if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
-			Handler: s.NewFiatOverageCreditReconciliationHandler(input),
-		}); err != nil {
-			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
-		}
+	if err := s.correctFiatOverageCreditRealizations(ctx, input); err != nil {
+		return err
 	}
 
+	return s.correctChargeCurrencyCreditRealizations(ctx, input)
+}
+
+// CorrectPreparedCustomCurrencyInvoiceRealizations unwinds a prepared custom-
+// currency invoice run in reverse accounting order while keeping accrued-usage
+// correction separate from credit realization correction.
+func (s *Service) CorrectPreparedCustomCurrencyInvoiceRealizations(
+	ctx context.Context,
+	input CreditReconciliationHandlerInput,
+) (flatfee.RealizationRun, error) {
+	if err := input.Validate(); err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+
+	accruedUsageInput := CorrectAccruedUsageInput{
+		Charge: input.Charge,
+		Run:    input.Run,
+	}
+	if err := accruedUsageInput.Validate(); err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+
+	if err := s.correctFiatOverageCreditRealizations(ctx, input); err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+
+	run, err := s.CorrectAccruedUsage(ctx, accruedUsageInput)
+	if err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+	input.Run = run
+
+	if err := s.correctChargeCurrencyCreditRealizations(ctx, input); err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+
+	runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:                                   input.Run.ID,
+		FiatOverageCreditAllocationCompleted: mo.Some(false),
+	})
+	if err != nil {
+		return flatfee.RealizationRun{}, fmt.Errorf("reset invoice preparation state: %w", err)
+	}
+	input.Run.RealizationRunBase = runBase
+
+	return input.Run, nil
+}
+
+func (s *Service) correctFiatOverageCreditRealizations(ctx context.Context, input CreditReconciliationHandlerInput) error {
+	if input.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
+		!input.Charge.Intent.GetCurrency().IsCustom() {
+		return nil
+	}
+
+	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
+		Handler: s.NewFiatOverageCreditReconciliationHandler(input),
+	}); err != nil {
+		return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) correctChargeCurrencyCreditRealizations(ctx context.Context, input CreditReconciliationHandlerInput) error {
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
 		Handler: s.NewChargeCurrencyCreditReconciliationHandler(input),
 	}); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -150,16 +151,92 @@ func (s *Service) AccrueInvoiceUsage(ctx context.Context, in AccrueInvoiceUsageI
 			result.Run.AccruedUsage = &accruedUsage
 		}
 
-		runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
-			ID:        currentRun.ID,
-			Immutable: mo.Some(true),
-		})
-		if err != nil {
-			return AccrueInvoiceUsageResult{}, fmt.Errorf("updating standard invoice run: %w", err)
-		}
-
-		result.Run.RealizationRunBase = runBase
-
 		return result, nil
 	})
+}
+
+type CorrectAccruedUsageInput struct {
+	Charge flatfee.Charge
+	Run    flatfee.RealizationRun
+}
+
+func (i CorrectAccruedUsageInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, errors.New("settlement mode must be credit_then_invoice"))
+	}
+
+	if !i.Charge.Intent.GetCurrency().IsCustom() {
+		errs = append(errs, errors.New("charge currency must be custom"))
+	}
+
+	if i.Run.Immutable {
+		errs = append(errs, errors.New("cannot correct accrued usage for immutable run"))
+	}
+
+	if i.Run.AccruedUsage == nil {
+		errs = append(errs, errors.New("run must have accrued usage"))
+	}
+
+	if i.Charge.Realizations.CurrentRun == nil {
+		errs = append(errs, errors.New("charge has no current realization run"))
+	} else if i.Charge.Realizations.CurrentRun.ID != i.Run.ID {
+		errs = append(errs, fmt.Errorf(
+			"run is not the charge's current realization run [current_run_id=%s run_id=%s]",
+			i.Charge.Realizations.CurrentRun.ID.ID,
+			i.Run.ID.ID,
+		))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// CorrectAccruedUsage reverses a mutable custom-currency run's prepared gross
+// overage and removes the transient preparation so the run can be prepared again.
+func (s *Service) CorrectAccruedUsage(ctx context.Context, input CorrectAccruedUsageInput) (flatfee.RealizationRun, error) {
+	if err := input.Validate(); err != nil {
+		return flatfee.RealizationRun{}, err
+	}
+
+	correctionInput := flatfee.OnCustomCurrencyOverageAccruedCorrectionInput{
+		Charge: input.Charge,
+		Run:    input.Run,
+	}
+	if err := correctionInput.Validate(); err != nil {
+		return flatfee.RealizationRun{}, fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+	}
+	if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+		return flatfee.RealizationRun{}, fmt.Errorf("correct custom-currency overage accrual: %w", err)
+	}
+
+	if err := s.adapter.DeleteInvoicedUsage(ctx, input.Run.AccruedUsage.NamespacedID); err != nil {
+		return flatfee.RealizationRun{}, fmt.Errorf("delete custom-currency overage preparation: %w", err)
+	}
+
+	input.Run.AccruedUsage = nil
+
+	return input.Run, nil
+}
+
+func (s *Service) MarkInvoiceIssued(ctx context.Context, run flatfee.RealizationRun) (flatfee.RealizationRun, error) {
+	runBase, err := s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:        run.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return flatfee.RealizationRun{}, fmt.Errorf("updating issued realization run: %w", err)
+	}
+
+	run.RealizationRunBase = runBase
+
+	return run, nil
 }

--- a/openmeter/billing/charges/invoiceupdater/patches.go
+++ b/openmeter/billing/charges/invoiceupdater/patches.go
@@ -1,6 +1,7 @@
 package invoiceupdater
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -73,6 +74,56 @@ func (p Patches) RequireSingularLineUpdatePatchForTarget(line billing.GenericInv
 	}
 
 	return updatePatch, nil
+}
+
+// RequireSingularStandardLineUpdateOrEmpty returns nil when no line update was
+// emitted and the target standard line when exactly one matching update was emitted.
+func (p Patches) RequireSingularStandardLineUpdateOrEmpty(lineID billing.LineID, invoiceID string) (*billing.StandardLine, error) {
+	if err := lineID.Validate(); err != nil {
+		return nil, fmt.Errorf("validating line ID: %w", err)
+	}
+
+	if invoiceID == "" {
+		return nil, errors.New("invoice ID is required")
+	}
+
+	if len(p) == 0 {
+		return nil, nil
+	}
+
+	patch, err := p.requireSingularPatch("standard line update")
+	if err != nil {
+		return nil, err
+	}
+
+	updatePatch, err := patch.AsUpdateLinePatch()
+	if err != nil {
+		return nil, err
+	}
+
+	target := updatePatch.TargetState
+	if target == nil {
+		return nil, errors.New("target state is required")
+	}
+
+	if target.GetLineID() != lineID {
+		return nil, fmt.Errorf("target line[%s] does not match line[%s]", target.GetLineID(), lineID)
+	}
+
+	if target.GetInvoiceID() != invoiceID {
+		return nil, fmt.Errorf("target invoice[%s] does not match invoice[%s]", target.GetInvoiceID(), invoiceID)
+	}
+
+	line, err := target.AsInvoiceLine().AsStandardLine()
+	if err != nil {
+		return nil, fmt.Errorf("target state must be a standard line: %w", err)
+	}
+
+	if err := line.Validate(); err != nil {
+		return nil, fmt.Errorf("validating target standard line: %w", err)
+	}
+
+	return &line, nil
 }
 
 func (p Patches) RequireSingularGatheringLinePatchForCharge(chargeID string) (Patch, error) {

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -8,6 +8,7 @@ var (
 	TriggerNext                   Trigger = "next"
 	TriggerInvoiceCreated         Trigger = "invoice_created"
 	TriggerCollectionCompleted    Trigger = "collection_completed"
+	TriggerInvoiceFinalizing      Trigger = "invoice_finalizing"
 	TriggerInvoiceIssued          Trigger = "invoice_issued"
 	TriggerLineManualEdit         Trigger = "line_manual_edit"
 	TriggerSetOverride            Trigger = "set_override"

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -37,15 +37,16 @@ func (m *mockLineageService) BackfillAdvanceLineageSegments(ctx context.Context,
 var _ flatfee.Handler = (*flatFeeTestHandler)(nil)
 
 type flatFeeTestHandler struct {
-	onAllocateCredits                     func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onInvoiceUsageAccrued                 func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
-	onCorrectCreditAllocations            func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
-	onPaymentAuthorized                   func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onPaymentUncollectible                func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
+	onAllocateCredits                        func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onCorrectCreditAllocations               func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input flatfee.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onPaymentAuthorized                      func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onPaymentUncollectible                   func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
 }
 
 func newFlatFeeTestHandler() *flatFeeTestHandler {
@@ -74,6 +75,14 @@ func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Context,
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *flatFeeTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
@@ -180,14 +189,15 @@ func (h *creditPurchaseTestHandler) Reset() {
 var _ usagebased.Handler = (*usageBasedTestHandler)(nil)
 
 type usageBasedTestHandler struct {
-	onInvoiceUsageAccrued                 func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCustomCurrencyOverageAccrued        func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
-	onPaymentAuthorized                   func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                      func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onCreditsOnlyUsageAccrued             func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
-	onCreditsOnlyUsageAccruedCorrection   func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
-	onAllocateFiatOverageCredits          func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
-	onCorrectFiatOverageCreditAllocations func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onInvoiceUsageAccrued                    func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCustomCurrencyOverageAccrued           func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error)
+	onCustomCurrencyOverageAccruedCorrection func(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error
+	onPaymentAuthorized                      func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                         func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onCreditsOnlyUsageAccrued                func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
+	onCreditsOnlyUsageAccruedCorrection      func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
+	onAllocateFiatOverageCredits             func(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onCorrectFiatOverageCreditAllocations    func(ctx context.Context, input usagebased.CorrectFiatOverageCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 }
 
 func newUsageBasedTestHandler() *usageBasedTestHandler {
@@ -208,6 +218,14 @@ func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccrued(ctx context.Conte
 	}
 
 	return h.onCustomCurrencyOverageAccrued(ctx, input)
+}
+
+func (h *usageBasedTestHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if h.onCustomCurrencyOverageAccruedCorrection == nil {
+		return nil
+	}
+
+	return h.onCustomCurrencyOverageAccruedCorrection(ctx, input)
 }
 
 func (h *usageBasedTestHandler) OnPaymentAuthorized(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -772,15 +772,27 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 	}
 }
 
+type flatFeePreparedOverageDeleteMode uint8
+
+const (
+	flatFeePreparedOverageDeleteModeNone flatFeePreparedOverageDeleteMode = iota
+	flatFeePreparedOverageDeleteModeInvoice
+	flatFeePreparedOverageDeleteModeCharge
+)
+
 func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
-	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(flatFeePreparedOverageDeleteModeNone)
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
-	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(flatFeePreparedOverageDeleteModeInvoice)
 }
 
-func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
+func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyPreparedOverageChargeDeleteReconcilesImmutableInvoice() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(flatFeePreparedOverageDeleteModeCharge)
+}
+
+func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteMode flatFeePreparedOverageDeleteMode) {
 	// given:
 	// - a custom-currency flat-fee run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -884,7 +896,7 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		correctionEvents = append(correctionEvents, "gross_overage_correction")
 		return nil
 	}
-	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	failChargeCurrencyCorrection := deleteMode == flatFeePreparedOverageDeleteModeInvoice
 	s.FlatFeeTestHandler.onCorrectCreditAllocations = func(
 		_ context.Context,
 		input flatfee.CorrectCreditAllocationsInput,
@@ -969,10 +981,12 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	if deleteAfterSyncFailure {
+	switch deleteMode {
+	case flatFeePreparedOverageDeleteModeInvoice:
 		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
-	} else {
+	case flatFeePreparedOverageDeleteModeNone:
 		mockApp.OnFinalizeStandardInvoice(nil)
+	case flatFeePreparedOverageDeleteModeCharge:
 	}
 
 	s.Run("when fiat allocation fails after gross preparation", func() {
@@ -1043,7 +1057,53 @@ func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInv
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
 
-	if deleteAfterSyncFailure {
+	if deleteMode == flatFeePreparedOverageDeleteModeCharge {
+		s.Run("when the owning charge is deleted after invoice preparation", func() {
+			// given the prepared run is still reversible
+			// when the owning charge is deleted directly
+			// then the state machine corrects it once and billing records the immutable invoice drift
+			deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				ChangeSource: billing.ChangeSourceSystem,
+				Policy:       meta.RefundAsCreditsDeletePolicy,
+			})
+			s.Require().NoError(err)
+			s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+				CustomerID: customer.GetID(),
+				PatchesByChargeID: map[string]charges.Patch{
+					chargeID.ID: deletePatch,
+				},
+			}))
+
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Equal(flatfee.StatusDeleted, charge.Status)
+			s.Nil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.PriorRuns, 1)
+			run := charge.Realizations.PriorRuns[0]
+			s.Require().NotNil(run.DeletedAt)
+			s.Nil(run.AccruedUsage)
+
+			immutableInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+				Invoice: invoice.GetInvoiceID(),
+				Expand:  billing.StandardInvoiceExpandAll,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, immutableInvoice.Status)
+			s.Require().Len(immutableInvoice.Lines.OrEmpty(), 1)
+			s.Nil(immutableInvoice.Lines.OrEmpty()[0].DeletedAt)
+			s.NotEmpty(immutableInvoice.ValidationIssues)
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
+
+	if deleteMode == flatFeePreparedOverageDeleteModeInvoice {
 		s.Run("when the first prepared cancellation fails", func() {
 			// given the overage and FIAT corrections succeed
 			// when the later charge-currency correction fails

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -194,6 +194,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 		creditsAllocated float64
 		// fiatOverageCreditsAvailable is the USD balance available for the converted overage.
 		fiatOverageCreditsAvailable float64
+		// disableFiatOverageCredits models the settlement handler rejecting FIAT credit use.
+		disableFiatOverageCredits bool
 
 		// expectRunTotals contains the realization run totals in TOKENS.
 		expectRunTotals billingtest.ExpectedTotals
@@ -225,6 +227,21 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 			expectDraftInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			expectInvoiceTotals:      billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			expectPaymentSettled:     true,
+		},
+		// given:
+		// - a 5 USD overage and enough settlement-fiat credits to cover it
+		// - the settlement handler does not allow those credits to be used
+		// then:
+		// - gross preparation still runs and the full 5 USD remains payable
+		{
+			name:                        "fiat overage credits disabled by handler",
+			chargeAmount:                10,
+			fiatOverageCreditsAvailable: 5,
+			disableFiatOverageCredits:   true,
+			expectRunTotals:             billingtest.ExpectedTotals{Amount: 10, Total: 10},
+			expectDraftInvoiceTotals:    billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			expectInvoiceTotals:         billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			expectPaymentSettled:        true,
 		},
 		// given:
 		// - a 10 TOKENS flat fee with 2 TOKENS allocated from credits
@@ -362,6 +379,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				input flatfee.AllocateFiatOverageCreditsInput,
 			) (creditrealization.CreateAllocationInputs, error) {
 				fiatOverageAllocationInvocations++
+				if test.disableFiatOverageCredits {
+					return nil, nil
+				}
 
 				return fiatOverageCreditsHandler.Allocate(ctx, input)
 			}
@@ -531,7 +551,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				s.Len(run.CreditRealizations, expectedCreditsApplied)
 				s.Len(run.DetailedLines.OrEmpty()[0].CreditsApplied, expectedCreditsApplied)
 				s.Equal(test.expectLineDeleted, run.NoFiatTransactionRequired)
-				s.Equal(test.expectLineDeleted, run.Immutable)
+				s.False(run.Immutable)
 				s.Equal(1, allocationCallback.nrInvocations)
 				s.Zero(fiatOverageAllocationInvocations)
 			})
@@ -539,7 +559,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 			s.Run("approve invoice and settle overage", func() {
 				fiatOverageCreditsHandler.AddAvailable(test.fiatOverageCreditsAvailable)
 
-				if test.expectPaymentSettled {
+				if !test.expectLineDeleted {
 					s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
 						customCurrencyOverageAccruedCalls++
 						s.Equal(chargeID.ID, input.Charge.ID)
@@ -560,10 +580,12 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 							TransactionGroup: ledgertransaction.GroupReference{
 								TransactionGroupID: accruedTransactionGroupID,
 							},
-							TotalFiatAmount: alpacadecimal.NewFromFloat(test.expectInvoiceTotals.Total),
+							TotalFiatAmount: alpacadecimal.NewFromFloat(test.expectInvoiceTotals.Amount),
 						}, nil
 					}
+				}
 
+				if test.expectPaymentSettled {
 					authorizedCallback = newCountedLedgerTransactionCallback[flatfee.OnPaymentAuthorizedInput]()
 					s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input flatfee.OnPaymentAuthorizedInput) {
 						assert.Equal(t, chargeID.ID, input.Charge.ID)
@@ -617,33 +639,46 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 				s.Require().NotNil(charge.Realizations.CurrentRun)
 				s.Empty(charge.Realizations.PriorRuns)
 				run := charge.Realizations.CurrentRun
-				s.True(run.Immutable)
+				s.Equal(!test.expectLineDeleted, run.Immutable)
 
 				s.Equal(runID, run.ID.ID)
 				s.RequireTotals(test.expectRunTotals, run.Totals)
 				s.Equal(!test.expectPaymentSettled, run.NoFiatTransactionRequired)
 				s.Equal(test.creditsAllocated, run.CreditRealizations.Sum().InexactFloat64())
-				s.Equal(test.fiatOverageCreditsAvailable, run.FiatOverageCreditRealizations.Sum().InexactFloat64())
+				expectedFiatCreditsAllocated := test.fiatOverageCreditsAvailable
+				if test.disableFiatOverageCredits {
+					expectedFiatCreditsAllocated = 0
+				}
+				s.Equal(expectedFiatCreditsAllocated, run.FiatOverageCreditRealizations.Sum().InexactFloat64())
 				s.True(run.DetailedLines.IsPresent())
 				s.Require().Len(run.DetailedLines.OrEmpty(), 1)
 				s.RequireTotals(test.expectRunTotals, run.DetailedLines.OrEmpty()[0].Totals)
 				expectedFiatRealizations := 0
-				if test.fiatOverageCreditsAvailable > 0 {
+				if expectedFiatCreditsAllocated > 0 {
 					expectedFiatRealizations = 1
 				}
 				s.Len(run.FiatOverageCreditRealizations, expectedFiatRealizations)
 
-				if test.expectPaymentSettled {
+				if !test.expectLineDeleted {
 					s.Equal(1, customCurrencyOverageAccruedCalls)
+					s.Require().NotNil(run.AccruedUsage)
+					s.Equal(servicePeriod, run.AccruedUsage.ServicePeriod)
+					s.Equal(accruedTransactionGroupID, run.AccruedUsage.LedgerTransaction.TransactionGroupID)
+					s.RequireTotals(billingtest.ExpectedTotals{
+						Amount: test.expectInvoiceTotals.Amount,
+						Total:  test.expectInvoiceTotals.Amount,
+					}, run.AccruedUsage.Totals)
+				} else {
+					s.Zero(customCurrencyOverageAccruedCalls)
+					s.Nil(run.AccruedUsage)
+				}
+
+				if test.expectPaymentSettled {
 					s.Require().NotNil(authorizedCallback)
 					s.Equal(1, authorizedCallback.nrInvocations)
 					s.Require().NotNil(settledCallback)
 					s.Equal(1, settledCallback.nrInvocations)
 
-					s.Require().NotNil(run.AccruedUsage)
-					s.Equal(servicePeriod, run.AccruedUsage.ServicePeriod)
-					s.Equal(accruedTransactionGroupID, run.AccruedUsage.LedgerTransaction.TransactionGroupID)
-					s.RequireTotals(test.expectInvoiceTotals, run.AccruedUsage.Totals)
 					s.Require().NotNil(run.Payment)
 					s.Equal(payment.StatusSettled, run.Payment.Status)
 					s.Equal(test.expectInvoiceTotals.Total, run.Payment.FiatAmount.InexactFloat64())
@@ -652,8 +687,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 					s.Require().NotNil(run.Payment.Settled)
 					s.Equal(settledCallback.id, run.Payment.Settled.TransactionGroupID)
 				} else {
-					s.Zero(customCurrencyOverageAccruedCalls)
-					s.Nil(run.AccruedUsage)
 					s.Nil(run.Payment)
 				}
 
@@ -710,11 +743,44 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceL
 					s.Nil(line.DeletedAt)
 				}
 			})
+
+			if test.name == "happy path" {
+				s.Run("delete issued charge without correcting immutable run", func() {
+					deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+						ChangeSource: billing.ChangeSourceSystem,
+						Policy:       meta.RefundAsCreditsDeletePolicy,
+					})
+					s.Require().NoError(err)
+					s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+						CustomerID: customer.GetID(),
+						PatchesByChargeID: map[string]charges.Patch{
+							chargeID.ID: deletePatch,
+						},
+					}))
+
+					charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+					s.Equal(flatfee.StatusDeleted, charge.Status)
+					s.Nil(charge.Realizations.CurrentRun)
+					s.Require().Len(charge.Realizations.PriorRuns, 1)
+					run := charge.Realizations.PriorRuns[0]
+					s.True(run.Immutable)
+					s.Nil(run.DeletedAt)
+					s.Require().NotNil(run.AccruedUsage)
+				})
+			}
 		})
 	}
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *InvoicableChargesTestSuite) runFlatFeeCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a custom-currency flat-fee run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -758,22 +824,78 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 	fiatOverageCreditsHandler := &flatFeeFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
 	}
+	accountingEvents := make([]string, 0, 2)
+	customCurrencyOverageAccruedInvocations := 0
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedInvocations++
+		accountingEvents = append(accountingEvents, "gross_overage")
+
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+
+		return flatfee.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
+	}
 	s.FlatFeeTestHandler.onAllocateCredits = func(
 		_ context.Context,
-		_ flatfee.OnAllocateCreditsInput,
+		input flatfee.OnAllocateCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
-		return nil, nil
+		return creditrealization.CreateAllocationInputs{
+			{
+				ServicePeriod: input.ServicePeriod,
+				LedgerTransaction: ledgertransaction.GroupReference{
+					TransactionGroupID: ulid.Make().String(),
+				},
+				Amount: alpacadecimal.NewFromInt(2),
+			},
+		}, nil
 	}
 	fiatOverageAllocationInvocations := 0
+	returnFiatAllocationError := true
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = func(
 		ctx context.Context,
 		input flatfee.AllocateFiatOverageCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
 		fiatOverageAllocationInvocations++
+		accountingEvents = append(accountingEvents, "fiat_coverage")
+		if returnFiatAllocationError {
+			return nil, errors.New("simulated fiat allocation failure")
+		}
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
+	correctionEvents := make([]string, 0, 6)
+	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input flatfee.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ flatfee.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.FlatFeeTestHandler.onCorrectCreditAllocations = func(
+		_ context.Context,
+		input flatfee.CorrectCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -808,7 +930,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 						},
 						InvoiceAt:             invoiceAt,
 						PaymentTerm:           productcatalog.InArrearsPaymentTerm,
-						AmountBeforeProration: alpacadecimal.NewFromInt(10),
+						AmountBeforeProration: alpacadecimal.NewFromInt(12),
 					},
 					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 					CostBasis:      &costBasisIntent,
@@ -847,25 +969,176 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
-	s.Run("when invoice sync fails after fiat allocation", func() {
+	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Nil(invoice.StatusDetails.AvailableActions.Delete)
+		s.Zero(invoiceSyncAttempts)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
+
+		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+		s.Equal(flatfee.StatusActiveRealizationProcessing, charge.Status)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		run := charge.Realizations.CurrentRun
+		s.Require().NotNil(run.AccruedUsage)
+		s.False(run.Immutable)
+		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
+		s.False(run.FiatOverageCreditAllocationCompleted)
+		s.False(run.NoFiatTransactionRequired)
+		s.Empty(run.FiatOverageCreditRealizations)
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+	})
+
+	returnFiatAllocationError = false
+	accountingEvents = accountingEvents[:0]
+
+	s.Run("when retry reaches sync after fiat allocation", func() {
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 		s.Equal(1, invoiceSyncAttempts)
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal([]string{"fiat_coverage"}, accountingEvents)
 		s.Zero(mockApp.FinalizeInvoiceCallCount())
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 
 		charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, charge.Status)
 		s.Require().NotNil(charge.Realizations.CurrentRun)
 		run := charge.Realizations.CurrentRun
+		s.Require().NotNil(run.AccruedUsage)
+		s.False(run.Immutable)
+		s.Require().NotNil(run.AccruedUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.AccruedUsage.Totals)
+		s.True(run.FiatOverageCreditAllocationCompleted)
 		s.True(run.NoFiatTransactionRequired)
 		s.Require().Len(run.FiatOverageCreditRealizations, 1)
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(5), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
+
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Require().NotNil(charge.Realizations.CurrentRun)
+			s.Require().NotNil(charge.Realizations.CurrentRun.AccruedUsage)
+			s.True(charge.Realizations.CurrentRun.FiatOverageCreditAllocationCompleted)
+			s.True(charge.Realizations.CurrentRun.NoFiatTransactionRequired)
+			s.Require().Len(charge.Realizations.CurrentRun.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, charge.Realizations.CurrentRun.CreditRealizations[0].Type)
+			s.Nil(charge.Realizations.CurrentRun.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Equal(flatfee.StatusDeleted, charge.Status)
+			s.Nil(charge.Realizations.CurrentRun)
+			s.Require().Len(charge.Realizations.PriorRuns, 1)
+			run := charge.Realizations.PriorRuns[0]
+			s.Require().NotNil(run.DeletedAt)
+			s.Nil(run.AccruedUsage)
+			s.False(run.FiatOverageCreditAllocationCompleted)
+			s.True(run.NoFiatTransactionRequired)
+			s.Require().Len(run.FiatOverageCreditRealizations, 2)
+			s.Zero(run.FiatOverageCreditRealizations.Sum().InexactFloat64())
+			s.Require().Len(run.CreditRealizations, 2)
+			s.Zero(run.CreditRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			charge := s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID)
+			s.Require().Len(charge.Realizations.PriorRuns, 1)
+			s.Nil(charge.Realizations.PriorRuns[0].AccruedUsage)
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
@@ -873,7 +1146,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.Equal(2, invoiceSyncAttempts)
 		s.Equal(1, mockApp.FinalizeInvoiceCallCount())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal(flatfee.StatusFinal, s.mustGetFlatFeeChargeByIDWithDetailedLines(chargeID).Status)
 
 		err = s.BillingService.TriggerInvoice(ctx, billing.InvoiceTriggerServiceInput{
 			InvoiceTriggerInput: billing.InvoiceTriggerInput{
@@ -893,7 +1168,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyFiatOverageAllocat
 		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 		s.Equal(5.0, invoice.Lines.OrEmpty()[0].CreditsApplied.SumAmount(fiatCurrency).InexactFloat64())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 		mockApp.AssertExpectations(s.T())
 	})
 }
@@ -958,6 +1233,19 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceR
 
 	fiatOverageCreditsHandler := &flatFeeFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
+	}
+	customCurrencyOverageAccruedCalls := 0
+	s.FlatFeeTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input flatfee.OnCustomCurrencyOverageAccruedInput) (flatfee.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedCalls++
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+
+		return flatfee.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
 	}
 	s.FlatFeeTestHandler.onAllocateFiatOverageCredits = fiatOverageCreditsHandler.Allocate
 	s.FlatFeeTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
@@ -1128,6 +1416,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceR
 		s.Require().Len(run.FiatOverageCreditRealizations, 1)
 		s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
 		s.Equal(float64(2), run.FiatOverageCreditRealizations[0].Amount.InexactFloat64())
+		s.Equal(1, customCurrencyOverageAccruedCalls)
 		s.True(run.NoFiatTransactionRequired)
 	})
 }
@@ -1362,7 +1651,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceM
 	})
 }
 
-func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyGatheringPreviewAndAPILineMutationRejection() {
+func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyGatheringPreviewAndAPILineMutation() {
 	s.enableFlatFeeCustomCurrenciesWithMockLineage()
 
 	ctx := s.T().Context()
@@ -1592,28 +1881,30 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyGatheringPreviewAn
 
 	for _, test := range []struct {
 		name   string
+		reject bool
 		mutate func(*billing.StandardLine)
 	}{
 		{
-			name: "update",
+			name:   "reject standard line update",
+			reject: true,
 			mutate: func(line *billing.StandardLine) {
 				line.Name = "manually updated"
 			},
 		},
 		{
-			name: "delete",
+			name: "delete standard line",
 			mutate: func(line *billing.StandardLine) {
 				line.DeletedAt = lo.ToPtr(clock.Now())
 			},
 		},
 	} {
-		s.Run("reject standard line "+test.name, func() {
+		s.Run(test.name, func() {
 			// given:
 			// - the custom-currency charge is attached to a mutable draft standard line
 			// when:
 			// - an API-originated update attempts to mutate that managed line
 			// then:
-			// - billing rejects the edit without changing the line or current run
+			// - field updates are rejected, while deletion reconciles the mutable charge run
 			_, err := s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
 				Invoice:      draftInvoice.GetInvoiceID(),
 				ChangeSource: billing.ChangeSourceAPIRequest,
@@ -1625,6 +1916,29 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyGatheringPreviewAn
 				},
 				IncludeDeletedLines: true,
 			})
+			if !test.reject {
+				s.Require().NoError(err)
+
+				reloadedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+					Invoice: draftInvoice.GetInvoiceID(),
+					Expand: billing.StandardInvoiceExpandAll.With(
+						billing.StandardInvoiceExpandDeletedLines,
+					),
+				})
+				s.Require().NoError(err)
+				s.Require().Len(reloadedInvoice.Lines.OrEmpty(), 1)
+				s.NotNil(reloadedInvoice.Lines.OrEmpty()[0].DeletedAt)
+
+				charge := mustGetFlatFeeChargeWithExpands(&s.BaseSuite, chargeID, meta.Expands{
+					meta.ExpandRealizations,
+					meta.ExpandDeletedRealizations,
+				})
+				s.Equal(flatfee.StatusDeleted, charge.Status)
+				s.Nil(charge.Realizations.CurrentRun)
+				s.Equal(1, allocationCallback.nrInvocations)
+				return
+			}
+
 			s.ErrorIs(err, billing.ErrCannotUpdateChargeManagedLine)
 
 			reloadedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
@@ -1691,7 +2005,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 			// when:
 			// - billing approves the invoice through the normal service lifecycle
 			// then:
-			// - invoice issuing becomes retryable without persisting accrued usage or payment
+			// - invoice finalization becomes retryable without persisting accrued usage or payment
 			ctx := s.T().Context()
 			ns := s.GetUniqueNamespace("charges-service-flatfee-custom-currency-invalid-accrual")
 
@@ -1802,7 +2116,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 
 			invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
 			s.Require().NoError(err)
-			s.Equal(billing.StandardInvoiceStatusIssuingChargeBookingFailed, invoice.Status)
+			s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
 			s.True(invoice.StatusDetails.Failed)
 			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
 			s.Require().NotEmpty(invoice.ValidationIssues)
@@ -1815,6 +2129,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyInvalidAccrualResu
 			s.Equal(runID, persistedCharge.Realizations.CurrentRun.ID)
 			s.False(persistedCharge.Realizations.CurrentRun.Immutable)
 			s.Nil(persistedCharge.Realizations.CurrentRun.AccruedUsage)
+			s.Empty(persistedCharge.Realizations.CurrentRun.FiatOverageCreditRealizations)
+			s.False(persistedCharge.Realizations.CurrentRun.FiatOverageCreditAllocationCompleted)
 			s.Nil(persistedCharge.Realizations.CurrentRun.Payment)
 			s.Equal(1, accrualCalls)
 			s.Zero(authorizedCallback.nrInvocations)
@@ -2128,7 +2444,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Equal(zeroFiatServicePeriodTo, charge.Realizations.CurrentRun.ServicePeriod.To)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 0.001, Total: 0.001}, charge.Realizations.CurrentRun.Totals)
 		s.True(charge.Realizations.CurrentRun.NoFiatTransactionRequired)
-		s.True(charge.Realizations.CurrentRun.Immutable)
+		s.False(charge.Realizations.CurrentRun.Immutable)
 		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
 		s.Nil(charge.Realizations.CurrentRun.Payment)
 		s.Empty(activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID))
@@ -2173,7 +2489,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCustomCurrencyCreditThenInvoiceS
 		s.Require().Len(charge.Realizations.PriorRuns, 1)
 		s.Equal(runID, charge.Realizations.PriorRuns[0].ID)
 		s.True(charge.Realizations.PriorRuns[0].NoFiatTransactionRequired)
-		s.True(charge.Realizations.PriorRuns[0].Immutable)
+		s.False(charge.Realizations.PriorRuns[0].Immutable)
 
 		gatheringLines := activeGatheringLinesForCharge(&s.BaseSuite, ns, customer.ID, chargeID.ID)
 		s.Require().Len(gatheringLines, 1)
@@ -3173,7 +3489,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.Len(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 
-	s.Run("post invoice issued without invoice usage accrual", func() {
+	s.Run("finalize invoice without invoice usage accrual", func() {
 		defer s.FlatFeeTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]()
@@ -3187,18 +3503,42 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.NoError(err)
 		invoice.Lines = billing.NewStandardInvoiceLines(lines)
 
+		lines, err = lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		invoice.Lines = billing.NewStandardInvoiceLines(lines)
+		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
+
+		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
+		s.False(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+
+		mismatchedLine, err := invoice.Lines.OrEmpty()[0].Clone()
+		s.NoError(err)
+		mismatchedLine.ID = "mismatched-issued-line"
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   billing.StandardLines{mismatchedLine},
+		})
+		s.ErrorContains(err, "does not match issued line")
+		s.Equal(flatfee.StatusActiveRealizationIssuing, s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID).Status)
+
 		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
 			Invoice: invoice,
 			Lines:   invoice.Lines.OrEmpty(),
 		})
 		s.NoError(err)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
-
-		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		updatedFlatFeeCharge = s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
-		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
-		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
-		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 	})
 }
 
@@ -3281,9 +3621,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		// given:
 		// - the standard line has zero Amount but non-zero ChargesTotal and Total
 		// when:
-		// - the flat-fee line engine receives the invoice-issued callback
+		// - the flat-fee line engine finalizes and then issues the invoice
 		// then:
-		// - invoice usage accrual still runs because the payable total is non-zero
+		// - invoice usage accrual runs only at issuance because the payable total is non-zero
 		defer s.FlatFeeTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]()
@@ -3312,6 +3652,25 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		})
 		s.NoError(err)
 		invoice.Lines = billing.NewStandardInvoiceLines(updatedLines)
+		finalizingLine := invoice.Lines.OrEmpty()[0]
+		expectedFinalizingLine, err := finalizingLine.Clone()
+		s.NoError(err)
+
+		updatedLines, err = lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(expectedFinalizingLine, finalizingLine)
+		s.Same(finalizingLine, updatedLines[0])
+		invoice.Lines = billing.NewStandardInvoiceLines(updatedLines)
+		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
+
+		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveRealizationIssuing, updatedFlatFeeCharge.Status)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.False(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
 
 		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
 			Invoice: invoice,
@@ -3319,9 +3678,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		})
 		s.NoError(err)
 		s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
-
-		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		updatedFlatFeeCharge = s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.Immutable)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.LedgerTransaction)
 		s.Equal(invoiceUsageAccruedCallback.id, updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage.LedgerTransaction.TransactionGroupID)
@@ -4386,22 +4746,64 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(float64(10), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
 	})
 
-	s.Run("#5 approve invoice with no fiat invoice usage accrual", func() {
+	s.Run("#5 finalize and issue invoice with no fiat invoice usage accrual", func() {
 		defer s.UsageBasedTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[usagebased.OnInvoiceUsageAccruedInput]()
 		s.UsageBasedTestHandler.onInvoiceUsageAccrued = invoiceUsageAccruedCallback.Handler(s.T())
 
-		var err error
-		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		lineEngine := s.Charges.usageBasedService.GetLineEngine()
+		finalizingLine := invoice.Lines.OrEmpty()[0]
+		expectedFinalizingLine, err := finalizingLine.Clone()
 		s.NoError(err)
+
+		finalizedLines, err := lineEngine.OnInvoiceFinalizing(ctx, billing.OnInvoiceFinalizingInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(expectedFinalizingLine, finalizingLine)
+		s.Same(finalizingLine, finalizedLines[0])
+		invoice.Lines = billing.NewStandardInvoiceLines(finalizedLines)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
 		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusActiveRealizationIssuing, usageBasedCharge.Status)
+		s.NotNil(usageBasedCharge.State.CurrentRealizationRunID)
+		s.Nil(usageBasedCharge.State.AdvanceAfter)
+		s.Len(usageBasedCharge.Realizations, 1)
+
+		preparedRun := usageBasedCharge.Realizations[0]
+		s.False(preparedRun.Immutable)
+		s.Equal(float64(100), preparedRun.MeteredQuantity.InexactFloat64())
+		s.NotNil(preparedRun.LineID)
+		s.Equal(stdLineID.ID, *preparedRun.LineID)
+		s.True(preparedRun.NoFiatTransactionRequired)
+		s.Nil(preparedRun.InvoiceUsage)
+
+		mismatchedLine, err := finalizingLine.Clone()
+		s.NoError(err)
+		mismatchedLine.ID = "mismatched-issued-line"
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   billing.StandardLines{mismatchedLine},
+		})
+		s.ErrorContains(err, "does not match issued line")
+		usageBasedCharge = s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusActiveRealizationIssuing, usageBasedCharge.Status)
+		s.Nil(usageBasedCharge.Realizations[0].InvoiceUsage)
+
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
+
+		usageBasedCharge = s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
 		s.Nil(usageBasedCharge.State.CurrentRealizationRunID)
 		s.Nil(usageBasedCharge.State.AdvanceAfter)
-		s.Len(usageBasedCharge.Realizations, 1)
 
 		finalRun := usageBasedCharge.Realizations[0]
 		s.True(finalRun.Immutable)

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -324,15 +324,27 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyCreditThenInvoi
 	})
 }
 
+type usageBasedPreparedOverageDeleteMode uint8
+
+const (
+	usageBasedPreparedOverageDeleteModeNone usageBasedPreparedOverageDeleteMode = iota
+	usageBasedPreparedOverageDeleteModeInvoice
+	usageBasedPreparedOverageDeleteModeCharge
+)
+
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
-	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(usageBasedPreparedOverageDeleteModeNone)
 }
 
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
-	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(usageBasedPreparedOverageDeleteModeInvoice)
 }
 
-func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
+func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyPreparedOverageChargeDeleteReconcilesImmutableInvoice() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(usageBasedPreparedOverageDeleteModeCharge)
+}
+
+func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteMode usageBasedPreparedOverageDeleteMode) {
 	// given:
 	// - a collected custom-currency usage run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
@@ -431,7 +443,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 		return nil
 	}
 	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(2)
-	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	failChargeCurrencyCorrection := deleteMode == usageBasedPreparedOverageDeleteModeInvoice
 	s.UsageBasedTestHandler.onCreditsOnlyUsageAccruedCorrection = func(
 		_ context.Context,
 		input usagebased.CreditsOnlyUsageAccruedCorrectionInput,
@@ -532,10 +544,12 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	if deleteAfterSyncFailure {
+	switch deleteMode {
+	case usageBasedPreparedOverageDeleteModeInvoice:
 		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
-	} else {
+	case usageBasedPreparedOverageDeleteModeNone:
 		mockApp.OnFinalizeStandardInvoice(nil)
+	case usageBasedPreparedOverageDeleteModeCharge:
 	}
 
 	s.Run("when fiat allocation fails after gross preparation", func() {
@@ -613,7 +627,58 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfter
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
 
-	if deleteAfterSyncFailure {
+	if deleteMode == usageBasedPreparedOverageDeleteModeCharge {
+		s.Run("when the owning charge is deleted after invoice preparation", func() {
+			// given the prepared run is still reversible
+			// when the owning charge is deleted directly
+			// then the state machine corrects it once and billing records the immutable invoice drift
+			deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				ChangeSource: billing.ChangeSourceSystem,
+				Policy:       meta.RefundAsCreditsDeletePolicy,
+			})
+			s.Require().NoError(err)
+			s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+				CustomerID: customer.GetID(),
+				PatchesByChargeID: map[string]charges.Patch{
+					chargeID.ID: deletePatch,
+				},
+			}))
+
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			s.Equal(usagebased.StatusDeleted, charge.Status)
+			s.Nil(charge.State.CurrentRealizationRunID)
+
+			dbRun, err := s.DBClient.ChargeUsageBasedRuns.Get(ctx, runID.ID)
+			s.Require().NoError(err)
+			s.Require().NotNil(dbRun.DeletedAt)
+			s.False(dbRun.FiatOverageCreditAllocationCompleted)
+			s.True(dbRun.NoFiatTransactionRequired)
+			hasInvoicedUsage, err := dbRun.QueryInvoicedUsage().Exist(ctx)
+			s.Require().NoError(err)
+			s.False(hasInvoicedUsage)
+
+			immutableInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+				Invoice: invoice.GetInvoiceID(),
+				Expand:  billing.StandardInvoiceExpandAll,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, immutableInvoice.Status)
+			s.Require().Len(immutableInvoice.Lines.OrEmpty(), 1)
+			s.Nil(immutableInvoice.Lines.OrEmpty()[0].DeletedAt)
+			s.NotEmpty(immutableInvoice.ValidationIssues)
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
+
+	if deleteMode == usageBasedPreparedOverageDeleteModeInvoice {
 		s.Run("when the first prepared cancellation fails", func() {
 			// given the overage and FIAT corrections succeed
 			// when the later charge-currency correction fails

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -325,14 +325,23 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyCreditThenInvoi
 }
 
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllocationSurvivesInvoiceSyncRetry() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(false)
+}
+
+func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyPreparedOverageCanBeDeletedAfterInvoiceSyncFailure() {
+	s.runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(true)
+}
+
+func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyFiatOverageAfterInvoiceSyncFailure(deleteAfterSyncFailure bool) {
 	// given:
 	// - a collected custom-currency usage run has a 5 USD gross overage
 	// - 5 USD of settlement credits are available at invoice finalization
 	// when:
-	// - invoice finalization persists the fiat allocation but external invoice sync fails
+	// - the first settlement attempt fails after gross preparation
+	// - retry completes settlement, then external invoice sync fails
 	// - issuing is retried after the invoicing app recovers
 	// then:
-	// - issuing reuses the persisted allocation without invoking allocation again
+	// - retry reuses gross preparation, and sync retry reuses completed settlement
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-fiat-overage-sync-retry")
@@ -375,17 +384,65 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 	fiatOverageCreditsHandler := &usageBasedFiatOverageCreditsHandler{
 		available: alpacadecimal.Zero,
 	}
+	accountingEvents := make([]string, 0, 2)
+	customCurrencyOverageAccruedInvocations := 0
+	s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
+		customCurrencyOverageAccruedInvocations++
+		accountingEvents = append(accountingEvents, "gross_overage")
+
+		fiatCurrency, err := input.GetFiatCurrency()
+		s.Require().NoError(err)
+		costBasis, err := input.GetCostBasis()
+		s.Require().NoError(err)
+
+		return usagebased.OnCustomCurrencyOverageAccruedResult{
+			TransactionGroup: ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()},
+			TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
+		}, nil
+	}
 	fiatOverageAllocationInvocations := 0
+	returnFiatAllocationError := true
 	s.UsageBasedTestHandler.onAllocateFiatOverageCredits = func(
 		ctx context.Context,
 		input usagebased.AllocateFiatOverageCreditsInput,
 	) (creditrealization.CreateAllocationInputs, error) {
 		fiatOverageAllocationInvocations++
+		accountingEvents = append(accountingEvents, "fiat_coverage")
+		if returnFiatAllocationError {
+			return nil, errors.New("simulated fiat allocation failure")
+		}
 
 		return fiatOverageCreditsHandler.Allocate(ctx, input)
 	}
-	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
-	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(0)
+	correctionEvents := make([]string, 0, 6)
+	s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = func(
+		ctx context.Context,
+		input usagebased.CorrectFiatOverageCreditAllocationsInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "fiat_coverage_correction")
+
+		return fiatOverageCreditsHandler.Correct(ctx, input)
+	}
+	s.UsageBasedTestHandler.onCustomCurrencyOverageAccruedCorrection = func(
+		_ context.Context,
+		_ usagebased.OnCustomCurrencyOverageAccruedCorrectionInput,
+	) error {
+		correctionEvents = append(correctionEvents, "gross_overage_correction")
+		return nil
+	}
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(2)
+	failChargeCurrencyCorrection := deleteAfterSyncFailure
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccruedCorrection = func(
+		_ context.Context,
+		input usagebased.CreditsOnlyUsageAccruedCorrectionInput,
+	) (creditrealization.CreateCorrectionInputs, error) {
+		correctionEvents = append(correctionEvents, "charge_currency_correction")
+		if failChargeCurrencyCorrection {
+			return nil, errors.New("simulated charge-currency correction failure")
+		}
+
+		return newCreditCorrectionInputs(input.Corrections), nil
+	}
 
 	costBasisIntent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: fiatCurrency,
@@ -397,6 +454,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 	var (
 		chargeID meta.ChargeID
+		runID    usagebased.RealizationRunID
 		invoice  billing.StandardInvoice
 	)
 
@@ -438,7 +496,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		s.MockStreamingConnector.AddSimpleEvent(
 			feature.Feature.Key,
-			5,
+			6,
 			usageAt,
 			streamingtestutils.WithStoredAt(usageAt),
 		)
@@ -474,27 +532,194 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 
 		return billing.NewUpsertStandardInvoiceResult(), nil
 	})
-	mockApp.OnFinalizeStandardInvoice(nil)
+	if deleteAfterSyncFailure {
+		mockApp.OnDeleteStandardInvoice(errors.New("simulated invoice delete sync failure"))
+	} else {
+		mockApp.OnFinalizeStandardInvoice(nil)
+	}
 
-	s.Run("when invoice sync fails after fiat allocation", func() {
+	s.Run("when fiat allocation fails after gross preparation", func() {
 		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Nil(invoice.StatusDetails.AvailableActions.Delete)
+		s.Zero(invoiceSyncAttempts)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal([]string{"gross_overage", "fiat_coverage"}, accountingEvents)
+
+		charge := s.mustGetUsageBasedChargeByID(chargeID)
+		run, err := charge.GetCurrentRealizationRun()
+		s.Require().NoError(err)
+		s.Require().NotNil(run.InvoiceUsage)
+		s.False(run.Immutable)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
+		s.Empty(run.FiatOverageCreditRealizations)
+		s.False(run.FiatOverageCreditAllocationCompleted)
+		s.False(run.NoFiatTransactionRequired)
+
+		_, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+			Invoice:        invoice.GetInvoiceID(),
+			DeletionSource: billing.ChangeSourceSystem,
+		})
+		s.ErrorContains(err, "invoice action not available")
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingLineFinalizationFailed, invoice.Status)
+	})
+
+	returnFiatAllocationError = false
+	accountingEvents = accountingEvents[:0]
+
+	s.Run("when retry reaches sync after fiat allocation", func() {
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
 		s.Require().NoError(err)
 		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 		s.Equal(1, invoiceSyncAttempts)
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
+		s.Equal([]string{"fiat_coverage"}, accountingEvents)
 		s.Zero(mockApp.FinalizeInvoiceCallCount())
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 
 		charge := s.mustGetUsageBasedChargeByID(chargeID)
 		run, err := charge.GetCurrentRealizationRun()
 		s.Require().NoError(err)
+		runID = run.ID
+		s.Require().NotNil(run.InvoiceUsage)
+		s.False(run.Immutable)
+		s.Require().NotNil(run.InvoiceUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, Total: 5}, run.InvoiceUsage.Totals)
+		s.True(run.FiatOverageCreditAllocationCompleted)
 		s.True(run.NoFiatTransactionRequired)
 		s.requireCreditRealizations(
 			[]expectedCreditRealization{{Type: creditrealization.TypeAllocation, Amount: 5}},
 			run.FiatOverageCreditRealizations,
 			"fiat overage",
 		)
+
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+
+		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.Require().NoError(err)
+		s.Equal(billing.StandardInvoiceStatusIssuingSyncFailed, invoice.Status)
 	})
+
+	if deleteAfterSyncFailure {
+		s.Run("when the first prepared cancellation fails", func() {
+			// given the overage and FIAT corrections succeed
+			// when the later charge-currency correction fails
+			// then the whole cleanup transaction rolls back
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Require().NotNil(invoice.StatusDetails.AvailableActions.Delete)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			run, err := charge.GetCurrentRealizationRun()
+			s.Require().NoError(err)
+			s.Require().NotNil(run.InvoiceUsage)
+			s.True(run.FiatOverageCreditAllocationCompleted)
+			s.True(run.NoFiatTransactionRequired)
+			s.Require().Len(run.FiatOverageCreditRealizations, 1)
+			s.Equal(creditrealization.TypeAllocation, run.FiatOverageCreditRealizations[0].Type)
+			s.Require().Len(run.CreditsAllocated, 1)
+			s.Equal(creditrealization.TypeAllocation, run.CreditsAllocated[0].Type)
+			s.Nil(run.DeletedAt)
+		})
+
+		failChargeCurrencyCorrection = false
+		s.Run("when cleanup commits before invoice delete sync fails", func() {
+			// given the correction failure is resolved
+			// when cleanup commits but the invoicing app delete fails
+			// then the prepared run stays deleted and only external sync remains retryable
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleteFailed, invoice.Status)
+			s.Equal(billing.ChangeSourceAPIRequest, invoice.DeletionSource)
+			s.Require().NotNil(invoice.DeletedAt)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(1, mockApp.DeleteInvoiceCallCount())
+
+			charge := s.mustGetUsageBasedChargeByID(chargeID)
+			s.Equal(usagebased.StatusDeleted, charge.Status)
+			s.Nil(charge.State.CurrentRealizationRunID)
+			dbRun, err := s.DBClient.ChargeUsageBasedRuns.Get(ctx, runID.ID)
+			s.Require().NoError(err)
+			s.Require().NotNil(dbRun.DeletedAt)
+			s.False(dbRun.FiatOverageCreditAllocationCompleted)
+			s.True(dbRun.NoFiatTransactionRequired)
+			hasInvoicedUsage, err := dbRun.QueryInvoicedUsage().Exist(ctx)
+			s.Require().NoError(err)
+			s.False(hasInvoicedUsage)
+			dbFiatRealizations, err := dbRun.QueryFiatOverageCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			fiatRealizations := creditrealization.FromDBRealizations(dbFiatRealizations)
+			s.Require().Len(fiatRealizations, 2)
+			s.Zero(fiatRealizations.Sum().InexactFloat64())
+			dbChargeRealizations, err := dbRun.QueryCreditAllocations().All(ctx)
+			s.Require().NoError(err)
+			chargeRealizations := creditrealization.FromDBRealizations(dbChargeRealizations)
+			s.Require().Len(chargeRealizations, 2)
+			s.Zero(chargeRealizations.Sum().InexactFloat64())
+		})
+
+		mockApp.OnDeleteStandardInvoice(nil)
+		s.Run("then invoice delete sync retries without repeating cleanup", func() {
+			// given charge cleanup already committed
+			// when invoice deletion is retried after the app recovers
+			// then billing only retries external sync
+			invoice, err = s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+				Invoice:        invoice.GetInvoiceID(),
+				DeletionSource: billing.ChangeSourceAPIRequest,
+			})
+			s.Require().NoError(err)
+			s.Equal(billing.StandardInvoiceStatusDeleted, invoice.Status)
+			s.Equal([]string{
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+				"fiat_coverage_correction",
+				"gross_overage_correction",
+				"charge_currency_correction",
+			}, correctionEvents)
+			s.Equal(2, mockApp.DeleteInvoiceCallCount())
+			dbRun, err := s.DBClient.ChargeUsageBasedRuns.Get(ctx, runID.ID)
+			s.Require().NoError(err)
+			hasInvoicedUsage, err := dbRun.QueryInvoicedUsage().Exist(ctx)
+			s.Require().NoError(err)
+			s.False(hasInvoicedUsage)
+			mockApp.AssertExpectations(s.T())
+		})
+
+		return
+	}
 
 	s.Run("then retry issuing without reallocating fiat credits", func() {
 		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
@@ -502,7 +727,8 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 		s.Equal(2, invoiceSyncAttempts)
 		s.Equal(1, mockApp.FinalizeInvoiceCallCount())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(1, customCurrencyOverageAccruedInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 
 		err = s.BillingService.TriggerInvoice(ctx, billing.InvoiceTriggerServiceInput{
 			InvoiceTriggerInput: billing.InvoiceTriggerInput{
@@ -522,7 +748,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCustomCurrencyFiatOverageAllo
 		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
 		s.RequireTotals(billingtest.ExpectedTotals{Amount: 5, CreditsTotal: 5}, invoice.Totals)
 		s.Equal(5.0, invoice.Lines.OrEmpty()[0].CreditsApplied.SumAmount(fiatCurrency).InexactFloat64())
-		s.Equal(1, fiatOverageAllocationInvocations)
+		s.Equal(2, fiatOverageAllocationInvocations)
 		mockApp.AssertExpectations(s.T())
 	})
 }
@@ -804,6 +1030,8 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 	type invoiceFinalizationPhase struct {
 		// fiatOverageCreditsAvailable is the USD balance available when the invoice is finalized.
 		fiatOverageCreditsAvailable float64
+		// disableFiatOverageCredits models the settlement handler rejecting FIAT credit use.
+		disableFiatOverageCredits bool
 		// expectInvoiceTotals contains the finalized invoice line totals in USD.
 		expectInvoiceTotals billingtest.ExpectedTotals
 		// expectFiatRealizations contains the immutable USD allocation and correction facts persisted so far.
@@ -850,6 +1078,29 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 			},
 			onInvoiceFinalization: invoiceFinalizationPhase{
 				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			expectPaymentSettled: true,
+		},
+		// given:
+		// - a 5 USD overage and enough settlement-fiat credits to cover it
+		// - the settlement handler does not allow those credits to be used
+		// then:
+		// - gross preparation still runs and the full 5 USD remains payable
+		{
+			name: "fiat overage credits disabled by handler",
+			onRunCreated: runPhase{
+				usageAdded:          5,
+				expectRunTotals:     billingtest.ExpectedTotals{Amount: 10, Total: 10},
+				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			onCollectionComplete: runPhase{
+				expectRunTotals:     billingtest.ExpectedTotals{Amount: 10, Total: 10},
+				expectInvoiceTotals: billingtest.ExpectedTotals{Amount: 5, Total: 5},
+			},
+			onInvoiceFinalization: invoiceFinalizationPhase{
+				fiatOverageCreditsAvailable: 5,
+				disableFiatOverageCredits:   true,
+				expectInvoiceTotals:         billingtest.ExpectedTotals{Amount: 5, Total: 5},
 			},
 			expectPaymentSettled: true,
 		},
@@ -1161,7 +1412,16 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 			fiatOverageCreditsHandler := &usageBasedFiatOverageCreditsHandler{
 				available: alpacadecimal.Zero,
 			}
-			s.UsageBasedTestHandler.onAllocateFiatOverageCredits = fiatOverageCreditsHandler.Allocate
+			s.UsageBasedTestHandler.onAllocateFiatOverageCredits = func(
+				ctx context.Context,
+				input usagebased.AllocateFiatOverageCreditsInput,
+			) (creditrealization.CreateAllocationInputs, error) {
+				if test.onInvoiceFinalization.disableFiatOverageCredits {
+					return nil, nil
+				}
+
+				return fiatOverageCreditsHandler.Allocate(ctx, input)
+			}
 			s.UsageBasedTestHandler.onCorrectFiatOverageCreditAllocations = fiatOverageCreditsHandler.Correct
 
 			s.Run("create realization run and fiat overage line", func() {
@@ -1353,28 +1613,28 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 
 				fiatOverageCreditsHandler.AddAvailable(test.onInvoiceFinalization.fiatOverageCreditsAvailable)
 
+				s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
+					customCurrencyOverageAccruedInvocations++
+					s.Equal(chargeID.ID, input.Charge.ID)
+					s.Equal(test.onCollectionComplete.expectRunTotals.Total, input.GetCustomCurrencyAmountAccrued().InexactFloat64())
+
+					resolvedCostBasis, err := input.GetCostBasis()
+					s.Require().NoError(err)
+					s.Equal(float64(0.5), resolvedCostBasis.InexactFloat64())
+
+					resolvedFiatCurrency, err := input.GetFiatCurrency()
+					s.Require().NoError(err)
+					s.Equal(USD, resolvedFiatCurrency.Details().Code)
+
+					return usagebased.OnCustomCurrencyOverageAccruedResult{
+						TransactionGroup: ledgertransaction.GroupReference{
+							TransactionGroupID: ulid.Make().String(),
+						},
+						TotalFiatAmount: alpacadecimal.NewFromFloat(test.onCollectionComplete.expectInvoiceTotals.Total),
+					}, nil
+				}
+
 				if test.expectPaymentSettled {
-					s.UsageBasedTestHandler.onCustomCurrencyOverageAccrued = func(_ context.Context, input usagebased.OnCustomCurrencyOverageAccruedInput) (usagebased.OnCustomCurrencyOverageAccruedResult, error) {
-						customCurrencyOverageAccruedInvocations++
-						s.Equal(chargeID.ID, input.Charge.ID)
-						s.Equal(test.onCollectionComplete.expectRunTotals.Total, input.GetCustomCurrencyAmountAccrued().InexactFloat64())
-
-						resolvedCostBasis, err := input.GetCostBasis()
-						s.Require().NoError(err)
-						s.Equal(float64(0.5), resolvedCostBasis.InexactFloat64())
-
-						resolvedFiatCurrency, err := input.GetFiatCurrency()
-						s.Require().NoError(err)
-						s.Equal(USD, resolvedFiatCurrency.Details().Code)
-
-						return usagebased.OnCustomCurrencyOverageAccruedResult{
-							TransactionGroup: ledgertransaction.GroupReference{
-								TransactionGroupID: ulid.Make().String(),
-							},
-							TotalFiatAmount: alpacadecimal.NewFromFloat(test.onInvoiceFinalization.expectInvoiceTotals.Total),
-						}, nil
-					}
-
 					authorizedCallback = newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
 					s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(_ *testing.T, input usagebased.OnPaymentAuthorizedInput) {
 						s.Equal(chargeID.ID, input.Charge.ID)
@@ -1433,6 +1693,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 				realizedRun, ok := charge.Realizations.Latest()
 				s.Require().True(ok)
 				s.Equal(realizationVariant.expectedRunType, realizedRun.Type)
+				s.Equal(!test.expectLineDeleted, realizedRun.Immutable)
 				s.Equal(
 					test.onCollectionComplete.expectRunTotals.CreditsTotal,
 					realizedRun.CreditsAllocated.Sum().InexactFloat64(),
@@ -1446,7 +1707,7 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.Nil(realizedRun.InvoiceUsage)
 				} else {
 					s.Require().NotNil(realizedRun.InvoiceUsage)
-					s.RequireTotals(expectInvoiceTotals, realizedRun.InvoiceUsage.Totals)
+					s.RequireTotals(test.onCollectionComplete.expectInvoiceTotals, realizedRun.InvoiceUsage.Totals)
 				}
 
 				if test.expectPaymentSettled {
@@ -1460,7 +1721,11 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.Equal(expectInvoiceTotals.Total, realizedRun.Payment.FiatAmount.InexactFloat64())
 					s.False(realizedRun.NoFiatTransactionRequired)
 				} else {
-					s.Zero(customCurrencyOverageAccruedInvocations)
+					if test.expectLineDeleted {
+						s.Zero(customCurrencyOverageAccruedInvocations)
+					} else {
+						s.Equal(1, customCurrencyOverageAccruedInvocations)
+					}
 					s.Nil(realizedRun.Payment)
 					s.True(realizedRun.NoFiatTransactionRequired)
 				}
@@ -1538,6 +1803,32 @@ func (s *UsageBasedChargesTestSuite) runUsageBasedCustomCurrencyCreditThenInvoic
 					s.True(servicePeriod.To.Equal(remainingLine.ServicePeriod.To))
 				}
 			})
+
+			if test.name == "happy path" && !realizationVariant.enableProgressiveBilling {
+				s.Run("delete issued charge without correcting immutable run", func() {
+					deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+						ChangeSource: billing.ChangeSourceSystem,
+						Policy:       meta.RefundAsCreditsDeletePolicy,
+					})
+					s.Require().NoError(err)
+					s.Require().NoError(s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+						CustomerID: customer.GetID(),
+						PatchesByChargeID: map[string]charges.Patch{
+							chargeID.ID: deletePatch,
+						},
+					}))
+
+					charge := s.mustGetUsageBasedChargeByID(chargeID)
+					s.Equal(usagebased.StatusDeleted, charge.Status)
+					s.Nil(charge.State.CurrentRealizationRunID)
+					s.Require().Len(charge.Realizations, 1)
+					run, ok := charge.Realizations.Latest()
+					s.Require().True(ok)
+					s.True(run.Immutable)
+					s.Nil(run.DeletedAt)
+					s.Require().NotNil(run.InvoiceUsage)
+				})
+			}
 		})
 	}
 }

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -66,6 +66,10 @@ func (mockFlatFeeHandler) OnCustomCurrencyOverageAccrued(_ context.Context, inpu
 	}, nil
 }
 
+func (mockFlatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
+}
+
 func (mockFlatFeeHandler) OnCorrectCreditAllocations(_ context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
 	return lo.Map(input.Corrections, func(correction creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
 		return creditrealization.CreateCorrectionInput{
@@ -151,6 +155,10 @@ func (mockUsageBasedHandler) OnCustomCurrencyOverageAccrued(_ context.Context, i
 		TransactionGroup: newMockLedgerTransactionGroupReference(),
 		TotalFiatAmount:  fiatCurrency.RoundToPrecision(input.GetCustomCurrencyAmountAccrued().Mul(costBasis)),
 	}, nil
+}
+
+func (mockUsageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(context.Context, usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return nil
 }
 
 func (mockUsageBasedHandler) OnPaymentAuthorized(context.Context, usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -97,6 +97,7 @@ func (i CreateCreditRealizationsInput) Validate() error {
 
 type RealizationRunInvoiceUsageAdapter interface {
 	CreateRunInvoicedUsage(ctx context.Context, runID RealizationRunID, invoicedUsage invoicedusage.AccruedUsage) (invoicedusage.AccruedUsage, error)
+	DeleteRunInvoicedUsage(ctx context.Context, id models.NamespacedID) error
 }
 
 type RealizationRunPaymentAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter/invoicedusage.go
+++ b/openmeter/billing/charges/usagebased/adapter/invoicedusage.go
@@ -2,10 +2,13 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	dbchargeusagebasedruninvoicedusage "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruninvoicedusage"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var _ usagebased.RealizationRunInvoiceUsageAdapter = (*adapter)(nil)
@@ -31,5 +34,21 @@ func (a *adapter) CreateRunInvoicedUsage(ctx context.Context, runID usagebased.R
 		}
 
 		return invoicedusage.MapAccruedUsageFromDB(entity), nil
+	})
+}
+
+func (a *adapter) DeleteRunInvoicedUsage(ctx context.Context, id models.NamespacedID) error {
+	if err := id.Validate(); err != nil {
+		return err
+	}
+
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		if err := tx.db.ChargeUsageBasedRunInvoicedUsage.DeleteOneID(id.ID).
+			Where(dbchargeusagebasedruninvoicedusage.NamespaceEQ(id.Namespace)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("deleting usage-based invoiced usage [id=%s]: %w", id.ID, err)
+		}
+
+		return nil
 	})
 }

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -188,6 +188,7 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) (usagebased.RealizationRun
 		Totals:                                totals.FromDB(dbRun),
 		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
 		Immutable:                             dbRun.Immutable,
+		FiatOverageCreditAllocationCompleted:  dbRun.FiatOverageCreditAllocationCompleted,
 		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
 	}, nil
 }

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -100,6 +100,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 			update = update.SetImmutable(input.Immutable.OrEmpty())
 		}
 
+		if input.FiatOverageCreditAllocationCompleted.IsPresent() {
+			update = update.SetFiatOverageCreditAllocationCompleted(input.FiatOverageCreditAllocationCompleted.OrEmpty())
+		}
+
 		dbRun, err := update.Save(ctx)
 		if err != nil {
 			return usagebased.RealizationRunBase{}, err

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -293,8 +293,14 @@ func (i OnCustomCurrencyOverageAccruedInput) Validate() error {
 
 type OnCustomCurrencyOverageAccruedResult struct {
 	TransactionGroup ledgertransaction.GroupReference `json:"transactionGroup"`
-	TotalFiatAmount  alpacadecimal.Decimal            `json:"totalFiatAmount"`
+	// TotalFiatAmount is the authoritative rounded gross amount persisted for
+	// invoice projection and later settlement-credit allocation.
+	TotalFiatAmount alpacadecimal.Decimal `json:"totalFiatAmount"`
 }
+
+// OnCustomCurrencyOverageAccruedCorrectionInput identifies the prepared gross
+// overage that must be corrected when invoice synchronization cannot complete.
+type OnCustomCurrencyOverageAccruedCorrectionInput = OnCustomCurrencyOverageAccruedInput
 
 func (r OnCustomCurrencyOverageAccruedResult) Validate() error {
 	var errs []error
@@ -354,9 +360,15 @@ type Handler interface {
 	// OnPaymentSettled is called when an invoice-backed usage-based run payment is settled.
 	OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
 
-	// OnCustomCurrencyOverageAccrued is called when uncovered custom-currency usage is accrued in fiat.
-	// This must be modeled as a credit purchase flow from the ledger point of view.
+	// OnCustomCurrencyOverageAccrued prepares the gross custom-currency overage
+	// during invoice line finalization, before settlement-fiat credit allocation.
 	OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error)
+
+	// OnCustomCurrencyOverageAccruedCorrection reverses the prepared gross
+	// overage before its realization run is deleted. The implementation must
+	// participate in the caller's transaction; billing can invoke it again only
+	// after that transaction rolls back.
+	OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error
 
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.
 	OnCreditsOnlyUsageAccrued(ctx context.Context, input CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
@@ -364,7 +376,8 @@ type Handler interface {
 	// OnCreditsOnlyUsageAccruedCorrection is called when a credit-only usage-based charge needs to be corrected.
 	OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
 
-	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against a custom-currency overage.
+	// OnAllocateFiatOverageCredits allocates settlement-fiat credits against an
+	// already-prepared custom-currency overage.
 	OnAllocateFiatOverageCredits(ctx context.Context, input AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error)
 
 	// OnCorrectFiatOverageCreditAllocations corrects settlement-fiat allocations for a custom-currency overage.
@@ -381,6 +394,10 @@ func (h UnimplementedHandler) OnInvoiceUsageAccrued(ctx context.Context, input O
 
 func (h UnimplementedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, input OnCustomCurrencyOverageAccruedInput) (OnCustomCurrencyOverageAccruedResult, error) {
 	return OnCustomCurrencyOverageAccruedResult{}, errors.New("not implemented")
+}
+
+func (h UnimplementedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	return errors.New("not implemented")
 }
 
 func (h UnimplementedHandler) OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -135,14 +135,15 @@ func (r CreateRealizationRunInput) Validate() error {
 type UpdateRealizationRunInput struct {
 	ID RealizationRunID
 
-	Type                      mo.Option[RealizationRunType]    `json:"type"`
-	StoredAtLT                mo.Option[time.Time]             `json:"storedAtLT"`
-	DeletedAt                 mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
-	LineID                    mo.Option[*string]               `json:"lineId,omitempty"`
-	MeteredQuantity           mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
-	Totals                    mo.Option[totals.Totals]         `json:"totals"`
-	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
-	Immutable                 mo.Option[bool]                  `json:"immutable"`
+	Type                                 mo.Option[RealizationRunType]    `json:"type"`
+	StoredAtLT                           mo.Option[time.Time]             `json:"storedAtLT"`
+	DeletedAt                            mo.Option[*time.Time]            `json:"deletedAt,omitempty"`
+	LineID                               mo.Option[*string]               `json:"lineId,omitempty"`
+	MeteredQuantity                      mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
+	Totals                               mo.Option[totals.Totals]         `json:"totals"`
+	NoFiatTransactionRequired            mo.Option[bool]                  `json:"noFiatTransactionRequired"`
+	Immutable                            mo.Option[bool]                  `json:"immutable"`
+	FiatOverageCreditAllocationCompleted mo.Option[bool]                  `json:"fiatOverageCreditAllocationCompleted"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -221,6 +222,9 @@ type RealizationRunBase struct {
 	NoFiatTransactionRequired bool          `json:"noFiatTransactionRequired"`
 	// Immutable means the backing invoice crossed the external issuance boundary.
 	Immutable bool `json:"immutable"`
+	// FiatOverageCreditAllocationCompleted distinguishes a successful
+	// zero-allocation result from pending allocation.
+	FiatOverageCreditAllocationCompleted bool `json:"fiatOverageCreditAllocationCompleted"`
 	// DetailedLinesIncludeCreditAllocations describes if credit allocation is applied to the detailed lines.
 	// Credits-only: always false
 	// Credit-then-invoice:

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -29,6 +29,8 @@ type CreditThenInvoiceStateMachine struct {
 	*stateMachine
 }
 
+var triggerSystemInvoiceLineDeleted meta.Trigger = "system_invoice_line_deleted"
+
 type periodPatch interface {
 	Op() meta.PatchType
 	GetTargetLayer(meta.LayeredIntentReader) (meta.ChangeTarget, error)
@@ -121,6 +123,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(triggerSystemInvoiceLineDeleted, statelessx.WithParameters(s.SystemInvoiceLineDeleted)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
@@ -135,6 +138,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(triggerSystemInvoiceLineDeleted, statelessx.WithParameters(s.SystemInvoiceLineDeleted)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
@@ -154,6 +158,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(triggerSystemInvoiceLineDeleted, statelessx.WithParameters(s.SystemInvoiceLineDeleted)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
@@ -423,51 +428,111 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
-	if s.Charge.State.CurrentRealizationRunID != nil {
-		run, err := s.Charge.GetCurrentRealizationRun()
-		if err != nil {
-			return fmt.Errorf("getting current realization run before delete: %w", err)
+// cancelRealizationRun owns charge-side cleanup for removing an invoice run.
+// Reversible runs are corrected and marked deleted before their invoice patch
+// is emitted; immutable and zero-fiat history is only detached from the current
+// realization slot.
+func (s *CreditThenInvoiceStateMachine) cancelRealizationRun(ctx context.Context, run usagebased.RealizationRun) error {
+	shouldCorrect := false
+	if !run.Immutable {
+		if run.Payment != nil {
+			return fmt.Errorf("cannot cancel realization run[%s] with payment allocation", run.ID.ID)
 		}
 
-		if run.InvoiceUsage != nil && !run.Immutable {
-			correctionInput := usagebasedrun.CreditReconciliationHandlerInput{
-				Charge:     s.Charge,
-				Run:        run,
-				AllocateAt: run.ServicePeriodTo,
+		fiatOverage, err := calculateFiatOverageForRun(s.Charge, run)
+		if err != nil {
+			return fmt.Errorf("calculating fiat overage for realization run[%s]: %w", run.ID.ID, err)
+		}
+		shouldCorrect = !fiatOverage.ShouldOmitInvoiceLine
+	}
+
+	if shouldCorrect {
+		correctionInput := usagebasedrun.CreditReconciliationHandlerInput{
+			Charge:     s.Charge,
+			Run:        run,
+			AllocateAt: run.ServicePeriodTo,
+		}
+		if run.InvoiceUsage != nil {
+			if !s.Charge.Intent.GetCurrency().IsCustom() {
+				return fmt.Errorf("cannot cancel mutable regular-fiat realization run[%s] with invoice usage", run.ID.ID)
 			}
-			if s.Charge.Intent.GetCurrency().IsCustom() {
-				correctedRun, err := s.Runs.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
-				if err != nil {
-					return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
-				}
-				run = correctedRun
-			} else if err := s.Runs.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
+
+			correctedRun, err := s.Runs.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
+			if err != nil {
 				return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
 			}
-
-			runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-				ID:        run.ID,
-				DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
-			})
-			if err != nil {
-				return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
-			}
-			run.RealizationRunBase = runBase
-
-			s.Charge.Realizations = s.Charge.Realizations.Without(run.ID)
-			s.Charge.State.CurrentRealizationRunID = nil
-			updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
-			if err != nil {
-				return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
-			}
-			s.Charge.ChargeBase = updatedChargeBase
+			run = correctedRun
+		} else if err := s.Runs.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
+			return fmt.Errorf("correcting realization run[%s]: %w", run.ID.ID, err)
 		}
+
+		runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+			ID:        run.ID,
+			DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+		})
+		if err != nil {
+			return fmt.Errorf("marking realization run[%s] deleted: %w", run.ID.ID, err)
+		}
+		run.RealizationRunBase = runBase
+		s.Charge.Realizations = s.Charge.Realizations.Without(run.ID)
 	}
 
-	patches := invoiceupdater.Patches{
-		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
+	if run.LineID != nil && run.InvoiceID != nil {
+		s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
+			billing.LineID{Namespace: s.Charge.Namespace, ID: *run.LineID},
+			*run.InvoiceID,
+		))
 	}
+
+	currentRunCanceled := s.Charge.State.CurrentRealizationRunID != nil && *s.Charge.State.CurrentRealizationRunID == run.ID.ID
+	if currentRunCanceled {
+		s.Charge.State.CurrentRealizationRunID = nil
+		if s.Charge.Status != usagebased.StatusDeleted {
+			s.Charge.Status = usagebased.StatusActive
+			s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To))
+		}
+
+		updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
+		if err != nil {
+			return fmt.Errorf("detaching realization run[%s]: %w", run.ID.ID, err)
+		}
+		s.Charge.ChargeBase = updatedChargeBase
+	}
+
+	return nil
+}
+
+// SystemInvoiceLineDeleted reconciles a mutable invoice-backed run before
+// billing completes a system-owned line deletion. The returned line patch is
+// consumed by the callback because billing is already applying that exact
+// effect; any gathering-line effect is forwarded back to billing.
+func (s *CreditThenInvoiceStateMachine) SystemInvoiceLineDeleted(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	run, err := s.Charge.Realizations.GetByLineID(input.Line.ID)
+	if err != nil {
+		return fmt.Errorf("getting realization run for deleted invoice line[%s]: %w", input.Line.ID, err)
+	}
+
+	if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("realization run[%s] is not associated with deleted invoice line[%s] on invoice[%s]", run.ID.ID, input.Line.ID, input.Invoice.ID)
+	}
+
+	if err := s.cancelRealizationRun(ctx, run); err != nil {
+		return fmt.Errorf("canceling realization run[%s] for deleted invoice line[%s]: %w", run.ID.ID, input.Line.ID, err)
+	}
+
+	if input.Invoice.DeletionSource != "" {
+		s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
+	}
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
+	s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
 
 	for _, run := range s.Charge.Realizations {
 		// Voided realizations were already cleaned up through billing, so the
@@ -476,20 +541,10 @@ func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Conte
 			continue
 		}
 
-		if run.LineID == nil || run.InvoiceID == nil {
-			continue
+		if err := s.cancelRealizationRun(ctx, run); err != nil {
+			return fmt.Errorf("canceling realization run[%s] for deleted charge: %w", run.ID.ID, err)
 		}
-
-		patches = append(patches, invoiceupdater.NewDeleteLinePatch(
-			billing.LineID{
-				Namespace: s.Charge.Namespace,
-				ID:        *run.LineID,
-			},
-			*run.InvoiceID,
-		))
 	}
-
-	s.AddInvoicePatch(patches...)
 
 	if err := s.Adapter.DeleteCharge(ctx, s.Charge); err != nil {
 		return fmt.Errorf("delete charge: %w", err)
@@ -578,7 +633,7 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch 
 		return err
 	}
 
-	if err := s.handleRunsOnShrink(); err != nil {
+	if err := s.handleRunsOnShrink(ctx); err != nil {
 		return fmt.Errorf("handling realization runs on shrink: %w", err)
 	}
 
@@ -789,7 +844,7 @@ func (s *CreditThenInvoiceStateMachine) ResolveDynamicCostBasis(ctx context.Cont
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
+func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink(ctx context.Context) error {
 	servicePeriod := s.Charge.Intent.GetEffectiveServicePeriod()
 	newServicePeriodTo := meta.NormalizeTimestamp(servicePeriod.To)
 	runsToKeep, runsToBeDeleted, err := s.Charge.BisectRealizationRunsByTimestamp(newServicePeriodTo)
@@ -804,16 +859,9 @@ func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 			)
 		}
 
-		// Billing owns line cleanup. Mutable invoices can delete the line and
-		// reverse draft effects; immutable invoices can keep history intact and
-		// surface the missing prorating/credit-note work as validation.
-		s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
-			billing.LineID{
-				Namespace: s.Charge.Namespace,
-				ID:        *run.LineID,
-			},
-			*run.InvoiceID,
-		))
+		if err := s.cancelRealizationRun(ctx, run); err != nil {
+			return fmt.Errorf("canceling realization run[%s] after shrink: %w", run.ID.ID, err)
+		}
 	}
 
 	gatheringLinePeriod := timeutil.ClosedPeriod{
@@ -956,16 +1004,9 @@ func (s *CreditThenInvoiceStateMachine) handleFinalRunOnExtend(ctx context.Conte
 			return mo.None[timeutil.ClosedPeriod](), fmt.Errorf("current terminal realization run must be invoice-backed [charge_id=%s,status=%s,run_id=%s]", s.Charge.ID, s.Charge.Status, currentRun.ID.ID)
 		}
 
-		// Billing's mutable-line deletion hook owns the cleanup: it reverses the
-		// draft allocations, marks this run deleted, and moves the charge back to
-		// active for the extended period.
-		s.AddInvoicePatch(invoiceupdater.NewDeleteLinePatch(
-			billing.LineID{
-				Namespace: s.Charge.Namespace,
-				ID:        *currentRun.LineID,
-			},
-			*currentRun.InvoiceID,
-		))
+		if err := s.cancelRealizationRun(ctx, currentRun); err != nil {
+			return mo.None[timeutil.ClosedPeriod](), fmt.Errorf("canceling final realization run[%s] after extend: %w", currentRun.ID.ID, err)
+		}
 
 		return mo.Some(s.Charge.Intent.GetEffectiveServicePeriod()), nil
 	}

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -149,7 +149,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsCurrentRunZeroFiatAmountOverage),
 		).
 		Permit(
-			meta.TriggerInvoiceIssued,
+			meta.TriggerInvoiceFinalizing,
 			usagebased.StatusActiveRealizationIssuing,
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
@@ -163,19 +163,19 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 
 	s.Configure(usagebased.StatusActiveRealizationIssuing).
 		Permit(
-			meta.TriggerNext,
+			meta.TriggerInvoiceIssued,
 			usagebased.StatusActiveRealizationCompleted,
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
-		// Extend is rejected while invoice-issued callbacks own this state.
+		// Extend is rejected while invoice callbacks own this state.
 		// Subscription sync can retry after billing advances the charge.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.UnsupportedShrinkToRealizedPeriodOperation)).
-		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
+		OnEntryFrom(meta.TriggerInvoiceFinalizing, statelessx.WithParameters(s.FinalizeInvoice))
 
 	// Zero-fiat-amount overages bypass invoice issuance after the run's converted
 	// fiat amount is durable. This state finalizes that run before normal
@@ -207,11 +207,13 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// transition to payment settlement. Subscription sync can retry.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		// Invoice-issued callbacks have already finalized the run in the
-		// issuing state. A gathering-line API delete may now shorten the
+		// Invoice-issued callbacks have already released the prepared run. A
+		// gathering-line API delete may now shorten the
 		// effective period to that completed run, and the next transition still
 		// owns routing the charge to active or payment settlement.
-		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod))
+		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.InvoiceIssued)).
+		OnActive(s.ReleaseInvoiceIssuedRun)
 
 	// Payment + final
 
@@ -422,6 +424,47 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) reconcileDeletedCharge(ctx context.Context) error {
+	if s.Charge.State.CurrentRealizationRunID != nil {
+		run, err := s.Charge.GetCurrentRealizationRun()
+		if err != nil {
+			return fmt.Errorf("getting current realization run before delete: %w", err)
+		}
+
+		if run.InvoiceUsage != nil && !run.Immutable {
+			correctionInput := usagebasedrun.CreditReconciliationHandlerInput{
+				Charge:     s.Charge,
+				Run:        run,
+				AllocateAt: run.ServicePeriodTo,
+			}
+			if s.Charge.Intent.GetCurrency().IsCustom() {
+				correctedRun, err := s.Runs.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, correctionInput)
+				if err != nil {
+					return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+				}
+				run = correctedRun
+			} else if err := s.Runs.CorrectAllCreditRealizations(ctx, correctionInput); err != nil {
+				return fmt.Errorf("correcting prepared realization run[%s]: %w", run.ID.ID, err)
+			}
+
+			runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+				ID:        run.ID,
+				DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+			})
+			if err != nil {
+				return fmt.Errorf("marking prepared realization run[%s] deleted: %w", run.ID.ID, err)
+			}
+			run.RealizationRunBase = runBase
+
+			s.Charge.Realizations = s.Charge.Realizations.Without(run.ID)
+			s.Charge.State.CurrentRealizationRunID = nil
+			updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
+			if err != nil {
+				return fmt.Errorf("detaching prepared realization run[%s]: %w", run.ID.ID, err)
+			}
+			s.Charge.ChargeBase = updatedChargeBase
+		}
+	}
+
 	patches := invoiceupdater.Patches{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
@@ -543,6 +586,10 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkToRealizedPeriod(ctx context.Context, patch meta.PatchShrinkToRealizedPeriod) error {
+	if err := s.correctReversibleInvoicePreparation(ctx, patch.Op()); err != nil {
+		return err
+	}
+
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
 		return fmt.Errorf("getting patch target layer: %w", err)
@@ -607,6 +654,10 @@ type creditThenInvoiceApplyPeriodPatchResult struct {
 }
 
 func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(ctx context.Context, patch periodPatch) (creditThenInvoiceApplyPeriodPatchResult, error) {
+	if err := s.correctReversibleInvoicePreparation(ctx, patch.Op()); err != nil {
+		return creditThenInvoiceApplyPeriodPatchResult{}, err
+	}
+
 	target, err := patch.GetTargetLayer(s.Charge.Intent)
 	if err != nil {
 		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("getting patch target layer: %w", err)
@@ -636,6 +687,40 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(ctx context.Context, pa
 	return creditThenInvoiceApplyPeriodPatchResult{
 		OldServicePeriod: oldServicePeriod,
 	}, nil
+}
+
+// correctReversibleInvoicePreparation removes invoice-finalization effects so
+// mutable usage-based intent changes never retain stale custom-currency state.
+func (s *CreditThenInvoiceStateMachine) correctReversibleInvoicePreparation(ctx context.Context, op meta.PatchType) error {
+	if s.Charge.State.CurrentRealizationRunID == nil {
+		return nil
+	}
+
+	currentRun, err := s.Charge.GetCurrentRealizationRun()
+	if err != nil {
+		return fmt.Errorf("getting current realization run before %s: %w", op, err)
+	}
+	if currentRun.Immutable || currentRun.InvoiceUsage == nil {
+		return nil
+	}
+
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		return fmt.Errorf("cannot %s usage-based charge %s: mutable realization run %s has unexpected regular-fiat invoice usage", op, s.Charge.ID, currentRun.ID.ID)
+	}
+
+	if _, err := s.Runs.CorrectPreparedCustomCurrencyInvoiceRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
+		Charge:     s.Charge,
+		Run:        currentRun,
+		AllocateAt: currentRun.ServicePeriodTo,
+	}); err != nil {
+		return fmt.Errorf("correct reversible realization run[%s] before %s: %w", currentRun.ID.ID, op, err)
+	}
+
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("refetch usage-based charge[%s] after correcting realization run[%s]: %w", s.Charge.ID, currentRun.ID.ID, err)
+	}
+
+	return nil
 }
 
 func (s *CreditThenInvoiceStateMachine) UnsupportedExtendOperation(_ context.Context, _ meta.PatchExtend) error {
@@ -1097,7 +1182,9 @@ func (s *CreditThenInvoiceStateMachine) FinalizeZeroFiatAmountOverageRun(_ conte
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+// FinalizeInvoice makes the line authoritative and performs reversible custom-
+// currency accounting preparation before external invoice synchronization.
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoice(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
@@ -1110,38 +1197,130 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("get current realization run: %w", err)
 	}
-
-	accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
-		Charge: s.Charge,
-		Run:    currentRun,
-		Line:   *input.Line,
-	})
-	if err != nil {
-		return fmt.Errorf("accrue invoice usage: %w", err)
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("realization run[%s] line does not match finalizing line[%s]", currentRun.ID.ID, input.Line.ID)
 	}
-	currentRun = accrueResult.Run
-	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:        currentRun.ID,
-		Immutable: mo.Some(true),
-	})
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("realization run[%s] invoice does not match finalizing invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
+	if s.Charge.Intent.GetCurrency().IsCustom() {
+		if currentRun.InvoiceUsage == nil && (len(currentRun.FiatOverageCreditRealizations) > 0 || currentRun.FiatOverageCreditAllocationCompleted) {
+			return fmt.Errorf("realization run[%s] has fiat overage allocation state without prepared invoice usage", currentRun.ID.ID)
+		}
+
+		line, err := input.Line.Clone()
+		if err != nil {
+			return fmt.Errorf("cloning finalizing line[%s]: %w", input.Line.ID, err)
+		}
+
+		if currentRun.InvoiceUsage == nil {
+			if err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+				Stage:  standardLinePopulationStageInvoiceFinalizing,
+			}); err != nil {
+				return fmt.Errorf("populating gross finalizing line[%s] from run[%s]: %w", line.ID, currentRun.ID.ID, err)
+			}
+
+			prepared, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+				Line:   *line,
+			})
+			if err != nil {
+				return fmt.Errorf("preparing custom-currency overage for finalizing line[%s]: %w", line.ID, err)
+			}
+			currentRun = prepared.Run
+		}
+
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			allocated, err := s.Runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
+				Charge: s.Charge,
+				Run:    currentRun,
+			})
+			if err != nil {
+				return fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", line.ID, err)
+			}
+			s.Charge = allocated.Charge
+			currentRun = allocated.Run
+		}
+
+		if err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
+			Charge: s.Charge,
+			Run:    currentRun,
+			Stage:  standardLinePopulationStageInvoiceFinalizing,
+		}); err != nil {
+			return fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", line.ID, currentRun.ID.ID, err)
+		}
+
+		s.AddInvoicePatch(invoiceupdater.NewUpdateLinePatch(line.AsGenericLine()))
+	}
+
+	s.Charge.State.AdvanceAfter = nil
+
+	return nil
+}
+
+// InvoiceIssued accrues regular-fiat invoice usage or verifies custom-currency
+// preparation, then marks the externally issued invoice history immutable.
+func (s *CreditThenInvoiceStateMachine) InvoiceIssued(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if s.Charge.State.CurrentRealizationRunID == nil {
+		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
+	}
+
+	currentRun, err := s.Charge.GetCurrentRealizationRun()
+	if err != nil {
+		return fmt.Errorf("get current realization run: %w", err)
+	}
+	if s.Charge.Intent.GetCurrency().IsCustom() {
+		if currentRun.InvoiceUsage == nil {
+			return fmt.Errorf("realization run[%s] has not been prepared for invoice issuance", currentRun.ID.ID)
+		}
+		if !currentRun.FiatOverageCreditAllocationCompleted {
+			return fmt.Errorf("realization run[%s] has not completed fiat overage credit allocation", currentRun.ID.ID)
+		}
+	}
+	if currentRun.LineID == nil || *currentRun.LineID != input.Line.ID {
+		return fmt.Errorf("prepared realization run[%s] line does not match issued line[%s]", currentRun.ID.ID, input.Line.ID)
+	}
+	if currentRun.InvoiceID == nil || *currentRun.InvoiceID != input.Invoice.ID {
+		return fmt.Errorf("prepared realization run[%s] invoice does not match issued invoice[%s]", currentRun.ID.ID, input.Invoice.ID)
+	}
+
+	if !s.Charge.Intent.GetCurrency().IsCustom() {
+		accrueResult, err := s.Runs.BookAccruedInvoiceUsage(ctx, usagebasedrun.BookAccruedInvoiceUsageInput{
+			Charge: s.Charge,
+			Run:    currentRun,
+			Line:   *input.Line,
+		})
+		if err != nil {
+			return fmt.Errorf("accruing issued invoice usage: %w", err)
+		}
+		currentRun = accrueResult.Run
+	}
+
+	currentRun, err = s.Runs.MarkInvoiceIssued(ctx, currentRun)
 	if err != nil {
 		return fmt.Errorf("marking issued realization run[%s] immutable: %w", currentRun.ID.ID, err)
 	}
-	currentRun.RealizationRunBase = runBase
 
 	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
-		return fmt.Errorf("update realization run: %w", err)
+		return fmt.Errorf("updating issued realization run[%s]: %w", currentRun.ID.ID, err)
 	}
 
+	return nil
+}
+
+// ReleaseInvoiceIssuedRun clears lifecycle scheduling after the prepared run
+// has accepted the external issuance event.
+func (s *CreditThenInvoiceStateMachine) ReleaseInvoiceIssuedRun(_ context.Context) error {
 	s.Charge.State.CurrentRealizationRunID = nil
 	s.Charge.State.AdvanceAfter = nil
-
-	updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
-	if err != nil {
-		return fmt.Errorf("update charge: %w", err)
-	}
-
-	s.Charge.ChargeBase = updatedChargeBase
 
 	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -173,6 +173,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		).
 		Permit(meta.TriggerClearOverride, usagebased.StatusDeletedClearOverride, statelessx.BoolFn(s.IsBaseIntentDeleted)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(triggerSystemInvoiceLineDeleted, statelessx.WithParameters(s.SystemInvoiceLineDeleted)).
 		InternalTransition(meta.TriggerSetOverride, statelessx.WithParameters(s.UnsupportedSetOverrideOperation)).
 		InternalTransition(meta.TriggerClearOverride, statelessx.WithParameters(s.UnsupportedClearOverrideOperation), statelessx.BoolFn(statelessx.Not(s.IsBaseIntentDeleted))).
 		// Extend is rejected while invoice callbacks own this state.

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
@@ -357,7 +358,10 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 	}
 
 	for _, line := range input.Deleted {
-		if err := e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line); err != nil {
+		err = transaction.RunWithNoValue(ctx, e.service.adapter, func(ctx context.Context) error {
+			return e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line)
+		})
+		if err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
@@ -600,6 +604,16 @@ func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoic
 			// This is an internal consistency error, we are not supposed to surface this to the user, so no typed error wrapping.
 			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
 		}
+
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return usagebased.Charge{}, fmt.Errorf("getting usage based realization run for line[%s]: %w", line.GetID(), err)
+		}
+		if charge.Intent.GetEffectiveIntent().Currency.IsCustom() {
+			if err := validateCustomCurrencyInvoiceLineDelete(invoice, line, run); err != nil {
+				return usagebased.Charge{}, err
+			}
+		}
 	default:
 		return usagebased.Charge{}, fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
 	}
@@ -665,7 +679,10 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		return nil
 	case billing.InvoiceLineTypeStandard:
-
+		run, err := charge.Realizations.GetByLineID(line.GetID())
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: getting realization run: %w", line.GetID(), err)
+		}
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,
 			Policy:       meta.RefundAsCreditsDeletePolicy,
@@ -689,27 +706,36 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		if len(stdInvoicePatches) != 1 {
-			return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
-		}
+		activeRun, activeRunFound := lo.Find(charge.Realizations.WithoutVoidedBillingHistory(), func(candidate usagebased.RealizationRun) bool {
+			return candidate.ID == run.ID
+		})
+		if activeRunFound {
+			if len(stdInvoicePatches) != 1 {
+				return fmt.Errorf("usage based line[%s]: active realization run[%s] requires one standard invoice delete patch, got %d: %v", line.GetID(), run.ID.ID, len(stdInvoicePatches), stdInvoicePatches)
+			}
 
-		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		if err := stdInvoicePatch.RequireTarget(line); err != nil {
-			return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			if err := stdInvoicePatch.RequireTarget(line); err != nil {
+				return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		standardLine, err := line.AsInvoiceLine().AsStandardLine()
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
-		}
+			standardLine, err := line.AsInvoiceLine().AsStandardLine()
+			if err != nil {
+				return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
+			}
 
-		_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+			if !activeRun.Immutable {
+				_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+				if err != nil {
+					return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
+				}
+			}
+		} else if len(stdInvoicePatches) != 0 {
+			return fmt.Errorf("usage based line[%s]: reconciled realization run[%s] emitted unexpected standard invoice patches: %v", line.GetID(), run.ID.ID, stdInvoicePatches)
 		}
 
 		// Handle the remaining gathering line patches
@@ -730,7 +756,34 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 	}
 }
 
-func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Context, charge usagebased.Charge, patch meta.Patch) (usagebased.Charge, invoiceupdater.Patches, error) {
+// validateCustomCurrencyInvoiceLineDelete verifies the invoice and run
+// association required to delete a custom-currency line.
+func validateCustomCurrencyInvoiceLineDelete(
+	invoice billing.GenericInvoiceReader,
+	line billing.GenericInvoiceLine,
+	run usagebased.RealizationRun,
+) error {
+	if err := line.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard); err != nil {
+		return fmt.Errorf("custom-currency usage based line[%s] must be a standard line: %w", line.GetID(), billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+	if err != nil {
+		return fmt.Errorf("usage based line[%s]: getting standard invoice: %w", line.GetID(), err)
+	}
+
+	if run.LineID == nil || *run.LineID != line.GetID() || run.InvoiceID == nil || *run.InvoiceID != standardInvoice.ID {
+		return fmt.Errorf("custom-currency usage based line[%s] does not match realization run[%s]: %w", line.GetID(), run.ID.ID, billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(
+	ctx context.Context,
+	charge usagebased.Charge,
+	patch meta.Patch,
+) (usagebased.Charge, invoiceupdater.Patches, error) {
 	if err := patch.Validate(); err != nil {
 		return usagebased.Charge{}, nil, fmt.Errorf("validating usage based charge[%s] API line edit patch: %w", charge.ID, err)
 	}
@@ -834,6 +887,10 @@ func (e *LineEngine) deleteMutableStandardLineRealization(
 
 	if run.Payment != nil {
 		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
+	}
+
+	if run.Immutable {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] was issued", stdLine.ID, run.ID.ID)
 	}
 
 	if run.InvoiceUsage != nil {
@@ -981,62 +1038,34 @@ func (e *LineEngine) OnInvoiceFinalizing(ctx context.Context, input billing.OnIn
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
-		meta.ExpandRealizations,
-	}, "invoice finalization")
-	if err != nil {
-		return nil, err
-	}
-
 	return slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
-		charge, ok := chargesByID[*stdLine.ChargeID]
-		if !ok {
-			return nil, fmt.Errorf("usage based charge[%s] not found for finalizing line[%s]", *stdLine.ChargeID, stdLine.ID)
-		}
-
-		if stdLine.IsDeleted() ||
-			charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
-			!charge.Intent.GetCurrency().IsCustom() {
+		if stdLine.IsDeleted() {
 			return stdLine, nil
 		}
 
-		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, fmt.Errorf("getting realization run for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, err
 		}
 
-		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
-			return nil, fmt.Errorf(
-				"realization run[%s] for finalizing line[%s] is not associated with invoice[%s]",
-				run.ID.ID,
-				stdLine.ID,
-				input.Invoice.ID,
-			)
+		if stateMachine.GetCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+			return stdLine, nil
 		}
 
-		allocated, err := e.service.runs.AllocateFiatOverageCredits(ctx, usagebasedrun.AllocateFiatOverageCreditsInput{
-			Charge: charge,
-			Run:    run,
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, meta.TriggerInvoiceFinalizing, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("allocating fiat overage credits for finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("finalizing invoice line for charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		updatedLine, err := stdLine.Clone()
+		updatedLine, err := patches.RequireSingularStandardLineUpdateOrEmpty(stdLine.GetLineID(), input.Invoice.ID)
 		if err != nil {
-			return nil, fmt.Errorf("cloning finalizing line[%s]: %w", stdLine.ID, err)
+			return nil, fmt.Errorf("validating finalizing update for line[%s]: %w", stdLine.ID, err)
 		}
-
-		if err := populateStandardLineFromRun(updatedLine, populateStandardLineFromRunInput{
-			Charge: allocated.Charge,
-			Run:    allocated.Run,
-			Stage:  standardLinePopulationStageInvoiceFinalizing,
-		}); err != nil {
-			return nil, fmt.Errorf("populating finalizing line[%s] from run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		if err := updatedLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating finalizing line[%s]: %w", stdLine.ID, err)
+		if updatedLine == nil {
+			return stdLine, nil
 		}
 
 		return updatedLine, nil

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
@@ -679,10 +678,6 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		return nil
 	case billing.InvoiceLineTypeStandard:
-		run, err := charge.Realizations.GetByLineID(line.GetID())
-		if err != nil {
-			return fmt.Errorf("usage based line[%s]: getting realization run: %w", line.GetID(), err)
-		}
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,
 			Policy:       meta.RefundAsCreditsDeletePolicy,
@@ -691,7 +686,7 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("creating usage based charge[%s] API delete patch: %w", charge.ID, err)
 		}
 
-		charge, patches, err := e.applyChargePatchForInvoiceLineEditViaAPI(ctx, charge, deletePatch)
+		_, patches, err := e.applyChargePatchForInvoiceLineEditViaAPI(ctx, charge, deletePatch)
 		if err != nil {
 			return fmt.Errorf("usage based line[%s]: applying charge delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
@@ -706,36 +701,29 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		activeRun, activeRunFound := lo.Find(charge.Realizations.WithoutVoidedBillingHistory(), func(candidate usagebased.RealizationRun) bool {
-			return candidate.ID == run.ID
-		})
-		if activeRunFound {
-			if len(stdInvoicePatches) != 1 {
-				return fmt.Errorf("usage based line[%s]: active realization run[%s] requires one standard invoice delete patch, got %d: %v", line.GetID(), run.ID.ID, len(stdInvoicePatches), stdInvoicePatches)
-			}
+		if len(stdInvoicePatches) != 1 {
+			return fmt.Errorf("usage based line[%s]: requires one standard invoice delete patch, got %d: %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
+		}
 
-			stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
-			if err != nil {
-				return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
-			}
+		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
+		}
 
-			if err := stdInvoicePatch.RequireTarget(line); err != nil {
-				return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
-			}
+		if err := stdInvoicePatch.RequireTarget(line); err != nil {
+			return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
+		}
 
-			standardLine, err := line.AsInvoiceLine().AsStandardLine()
-			if err != nil {
-				return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
-			}
+		standardLine, err := line.AsInvoiceLine().AsStandardLine()
+		if err != nil {
+			return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
+		}
 
-			if !activeRun.Immutable {
-				_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
-				if err != nil {
-					return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
-				}
-			}
-		} else if len(stdInvoicePatches) != 0 {
-			return fmt.Errorf("usage based line[%s]: reconciled realization run[%s] emitted unexpected standard invoice patches: %v", line.GetID(), run.ID.ID, stdInvoicePatches)
+		if err := e.validateDeletedStandardLines(ctx, billing.StandardLineEventInput{
+			Invoice: standardInvoice,
+			Lines:   billing.StandardLines{&standardLine},
+		}); err != nil {
+			return fmt.Errorf("usage based line[%s]: validating API delete line patch result for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		// Handle the remaining gathering line patches
@@ -806,20 +794,121 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		return fmt.Errorf("validating input: %w", err)
 	}
 
+	gatheringLinePatches, err := e.reconcileDeletedStandardLines(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	if err := e.validateDeletedStandardLines(ctx, input); err != nil {
+		return err
+	}
+
+	if len(gatheringLinePatches) > 0 {
+		if err := e.service.invoiceUpdater.ApplyPatches(ctx, input.Invoice.GetCustomerID(), gatheringLinePatches); err != nil {
+			return fmt.Errorf("applying gathering line delete patches for deleted usage based standard lines: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// reconcileDeletedStandardLines routes system-owned invoice deletions through
+// the charge state machine when the originating charge operation has not
+// already canceled the run. It consumes the matching line patch because
+// billing is already applying that deletion and returns any gathering-line
+// effects for the invoice updater.
+func (e *LineEngine) reconcileDeletedStandardLines(ctx context.Context, input billing.StandardLineEventInput) (invoiceupdater.Patches, error) {
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
-		meta.ExpandDetailedLines,
+		meta.ExpandDeletedRealizations,
+	}, "reconciling deleted standard lines")
+	if err != nil {
+		return nil, err
+	}
+
+	gatheringLinePatches := make(invoiceupdater.Patches, 0, len(input.Lines))
+	for _, stdLine := range input.Lines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("usage based charge[%s] not found for deleted standard line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		if err != nil {
+			return nil, fmt.Errorf("getting realization run for deleted usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
+			return nil, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
+		}
+
+		if run.DeletedAt != nil || run.Immutable {
+			continue
+		}
+
+		fiatOverage, err := calculateFiatOverageForRun(charge, run)
+		if err != nil {
+			return nil, fmt.Errorf("calculating fiat overage for usage based realization run[%s]: %w", run.ID.ID, err)
+		}
+		if fiatOverage.ShouldOmitInvoiceLine {
+			continue
+		}
+
+		stateMachine, err := e.service.newStateMachineForCharge(ctx, charge)
+		if err != nil {
+			return nil, fmt.Errorf("new state machine for usage based charge[%s]: %w", charge.ID, err)
+		}
+
+		patches, err := stateMachine.FireAndAdvanceUntilInvoicePatchesOrStable(ctx, triggerSystemInvoiceLineDeleted, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciling deleted usage based standard line[%s] through charge[%s]: %w", stdLine.ID, charge.ID, err)
+		}
+
+		standardInvoicePatches, remainingPatches, err := patches.BisectByStandardInvoiceID(input.Invoice.ID)
+		if err != nil {
+			return nil, fmt.Errorf("bisecting reconciled patches for deleted usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		deletePatch, err := standardInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+		if err != nil {
+			return nil, fmt.Errorf("requiring singular delete patch for reconciled usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		if err := deletePatch.RequireTarget(stdLine.AsGenericLine()); err != nil {
+			return nil, fmt.Errorf("validating reconciled delete patch target for usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		if err := remainingPatches.RequireType(invoiceupdater.PatchOpDeleteGatheringLineByChargeID, invoiceupdater.CountLessThanOrEqualTo(1)); err != nil {
+			return nil, fmt.Errorf("validating gathering patches for deleted usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		if len(remainingPatches) > 0 {
+			if _, err := remainingPatches.RequireSingularGatheringLinePatchForCharge(charge.ID); err != nil {
+				return nil, fmt.Errorf("validating gathering patch target for deleted usage based standard line[%s]: %w", stdLine.ID, err)
+			}
+
+			gatheringLinePatches = append(gatheringLinePatches, remainingPatches...)
+		}
+	}
+
+	return gatheringLinePatches, nil
+}
+
+// validateDeletedStandardLines confirms that charge lifecycle handling ran
+// before billing persisted a standard-line deletion. It never changes charge
+// accounting or realization state.
+func (e *LineEngine) validateDeletedStandardLines(ctx context.Context, input billing.StandardLineEventInput) error {
+	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
+		meta.ExpandRealizations,
+		meta.ExpandDeletedRealizations,
 	}, "deleted standard lines")
 	if err != nil {
 		return err
 	}
 
-	// Whole-invoice deletion needs to remove the leftover gathering line for the
-	// same charge. Charge patch updates can delete a mutable standard line while
-	// also emitting replacement gathering-line patches, so this hook must not
-	// apply an extra delete for ordinary system line updates.
-	isInvoiceDelete := input.Invoice.DeletionSource != ""
-	gatheringLineDeletePatches := make(invoiceupdater.Patches, 0, len(input.Lines))
 	for _, stdLine := range input.Lines {
 		charge, ok := chargesByID[*stdLine.ChargeID]
 		if !ok {
@@ -829,6 +918,22 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		run, err := charge.Realizations.GetByLineID(stdLine.ID)
 		if err != nil {
 			return fmt.Errorf("getting realization run for deleted usage based standard line[%s]: %w", stdLine.ID, err)
+		}
+
+		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
+			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
+		}
+
+		// A deleted run proves that its state machine completed reversible
+		// cleanup before handing the invoice effect to billing.
+		if run.DeletedAt != nil {
+			continue
+		}
+
+		// Immutable runs retain their accounting when billing can only record
+		// unsupported invoice drift.
+		if run.Immutable {
+			continue
 		}
 
 		// Collection deletes only the presentation line for a zero-fiat-amount
@@ -842,76 +947,10 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 			continue
 		}
 
-		charge, err = e.deleteMutableStandardLineRealization(ctx, charge, input.Invoice, stdLine)
-		if err != nil {
-			return err
-		}
-
-		chargesByID[*stdLine.ChargeID] = charge
-		if isInvoiceDelete {
-			gatheringLineDeletePatches = append(gatheringLineDeletePatches, invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(*stdLine.ChargeID))
-		}
-	}
-
-	if len(gatheringLineDeletePatches) > 0 {
-		if err := e.service.invoiceUpdater.ApplyPatches(ctx, input.Invoice.GetCustomerID(), gatheringLineDeletePatches); err != nil {
-			return fmt.Errorf("applying gathering line delete patches for deleted usage based standard lines: %w", err)
-		}
+		return fmt.Errorf("usage based standard line[%s] cannot be deleted because mutable realization run[%s] was not canceled by the charge state machine", stdLine.ID, run.ID.ID)
 	}
 
 	return nil
-}
-
-// deleteMutableStandardLineRealization removes the usage-based realization
-// backing a mutable deleted standard invoice line, including credit correction
-// and current-run detachment.
-func (e *LineEngine) deleteMutableStandardLineRealization(
-	ctx context.Context,
-	charge usagebased.Charge,
-	invoice billing.StandardInvoice,
-	stdLine *billing.StandardLine,
-) (usagebased.Charge, error) {
-	run, err := charge.Realizations.GetByLineID(stdLine.ID)
-	if err != nil {
-		return usagebased.Charge{}, err
-	}
-	// Deleted realizations have already been cleaned up through a prior line deletion,
-	// so billing must not run the cleanup path for them again.
-	if run.DeletedAt != nil {
-		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
-	}
-
-	if run.InvoiceID == nil || *run.InvoiceID != invoice.ID {
-		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, invoice.ID)
-	}
-
-	if run.Payment != nil {
-		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
-	}
-
-	if run.Immutable {
-		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] was issued", stdLine.ID, run.ID.ID)
-	}
-
-	if run.InvoiceUsage != nil {
-		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
-	}
-
-	now := clock.Now()
-	if err := e.service.runs.CorrectAllCreditRealizations(ctx, usagebasedrun.CreditReconciliationHandlerInput{
-		Charge:     charge,
-		Run:        run,
-		AllocateAt: run.ServicePeriodTo,
-	}); err != nil {
-		return usagebased.Charge{}, fmt.Errorf("correcting credits for deleted usage based standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
-	}
-
-	charge, err = e.markMutableStandardLineRunDeleted(ctx, charge, run, now)
-	if err != nil {
-		return usagebased.Charge{}, fmt.Errorf("marking realization run[%s] deleted for usage based standard line[%s]: %w", run.ID.ID, stdLine.ID, err)
-	}
-
-	return charge, nil
 }
 
 func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.OnUnsupportedCreditNoteInput) error {
@@ -921,6 +960,7 @@ func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.
 
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
+		meta.ExpandDeletedRealizations,
 	}, "unsupported credit note")
 	if err != nil {
 		return err
@@ -945,7 +985,7 @@ func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.
 		}
 
 		if run.DeletedAt != nil {
-			return fmt.Errorf("usage based standard line[%s] cannot be marked unsupported credit note because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
+			continue
 		}
 
 		if run.Type == usagebased.RealizationRunTypeInvalidDueToUnsupportedCreditNote {
@@ -962,40 +1002,6 @@ func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.
 	}
 
 	return nil
-}
-
-func (e *LineEngine) markMutableStandardLineRunDeleted(
-	ctx context.Context,
-	charge usagebased.Charge,
-	run usagebased.RealizationRun,
-	deletedAt time.Time,
-) (usagebased.Charge, error) {
-	if _, err := e.service.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:        run.ID,
-		DeletedAt: mo.Some(lo.ToPtr(deletedAt)),
-	}); err != nil {
-		return usagebased.Charge{}, err
-	}
-
-	charge.Realizations = charge.Realizations.Without(run.ID)
-
-	currentRunDeleted := charge.State.CurrentRealizationRunID != nil && *charge.State.CurrentRealizationRunID == run.ID.ID
-	if currentRunDeleted {
-		charge.State.CurrentRealizationRunID = nil
-		if charge.Status != usagebased.StatusDeleted {
-			charge.Status = usagebased.StatusActive
-			charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To))
-		}
-
-		updatedChargeBase, err := e.service.adapter.UpdateCharge(ctx, charge.ChargeBase)
-		if err != nil {
-			return usagebased.Charge{}, err
-		}
-
-		charge.ChargeBase = updatedChargeBase
-	}
-
-	return charge, nil
 }
 
 func (e *LineEngine) getChargesForStandardLineEvent(ctx context.Context, input billing.StandardLineEventInput, expands meta.Expands, operation string) (map[string]usagebased.Charge, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine_test.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -84,6 +85,33 @@ func TestLineEngineSplitGatheringLineKeepsChargeGroupingWithoutChildReferences(t
 	require.Nil(t, result.PostSplitAtLine.SplitLineGroupID)
 	require.Nil(t, result.PostSplitAtLine.ChildUniqueReferenceID)
 	require.Equal(t, splitAt, result.PostSplitAtLine.ServicePeriod.From)
+}
+
+func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newUsageBasedStandardLineForTest(servicePeriod)
+	run := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "run-id",
+			},
+			LineID:    lo.ToPtr(line.ID),
+			InvoiceID: lo.ToPtr(line.InvoiceID),
+		},
+	}
+	invoice := &billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			Namespace: line.Namespace,
+			ID:        line.InvoiceID,
+			Status:    billing.StandardInvoiceStatusDraftCreated,
+		},
+	}
+
+	require.NoError(t, validateCustomCurrencyInvoiceLineDelete(invoice, line.AsGenericLine(), run))
 }
 
 func billingtestFeatureMeters() feature.FeatureMeters {

--- a/openmeter/billing/charges/usagebased/service/linemapper.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper.go
@@ -183,6 +183,37 @@ func calculateFiatOverageForRun(charge usagebased.Charge, run usagebased.Realiza
 	}, nil
 }
 
+// resolveFiatOverageForLinePopulation reuses the gross FIAT amount persisted
+// by invoice preparation. This keeps retries from repeating conversion after
+// the durable accounting boundary has been crossed.
+func resolveFiatOverageForLinePopulation(
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	stage standardLinePopulationStage,
+) (calculateFiatOverageForRunResult, error) {
+	if stage != standardLinePopulationStageInvoiceFinalizing || run.InvoiceUsage == nil {
+		return calculateFiatOverageForRun(charge, run)
+	}
+
+	costBasisIntent := charge.Intent.GetCostBasisIntent()
+	if costBasisIntent == nil {
+		return calculateFiatOverageForRunResult{}, errors.New("cost basis intent is required for a custom-currency invoice")
+	}
+
+	fiatCurrency, err := costBasisIntent.GetFiatCurrency()
+	if err != nil {
+		return calculateFiatOverageForRunResult{}, err
+	}
+
+	grossFiatAmount := run.InvoiceUsage.Totals.Total
+
+	return calculateFiatOverageForRunResult{
+		FiatCurrency:          fiatCurrency,
+		FiatOverage:           grossFiatAmount,
+		ShouldOmitInvoiceLine: grossFiatAmount.IsZero(),
+	}, nil
+}
+
 func (i populateStandardLineFromRunInput) Validate() error {
 	var errs []error
 
@@ -279,7 +310,7 @@ func populateCustomCurrencyOverageFromRun(
 	charge := input.Charge
 	run := input.Run
 
-	fiatOverage, err := calculateFiatOverageForRun(charge, run)
+	fiatOverage, err := resolveFiatOverageForLinePopulation(charge, run, input.Stage)
 	if err != nil {
 		return fmt.Errorf("custom currency charge[%s] converting overage to fiat: %w", charge.ID, err)
 	}

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	chargedetailedline "github.com/openmeterio/openmeter/openmeter/billing/charges/models/detailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
@@ -369,6 +370,25 @@ func TestPopulateUsageBasedStandardLineFromCustomCurrencyRunCreatesFiatOverage(t
 	require.Len(t, line.DetailedLines, 1)
 	require.Equal(t, "existing-overage-id", line.DetailedLines[0].ID)
 	require.Nil(t, line.DeletedAt)
+
+	preparedRun := run
+	preparedRun.InvoiceUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: period,
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
+		},
+	}
+
+	// The current cost basis would convert the run to 6 USD. Finalization must
+	// reuse the persisted 5 USD result instead of converting again.
+	preparedFiatOverage, err := resolveFiatOverageForLinePopulation(
+		charge,
+		preparedRun,
+		standardLinePopulationStageInvoiceFinalizing,
+	)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), preparedFiatOverage.FiatOverage.InexactFloat64())
 
 	for _, stage := range []standardLinePopulationStage{
 		standardLinePopulationStageGatheringPreview,

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -334,12 +334,12 @@ func (i AllocateFiatOverageCreditsInput) Validate() error {
 		))
 	}
 
-	if i.Run.InvoiceUsage != nil {
-		errs = append(errs, errors.New("run already has accrued invoice usage"))
+	if i.Run.InvoiceUsage == nil {
+		errs = append(errs, errors.New("run must have prepared invoice usage before fiat allocation"))
 	}
 
-	if len(i.Run.FiatOverageCreditRealizations) > 0 {
-		errs = append(errs, errors.New("run already has fiat overage credit realizations"))
+	if i.Run.FiatOverageCreditAllocationCompleted {
+		errs = append(errs, errors.New("fiat overage credit allocation already completed"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -362,34 +362,45 @@ func (s *Service) AllocateFiatOverageCredits(
 		return AllocateFiatOverageCreditsResult{}, err
 	}
 
-	fiatOverage, err := in.Charge.ConvertCustomCurrencyOverageToFiat(in.Run.Totals)
+	fiatCurrency, err := in.Charge.GetInvoiceCurrency()
 	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("convert custom currency overage to fiat: %w", err)
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("get invoice currency: %w", err)
 	}
+	grossFiatAmount := in.Run.InvoiceUsage.Totals.Total
 
 	run := in.Run
-	allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
-		Amount: fiatOverage.Amount,
-		Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
-			Charge: in.Charge,
-			Run:    run,
-			// Fiat overage allocation is an invoice-finalization effect. Using the
-			// current time makes any outstanding settlement-fiat balance, such as
-			// USD credits, eligible for allocation when the invoice is finalized.
-			AllocateAt: clock.Now(),
-		}),
-	})
-	if err != nil {
-		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+	if len(run.FiatOverageCreditRealizations) == 0 {
+		allocationResult, err := creditreconciliation.Allocate(ctx, creditreconciliation.AllocateInput{
+			Amount: grossFiatAmount,
+			Handler: s.NewFiatOverageCreditReconciliationHandler(CreditReconciliationHandlerInput{
+				Charge: in.Charge,
+				Run:    run,
+				// Fiat overage allocation is an invoice-finalization effect. Using the
+				// current time makes any outstanding settlement-fiat balance, such as
+				// USD credits, eligible for allocation when the invoice is finalized.
+				AllocateAt: clock.Now(),
+			}),
+		})
+		if err != nil {
+			return AllocateFiatOverageCreditsResult{}, fmt.Errorf("allocate fiat overage credits: %w", err)
+		}
+
+		run.FiatOverageCreditRealizations = allocationResult.Realizations
 	}
 
-	run.FiatOverageCreditRealizations = allocationResult.Realizations
-
-	allocated := fiatOverage.Currency.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
-	remainingFiatOverage := fiatOverage.Currency.RoundToPrecision(fiatOverage.Amount.Sub(allocated))
+	fiatCurrencyCalculator, err := currencyx.NewFiatCurrency(fiatCurrency)
+	if err != nil {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("create invoice currency calculator: %w", err)
+	}
+	allocated := fiatCurrencyCalculator.RoundToPrecision(run.FiatOverageCreditRealizations.Sum())
+	if allocated.GreaterThan(grossFiatAmount) {
+		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("fiat overage credit allocations exceed prepared gross amount: %s > %s", allocated, grossFiatAmount)
+	}
+	remainingFiatOverage := fiatCurrencyCalculator.RoundToPrecision(grossFiatAmount.Sub(allocated))
 	runBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:                        run.ID,
-		NoFiatTransactionRequired: mo.Some(remainingFiatOverage.IsZero()),
+		ID:                                   run.ID,
+		NoFiatTransactionRequired:            mo.Some(remainingFiatOverage.IsZero()),
+		FiatOverageCreditAllocationCompleted: mo.Some(true),
 	})
 	if err != nil {
 		return AllocateFiatOverageCreditsResult{}, fmt.Errorf("update realization run after fiat overage allocation: %w", err)
@@ -408,8 +419,7 @@ func (s *Service) AllocateFiatOverageCredits(
 }
 
 // CorrectAllCreditRealizations reverses every active credit allocation for a
-// usage-based run. Custom-currency credit-then-invoice runs unwind settlement
-// fiat before the charge currency from which that overage was derived.
+// usage-based run without changing its accrued invoice usage.
 func (s *Service) CorrectAllCreditRealizations(
 	ctx context.Context,
 	input CreditReconciliationHandlerInput,
@@ -418,15 +428,74 @@ func (s *Service) CorrectAllCreditRealizations(
 		return err
 	}
 
-	if input.Charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode &&
-		input.Charge.Intent.GetCurrency().IsCustom() {
-		if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
-			Handler: s.NewFiatOverageCreditReconciliationHandler(input),
-		}); err != nil {
-			return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
-		}
+	if err := s.correctFiatOverageCreditRealizations(ctx, input); err != nil {
+		return err
 	}
 
+	return s.correctChargeCurrencyCreditRealizations(ctx, input)
+}
+
+// CorrectPreparedCustomCurrencyInvoiceRealizations unwinds a prepared custom-
+// currency invoice run in reverse accounting order while keeping accrued-usage
+// correction separate from credit realization correction.
+func (s *Service) CorrectPreparedCustomCurrencyInvoiceRealizations(
+	ctx context.Context,
+	input CreditReconciliationHandlerInput,
+) (usagebased.RealizationRun, error) {
+	if err := input.Validate(); err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+
+	accruedUsageInput := CorrectAccruedUsageInput{
+		Charge: input.Charge,
+		Run:    input.Run,
+	}
+	if err := accruedUsageInput.Validate(); err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+
+	if err := s.correctFiatOverageCreditRealizations(ctx, input); err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+
+	run, err := s.CorrectAccruedUsage(ctx, accruedUsageInput)
+	if err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+	input.Run = run
+
+	if err := s.correctChargeCurrencyCreditRealizations(ctx, input); err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+
+	runBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:                                   input.Run.ID,
+		FiatOverageCreditAllocationCompleted: mo.Some(false),
+	})
+	if err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("reset invoice preparation state: %w", err)
+	}
+	input.Run.RealizationRunBase = runBase
+
+	return input.Run, nil
+}
+
+func (s *Service) correctFiatOverageCreditRealizations(ctx context.Context, input CreditReconciliationHandlerInput) error {
+	if input.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode ||
+		!input.Charge.Intent.GetCurrency().IsCustom() {
+		return nil
+	}
+
+	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
+		Handler: s.NewFiatOverageCreditReconciliationHandler(input),
+	}); err != nil {
+		return fmt.Errorf("correct all fiat overage credit realizations: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) correctChargeCurrencyCreditRealizations(ctx context.Context, input CreditReconciliationHandlerInput) error {
 	if _, err := creditreconciliation.CorrectAll(ctx, creditreconciliation.CorrectAllInput{
 		Handler: s.NewChargeCurrencyCreditReconciliationHandler(input),
 	}); err != nil {

--- a/openmeter/billing/charges/usagebased/service/run/credits_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
@@ -26,9 +26,9 @@ func TestChargeCurrencyCreditReconciliationHandlerOwnsCurrencyCalculator(t *test
 	require.Equal(t, "USD", handler.CurrencyCalculator().Details().Code.String())
 }
 
-func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T) {
+func TestAllocateFiatOverageCreditsInputRejectsCompletedAllocation(t *testing.T) {
 	// given:
-	// - a custom-currency credit-then-invoice run already has a fiat allocation
+	// - a custom-currency credit-then-invoice run already completed fiat allocation
 	charge := newUsageBasedCharge(t)
 	baseIntent := charge.Intent.GetBaseIntent()
 	baseIntent.Currency = currenciestestutils.NewCustomCurrency(t, "TOKENS", 2)
@@ -46,22 +46,17 @@ func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T
 	run := newUsageBasedRun("line-1")
 	currentRunID := run.ID.ID
 	charge.State.CurrentRealizationRunID = &currentRunID
-	run.FiatOverageCreditRealizations = creditrealization.Realizations{
-		{
-			CreateInput: creditrealization.CreateInput{
-				ID:            "fiat-allocation-1",
-				ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
-				LedgerTransaction: ledgertransaction.GroupReference{
-					TransactionGroupID: "fiat-allocation-transaction-1",
-				},
-				Amount: alpacadecimal.NewFromInt(5),
-				Type:   creditrealization.TypeAllocation,
-			},
+	run.InvoiceUsage = &invoicedusage.AccruedUsage{
+		ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
+		Totals: totals.Totals{
+			Amount: alpacadecimal.NewFromInt(5),
+			Total:  alpacadecimal.NewFromInt(5),
 		},
 	}
+	run.FiatOverageCreditAllocationCompleted = true
 
 	// when:
-	// - invoice finalization attempts the one-shot fiat allocation again
+	// - invoice finalization attempts the completed allocation again
 	err = (AllocateFiatOverageCreditsInput{
 		Charge: charge,
 		Run:    run,
@@ -69,5 +64,5 @@ func TestAllocateFiatOverageCreditsInputRejectsExistingRealizations(t *testing.T
 
 	// then:
 	// - validation rejects the repeated allocation before any handler effect
-	require.ErrorContains(t, err, "run already has fiat overage credit realizations")
+	require.ErrorContains(t, err, "fiat overage credit allocation already completed")
 }

--- a/openmeter/billing/charges/usagebased/service/run/invoice.go
+++ b/openmeter/billing/charges/usagebased/service/run/invoice.go
@@ -2,12 +2,17 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type BookAccruedInvoiceUsageInput struct {
@@ -143,4 +148,90 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 		Run:          in.Run,
 		InvoiceUsage: &accruedUsage,
 	}, nil
+}
+
+type CorrectAccruedUsageInput struct {
+	Charge usagebased.Charge
+	Run    usagebased.RealizationRun
+}
+
+func (i CorrectAccruedUsageInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, errors.New("settlement mode must be credit_then_invoice"))
+	}
+
+	if !i.Charge.Intent.GetCurrency().IsCustom() {
+		errs = append(errs, errors.New("charge currency must be custom"))
+	}
+
+	if i.Run.Immutable {
+		errs = append(errs, errors.New("cannot correct accrued usage for immutable run"))
+	}
+
+	if i.Run.InvoiceUsage == nil {
+		errs = append(errs, errors.New("run must have accrued usage"))
+	}
+
+	if i.Charge.State.CurrentRealizationRunID == nil {
+		errs = append(errs, errors.New("charge has no current realization run"))
+	} else if *i.Charge.State.CurrentRealizationRunID != i.Run.ID.ID {
+		errs = append(errs, fmt.Errorf(
+			"run is not the charge's current realization run [current_run_id=%s run_id=%s]",
+			*i.Charge.State.CurrentRealizationRunID,
+			i.Run.ID.ID,
+		))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// CorrectAccruedUsage reverses a mutable custom-currency run's prepared gross
+// overage and removes the transient preparation so the run can be prepared again.
+func (s *Service) CorrectAccruedUsage(ctx context.Context, input CorrectAccruedUsageInput) (usagebased.RealizationRun, error) {
+	if err := input.Validate(); err != nil {
+		return usagebased.RealizationRun{}, err
+	}
+
+	correctionInput := usagebased.OnCustomCurrencyOverageAccruedCorrectionInput{
+		Charge: input.Charge,
+		Run:    input.Run,
+	}
+	if err := correctionInput.Validate(); err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("validate custom-currency overage accrual correction: %w", err)
+	}
+	if err := s.handler.OnCustomCurrencyOverageAccruedCorrection(ctx, correctionInput); err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("correct custom-currency overage accrual: %w", err)
+	}
+
+	if err := s.adapter.DeleteRunInvoicedUsage(ctx, input.Run.InvoiceUsage.NamespacedID); err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("delete custom-currency overage preparation: %w", err)
+	}
+
+	input.Run.InvoiceUsage = nil
+
+	return input.Run, nil
+}
+
+func (s *Service) MarkInvoiceIssued(ctx context.Context, run usagebased.RealizationRun) (usagebased.RealizationRun, error) {
+	runBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        run.ID,
+		Immutable: mo.Some(true),
+	})
+	if err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("updating issued realization run: %w", err)
+	}
+
+	run.RealizationRunBase = runBase
+
+	return run, nil
 }

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -287,7 +287,8 @@ type LineEngine interface {
 	// Implementations may persist retry-safe engine-owned effects and must return fully calculated
 	// lines with exactly the same IDs as the input.
 	OnInvoiceFinalizing(ctx context.Context, input OnInvoiceFinalizingInput) (StandardLines, error)
-	// OnInvoiceIssued is invoked when a standard invoice reaches the issued state.
+	// OnInvoiceIssued is invoked after external invoice issuance succeeds, while
+	// billing books charge effects, and before entering the issued state.
 	OnInvoiceIssued(ctx context.Context, input OnInvoiceIssuedInput) error
 	// OnPaymentAuthorized is invoked when a standard invoice reaches the payment authorized state.
 	OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) error

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -766,6 +766,11 @@ func (s *Service) DeleteInvoice(ctx context.Context, input billing.DeleteInvoice
 			if input.DeletionSource != billing.ChangeSourceAPIRequest {
 				return nil
 			}
+			// Charge cleanup committed before invoice-app synchronization. A retry
+			// must not validate or dispatch those already-applied line deletions.
+			if sm.Invoice.DeletedAt != nil {
+				return nil
+			}
 
 			if err := s.validateAPIStandardLineDeletions(
 				ctx,

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -221,7 +221,9 @@ func allocateStateMachine() *InvoiceStateMachine {
 
 	stateMachine.Configure(billing.StandardInvoiceStatusDeleted)
 
-	// Issuing state
+	// Issuing state. Line finalization handlers can persist durable preparation
+	// before returning. Preparation failures remain retry-only, while invoice-app
+	// synchronization can be abandoned through the charge-owned correction path.
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalization).
 		Permit(
@@ -229,14 +231,12 @@ func allocateStateMachine() *InvoiceStateMachine {
 			billing.StandardInvoiceStatusIssuingSyncing,
 		).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingLineFinalizationFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(statelessx.AllOf(
 			out.onInvoiceFinalizing,
 			out.requireDBSave,
 		))
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingLineFinalizationFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingLineFinalization)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingSyncing).
@@ -245,7 +245,6 @@ func allocateStateMachine() *InvoiceStateMachine {
 			statelessx.BoolFn(out.canIssuingSyncAdvance),
 		).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingSyncFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(statelessx.AllOf(
 			out.finalizeInvoice,
 		))
@@ -257,11 +256,9 @@ func allocateStateMachine() *InvoiceStateMachine {
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBooking).
 		Permit(billing.TriggerNext, billing.StandardInvoiceStatusIssued).
 		Permit(billing.TriggerFailed, billing.StandardInvoiceStatusIssuingChargeBookingFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		OnActive(out.onInvoiceIssued)
 
 	stateMachine.Configure(billing.StandardInvoiceStatusIssuingChargeBookingFailed).
-		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerRetry, billing.StandardInvoiceStatusIssuingChargeBooking)
 
 	// Issued state

--- a/openmeter/ent/db/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun.go
@@ -66,6 +66,8 @@ type ChargeFlatFeeRun struct {
 	AmountAfterProration alpacadecimal.Decimal `json:"amount_after_proration,omitempty"`
 	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
+	// FiatOverageCreditAllocationCompleted holds the value of the "fiat_overage_credit_allocation_completed" field.
+	FiatOverageCreditAllocationCompleted bool `json:"fiat_overage_credit_allocation_completed,omitempty"`
 	// Immutable holds the value of the "immutable" field.
 	Immutable bool `json:"immutable,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -186,7 +188,7 @@ func (*ChargeFlatFeeRun) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeflatfeerun.FieldAmount, chargeflatfeerun.FieldTaxesTotal, chargeflatfeerun.FieldTaxesInclusiveTotal, chargeflatfeerun.FieldTaxesExclusiveTotal, chargeflatfeerun.FieldChargesTotal, chargeflatfeerun.FieldDiscountsTotal, chargeflatfeerun.FieldCreditsTotal, chargeflatfeerun.FieldTotal, chargeflatfeerun.FieldAmountAfterProration:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeflatfeerun.FieldNoFiatTransactionRequired, chargeflatfeerun.FieldImmutable:
+		case chargeflatfeerun.FieldNoFiatTransactionRequired, chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, chargeflatfeerun.FieldImmutable:
 			values[i] = new(sql.NullBool)
 		case chargeflatfeerun.FieldID, chargeflatfeerun.FieldNamespace, chargeflatfeerun.FieldChargeID, chargeflatfeerun.FieldType, chargeflatfeerun.FieldInitialType, chargeflatfeerun.FieldLineID, chargeflatfeerun.FieldInvoiceID:
 			values[i] = new(sql.NullString)
@@ -342,6 +344,12 @@ func (_m *ChargeFlatFeeRun) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.NoFiatTransactionRequired = value.Bool
 			}
+		case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field fiat_overage_credit_allocation_completed", values[i])
+			} else if value.Valid {
+				_m.FiatOverageCreditAllocationCompleted = value.Bool
+			}
 		case chargeflatfeerun.FieldImmutable:
 			if value, ok := values[i].(*sql.NullBool); !ok {
 				return fmt.Errorf("unexpected type %T for field immutable", values[i])
@@ -492,6 +500,9 @@ func (_m *ChargeFlatFeeRun) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("no_fiat_transaction_required=")
 	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
+	builder.WriteString(", ")
+	builder.WriteString("fiat_overage_credit_allocation_completed=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatOverageCreditAllocationCompleted))
 	builder.WriteString(", ")
 	builder.WriteString("immutable=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))

--- a/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
@@ -58,6 +58,8 @@ const (
 	FieldAmountAfterProration = "amount_after_proration"
 	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
+	// FieldFiatOverageCreditAllocationCompleted holds the string denoting the fiat_overage_credit_allocation_completed field in the database.
+	FieldFiatOverageCreditAllocationCompleted = "fiat_overage_credit_allocation_completed"
 	// FieldImmutable holds the string denoting the immutable field in the database.
 	FieldImmutable = "immutable"
 	// EdgeFlatFee holds the string denoting the flat_fee edge name in mutations.
@@ -160,6 +162,7 @@ var Columns = []string{
 	FieldInvoiceID,
 	FieldAmountAfterProration,
 	FieldNoFiatTransactionRequired,
+	FieldFiatOverageCreditAllocationCompleted,
 	FieldImmutable,
 }
 
@@ -186,6 +189,8 @@ var (
 	LineIDValidator func(string) error
 	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	InvoiceIDValidator func(string) error
+	// DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the "fiat_overage_credit_allocation_completed" field.
+	DefaultFiatOverageCreditAllocationCompleted bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -321,6 +326,11 @@ func ByAmountAfterProration(opts ...sql.OrderTermOption) OrderOption {
 // ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
 func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
+}
+
+// ByFiatOverageCreditAllocationCompleted orders the results by the fiat_overage_credit_allocation_completed field.
+func ByFiatOverageCreditAllocationCompleted(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatOverageCreditAllocationCompleted, opts...).ToFunc()
 }
 
 // ByImmutable orders the results by the immutable field.

--- a/openmeter/ent/db/chargeflatfeerun/where.go
+++ b/openmeter/ent/db/chargeflatfeerun/where.go
@@ -162,6 +162,11 @@ func NoFiatTransactionRequired(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
 }
 
+// FiatOverageCreditAllocationCompleted applies equality check predicate on the "fiat_overage_credit_allocation_completed" field. It's identical to FiatOverageCreditAllocationCompletedEQ.
+func FiatOverageCreditAllocationCompleted(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
 // Immutable applies equality check predicate on the "immutable" field. It's identical to ImmutableEQ.
 func Immutable(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldImmutable, v))
@@ -1085,6 +1090,16 @@ func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeFlatFeeRun {
 // NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
 func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// FiatOverageCreditAllocationCompletedEQ applies the EQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
+// FiatOverageCreditAllocationCompletedNEQ applies the NEQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedNEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldFiatOverageCreditAllocationCompleted, v))
 }
 
 // ImmutableEQ applies the EQ predicate on the "immutable" field.

--- a/openmeter/ent/db/chargeflatfeerun_create.go
+++ b/openmeter/ent/db/chargeflatfeerun_create.go
@@ -199,6 +199,20 @@ func (_c *ChargeFlatFeeRunCreate) SetNoFiatTransactionRequired(v bool) *ChargeFl
 	return _c
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_c *ChargeFlatFeeRunCreate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _c
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunCreate {
+	if v != nil {
+		_c.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _c
+}
+
 // SetImmutable sets the "immutable" field.
 func (_c *ChargeFlatFeeRunCreate) SetImmutable(v bool) *ChargeFlatFeeRunCreate {
 	_c.mutation.SetImmutable(v)
@@ -394,6 +408,10 @@ func (_c *ChargeFlatFeeRunCreate) defaults() {
 		v := chargeflatfeerun.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		v := chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted
+		_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeflatfeerun.DefaultID()
 		_c.mutation.SetID(v)
@@ -480,6 +498,9 @@ func (_c *ChargeFlatFeeRunCreate) check() error {
 	}
 	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
 		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeFlatFeeRun.no_fiat_transaction_required"`)}
+	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		return &ValidationError{Name: "fiat_overage_credit_allocation_completed", err: errors.New(`db: missing required field "ChargeFlatFeeRun.fiat_overage_credit_allocation_completed"`)}
 	}
 	if _, ok := _c.mutation.Immutable(); !ok {
 		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeFlatFeeRun.immutable"`)}
@@ -594,6 +615,10 @@ func (_c *ChargeFlatFeeRunCreate) createSpec() (*ChargeFlatFeeRun, *sqlgraph.Cre
 	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
 		_node.NoFiatTransactionRequired = value
+	}
+	if value, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
+		_node.FiatOverageCreditAllocationCompleted = value
 	}
 	if value, ok := _c.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)
@@ -1004,6 +1029,18 @@ func (u *ChargeFlatFeeRunUpsert) UpdateNoFiatTransactionRequired() *ChargeFlatFe
 	return u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsert) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsert {
+	u.Set(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, v)
+	return u
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsert) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsert {
+	u.SetExcluded(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted)
+	return u
+}
+
 // SetImmutable sets the "immutable" field.
 func (u *ChargeFlatFeeRunUpsert) SetImmutable(v bool) *ChargeFlatFeeRunUpsert {
 	u.Set(chargeflatfeerun.FieldImmutable, v)
@@ -1332,6 +1369,20 @@ func (u *ChargeFlatFeeRunUpsertOne) SetNoFiatTransactionRequired(v bool) *Charge
 func (u *ChargeFlatFeeRunUpsertOne) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsertOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertOne) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 
@@ -1832,6 +1883,20 @@ func (u *ChargeFlatFeeRunUpsertBulk) SetNoFiatTransactionRequired(v bool) *Charg
 func (u *ChargeFlatFeeRunUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateNoFiatTransactionRequired()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeFlatFeeRunUpsertBulk) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertBulk) UpdateFiatOverageCreditAllocationCompleted() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeerun_update.go
+++ b/openmeter/ent/db/chargeflatfeerun_update.go
@@ -285,6 +285,20 @@ func (_u *ChargeFlatFeeRunUpdate) SetNillableNoFiatTransactionRequired(v *bool) 
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeFlatFeeRunUpdate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunUpdate {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetImmutable sets the "immutable" field.
 func (_u *ChargeFlatFeeRunUpdate) SetImmutable(v bool) *ChargeFlatFeeRunUpdate {
 	_u.mutation.SetImmutable(v)
@@ -630,6 +644,9 @@ func (_u *ChargeFlatFeeRunUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)
@@ -1153,6 +1170,20 @@ func (_u *ChargeFlatFeeRunUpdateOne) SetNillableNoFiatTransactionRequired(v *boo
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeFlatFeeRunUpdateOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeFlatFeeRunUpdateOne {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetImmutable sets the "immutable" field.
 func (_u *ChargeFlatFeeRunUpdateOne) SetImmutable(v bool) *ChargeFlatFeeRunUpdateOne {
 	_u.mutation.SetImmutable(v)
@@ -1528,6 +1559,9 @@ func (_u *ChargeFlatFeeRunUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 	}
 	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
 		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeflatfeerun.FieldImmutable, field.TypeBool, value)

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -79,6 +79,8 @@ type ChargeUsageBasedRuns struct {
 	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
 	// Immutable holds the value of the "immutable" field.
 	Immutable bool `json:"immutable,omitempty"`
+	// FiatOverageCreditAllocationCompleted holds the value of the "fiat_overage_credit_allocation_completed" field.
+	FiatOverageCreditAllocationCompleted bool `json:"fiat_overage_credit_allocation_completed,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunsQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunsEdges `json:"edges"`
@@ -245,7 +247,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable, chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldSchemaLevel:
 			values[i] = new(sql.NullInt64)
@@ -440,6 +442,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.Immutable = value.Bool
 			}
+		case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field fiat_overage_credit_allocation_completed", values[i])
+			} else if value.Valid {
+				_m.FiatOverageCreditAllocationCompleted = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -624,6 +632,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("immutable=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Immutable))
+	builder.WriteString(", ")
+	builder.WriteString("fiat_overage_credit_allocation_completed=")
+	builder.WriteString(fmt.Sprintf("%v", _m.FiatOverageCreditAllocationCompleted))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -70,6 +70,8 @@ const (
 	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
 	// FieldImmutable holds the string denoting the immutable field in the database.
 	FieldImmutable = "immutable"
+	// FieldFiatOverageCreditAllocationCompleted holds the string denoting the fiat_overage_credit_allocation_completed field in the database.
+	FieldFiatOverageCreditAllocationCompleted = "fiat_overage_credit_allocation_completed"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeFeature holds the string denoting the feature edge name in mutations.
@@ -206,6 +208,7 @@ var Columns = []string{
 	FieldMeteredQuantity,
 	FieldNoFiatTransactionRequired,
 	FieldImmutable,
+	FieldFiatOverageCreditAllocationCompleted,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -239,6 +242,8 @@ var (
 	InvoiceIDValidator func(string) error
 	// DefaultImmutable holds the default value on creation for the "immutable" field.
 	DefaultImmutable bool
+	// DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the "fiat_overage_credit_allocation_completed" field.
+	DefaultFiatOverageCreditAllocationCompleted bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -404,6 +409,11 @@ func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
 // ByImmutable orders the results by the immutable field.
 func ByImmutable(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldImmutable, opts...).ToFunc()
+}
+
+// ByFiatOverageCreditAllocationCompleted orders the results by the fiat_overage_credit_allocation_completed field.
+func ByFiatOverageCreditAllocationCompleted(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFiatOverageCreditAllocationCompleted, opts...).ToFunc()
 }
 
 // ByUsageBasedField orders the results by usage_based field.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -192,6 +192,11 @@ func Immutable(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldImmutable, v))
 }
 
+// FiatOverageCreditAllocationCompleted applies equality check predicate on the "fiat_overage_credit_allocation_completed" field. It's identical to FiatOverageCreditAllocationCompletedEQ.
+func FiatOverageCreditAllocationCompleted(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNamespace, v))
@@ -1320,6 +1325,16 @@ func ImmutableEQ(v bool) predicate.ChargeUsageBasedRuns {
 // ImmutableNEQ applies the NEQ predicate on the "immutable" field.
 func ImmutableNEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldImmutable, v))
+}
+
+// FiatOverageCreditAllocationCompletedEQ applies the EQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldFiatOverageCreditAllocationCompleted, v))
+}
+
+// FiatOverageCreditAllocationCompletedNEQ applies the NEQ predicate on the "fiat_overage_credit_allocation_completed" field.
+func FiatOverageCreditAllocationCompletedNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldFiatOverageCreditAllocationCompleted, v))
 }
 
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -268,6 +268,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetNillableImmutable(v *bool) *ChargeUsage
 	return _c
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_c *ChargeUsageBasedRunsCreate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _c
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetID(v)
@@ -509,6 +523,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultImmutable
 		_c.mutation.SetImmutable(v)
 	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		v := chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted
+		_c.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := chargeusagebasedruns.DefaultID()
 		_c.mutation.SetID(v)
@@ -615,6 +633,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.Immutable(); !ok {
 		return &ValidationError{Name: "immutable", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.immutable"`)}
+	}
+	if _, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); !ok {
+		return &ValidationError{Name: "fiat_overage_credit_allocation_completed", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.fiat_overage_credit_allocation_completed"`)}
 	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedRuns.usage_based"`)}
@@ -745,6 +766,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
 		_node.Immutable = value
+	}
+	if value, ok := _c.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
+		_node.FiatOverageCreditAllocationCompleted = value
 	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1241,6 +1266,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateImmutable() *ChargeUsageBasedRunsUpse
 	return u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsert) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, v)
+	return u
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1597,6 +1634,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetImmutable(v bool) *ChargeUsageBasedRu
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateImmutable() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateImmutable()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 
@@ -2123,6 +2174,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetImmutable(v bool) *ChargeUsageBasedR
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateImmutable() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateImmutable()
+	})
+}
+
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetFiatOverageCreditAllocationCompleted(v)
+	})
+}
+
+// UpdateFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateFiatOverageCreditAllocationCompleted() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateFiatOverageCreditAllocationCompleted()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -313,6 +313,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableImmutable(v *bool) *ChargeUsage
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -701,6 +715,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1311,6 +1328,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableImmutable(v *bool) *ChargeUs
 	return _u
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetFiatOverageCreditAllocationCompleted(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetFiatOverageCreditAllocationCompleted(v)
+	return _u
+}
+
+// SetNillableFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableFiatOverageCreditAllocationCompleted(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetFiatOverageCreditAllocationCompleted(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -1729,6 +1760,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.Immutable(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldImmutable, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FiatOverageCreditAllocationCompleted(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted, field.TypeBool, value)
 	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2480,6 +2480,7 @@ var (
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "amount_after_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
+		{Name: "fiat_overage_credit_allocation_completed", Type: field.TypeBool, Default: false},
 		{Name: "immutable", Type: field.TypeBool},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2493,19 +2494,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_flat_fee_runs_billing_invoices_charge_flat_fee_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[20]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[21]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fee_runs_billing_invoice_lines_charge_flat_fee_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[21]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[22]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fee_runs_charge_flat_fees_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[23]},
 				RefColumns: []*schema.Column{ChargeFlatFeesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -2524,7 +2525,7 @@ var (
 			{
 				Name:    "chargeflatfeerun_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[22]},
+				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[23]},
 			},
 		},
 	}
@@ -3520,6 +3521,7 @@ var (
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
 		{Name: "immutable", Type: field.TypeBool, Default: false},
+		{Name: "fiat_overage_credit_allocation_completed", Type: field.TypeBool, Default: false},
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -3534,31 +3536,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[26]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_ub_run_prior_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[26]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[27]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[27]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[28]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3577,7 +3579,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[25]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[26]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -54266,51 +54266,52 @@ func (m *ChargeFlatFeeOverrideMutation) ResetEdge(name string) error {
 // ChargeFlatFeeRunMutation represents an operation that mutates the ChargeFlatFeeRun nodes in the graph.
 type ChargeFlatFeeRunMutation struct {
 	config
-	op                                     Op
-	typ                                    string
-	id                                     *string
-	namespace                              *string
-	created_at                             *time.Time
-	updated_at                             *time.Time
-	deleted_at                             *time.Time
-	amount                                 *alpacadecimal.Decimal
-	taxes_total                            *alpacadecimal.Decimal
-	taxes_inclusive_total                  *alpacadecimal.Decimal
-	taxes_exclusive_total                  *alpacadecimal.Decimal
-	charges_total                          *alpacadecimal.Decimal
-	discounts_total                        *alpacadecimal.Decimal
-	credits_total                          *alpacadecimal.Decimal
-	total                                  *alpacadecimal.Decimal
-	_type                                  *flatfee.RealizationRunType
-	initial_type                           *flatfee.RealizationRunType
-	service_period_from                    *time.Time
-	service_period_to                      *time.Time
-	amount_after_proration                 *alpacadecimal.Decimal
-	no_fiat_transaction_required           *bool
-	immutable                              *bool
-	clearedFields                          map[string]struct{}
-	flat_fee                               *string
-	clearedflat_fee                        bool
-	billing_invoice_line                   *string
-	clearedbilling_invoice_line            bool
-	billing_invoice                        *string
-	clearedbilling_invoice                 bool
-	credit_allocations                     map[string]struct{}
-	removedcredit_allocations              map[string]struct{}
-	clearedcredit_allocations              bool
-	fiat_overage_credit_allocations        map[string]struct{}
-	removedfiat_overage_credit_allocations map[string]struct{}
-	clearedfiat_overage_credit_allocations bool
-	detailed_lines                         map[string]struct{}
-	removeddetailed_lines                  map[string]struct{}
-	cleareddetailed_lines                  bool
-	invoiced_usage                         *string
-	clearedinvoiced_usage                  bool
-	payment                                *string
-	clearedpayment                         bool
-	done                                   bool
-	oldValue                               func(context.Context) (*ChargeFlatFeeRun, error)
-	predicates                             []predicate.ChargeFlatFeeRun
+	op                                       Op
+	typ                                      string
+	id                                       *string
+	namespace                                *string
+	created_at                               *time.Time
+	updated_at                               *time.Time
+	deleted_at                               *time.Time
+	amount                                   *alpacadecimal.Decimal
+	taxes_total                              *alpacadecimal.Decimal
+	taxes_inclusive_total                    *alpacadecimal.Decimal
+	taxes_exclusive_total                    *alpacadecimal.Decimal
+	charges_total                            *alpacadecimal.Decimal
+	discounts_total                          *alpacadecimal.Decimal
+	credits_total                            *alpacadecimal.Decimal
+	total                                    *alpacadecimal.Decimal
+	_type                                    *flatfee.RealizationRunType
+	initial_type                             *flatfee.RealizationRunType
+	service_period_from                      *time.Time
+	service_period_to                        *time.Time
+	amount_after_proration                   *alpacadecimal.Decimal
+	no_fiat_transaction_required             *bool
+	fiat_overage_credit_allocation_completed *bool
+	immutable                                *bool
+	clearedFields                            map[string]struct{}
+	flat_fee                                 *string
+	clearedflat_fee                          bool
+	billing_invoice_line                     *string
+	clearedbilling_invoice_line              bool
+	billing_invoice                          *string
+	clearedbilling_invoice                   bool
+	credit_allocations                       map[string]struct{}
+	removedcredit_allocations                map[string]struct{}
+	clearedcredit_allocations                bool
+	fiat_overage_credit_allocations          map[string]struct{}
+	removedfiat_overage_credit_allocations   map[string]struct{}
+	clearedfiat_overage_credit_allocations   bool
+	detailed_lines                           map[string]struct{}
+	removeddetailed_lines                    map[string]struct{}
+	cleareddetailed_lines                    bool
+	invoiced_usage                           *string
+	clearedinvoiced_usage                    bool
+	payment                                  *string
+	clearedpayment                           bool
+	done                                     bool
+	oldValue                                 func(context.Context) (*ChargeFlatFeeRun, error)
+	predicates                               []predicate.ChargeFlatFeeRun
 }
 
 var _ ent.Mutation = (*ChargeFlatFeeRunMutation)(nil)
@@ -55212,6 +55213,42 @@ func (m *ChargeFlatFeeRunMutation) ResetNoFiatTransactionRequired() {
 	m.no_fiat_transaction_required = nil
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeFlatFeeRunMutation) SetFiatOverageCreditAllocationCompleted(b bool) {
+	m.fiat_overage_credit_allocation_completed = &b
+}
+
+// FiatOverageCreditAllocationCompleted returns the value of the "fiat_overage_credit_allocation_completed" field in the mutation.
+func (m *ChargeFlatFeeRunMutation) FiatOverageCreditAllocationCompleted() (r bool, exists bool) {
+	v := m.fiat_overage_credit_allocation_completed
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFiatOverageCreditAllocationCompleted returns the old "fiat_overage_credit_allocation_completed" field's value of the ChargeFlatFeeRun entity.
+// If the ChargeFlatFeeRun object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeRunMutation) OldFiatOverageCreditAllocationCompleted(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFiatOverageCreditAllocationCompleted: %w", err)
+	}
+	return oldValue.FiatOverageCreditAllocationCompleted, nil
+}
+
+// ResetFiatOverageCreditAllocationCompleted resets all changes to the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeFlatFeeRunMutation) ResetFiatOverageCreditAllocationCompleted() {
+	m.fiat_overage_credit_allocation_completed = nil
+}
+
 // SetImmutable sets the "immutable" field.
 func (m *ChargeFlatFeeRunMutation) SetImmutable(b bool) {
 	m.immutable = &b
@@ -55642,7 +55679,7 @@ func (m *ChargeFlatFeeRunMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeRunMutation) Fields() []string {
-	fields := make([]string, 0, 22)
+	fields := make([]string, 0, 23)
 	if m.namespace != nil {
 		fields = append(fields, chargeflatfeerun.FieldNamespace)
 	}
@@ -55706,6 +55743,9 @@ func (m *ChargeFlatFeeRunMutation) Fields() []string {
 	if m.no_fiat_transaction_required != nil {
 		fields = append(fields, chargeflatfeerun.FieldNoFiatTransactionRequired)
 	}
+	if m.fiat_overage_credit_allocation_completed != nil {
+		fields = append(fields, chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted)
+	}
 	if m.immutable != nil {
 		fields = append(fields, chargeflatfeerun.FieldImmutable)
 	}
@@ -55759,6 +55799,8 @@ func (m *ChargeFlatFeeRunMutation) Field(name string) (ent.Value, bool) {
 		return m.AmountAfterProration()
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		return m.NoFiatTransactionRequired()
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		return m.FiatOverageCreditAllocationCompleted()
 	case chargeflatfeerun.FieldImmutable:
 		return m.Immutable()
 	}
@@ -55812,6 +55854,8 @@ func (m *ChargeFlatFeeRunMutation) OldField(ctx context.Context, name string) (e
 		return m.OldAmountAfterProration(ctx)
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		return m.OldNoFiatTransactionRequired(ctx)
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		return m.OldFiatOverageCreditAllocationCompleted(ctx)
 	case chargeflatfeerun.FieldImmutable:
 		return m.OldImmutable(ctx)
 	}
@@ -55970,6 +56014,13 @@ func (m *ChargeFlatFeeRunMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetNoFiatTransactionRequired(v)
 		return nil
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFiatOverageCreditAllocationCompleted(v)
+		return nil
 	case chargeflatfeerun.FieldImmutable:
 		v, ok := value.(bool)
 		if !ok {
@@ -56109,6 +56160,9 @@ func (m *ChargeFlatFeeRunMutation) ResetField(name string) error {
 		return nil
 	case chargeflatfeerun.FieldNoFiatTransactionRequired:
 		m.ResetNoFiatTransactionRequired()
+		return nil
+	case chargeflatfeerun.FieldFiatOverageCreditAllocationCompleted:
+		m.ResetFiatOverageCreditAllocationCompleted()
 		return nil
 	case chargeflatfeerun.FieldImmutable:
 		m.ResetImmutable()
@@ -77907,6 +77961,7 @@ type ChargeUsageBasedRunsMutation struct {
 	metered_quantity                          *alpacadecimal.Decimal
 	no_fiat_transaction_required              *bool
 	immutable                                 *bool
+	fiat_overage_credit_allocation_completed  *bool
 	clearedFields                             map[string]struct{}
 	usage_based                               *string
 	clearedusage_based                        bool
@@ -79090,6 +79145,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetImmutable() {
 	m.immutable = nil
 }
 
+// SetFiatOverageCreditAllocationCompleted sets the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeUsageBasedRunsMutation) SetFiatOverageCreditAllocationCompleted(b bool) {
+	m.fiat_overage_credit_allocation_completed = &b
+}
+
+// FiatOverageCreditAllocationCompleted returns the value of the "fiat_overage_credit_allocation_completed" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) FiatOverageCreditAllocationCompleted() (r bool, exists bool) {
+	v := m.fiat_overage_credit_allocation_completed
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFiatOverageCreditAllocationCompleted returns the old "fiat_overage_credit_allocation_completed" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldFiatOverageCreditAllocationCompleted(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFiatOverageCreditAllocationCompleted requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFiatOverageCreditAllocationCompleted: %w", err)
+	}
+	return oldValue.FiatOverageCreditAllocationCompleted, nil
+}
+
+// ResetFiatOverageCreditAllocationCompleted resets all changes to the "fiat_overage_credit_allocation_completed" field.
+func (m *ChargeUsageBasedRunsMutation) ResetFiatOverageCreditAllocationCompleted() {
+	m.fiat_overage_credit_allocation_completed = nil
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -79646,7 +79737,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 27)
+	fields := make([]string, 0, 28)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -79728,6 +79819,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.immutable != nil {
 		fields = append(fields, chargeusagebasedruns.FieldImmutable)
 	}
+	if m.fiat_overage_credit_allocation_completed != nil {
+		fields = append(fields, chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted)
+	}
 	return fields
 }
 
@@ -79790,6 +79884,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.NoFiatTransactionRequired()
 	case chargeusagebasedruns.FieldImmutable:
 		return m.Immutable()
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		return m.FiatOverageCreditAllocationCompleted()
 	}
 	return nil, false
 }
@@ -79853,6 +79949,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldNoFiatTransactionRequired(ctx)
 	case chargeusagebasedruns.FieldImmutable:
 		return m.OldImmutable(ctx)
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		return m.OldFiatOverageCreditAllocationCompleted(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -80051,6 +80149,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetImmutable(v)
 		return nil
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFiatOverageCreditAllocationCompleted(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -80222,6 +80327,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldImmutable:
 		m.ResetImmutable()
+		return nil
+	case chargeusagebasedruns.FieldFiatOverageCreditAllocationCompleted:
+		m.ResetFiatOverageCreditAllocationCompleted()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1354,6 +1354,10 @@ func init() {
 	chargeflatfeerunDescInvoiceID := chargeflatfeerunFields[6].Descriptor()
 	// chargeflatfeerun.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeflatfeerun.InvoiceIDValidator = chargeflatfeerunDescInvoiceID.Validators[0].(func(string) error)
+	// chargeflatfeerunDescFiatOverageCreditAllocationCompleted is the schema descriptor for fiat_overage_credit_allocation_completed field.
+	chargeflatfeerunDescFiatOverageCreditAllocationCompleted := chargeflatfeerunFields[9].Descriptor()
+	// chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the fiat_overage_credit_allocation_completed field.
+	chargeflatfeerun.DefaultFiatOverageCreditAllocationCompleted = chargeflatfeerunDescFiatOverageCreditAllocationCompleted.Default.(bool)
 	// chargeflatfeerunDescID is the schema descriptor for id field.
 	chargeflatfeerunDescID := chargeflatfeerunMixinFields1[0].Descriptor()
 	// chargeflatfeerun.DefaultID holds the default value on creation for the id field.
@@ -1849,6 +1853,10 @@ func init() {
 	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[14].Descriptor()
 	// chargeusagebasedruns.DefaultImmutable holds the default value on creation for the immutable field.
 	chargeusagebasedruns.DefaultImmutable = chargeusagebasedrunsDescImmutable.Default.(bool)
+	// chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted is the schema descriptor for fiat_overage_credit_allocation_completed field.
+	chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted := chargeusagebasedrunsFields[15].Descriptor()
+	// chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted holds the default value on creation for the fiat_overage_credit_allocation_completed field.
+	chargeusagebasedruns.DefaultFiatOverageCreditAllocationCompleted = chargeusagebasedrunsDescFiatOverageCreditAllocationCompleted.Default.(bool)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.
 	chargeusagebasedrunsDescID := chargeusagebasedrunsMixinFields1[0].Descriptor()
 	// chargeusagebasedruns.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -371,6 +371,9 @@ func (ChargeFlatFeeRun) Fields() []ent.Field {
 
 		field.Bool("no_fiat_transaction_required"),
 
+		field.Bool("fiat_overage_credit_allocation_completed").
+			Default(false),
+
 		field.Bool("immutable"),
 	}
 }

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -405,6 +405,9 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 
 		field.Bool("immutable").
 			Default(false),
+
+		field.Bool("fiat_overage_credit_allocation_completed").
+			Default(false),
 	}
 }
 

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -165,6 +165,14 @@ func (h *flatFeeHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, inp
 	return flatfee.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *flatFeeHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input flatfee.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *flatFeeHandler) OnAllocateFiatOverageCredits(ctx context.Context, input flatfee.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -179,6 +179,14 @@ func (h *usageBasedHandler) OnCustomCurrencyOverageAccrued(ctx context.Context, 
 	return usagebased.OnCustomCurrencyOverageAccruedResult{}, fmt.Errorf("implement OnCustomCurrencyOverageAccrued: %w", meta.ErrCustomCurrencyNotSupported)
 }
 
+func (h *usageBasedHandler) OnCustomCurrencyOverageAccruedCorrection(ctx context.Context, input usagebased.OnCustomCurrencyOverageAccruedCorrectionInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("implement OnCustomCurrencyOverageAccruedCorrection: %w", meta.ErrCustomCurrencyNotSupported)
+}
+
 func (h *usageBasedHandler) OnAllocateFiatOverageCredits(ctx context.Context, input usagebased.AllocateFiatOverageCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err

--- a/tools/migrate/migrations/20260827103408_add_charge_overage_preparation_state.down.sql
+++ b/tools/migrate/migrations/20260827103408_add_charge_overage_preparation_state.down.sql
@@ -1,0 +1,4 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "fiat_overage_credit_allocation_completed";
+-- reverse: modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" DROP COLUMN "fiat_overage_credit_allocation_completed";

--- a/tools/migrate/migrations/20260827103408_add_charge_overage_preparation_state.up.sql
+++ b/tools/migrate/migrations/20260827103408_add_charge_overage_preparation_state.up.sql
@@ -1,0 +1,4 @@
+-- modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" ADD COLUMN "fiat_overage_credit_allocation_completed" boolean NOT NULL DEFAULT false;
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "fiat_overage_credit_allocation_completed" boolean NOT NULL DEFAULT false;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Seuv0C/YTYzCTePS9krruO9WAuqxJ2e4CcH8ZVEDaDY=
+h1:NJkByX7l8bxNbBh1hdcAAvD27fowunB8rdRv/wsInQs=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -274,3 +274,4 @@ h1:Seuv0C/YTYzCTePS9krruO9WAuqxJ2e4CcH8ZVEDaDY=
 20260826113408_backfill_usage_based_run_immutable.up.sql h1:D0b69QdV15gKaqoQ5PEKvw60rtNWEHMk1Iv/rign4kI=
 20260826120555_backfill_usage_based_run_prior_lineage.up.sql h1:6WJ8jhOtRTCNDa01cCTuyiq777slyDS+PgydKK40dfQ=
 20260826131456_usage_based_run_schema_level_2_only.up.sql h1:t6pW+zlYNcF/nR4hdXHoLsEKxyDledrehUaVxXNxshM=
+20260827103408_add_charge_overage_preparation_state.up.sql h1:BmCUpvxwwWOPo4OhPJoB32kELVamexLpaOlGQqbvRPc=


### PR DESCRIPTION
## Overview

Align flat-fee and usage-based credit-then-invoice charges around the same invoice lifecycle boundaries.

Invoice finalization now drives charge preparation through the charge state machine and returns explicit invoice line patches. Invoice issuance remains a distinct charge transition: it validates the issued line, records regular-fiat accrued usage, and marks the realization run immutable only after external invoice synchronization has completed.

## Behavioral changes

- Custom-currency finalization persists the gross converted overage, allocates settlement-fiat credits once, and patches the invoice line with the resulting collectible total.
- Regular-fiat accrued usage moves to invoice issuance, matching the point where the invoice has been sent to the customer.
- Issuance receives the standard line together with its invoice header, validates the persisted line and invoice references, and then marks the run immutable.
- Finalization no longer mutates billing-owned standard-line pointers. Charge handlers return zero or one update patch targeting the input line, and billing applies the returned line.
- Mutable custom-currency preparation is reversible. Correction unwinds settlement-fiat allocations, the prepared gross overage, and charge-currency allocations in accounting order.
- Successful reversal deletes the transient accrued-usage preparation instead of retaining a void marker. It resets only the fiat-allocation completion marker; the rating-owned no-fiat-transaction decision is preserved.
- Reversal itself keeps the realization run attached and reusable. Actual charge or invoice-line deletion still owns any subsequent run deletion or detachment.
- Issued immutable runs retain accrued usage and are not reversed when their charge is deleted.
- Flat-fee and usage-based line deletion defer lifecycle decisions to their charge state machines rather than rejecting invoice states that are safe to reconcile.

The schema change is represented by one migration adding the fiat-overage allocation-completion marker to both realization-run types. No accrued-usage void column is introduced.

## Notes for reviewer

The key boundary is intentional: invoice finalization may create reversible preparation, while invoice issuance is the point that makes the run immutable. The ledger remains the audit history for reversed preparation; the transient accrued-usage row represents only currently active preparation.

There is no linked Jira issue.

## Verification

- PostgreSQL-backed flat-fee and usage-based charge lifecycle suites
- Atlas schema diff, migration lint, and migration validation through direnv
- Fast configured Go lint: 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice lines are finalized before external issuance, with preparation and issuance handled separately.
  * Custom-currency overage calculations and settlement credits are prepared reliably and tracked for completion.
  * Invoice and charge-line deletion supports safer cleanup, correction, and retry handling.

* **Bug Fixes**
  * Invoice retries reuse persisted amounts instead of recalculating them.
  * Failed synchronization cleanup can be retried without duplicating accounting effects.
  * Draft custom-currency invoice lines can be deleted when valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates reversible invoice-line preparation from post-synchronization issuance for flat-fee and usage-based charges.
- Moves custom-currency overage preparation and settlement-credit allocation into invoice finalization.
- Accrues regular-fiat usage and seals realization runs only after invoice issuance.
- Adds reversible cleanup for prepared accounting state and explicit invoice-line patches.
- Adds a persisted completion marker for settlement-fiat overage allocation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/flatfee/service/creditheninvoice.go | Separates reversible finalization preparation from issuance-time accrual and immutability, while routing cleanup through the charge state machine. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Aligns usage-based charge preparation, invoice patches, issuance, and realization-run lifecycle boundaries. |
| openmeter/billing/charges/flatfee/service/realizations/credits.go | Adds ordered correction of settlement-fiat allocations, prepared gross overage, and charge-currency allocations. |
| openmeter/billing/charges/usagebased/service/run/credits.go | Implements persisted allocation completion and reversible custom-currency preparation for usage-based runs. |
| openmeter/billing/service/stdinvoicestate.go | Applies finalized line-engine output before external synchronization and dispatches issuance callbacks afterward. |
| tools/migrate/migrations/20260827103408_add_charge_overage_preparation_state.up.sql | Adds a non-null, false-defaulted allocation-completion marker to both realization-run tables. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Billing
    participant C as Charge state machine
    participant L as Ledger and realizations
    participant X as External invoicing app
    B->>C: Invoice finalizing
    C->>L: Prepare custom-currency gross overage
    C->>L: Allocate settlement-fiat credits
    C-->>B: Updated invoice-line patch
    B->>X: Synchronize and issue invoice
    X-->>B: Issued
    B->>C: Invoice issued
    C->>L: Accrue regular-fiat usage when applicable
    C->>L: Mark realization run immutable
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(charges): handle usage line deletion..."](https://github.com/openmeterio/openmeter/commit/0ba3d6ffdd6922beb8d6939458b548ba30c6c4eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56663063)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)
- Knowledge Base — [Credit and ledger accounting](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-and-ledger-accounting.md)
</details>


<!-- /greptile_comment -->