### PR TITLE
feat(charges): persist usage run lineage

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -236,11 +236,11 @@ one.
   nominal period. Its service period therefore describes the nominal checkpoint
   covered by the run, not strict provenance for every event included in its
   metered quantity.
-- Usage-based run metered quantity is cumulative from charge start to the run
+- A usage-based run's metered quantity is cumulative from charge start to the run
   boundary. A billing standard line expects line-period and pre-line-period
   quantities, so charge mappers translate rather than copy it. Translation
-  requires known run lineage and reads the referenced run's persisted quantity;
-  it does not infer a predecessor from run timestamps.
+  for schema-level-2 runs reads the referenced run's persisted quantity;
+  schema-level-1 runs retain the ordering-based fallback until backfill.
 - Corrections reconcile against persisted allocations in the same realization
   run and monetary domain, preserving lineage to the facts previously billed
   or posted.

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -222,13 +222,25 @@ one.
   `ServicePeriod.To`. Full-service, billing-period, and invoice timing reconcile
   to their target values independently; charge-type lifecycles use the service
   direction when deciding how to preserve or replace realizations.
-- A usage-based realization run is a persisted checkpoint. `ServicePeriodTo`
-  is the exclusive event-time bound; `StoredAtLT` is the exclusive ingestion
-  bound. Waiting and correction logic uses the persisted bounds rather than
-  recomputing them.
+- A usage-based realization run is a persisted checkpoint. Its nominal service
+  period starts at the preceding non-voided run's persisted `ServicePeriodTo`,
+  or at the effective intent's service-period start for the first run. The
+  persisted `PriorRunID` records which case applies. Schema-level-2 runs always
+  carry known lineage: a null prior identifies the first run, while an ID names
+  its predecessor. Schema-level-1 runs predate that lineage and retain the
+  ordering-based fallback until backfill. The run's own `ServicePeriodTo` is the
+  exclusive event-time bound; `StoredAtLT` is the exclusive ingestion bound.
+  Waiting and correction logic uses persisted run boundaries and lineage; only
+  a known first run takes its start from the effective intent.
+- A run can include late-arriving events whose event time belongs to an earlier
+  nominal period. Its service period therefore describes the nominal checkpoint
+  covered by the run, not strict provenance for every event included in its
+  metered quantity.
 - Usage-based run metered quantity is cumulative from charge start to the run
   boundary. A billing standard line expects line-period and pre-line-period
-  quantities, so charge mappers translate rather than copy it.
+  quantities, so charge mappers translate rather than copy it. Translation
+  requires known run lineage and reads the referenced run's persisted quantity;
+  it does not infer a predecessor from run timestamps.
 - Corrections reconcile against persisted allocations in the same realization
   run and monetary domain, preserving lineage to the facts previously billed
   or posted.

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -41,10 +41,34 @@ type ChargeAdapter interface {
 }
 
 type RealizationRunAdapter interface {
-	CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input CreateRealizationRunInput) (RealizationRunBase, error)
+	CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input CreateRealizationRunAdapterInput) (RealizationRunBase, error)
 	UpdateRealizationRun(ctx context.Context, input UpdateRealizationRunInput) (RealizationRunBase, error)
 	UpsertRunDetailedLines(ctx context.Context, input UpsertRunDetailedLinesInput) error
 	FetchDetailedLines(ctx context.Context, charge Charge) (Charge, error)
+}
+
+type CreateRealizationRunAdapterInput struct {
+	CreateRealizationRunInput
+
+	PriorRunID *RealizationRunID
+}
+
+var _ models.Validator = (*CreateRealizationRunAdapterInput)(nil)
+
+func (i CreateRealizationRunAdapterInput) Validate() error {
+	var errs []error
+
+	if err := i.CreateRealizationRunInput.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if i.PriorRunID != nil {
+		if err := i.PriorRunID.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("prior run id: %w", err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type RealizationRunCreditAllocationAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -136,26 +136,30 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 	s.Require().Equal(usagebased.RatingEngineDelta, createdCharges[0].State.RatingEngine)
 
 	charge := createdCharges[0]
-	correctedRunBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       "feature-1",
-		Type:            usagebased.RealizationRunTypePartialInvoice,
-		StoredAtLT:      servicePeriod.From,
-		ServicePeriodTo: servicePeriod.From,
-		MeteredQuantity: alpacadecimal.NewFromInt(0),
-		Totals:          totals.Totals{},
+	correctedRunBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       "feature-1",
+			Type:            usagebased.RealizationRunTypePartialInvoice,
+			StoredAtLT:      servicePeriod.From,
+			ServicePeriodTo: servicePeriod.From,
+			MeteredQuantity: alpacadecimal.NewFromInt(0),
+			Totals:          totals.Totals{},
+		},
 	})
 	s.Require().NoError(err)
 
-	runBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       "feature-1",
-		Type:            usagebased.RealizationRunTypeFinalRealization,
-		StoredAtLT:      servicePeriod.To,
-		ServicePeriodTo: servicePeriod.To,
-		MeteredQuantity: alpacadecimal.NewFromInt(10),
-		Totals: totals.Totals{
-			Amount:       alpacadecimal.NewFromInt(1),
-			ChargesTotal: alpacadecimal.NewFromInt(1),
-			Total:        alpacadecimal.NewFromInt(1),
+	runBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       "feature-1",
+			Type:            usagebased.RealizationRunTypeFinalRealization,
+			StoredAtLT:      servicePeriod.To,
+			ServicePeriodTo: servicePeriod.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(10),
+			Totals: totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(1),
+				ChargesTotal: alpacadecimal.NewFromInt(1),
+				Total:        alpacadecimal.NewFromInt(1),
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -482,13 +486,15 @@ func (s *DetailedLineAdapterSuite) TestExpandRealizationsExcludesDeletedRuns() {
 	namespace := "usagebased-realizations-exclude-deleted-runs"
 	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
 
-	deletedRunBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       runBase.FeatureID,
-		Type:            usagebased.RealizationRunTypePartialInvoice,
-		StoredAtLT:      servicePeriod.From,
-		ServicePeriodTo: servicePeriod.From,
-		MeteredQuantity: alpacadecimal.Zero,
-		Totals:          totals.Totals{},
+	deletedRunBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       runBase.FeatureID,
+			Type:            usagebased.RealizationRunTypePartialInvoice,
+			StoredAtLT:      servicePeriod.From,
+			ServicePeriodTo: servicePeriod.From,
+			MeteredQuantity: alpacadecimal.Zero,
+			Totals:          totals.Totals{},
+		},
 	})
 	s.Require().NoError(err)
 
@@ -511,13 +517,15 @@ func (s *DetailedLineAdapterSuite) TestRealizationRunImmutableFlag() {
 	ctx := s.T().Context()
 	charge, _, servicePeriod := s.createChargeWithRun("usagebased-run-immutable")
 
-	createdRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       charge.State.FeatureID,
-		Type:            usagebased.RealizationRunTypePartialInvoice,
-		StoredAtLT:      servicePeriod.To,
-		ServicePeriodTo: servicePeriod.To,
-		MeteredQuantity: alpacadecimal.Zero,
-		Totals:          totals.Totals{},
+	createdRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       charge.State.FeatureID,
+			Type:            usagebased.RealizationRunTypePartialInvoice,
+			StoredAtLT:      servicePeriod.To,
+			ServicePeriodTo: servicePeriod.To,
+			MeteredQuantity: alpacadecimal.Zero,
+			Totals:          totals.Totals{},
+		},
 	})
 	s.Require().NoError(err)
 	s.False(createdRun.Immutable)
@@ -593,16 +601,18 @@ func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usageb
 	s.Require().Equal(usagebased.RatingEngineDelta, createdCharges[0].State.RatingEngine)
 
 	charge := createdCharges[0]
-	runBase, err := s.adapter.CreateRealizationRun(s.T().Context(), charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       featureID,
-		Type:            usagebased.RealizationRunTypeFinalRealization,
-		StoredAtLT:      servicePeriod.To,
-		ServicePeriodTo: servicePeriod.To,
-		MeteredQuantity: alpacadecimal.NewFromInt(10),
-		Totals: totals.Totals{
-			Amount:       alpacadecimal.NewFromInt(1),
-			ChargesTotal: alpacadecimal.NewFromInt(1),
-			Total:        alpacadecimal.NewFromInt(1),
+	runBase, err := s.adapter.CreateRealizationRun(s.T().Context(), charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       featureID,
+			Type:            usagebased.RealizationRunTypeFinalRealization,
+			StoredAtLT:      servicePeriod.To,
+			ServicePeriodTo: servicePeriod.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(10),
+			Totals: totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(1),
+				ChargesTotal: alpacadecimal.NewFromInt(1),
+				Total:        alpacadecimal.NewFromInt(1),
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -617,18 +627,20 @@ func (s *DetailedLineAdapterSuite) TestCreateRealizationRunPersistsPriorRunSchem
 	s.Require().True(firstRun.PriorRunID.IsPresent())
 	s.Require().Nil(firstRun.PriorRunID.OrEmpty())
 
-	secondRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
-		FeatureID:       charge.State.FeatureID,
-		Type:            usagebased.RealizationRunTypeFinalRealization,
-		StoredAtLT:      servicePeriod.To,
-		ServicePeriodTo: servicePeriod.To,
-		PriorRunID:      &firstRun.ID,
-		MeteredQuantity: alpacadecimal.NewFromInt(10),
-		Totals: totals.Totals{
-			Amount:       alpacadecimal.NewFromInt(1),
-			ChargesTotal: alpacadecimal.NewFromInt(1),
-			Total:        alpacadecimal.NewFromInt(1),
+	secondRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: usagebased.CreateRealizationRunInput{
+			FeatureID:       charge.State.FeatureID,
+			Type:            usagebased.RealizationRunTypeFinalRealization,
+			StoredAtLT:      servicePeriod.To,
+			ServicePeriodTo: servicePeriod.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(10),
+			Totals: totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(1),
+				ChargesTotal: alpacadecimal.NewFromInt(1),
+				Total:        alpacadecimal.NewFromInt(1),
+			},
 		},
+		PriorRunID: &firstRun.ID,
 	})
 	s.Require().NoError(err)
 	s.Require().True(secondRun.PriorRunID.IsPresent())

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -610,6 +610,73 @@ func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usageb
 	return charge, runBase, servicePeriod
 }
 
+func (s *DetailedLineAdapterSuite) TestCreateRealizationRunPersistsPriorRunSchema() {
+	ctx := s.T().Context()
+	charge, firstRun, servicePeriod := s.createChargeWithRun("usagebased-run-lineage-" + ulid.Make().String())
+
+	s.Require().True(firstRun.PriorRunID.IsPresent())
+	s.Require().Nil(firstRun.PriorRunID.OrEmpty())
+
+	secondRun, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:       charge.State.FeatureID,
+		Type:            usagebased.RealizationRunTypeFinalRealization,
+		StoredAtLT:      servicePeriod.To,
+		ServicePeriodTo: servicePeriod.To,
+		PriorRunID:      &firstRun.ID,
+		MeteredQuantity: alpacadecimal.NewFromInt(10),
+		Totals: totals.Totals{
+			Amount:       alpacadecimal.NewFromInt(1),
+			ChargesTotal: alpacadecimal.NewFromInt(1),
+			Total:        alpacadecimal.NewFromInt(1),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().True(secondRun.PriorRunID.IsPresent())
+	s.Require().Equal(&firstRun.ID, secondRun.PriorRunID.OrEmpty())
+
+	persisted, err := s.dbClient.ChargeUsageBasedRuns.Get(ctx, secondRun.ID.ID)
+	s.Require().NoError(err)
+	s.Equal(usagebased.RealizationRunSchemaLevelPriorRun, persisted.SchemaLevel)
+	s.Equal(firstRun.ID.ID, lo.FromPtr(persisted.PriorRunID))
+}
+
+func (s *DetailedLineAdapterSuite) TestSchemaDefaultCreatesLegacyRun() {
+	ctx := s.T().Context()
+	charge, _, servicePeriod := s.createChargeWithRun("usagebased-run-legacy-" + ulid.Make().String())
+
+	create := s.dbClient.ChargeUsageBasedRuns.Create().
+		SetNamespace(charge.Namespace).
+		SetChargeID(charge.ID).
+		SetFeatureID(charge.State.FeatureID).
+		SetType(usagebased.RealizationRunTypeFinalRealization).
+		SetInitialType(usagebased.RealizationRunTypeFinalRealization).
+		SetStoredAtLt(servicePeriod.To).
+		SetServicePeriodTo(servicePeriod.To).
+		SetDetailedLinesPresent(false).
+		SetMeteredQuantity(alpacadecimal.Zero).
+		SetNoFiatTransactionRequired(true)
+	create = totals.Set(create, totals.Totals{})
+
+	legacyRun, err := create.Save(ctx)
+	s.Require().NoError(err)
+	s.Equal(usagebased.RealizationRunSchemaLevelLegacy, legacyRun.SchemaLevel)
+
+	mapped, err := fromDBRunBase(legacyRun)
+	s.Require().NoError(err)
+	s.True(mapped.PriorRunID.IsAbsent())
+
+	updatedRun, err := s.dbClient.ChargeUsageBasedRuns.UpdateOneID(legacyRun.ID).
+		SetSchemaLevel(usagebased.RealizationRunSchemaLevelPriorRun).
+		Save(ctx)
+	s.Require().NoError(err)
+	s.Equal(usagebased.RealizationRunSchemaLevelPriorRun, updatedRun.SchemaLevel)
+
+	mapped, err = fromDBRunBase(updatedRun)
+	s.Require().NoError(err)
+	s.True(mapped.PriorRunID.IsPresent())
+	s.Nil(mapped.PriorRunID.OrEmpty())
+}
+
 func (s *DetailedLineAdapterSuite) createCustomer(namespace string) string {
 	s.T().Helper()
 

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/chargemeta"
@@ -152,7 +153,30 @@ func fromDBRuns(entity *entdb.ChargeUsageBased) (usagebased.RealizationRuns, err
 	return runs, nil
 }
 
-func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunBase {
+func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) (usagebased.RealizationRunBase, error) {
+	priorRunID := mo.None[*usagebased.RealizationRunID]()
+	switch dbRun.SchemaLevel {
+	case usagebased.RealizationRunSchemaLevelLegacy:
+		if dbRun.PriorRunID != nil {
+			return usagebased.RealizationRunBase{}, fmt.Errorf("legacy usage-based realization run has prior run id [id=%s]", dbRun.ID)
+		}
+	case usagebased.RealizationRunSchemaLevelPriorRun:
+		var mappedPriorRunID *usagebased.RealizationRunID
+		if dbRun.PriorRunID != nil {
+			if *dbRun.PriorRunID == dbRun.ID {
+				return usagebased.RealizationRunBase{}, fmt.Errorf("usage-based realization run cannot reference itself as prior run [id=%s]", dbRun.ID)
+			}
+
+			mappedPriorRunID = &usagebased.RealizationRunID{
+				Namespace: dbRun.Namespace,
+				ID:        *dbRun.PriorRunID,
+			}
+		}
+		priorRunID = mo.Some(mappedPriorRunID)
+	default:
+		return usagebased.RealizationRunBase{}, fmt.Errorf("unsupported usage-based realization run schema level: %d", dbRun.SchemaLevel)
+	}
+
 	return usagebased.RealizationRunBase{
 		ID: usagebased.RealizationRunID{
 			Namespace: dbRun.Namespace,
@@ -167,19 +191,24 @@ func fromDBRunBase(dbRun *entdb.ChargeUsageBasedRuns) usagebased.RealizationRunB
 		InitialType:                           dbRun.InitialType,
 		StoredAtLT:                            dbRun.StoredAtLt.UTC(),
 		ServicePeriodTo:                       dbRun.ServicePeriodTo.UTC(),
+		PriorRunID:                            priorRunID,
 		MeteredQuantity:                       dbRun.MeteredQuantity,
 		Totals:                                totals.FromDB(dbRun),
 		NoFiatTransactionRequired:             dbRun.NoFiatTransactionRequired,
 		Immutable:                             dbRun.Immutable,
 		DetailedLinesIncludeCreditAllocations: dbRun.DetailedLinesIncludeCreditAllocations,
-	}
+	}, nil
 }
 
 func fromDBRun(dbRun *entdb.ChargeUsageBasedRuns) (usagebased.RealizationRun, error) {
-	run := usagebased.RealizationRun{
-		RealizationRunBase: fromDBRunBase(dbRun),
+	base, err := fromDBRunBase(dbRun)
+	if err != nil {
+		return usagebased.RealizationRun{}, err
 	}
-	var err error
+
+	run := usagebased.RealizationRun{
+		RealizationRunBase: base,
+	}
 
 	run.CreditsAllocated, err = creditrealization.FromDBRealizationsOrErr(dbRun.Edges.CreditAllocationsOrErr())
 	if err != nil {

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -21,6 +22,10 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 		return usagebased.RealizationRunBase{}, err
 	}
 
+	if input.PriorRunID != nil && input.PriorRunID.Namespace != chargeID.Namespace {
+		return usagebased.RealizationRunBase{}, fmt.Errorf("prior run namespace must match charge namespace")
+	}
+
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.RealizationRunBase, error) {
 		create := tx.db.ChargeUsageBasedRuns.Create().
 			SetNamespace(chargeID.Namespace).
@@ -30,11 +35,16 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 			SetInitialType(input.Type).
 			SetStoredAtLt(meta.NormalizeTimestamp(input.StoredAtLT)).
 			SetServicePeriodTo(meta.NormalizeTimestamp(input.ServicePeriodTo)).
+			SetSchemaLevel(usagebased.CurrentRealizationRunSchemaLevel).
 			SetDetailedLinesPresent(false).
 			SetNillableBillingInvoiceLineID(input.LineID).
 			SetNillableBillingInvoiceID(input.InvoiceID).
 			SetMeteredQuantity(input.MeteredQuantity).
 			SetNoFiatTransactionRequired(input.NoFiatTransactionRequired)
+
+		if input.PriorRunID != nil {
+			create = create.SetPriorRunID(input.PriorRunID.ID)
+		}
 
 		create = totals.Set(create, input.Totals)
 
@@ -43,7 +53,7 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 			return usagebased.RealizationRunBase{}, err
 		}
 
-		return fromDBRunBase(dbRun), nil
+		return fromDBRunBase(dbRun)
 	})
 }
 
@@ -95,6 +105,6 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 			return usagebased.RealizationRunBase{}, err
 		}
 
-		return fromDBRunBase(dbRun), nil
+		return fromDBRunBase(dbRun)
 	})
 }

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -13,7 +13,7 @@ import (
 
 var _ usagebased.RealizationRunAdapter = (*adapter)(nil)
 
-func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input usagebased.CreateRealizationRunInput) (usagebased.RealizationRunBase, error) {
+func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input usagebased.CreateRealizationRunAdapterInput) (usagebased.RealizationRunBase, error) {
 	if err := chargeID.Validate(); err != nil {
 		return usagebased.RealizationRunBase{}, err
 	}

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun_test.go
@@ -1,0 +1,82 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+)
+
+func TestFromDBRunBaseMapsSchemaLevelPriorRunSemantics(t *testing.T) {
+	t.Run("legacy lineage is unknown", func(t *testing.T) {
+		mapped, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-1",
+			Namespace:   "namespace",
+			SchemaLevel: usagebased.RealizationRunSchemaLevelLegacy,
+		})
+		require.NoError(t, err)
+		require.True(t, mapped.PriorRunID.IsAbsent())
+	})
+
+	t.Run("level two first run has known empty lineage", func(t *testing.T) {
+		mapped, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-1",
+			Namespace:   "namespace",
+			SchemaLevel: usagebased.RealizationRunSchemaLevelPriorRun,
+		})
+		require.NoError(t, err)
+		require.True(t, mapped.PriorRunID.IsPresent())
+		require.Nil(t, mapped.PriorRunID.OrEmpty())
+	})
+
+	t.Run("level two maps referenced prior run", func(t *testing.T) {
+		priorRunID := "run-1"
+		mapped, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-2",
+			Namespace:   "namespace",
+			SchemaLevel: usagebased.RealizationRunSchemaLevelPriorRun,
+			PriorRunID:  &priorRunID,
+		})
+		require.NoError(t, err)
+		require.True(t, mapped.PriorRunID.IsPresent())
+		require.Equal(t, &usagebased.RealizationRunID{
+			Namespace: "namespace",
+			ID:        priorRunID,
+		}, mapped.PriorRunID.OrEmpty())
+	})
+}
+
+func TestFromDBRunBaseRejectsInvalidSchemaLevelState(t *testing.T) {
+	t.Run("unknown schema level", func(t *testing.T) {
+		_, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-1",
+			Namespace:   "namespace",
+			SchemaLevel: 3,
+		})
+		require.ErrorContains(t, err, "unsupported usage-based realization run schema level: 3")
+	})
+
+	t.Run("legacy run with prior run id", func(t *testing.T) {
+		priorRunID := "prior-run"
+		_, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-1",
+			Namespace:   "namespace",
+			SchemaLevel: usagebased.RealizationRunSchemaLevelLegacy,
+			PriorRunID:  &priorRunID,
+		})
+		require.ErrorContains(t, err, "legacy usage-based realization run has prior run id")
+	})
+
+	t.Run("self-referencing prior run", func(t *testing.T) {
+		priorRunID := "run-1"
+		_, err := fromDBRunBase(&entdb.ChargeUsageBasedRuns{
+			ID:          "run-1",
+			Namespace:   "namespace",
+			SchemaLevel: usagebased.RealizationRunSchemaLevelPriorRun,
+			PriorRunID:  &priorRunID,
+		})
+		require.ErrorContains(t, err, "cannot reference itself as prior run")
+	})
+}

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -3,6 +3,7 @@ package usagebased
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -167,6 +168,98 @@ func (c Charge) GetCurrentRealizationRun() (RealizationRun, error) {
 	}
 
 	return c.Realizations.GetByID(*c.State.CurrentRealizationRunID)
+}
+
+// ServicePeriodFor returns the nominal service period of a realization run.
+// Runs with explicit lineage use the referenced run's persisted end as their
+// start. Legacy runs retain the ordering-based fallback until their lineage is
+// backfilled.
+func (c Charge) ServicePeriodFor(currentRun RealizationRun) (timeutil.ClosedPeriod, error) {
+	chargeIntentServicePeriod := c.Intent.GetEffectiveServicePeriod()
+	periodTo := meta.NormalizeTimestamp(currentRun.ServicePeriodTo)
+	periodFrom := meta.NormalizeTimestamp(chargeIntentServicePeriod.From)
+
+	if currentRun.PriorRunID.IsPresent() {
+		priorRunID := currentRun.PriorRunID.OrEmpty()
+		if priorRunID == nil {
+			return timeutil.ClosedPeriod{From: periodFrom, To: periodTo}, nil
+		}
+
+		priorRun, err := c.Realizations.GetByID(priorRunID.ID)
+		if err != nil {
+			return timeutil.ClosedPeriod{}, fmt.Errorf("resolve prior realization run %s for run %s: %w", priorRunID.ID, currentRun.ID.ID, err)
+		}
+
+		if priorRun.ID.Namespace != currentRun.ID.Namespace {
+			return timeutil.ClosedPeriod{}, fmt.Errorf("prior realization run %s namespace does not match run %s namespace", priorRun.ID.ID, currentRun.ID.ID)
+		}
+
+		if priorRun.ID == currentRun.ID {
+			return timeutil.ClosedPeriod{}, fmt.Errorf("prior realization run cannot reference run %s itself", currentRun.ID.ID)
+		}
+
+		return timeutil.ClosedPeriod{
+			From: meta.NormalizeTimestamp(priorRun.ServicePeriodTo),
+			To:   periodTo,
+		}, nil
+	}
+
+	nonVoidedRuns := c.Realizations.WithoutVoidedBillingHistory()
+	slices.SortStableFunc(nonVoidedRuns, func(a RealizationRun, b RealizationRun) int {
+		if comparison := meta.NormalizeTimestamp(a.ServicePeriodTo).Compare(meta.NormalizeTimestamp(b.ServicePeriodTo)); comparison != 0 {
+			return comparison
+		}
+
+		return a.CreatedAt.Compare(b.CreatedAt)
+	})
+
+	for _, run := range nonVoidedRuns {
+		if run.ID == currentRun.ID {
+			return timeutil.ClosedPeriod{From: periodFrom, To: periodTo}, nil
+		}
+
+		periodFrom = meta.NormalizeTimestamp(run.ServicePeriodTo)
+	}
+
+	return timeutil.ClosedPeriod{}, fmt.Errorf("realization run not found while resolving service period [id=%s]", currentRun.ID.ID)
+}
+
+// BisectRealizationRunsByTimestamp splits non-voided realization runs by their
+// nominal service period relative to at.
+//
+// The returned before slice contains every non-voided run whose derived
+// service period ends at or before at. The returned containingOrAfter slice
+// contains every non-voided run whose derived service period contains at, or
+// whose nominal service period starts after at. Both returned slices are sorted
+// by ServicePeriodTo and then CreatedAt.
+func (c Charge) BisectRealizationRunsByTimestamp(at time.Time) (before RealizationRuns, containingOrAfter RealizationRuns, err error) {
+	at = meta.NormalizeTimestamp(at)
+
+	nonVoidedRuns := c.Realizations.WithoutVoidedBillingHistory()
+	slices.SortStableFunc(nonVoidedRuns, func(a RealizationRun, b RealizationRun) int {
+		if comparison := meta.NormalizeTimestamp(a.ServicePeriodTo).Compare(meta.NormalizeTimestamp(b.ServicePeriodTo)); comparison != 0 {
+			return comparison
+		}
+
+		return a.CreatedAt.Compare(b.CreatedAt)
+	})
+
+	for _, run := range nonVoidedRuns {
+		runPeriod, err := c.ServicePeriodFor(run)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		containsAt := !at.Before(runPeriod.From) && at.Before(runPeriod.To)
+		startsAfterAt := runPeriod.From.After(at)
+		if containsAt || startsAfterAt {
+			containingOrAfter = append(containingOrAfter, run)
+		} else {
+			before = append(before, run)
+		}
+	}
+
+	return before, containingOrAfter, nil
 }
 
 func (c Charge) ConvertCustomCurrencyOverageToFiat(creditCurrencyTotals totals.Totals) (meta.FiatOverage, error) {

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -204,8 +204,9 @@ func (c Charge) ServicePeriodFor(currentRun RealizationRun) (timeutil.ClosedPeri
 		}, nil
 	}
 
-	nonVoidedRuns := c.Realizations.WithoutVoidedBillingHistory()
-	slices.SortStableFunc(nonVoidedRuns, func(a RealizationRun, b RealizationRun) int {
+	// TODO: Remove once schema-level-1 support has been removed.
+	legacyRuns := c.Realizations.WithoutVoidedBillingHistory()
+	slices.SortStableFunc(legacyRuns, func(a RealizationRun, b RealizationRun) int {
 		if comparison := meta.NormalizeTimestamp(a.ServicePeriodTo).Compare(meta.NormalizeTimestamp(b.ServicePeriodTo)); comparison != 0 {
 			return comparison
 		}
@@ -213,7 +214,7 @@ func (c Charge) ServicePeriodFor(currentRun RealizationRun) (timeutil.ClosedPeri
 		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 
-	for _, run := range nonVoidedRuns {
+	for _, run := range legacyRuns {
 		if run.ID == currentRun.ID {
 			return timeutil.ClosedPeriod{From: periodFrom, To: periodTo}, nil
 		}

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -82,7 +82,6 @@ type CreateRealizationRunInput struct {
 	Type                      RealizationRunType    `json:"type"`
 	StoredAtLT                time.Time             `json:"storedAtLT"`
 	ServicePeriodTo           time.Time             `json:"servicePeriodTo"`
-	PriorRunID                *RealizationRunID     `json:"priorRunId,omitempty"`
 	LineID                    *string               `json:"lineId,omitempty"`
 	InvoiceID                 *string               `json:"invoiceId,omitempty"`
 	MeteredQuantity           alpacadecimal.Decimal `json:"meteredQuantity"`
@@ -126,12 +125,6 @@ func (r CreateRealizationRunInput) Validate() error {
 
 	if r.ServicePeriodTo.IsZero() {
 		errs = append(errs, fmt.Errorf("service period to must be set"))
-	}
-
-	if r.PriorRunID != nil {
-		if err := r.PriorRunID.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("prior run id: %w", err))
-		}
 	}
 
 	if r.LineID != nil && *r.LineID == "" {
@@ -390,32 +383,52 @@ type RealizationRuns []RealizationRun
 
 func (r RealizationRuns) MapToBillingMeteredQuantity(currentRun RealizationRun) (BillingMeteredQuantity, error) {
 	preLinePeriod := alpacadecimal.Zero
+	var priorRun *RealizationRun
 
-	if currentRun.PriorRunID.IsAbsent() {
-		return BillingMeteredQuantity{}, fmt.Errorf("prior realization run lineage is unknown for run %s", currentRun.ID.ID)
+	if currentRun.PriorRunID.IsPresent() {
+		priorRunID := currentRun.PriorRunID.OrEmpty()
+		if priorRunID != nil {
+			resolvedPriorRun, err := r.GetByID(priorRunID.ID)
+			if err != nil {
+				return BillingMeteredQuantity{}, fmt.Errorf("resolve prior realization run %s for run %s: %w", priorRunID.ID, currentRun.ID.ID, err)
+			}
+
+			if resolvedPriorRun.ID.Namespace != currentRun.ID.Namespace {
+				return BillingMeteredQuantity{}, fmt.Errorf("prior realization run %s namespace does not match run %s namespace", resolvedPriorRun.ID.ID, currentRun.ID.ID)
+			}
+
+			if resolvedPriorRun.ID == currentRun.ID {
+				return BillingMeteredQuantity{}, fmt.Errorf("prior realization run cannot reference run %s itself", currentRun.ID.ID)
+			}
+
+			priorRun = &resolvedPriorRun
+		}
+	} else {
+		// TODO: Remove once schema-level-1 support has been removed.
+		// Schema-level-1 runs and unsaved previews do not carry lineage. Keep the
+		// legacy ordering fallback until persisted runs have been backfilled.
+		for idx := range r {
+			if r[idx].IsVoidedBillingHistory() {
+				continue
+			}
+
+			if !r[idx].ServicePeriodTo.Before(currentRun.ServicePeriodTo) {
+				continue
+			}
+
+			if priorRun == nil || r[idx].ServicePeriodTo.After(priorRun.ServicePeriodTo) {
+				priorRun = &r[idx]
+			}
+		}
 	}
 
-	// Standard invoice line quantities intentionally use the prior run's
-	// persisted cumulative quantity. That value may have been captured with an
-	// older StoredAtLT than the current run. Period-preserving rating may still
-	// freshly snapshot prior event-time periods with the current StoredAtLT for
-	// correction calculation, but invoice line quantities should reflect what
-	// was previously billed.
-	priorRunID := currentRun.PriorRunID.OrEmpty()
-	if priorRunID != nil {
-		priorRun, err := r.GetByID(priorRunID.ID)
-		if err != nil {
-			return BillingMeteredQuantity{}, fmt.Errorf("resolve prior realization run %s for run %s: %w", priorRunID.ID, currentRun.ID.ID, err)
-		}
-
-		if priorRun.ID.Namespace != currentRun.ID.Namespace {
-			return BillingMeteredQuantity{}, fmt.Errorf("prior realization run %s namespace does not match run %s namespace", priorRun.ID.ID, currentRun.ID.ID)
-		}
-
-		if priorRun.ID == currentRun.ID {
-			return BillingMeteredQuantity{}, fmt.Errorf("prior realization run cannot reference run %s itself", currentRun.ID.ID)
-		}
-
+	if priorRun != nil {
+		// Standard invoice line quantities intentionally use the prior run's
+		// persisted cumulative quantity. That value may have been captured with
+		// an older StoredAtLT than the current run. Period-preserving rating may
+		// still freshly snapshot prior event-time periods with the current
+		// StoredAtLT for correction calculation, but invoice line quantities
+		// should reflect what was previously billed.
 		preLinePeriod = priorRun.MeteredQuantity
 	}
 

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type RealizationRunType string
@@ -54,6 +53,16 @@ func (i RealizationRunID) Validate() error {
 	return models.NamespacedID(i).Validate()
 }
 
+const (
+	// RealizationRunSchemaLevelLegacy identifies runs created before explicit
+	// prior-run lineage was persisted.
+	RealizationRunSchemaLevelLegacy = 1
+	// RealizationRunSchemaLevelPriorRun identifies runs whose PriorRunID is
+	// known, including first runs for which it is explicitly nil.
+	RealizationRunSchemaLevelPriorRun = 2
+	CurrentRealizationRunSchemaLevel  = RealizationRunSchemaLevelPriorRun
+)
+
 // BillingMeteredQuantity maps a cumulative charge run quantity to the quantity
 // semantics expected by billing.StandardLine. RealizationRun.MeteredQuantity is
 // cumulative from the charge service-period start to the run's ServicePeriodTo,
@@ -73,6 +82,7 @@ type CreateRealizationRunInput struct {
 	Type                      RealizationRunType    `json:"type"`
 	StoredAtLT                time.Time             `json:"storedAtLT"`
 	ServicePeriodTo           time.Time             `json:"servicePeriodTo"`
+	PriorRunID                *RealizationRunID     `json:"priorRunId,omitempty"`
 	LineID                    *string               `json:"lineId,omitempty"`
 	InvoiceID                 *string               `json:"invoiceId,omitempty"`
 	MeteredQuantity           alpacadecimal.Decimal `json:"meteredQuantity"`
@@ -116,6 +126,12 @@ func (r CreateRealizationRunInput) Validate() error {
 
 	if r.ServicePeriodTo.IsZero() {
 		errs = append(errs, fmt.Errorf("service period to must be set"))
+	}
+
+	if r.PriorRunID != nil {
+		if err := r.PriorRunID.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("prior run id: %w", err))
+		}
 	}
 
 	if r.LineID != nil && *r.LineID == "" {
@@ -208,6 +224,9 @@ type RealizationRunBase struct {
 	StoredAtLT  time.Time          `json:"storedAtLT"`
 	// ServicePeriodTo is the end of the service period for the realization run.
 	ServicePeriodTo time.Time `json:"servicePeriodTo"`
+	// PriorRunID distinguishes legacy runs with unknown lineage (None) from
+	// runs with known lineage (Some). Some(nil) identifies the first run.
+	PriorRunID mo.Option[*RealizationRunID] `json:"priorRunId,omitzero"`
 	// MeteredQuantity is the metered quantity for time IN [intent.servicePeriod.from, servicePeriodTo) capped by stored_at < StoredAtLT.
 	MeteredQuantity alpacadecimal.Decimal `json:"meteredQuantity"`
 	// Totals includes credit allocations and excludes taxes.
@@ -281,6 +300,23 @@ func (r RealizationRunBase) Validate() error {
 		errs = append(errs, fmt.Errorf("service period to must be set"))
 	}
 
+	if r.PriorRunID.IsPresent() {
+		priorRunID := r.PriorRunID.OrEmpty()
+		if priorRunID != nil {
+			if err := priorRunID.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("prior run id: %w", err))
+			}
+
+			if priorRunID.Namespace != r.ID.Namespace {
+				errs = append(errs, fmt.Errorf("prior run namespace must match run namespace"))
+			}
+
+			if *priorRunID == r.ID {
+				errs = append(errs, fmt.Errorf("prior run id cannot reference the run itself"))
+			}
+		}
+	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
@@ -352,73 +388,35 @@ func (r RealizationRun) IsVoidedBillingHistory() bool {
 
 type RealizationRuns []RealizationRun
 
-// BisectByTimestamp splits non-voided realization runs by their
-// derived service period relative to at.
-//
-// The returned before slice contains every non-voided run whose derived
-// service period ends at or before at. The returned containingOrAfter slice
-// contains every non-voided run whose derived service period contains at, or
-// whose derived service period starts after at. Each run's service-period start
-// is derived from the previous non-voided run's ServicePeriodTo, with the first
-// run starting at chargeIntentServicePeriod.From. Both returned slices are
-// sorted by ServicePeriodTo and then CreatedAt.
-func (r RealizationRuns) BisectByTimestamp(chargeIntentServicePeriod timeutil.ClosedPeriod, at time.Time) (before RealizationRuns, containingOrAfter RealizationRuns) {
-	previousServicePeriodTo := meta.NormalizeTimestamp(chargeIntentServicePeriod.From)
-	at = meta.NormalizeTimestamp(at)
-
-	nonVoidedRuns := r.WithoutVoidedBillingHistory()
-
-	slices.SortStableFunc(nonVoidedRuns, func(a RealizationRun, b RealizationRun) int {
-		if c := meta.NormalizeTimestamp(a.ServicePeriodTo).Compare(meta.NormalizeTimestamp(b.ServicePeriodTo)); c != 0 {
-			return c
-		}
-
-		return a.CreatedAt.Compare(b.CreatedAt)
-	})
-
-	for _, run := range nonVoidedRuns {
-		runPeriodTo := meta.NormalizeTimestamp(run.ServicePeriodTo)
-
-		containsAt := !at.Before(previousServicePeriodTo) && at.Before(runPeriodTo)
-		startsAfterAt := previousServicePeriodTo.After(at)
-		if containsAt || startsAfterAt {
-			containingOrAfter = append(containingOrAfter, run)
-		} else {
-			before = append(before, run)
-		}
-
-		previousServicePeriodTo = runPeriodTo
-	}
-
-	return before, containingOrAfter
-}
-
 func (r RealizationRuns) MapToBillingMeteredQuantity(currentRun RealizationRun) (BillingMeteredQuantity, error) {
 	preLinePeriod := alpacadecimal.Zero
-	var latestPriorRun *RealizationRun
 
-	for idx := range r {
-		if r[idx].IsVoidedBillingHistory() {
-			continue
-		}
-
-		if !r[idx].ServicePeriodTo.Before(currentRun.ServicePeriodTo) {
-			continue
-		}
-
-		if latestPriorRun == nil || r[idx].ServicePeriodTo.After(latestPriorRun.ServicePeriodTo) {
-			latestPriorRun = &r[idx]
-		}
+	if currentRun.PriorRunID.IsAbsent() {
+		return BillingMeteredQuantity{}, fmt.Errorf("prior realization run lineage is unknown for run %s", currentRun.ID.ID)
 	}
 
-	if latestPriorRun != nil {
-		// Standard invoice line quantities intentionally use the prior run's
-		// persisted cumulative quantity. That value may have been captured with
-		// an older StoredAtLT than the current run. Period-preserving rating may
-		// still freshly snapshot prior event-time periods with the current
-		// StoredAtLT for correction calculation, but invoice line quantities
-		// should reflect what was previously billed.
-		preLinePeriod = latestPriorRun.MeteredQuantity
+	// Standard invoice line quantities intentionally use the prior run's
+	// persisted cumulative quantity. That value may have been captured with an
+	// older StoredAtLT than the current run. Period-preserving rating may still
+	// freshly snapshot prior event-time periods with the current StoredAtLT for
+	// correction calculation, but invoice line quantities should reflect what
+	// was previously billed.
+	priorRunID := currentRun.PriorRunID.OrEmpty()
+	if priorRunID != nil {
+		priorRun, err := r.GetByID(priorRunID.ID)
+		if err != nil {
+			return BillingMeteredQuantity{}, fmt.Errorf("resolve prior realization run %s for run %s: %w", priorRunID.ID, currentRun.ID.ID, err)
+		}
+
+		if priorRun.ID.Namespace != currentRun.ID.Namespace {
+			return BillingMeteredQuantity{}, fmt.Errorf("prior realization run %s namespace does not match run %s namespace", priorRun.ID.ID, currentRun.ID.ID)
+		}
+
+		if priorRun.ID == currentRun.ID {
+			return BillingMeteredQuantity{}, fmt.Errorf("prior realization run cannot reference run %s itself", currentRun.ID.ID)
+		}
+
+		preLinePeriod = priorRun.MeteredQuantity
 	}
 
 	linePeriod := currentRun.MeteredQuantity.Sub(preLinePeriod)
@@ -459,6 +457,26 @@ func (r RealizationRuns) Latest() (RealizationRun, bool) {
 
 		return run.CreatedAt.After(latest.CreatedAt)
 	}), true
+}
+
+// PriorRunIDForNextRun returns the most recently created run that still
+// represents effective billing history. A nil result identifies the first
+// effective run.
+func (r RealizationRuns) PriorRunIDForNextRun() *RealizationRunID {
+	nonVoidedRuns := r.WithoutVoidedBillingHistory()
+	if len(nonVoidedRuns) == 0 {
+		return nil
+	}
+
+	priorRun := lo.MaxBy(nonVoidedRuns, func(run RealizationRun, latest RealizationRun) bool {
+		if c := run.CreatedAt.Compare(latest.CreatedAt); c != 0 {
+			return c > 0
+		}
+
+		return run.ID.ID > latest.ID.ID
+	})
+
+	return lo.ToPtr(priorRun.ID)
 }
 
 func (r RealizationRuns) Validate() error {

--- a/openmeter/billing/charges/usagebased/realizationrun_test.go
+++ b/openmeter/billing/charges/usagebased/realizationrun_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -20,6 +22,8 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 		name        string
 		runs        RealizationRuns
 		currentRun  RealizationRun
+		priorRunID  *RealizationRunID
+		knownFirst  bool
 		wantLine    float64
 		wantPreLine float64
 		wantErr     bool
@@ -32,6 +36,7 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 				periodStart.Add(24*time.Hour),
 				5,
 			),
+			knownFirst:  true,
 			wantLine:    5,
 			wantPreLine: 0,
 		},
@@ -57,6 +62,7 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 				periodStart.Add(72*time.Hour),
 				20,
 			),
+			priorRunID:  lo.ToPtr(RealizationRunID{Namespace: "namespace", ID: "run-2"}),
 			wantLine:    12,
 			wantPreLine: 8,
 		},
@@ -76,7 +82,8 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 				periodStart.Add(48*time.Hour),
 				5,
 			),
-			wantErr: true,
+			priorRunID: lo.ToPtr(RealizationRunID{Namespace: "namespace", ID: "run-1"}),
+			wantErr:    true,
 		},
 		{
 			name: "ignores deleted prior runs",
@@ -104,6 +111,7 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 				periodStart.Add(72*time.Hour),
 				20,
 			),
+			priorRunID:  lo.ToPtr(RealizationRunID{Namespace: "namespace", ID: "run-1"}),
 			wantLine:    15,
 			wantPreLine: 5,
 		},
@@ -129,6 +137,7 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 				periodStart.Add(72*time.Hour),
 				20,
 			),
+			priorRunID:  lo.ToPtr(RealizationRunID{Namespace: "namespace", ID: "run-1"}),
 			wantLine:    15,
 			wantPreLine: 5,
 		},
@@ -136,6 +145,10 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.knownFirst || tt.priorRunID != nil {
+				tt.currentRun.PriorRunID = mo.Some(tt.priorRunID)
+			}
+
 			billingMeteredQuantity, err := tt.runs.MapToBillingMeteredQuantity(tt.currentRun)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -147,6 +160,88 @@ func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
 			require.Equal(t, tt.wantPreLine, billingMeteredQuantity.PreLinePeriod.InexactFloat64())
 		})
 	}
+}
+
+func TestRealizationRuns_MapToBillingMeteredQuantityUsesPriorRunLineage(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	runs := RealizationRuns{
+		newRealizationRunForBillingMeteredQuantityTest(
+			"referenced-run",
+			RealizationRunTypePartialInvoice,
+			periodStart.Add(24*time.Hour),
+			5,
+		),
+		newRealizationRunForBillingMeteredQuantityTest(
+			"later-unreferenced-run",
+			RealizationRunTypePartialInvoice,
+			periodStart.Add(48*time.Hour),
+			8,
+		),
+	}
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current",
+		RealizationRunTypeFinalRealization,
+		periodStart.Add(72*time.Hour),
+		20,
+	)
+	priorRunID := runs[0].ID
+	currentRun.PriorRunID = mo.Some(&priorRunID)
+
+	billingMeteredQuantity, err := runs.MapToBillingMeteredQuantity(currentRun)
+	require.NoError(t, err)
+	require.Equal(t, 15.0, billingMeteredQuantity.LinePeriod.InexactFloat64())
+	require.Equal(t, 5.0, billingMeteredQuantity.PreLinePeriod.InexactFloat64())
+}
+
+func TestRealizationRuns_MapToBillingMeteredQuantityUsesZeroForKnownFirstRun(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	runs := RealizationRuns{
+		newRealizationRunForBillingMeteredQuantityTest(
+			"unrelated-run",
+			RealizationRunTypePartialInvoice,
+			periodStart.Add(24*time.Hour),
+			5,
+		),
+	}
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current",
+		RealizationRunTypeFinalRealization,
+		periodStart.Add(48*time.Hour),
+		20,
+	)
+	currentRun.PriorRunID = mo.Some[*RealizationRunID](nil)
+
+	billingMeteredQuantity, err := runs.MapToBillingMeteredQuantity(currentRun)
+	require.NoError(t, err)
+	require.Equal(t, 20.0, billingMeteredQuantity.LinePeriod.InexactFloat64())
+	require.Equal(t, 0.0, billingMeteredQuantity.PreLinePeriod.InexactFloat64())
+}
+
+func TestRealizationRuns_MapToBillingMeteredQuantityRejectsMissingPriorRun(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current",
+		RealizationRunTypeFinalRealization,
+		periodStart.Add(48*time.Hour),
+		20,
+	)
+	priorRunID := RealizationRunID{Namespace: "namespace", ID: "missing-run"}
+	currentRun.PriorRunID = mo.Some(&priorRunID)
+
+	_, err := (RealizationRuns{}).MapToBillingMeteredQuantity(currentRun)
+	require.ErrorContains(t, err, "resolve prior realization run missing-run")
+}
+
+func TestRealizationRuns_MapToBillingMeteredQuantityRejectsUnknownPriorRunLineage(t *testing.T) {
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current",
+		RealizationRunTypeFinalRealization,
+		time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		20,
+	)
+
+	_, err := (RealizationRuns{}).MapToBillingMeteredQuantity(currentRun)
+	require.ErrorContains(t, err, "prior realization run lineage is unknown")
 }
 
 func TestRealizationRunType_IsVoidedBillingHistory(t *testing.T) {
@@ -277,7 +372,7 @@ func TestRealizationRuns_GetByLineID(t *testing.T) {
 	require.ErrorContains(t, err, "realization run not found")
 }
 
-func TestRealizationRuns_BisectByTimestamp(t *testing.T) {
+func TestCharge_BisectRealizationRunsByTimestamp(t *testing.T) {
 	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	servicePeriod := timeutil.ClosedPeriod{
 		From: periodStart,
@@ -316,8 +411,10 @@ func TestRealizationRuns_BisectByTimestamp(t *testing.T) {
 			1,
 		),
 	}
+	charge := newChargeWithRealizationsForServicePeriodTest(servicePeriod, runs)
 
-	before, containingOrAfter := runs.BisectByTimestamp(servicePeriod, at)
+	before, containingOrAfter, err := charge.BisectRealizationRunsByTimestamp(at)
+	require.NoError(t, err)
 
 	require.Equal(t, []string{"before-run"}, lo.Map(before, func(run RealizationRun, _ int) string {
 		return run.ID.ID
@@ -326,7 +423,8 @@ func TestRealizationRuns_BisectByTimestamp(t *testing.T) {
 		return run.ID.ID
 	}))
 
-	before, containingOrAfter = runs.BisectByTimestamp(servicePeriod, periodStart.Add(48*time.Hour))
+	before, containingOrAfter, err = charge.BisectRealizationRunsByTimestamp(periodStart.Add(48 * time.Hour))
+	require.NoError(t, err)
 
 	require.Equal(t, []string{"before-run", "containing-run"}, lo.Map(before, func(run RealizationRun, _ int) string {
 		return run.ID.ID
@@ -334,6 +432,106 @@ func TestRealizationRuns_BisectByTimestamp(t *testing.T) {
 	require.Equal(t, []string{"after-run"}, lo.Map(containingOrAfter, func(run RealizationRun, _ int) string {
 		return run.ID.ID
 	}))
+}
+
+func TestCharge_ServicePeriodForUsesPriorRunLineage(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	intentPeriod := timeutil.ClosedPeriod{
+		From: periodStart,
+		To:   periodStart.Add(96 * time.Hour),
+	}
+	priorRun := newRealizationRunForBillingMeteredQuantityTest(
+		"prior-run",
+		RealizationRunTypePartialInvoice,
+		periodStart.Add(24*time.Hour),
+		5,
+	)
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current-run",
+		RealizationRunTypeFinalRealization,
+		periodStart.Add(72*time.Hour),
+		20,
+	)
+	priorRunID := priorRun.ID
+	currentRun.PriorRunID = mo.Some(&priorRunID)
+	charge := newChargeWithRealizationsForServicePeriodTest(intentPeriod, RealizationRuns{priorRun, currentRun})
+
+	period, err := charge.ServicePeriodFor(currentRun)
+	require.NoError(t, err)
+	require.Equal(t, priorRun.ServicePeriodTo, period.From)
+	require.Equal(t, currentRun.ServicePeriodTo, period.To)
+}
+
+func TestCharge_ServicePeriodForKnownFirstRunUsesIntentStart(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	intentPeriod := timeutil.ClosedPeriod{
+		From: periodStart,
+		To:   periodStart.Add(48 * time.Hour),
+	}
+	currentRun := newRealizationRunForBillingMeteredQuantityTest(
+		"current-run",
+		RealizationRunTypeFinalRealization,
+		periodStart.Add(24*time.Hour),
+		20,
+	)
+	currentRun.PriorRunID = mo.Some[*RealizationRunID](nil)
+	charge := newChargeWithRealizationsForServicePeriodTest(intentPeriod, RealizationRuns{currentRun})
+
+	period, err := charge.ServicePeriodFor(currentRun)
+	require.NoError(t, err)
+	require.Equal(t, intentPeriod.From, period.From)
+	require.Equal(t, currentRun.ServicePeriodTo, period.To)
+}
+
+func newChargeWithRealizationsForServicePeriodTest(servicePeriod timeutil.ClosedPeriod, runs RealizationRuns) Charge {
+	return Charge{
+		ChargeBase: ChargeBase{
+			Intent: Intent{
+				IntentMutableFields: IntentMutableFields{
+					IntentMutableFields: chargesmeta.IntentMutableFields{
+						ServicePeriod: servicePeriod,
+					},
+				},
+			}.AsOverridableIntent(),
+		},
+		Realizations: runs,
+	}
+}
+
+func TestRealizationRuns_PriorRunIDForNextRunUsesCreatedOrderAndSkipsVoidedHistory(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	deletedAt := periodStart.Add(time.Hour)
+
+	validRun := newRealizationRunForBillingMeteredQuantityTest(
+		"valid-run",
+		RealizationRunTypePartialInvoice,
+		periodStart.Add(24*time.Hour),
+		5,
+	)
+	newerValidRun := newRealizationRunForBillingMeteredQuantityTest(
+		"newer-valid-run",
+		RealizationRunTypePartialInvoice,
+		periodStart.Add(12*time.Hour),
+		3,
+	)
+	newerValidRun.CreatedAt = periodStart.Add(96 * time.Hour)
+	invalidRun := newRealizationRunForBillingMeteredQuantityTest(
+		"invalid-run",
+		RealizationRunTypeInvalidDueToUnsupportedCreditNote,
+		periodStart.Add(48*time.Hour),
+		8,
+	)
+	deletedRun := newRealizationRunForBillingMeteredQuantityTest(
+		"deleted-run",
+		RealizationRunTypePartialInvoice,
+		periodStart.Add(72*time.Hour),
+		10,
+	)
+	deletedRun.DeletedAt = &deletedAt
+
+	priorRunID := (RealizationRuns{validRun, newerValidRun, invalidRun, deletedRun}).PriorRunIDForNextRun()
+	require.Equal(t, &newerValidRun.ID, priorRunID)
+	require.Nil(t, (RealizationRuns{}).PriorRunIDForNextRun())
 }
 
 func newRealizationRunForBillingMeteredQuantityTest(id string, typ RealizationRunType, servicePeriodTo time.Time, meteredQuantity int64) RealizationRun {

--- a/openmeter/billing/charges/usagebased/realizationrun_test.go
+++ b/openmeter/billing/charges/usagebased/realizationrun_test.go
@@ -232,16 +232,42 @@ func TestRealizationRuns_MapToBillingMeteredQuantityRejectsMissingPriorRun(t *te
 	require.ErrorContains(t, err, "resolve prior realization run missing-run")
 }
 
-func TestRealizationRuns_MapToBillingMeteredQuantityRejectsUnknownPriorRunLineage(t *testing.T) {
+func TestRealizationRuns_MapToBillingMeteredQuantityFallsBackForUnknownPriorRunLineage(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	deletedAt := periodStart.Add(time.Hour)
+	deletedRun := newRealizationRunForBillingMeteredQuantityTest(
+		"deleted-run",
+		RealizationRunTypePartialInvoice,
+		periodStart.Add(48*time.Hour),
+		100,
+	)
+	deletedRun.DeletedAt = &deletedAt
+	runs := RealizationRuns{
+		deletedRun,
+		newRealizationRunForBillingMeteredQuantityTest(
+			"later-run",
+			RealizationRunTypePartialInvoice,
+			periodStart.Add(72*time.Hour),
+			30,
+		),
+		newRealizationRunForBillingMeteredQuantityTest(
+			"prior-run",
+			RealizationRunTypePartialInvoice,
+			periodStart.Add(24*time.Hour),
+			5,
+		),
+	}
 	currentRun := newRealizationRunForBillingMeteredQuantityTest(
 		"current",
 		RealizationRunTypeFinalRealization,
-		time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		periodStart.Add(48*time.Hour),
 		20,
 	)
 
-	_, err := (RealizationRuns{}).MapToBillingMeteredQuantity(currentRun)
-	require.ErrorContains(t, err, "prior realization run lineage is unknown")
+	billingMeteredQuantity, err := runs.MapToBillingMeteredQuantity(currentRun)
+	require.NoError(t, err)
+	require.Equal(t, 15.0, billingMeteredQuantity.LinePeriod.InexactFloat64())
+	require.Equal(t, 5.0, billingMeteredQuantity.PreLinePeriod.InexactFloat64())
 }
 
 func TestRealizationRunType_IsVoidedBillingHistory(t *testing.T) {
@@ -532,6 +558,27 @@ func TestRealizationRuns_PriorRunIDForNextRunUsesCreatedOrderAndSkipsVoidedHisto
 	priorRunID := (RealizationRuns{validRun, newerValidRun, invalidRun, deletedRun}).PriorRunIDForNextRun()
 	require.Equal(t, &newerValidRun.ID, priorRunID)
 	require.Nil(t, (RealizationRuns{}).PriorRunIDForNextRun())
+}
+
+func TestRealizationRuns_PriorRunIDForNextRunUsesIDToBreakCreatedAtTie(t *testing.T) {
+	createdAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	firstRun := newRealizationRunForBillingMeteredQuantityTest(
+		"01-first-run",
+		RealizationRunTypePartialInvoice,
+		createdAt.Add(24*time.Hour),
+		5,
+	)
+	firstRun.CreatedAt = createdAt
+	secondRun := newRealizationRunForBillingMeteredQuantityTest(
+		"02-second-run",
+		RealizationRunTypePartialInvoice,
+		createdAt.Add(48*time.Hour),
+		10,
+	)
+	secondRun.CreatedAt = createdAt
+
+	priorRunID := (RealizationRuns{secondRun, firstRun}).PriorRunIDForNextRun()
+	require.Equal(t, &secondRun.ID, priorRunID)
 }
 
 func newRealizationRunForBillingMeteredQuantityTest(id string, typ RealizationRunType, servicePeriodTo time.Time, meteredQuantity int64) RealizationRun {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -707,10 +707,10 @@ func (s *CreditThenInvoiceStateMachine) ResolveDynamicCostBasis(ctx context.Cont
 func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 	servicePeriod := s.Charge.Intent.GetEffectiveServicePeriod()
 	newServicePeriodTo := meta.NormalizeTimestamp(servicePeriod.To)
-	runsToKeep, runsToBeDeleted := s.Charge.Realizations.BisectByTimestamp(
-		servicePeriod,
-		newServicePeriodTo,
-	)
+	runsToKeep, runsToBeDeleted, err := s.Charge.BisectRealizationRunsByTimestamp(newServicePeriodTo)
+	if err != nil {
+		return fmt.Errorf("bisecting usage-based realization runs: %w", err)
+	}
 
 	for _, run := range runsToBeDeleted {
 		if run.LineID == nil || run.InvoiceID == nil {

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -102,6 +102,8 @@ func TestPopulateUsageBasedStandardLineFromRunProjectsDetailsAndCredits(t *testi
 			},
 		},
 	}
+	priorRunID := priorRun.ID
+	run.PriorRunID = mo.Some(&priorRunID)
 
 	err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
 		Charge: usagebased.Charge{
@@ -175,6 +177,8 @@ func TestPopulateUsageBasedStandardLineFromRunAppliesUsageDiscount(t *testing.T)
 			MeteredQuantity: alpacadecimal.NewFromInt(5),
 		},
 	}
+	priorRunID := priorRun.ID
+	run.PriorRunID = mo.Some(&priorRunID)
 
 	err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
 		Charge: usagebased.Charge{
@@ -225,6 +229,7 @@ func TestPopulateUsageBasedStandardLineFromRunRequiresExpandedDetails(t *testing
 			},
 		},
 	}
+	run.PriorRunID = mo.Some[*usagebased.RealizationRunID](nil)
 
 	err := populateStandardLineFromRun(line, populateStandardLineFromRunInput{
 		Charge: usagebased.Charge{

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -102,7 +102,10 @@ func (s *Service) createNewRealizationRun(ctx context.Context, charge usagebased
 		return usagebased.Charge{}, fmt.Errorf("current realization run already exists [charge_id=%s]", charge.GetChargeID())
 	}
 
-	run, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), in)
+	run, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunAdapterInput{
+		CreateRealizationRunInput: in,
+		PriorRunID:                charge.Realizations.PriorRunIDForNextRun(),
+	})
 	if err != nil {
 		return usagebased.Charge{}, fmt.Errorf("create realization run: %w", err)
 	}
@@ -156,7 +159,6 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		Type:                      in.Type,
 		StoredAtLT:                in.StoredAtLT,
 		ServicePeriodTo:           in.ServicePeriodTo,
-		PriorRunID:                in.Charge.Realizations.PriorRunIDForNextRun(),
 		LineID:                    in.LineID,
 		InvoiceID:                 in.InvoiceID,
 		MeteredQuantity:           ratingResult.Quantity,

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -156,6 +156,7 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		Type:                      in.Type,
 		StoredAtLT:                in.StoredAtLT,
 		ServicePeriodTo:           in.ServicePeriodTo,
+		PriorRunID:                in.Charge.Realizations.PriorRunIDForNextRun(),
 		LineID:                    in.LineID,
 		InvoiceID:                 in.InvoiceID,
 		MeteredQuantity:           ratingResult.Quantity,

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -61,6 +61,10 @@ type ChargeUsageBasedRuns struct {
 	StoredAtLt time.Time `json:"stored_at_lt,omitempty"`
 	// ServicePeriodTo holds the value of the "service_period_to" field.
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
+	// SchemaLevel holds the value of the "schema_level" field.
+	SchemaLevel int `json:"schema_level,omitempty"`
+	// PriorRunID holds the value of the "prior_run_id" field.
+	PriorRunID *string `json:"prior_run_id,omitempty"`
 	// DetailedLinesPresent holds the value of the "detailed_lines_present" field.
 	DetailedLinesPresent bool `json:"detailed_lines_present,omitempty"`
 	// DetailedLinesIncludeCreditAllocations holds the value of the "detailed_lines_include_credit_allocations" field.
@@ -91,6 +95,10 @@ type ChargeUsageBasedRunsEdges struct {
 	BillingInvoiceLine *BillingInvoiceLine `json:"billing_invoice_line,omitempty"`
 	// BillingInvoice holds the value of the billing_invoice edge.
 	BillingInvoice *BillingInvoice `json:"billing_invoice,omitempty"`
+	// NextRuns holds the value of the next_runs edge.
+	NextRuns []*ChargeUsageBasedRuns `json:"next_runs,omitempty"`
+	// PriorRun holds the value of the prior_run edge.
+	PriorRun *ChargeUsageBasedRuns `json:"prior_run,omitempty"`
 	// CreditAllocations holds the value of the credit_allocations edge.
 	CreditAllocations []*ChargeUsageBasedRunCreditAllocations `json:"credit_allocations,omitempty"`
 	// FiatOverageCreditAllocations holds the value of the fiat_overage_credit_allocations edge.
@@ -105,7 +113,7 @@ type ChargeUsageBasedRunsEdges struct {
 	Payment *ChargeUsageBasedRunPayment `json:"payment,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [10]bool
+	loadedTypes [12]bool
 }
 
 // UsageBasedOrErr returns the UsageBased value or an error if the edge
@@ -152,10 +160,30 @@ func (e ChargeUsageBasedRunsEdges) BillingInvoiceOrErr() (*BillingInvoice, error
 	return nil, &NotLoadedError{edge: "billing_invoice"}
 }
 
+// NextRunsOrErr returns the NextRuns value or an error if the edge
+// was not loaded in eager-loading.
+func (e ChargeUsageBasedRunsEdges) NextRunsOrErr() ([]*ChargeUsageBasedRuns, error) {
+	if e.loadedTypes[4] {
+		return e.NextRuns, nil
+	}
+	return nil, &NotLoadedError{edge: "next_runs"}
+}
+
+// PriorRunOrErr returns the PriorRun value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ChargeUsageBasedRunsEdges) PriorRunOrErr() (*ChargeUsageBasedRuns, error) {
+	if e.PriorRun != nil {
+		return e.PriorRun, nil
+	} else if e.loadedTypes[5] {
+		return nil, &NotFoundError{label: chargeusagebasedruns.Label}
+	}
+	return nil, &NotLoadedError{edge: "prior_run"}
+}
+
 // CreditAllocationsOrErr returns the CreditAllocations value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) CreditAllocationsOrErr() ([]*ChargeUsageBasedRunCreditAllocations, error) {
-	if e.loadedTypes[4] {
+	if e.loadedTypes[6] {
 		return e.CreditAllocations, nil
 	}
 	return nil, &NotLoadedError{edge: "credit_allocations"}
@@ -164,7 +192,7 @@ func (e ChargeUsageBasedRunsEdges) CreditAllocationsOrErr() ([]*ChargeUsageBased
 // FiatOverageCreditAllocationsOrErr returns the FiatOverageCreditAllocations value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) FiatOverageCreditAllocationsOrErr() ([]*ChargeUsageBasedRunOverageCreditAllocations, error) {
-	if e.loadedTypes[5] {
+	if e.loadedTypes[7] {
 		return e.FiatOverageCreditAllocations, nil
 	}
 	return nil, &NotLoadedError{edge: "fiat_overage_credit_allocations"}
@@ -173,7 +201,7 @@ func (e ChargeUsageBasedRunsEdges) FiatOverageCreditAllocationsOrErr() ([]*Charg
 // DetailedLinesOrErr returns the DetailedLines value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) DetailedLinesOrErr() ([]*ChargeUsageBasedRunDetailedLine, error) {
-	if e.loadedTypes[6] {
+	if e.loadedTypes[8] {
 		return e.DetailedLines, nil
 	}
 	return nil, &NotLoadedError{edge: "detailed_lines"}
@@ -182,7 +210,7 @@ func (e ChargeUsageBasedRunsEdges) DetailedLinesOrErr() ([]*ChargeUsageBasedRunD
 // CorrectedDetailedLinesOrErr returns the CorrectedDetailedLines value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) CorrectedDetailedLinesOrErr() ([]*ChargeUsageBasedRunDetailedLine, error) {
-	if e.loadedTypes[7] {
+	if e.loadedTypes[9] {
 		return e.CorrectedDetailedLines, nil
 	}
 	return nil, &NotLoadedError{edge: "corrected_detailed_lines"}
@@ -193,7 +221,7 @@ func (e ChargeUsageBasedRunsEdges) CorrectedDetailedLinesOrErr() ([]*ChargeUsage
 func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInvoicedUsage, error) {
 	if e.InvoicedUsage != nil {
 		return e.InvoicedUsage, nil
-	} else if e.loadedTypes[8] {
+	} else if e.loadedTypes[10] {
 		return nil, &NotFoundError{label: chargeusagebasedruninvoicedusage.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoiced_usage"}
@@ -204,7 +232,7 @@ func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInv
 func (e ChargeUsageBasedRunsEdges) PaymentOrErr() (*ChargeUsageBasedRunPayment, error) {
 	if e.Payment != nil {
 		return e.Payment, nil
-	} else if e.loadedTypes[9] {
+	} else if e.loadedTypes[11] {
 		return nil, &NotFoundError{label: chargeusagebasedrunpayment.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment"}
@@ -219,7 +247,9 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations, chargeusagebasedruns.FieldNoFiatTransactionRequired, chargeusagebasedruns.FieldImmutable:
 			values[i] = new(sql.NullBool)
-		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
+		case chargeusagebasedruns.FieldSchemaLevel:
+			values[i] = new(sql.NullInt64)
+		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldInitialType, chargeusagebasedruns.FieldPriorRunID, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
 		case chargeusagebasedruns.FieldCreatedAt, chargeusagebasedruns.FieldUpdatedAt, chargeusagebasedruns.FieldDeletedAt, chargeusagebasedruns.FieldStoredAtLt, chargeusagebasedruns.FieldServicePeriodTo:
 			values[i] = new(sql.NullTime)
@@ -353,6 +383,19 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.ServicePeriodTo = value.Time
 			}
+		case chargeusagebasedruns.FieldSchemaLevel:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field schema_level", values[i])
+			} else if value.Valid {
+				_m.SchemaLevel = int(value.Int64)
+			}
+		case chargeusagebasedruns.FieldPriorRunID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field prior_run_id", values[i])
+			} else if value.Valid {
+				_m.PriorRunID = new(string)
+				*_m.PriorRunID = value.String
+			}
 		case chargeusagebasedruns.FieldDetailedLinesPresent:
 			if value, ok := values[i].(*sql.NullBool); !ok {
 				return fmt.Errorf("unexpected type %T for field detailed_lines_present", values[i])
@@ -428,6 +471,16 @@ func (_m *ChargeUsageBasedRuns) QueryBillingInvoiceLine() *BillingInvoiceLineQue
 // QueryBillingInvoice queries the "billing_invoice" edge of the ChargeUsageBasedRuns entity.
 func (_m *ChargeUsageBasedRuns) QueryBillingInvoice() *BillingInvoiceQuery {
 	return NewChargeUsageBasedRunsClient(_m.config).QueryBillingInvoice(_m)
+}
+
+// QueryNextRuns queries the "next_runs" edge of the ChargeUsageBasedRuns entity.
+func (_m *ChargeUsageBasedRuns) QueryNextRuns() *ChargeUsageBasedRunsQuery {
+	return NewChargeUsageBasedRunsClient(_m.config).QueryNextRuns(_m)
+}
+
+// QueryPriorRun queries the "prior_run" edge of the ChargeUsageBasedRuns entity.
+func (_m *ChargeUsageBasedRuns) QueryPriorRun() *ChargeUsageBasedRunsQuery {
+	return NewChargeUsageBasedRunsClient(_m.config).QueryPriorRun(_m)
 }
 
 // QueryCreditAllocations queries the "credit_allocations" edge of the ChargeUsageBasedRuns entity.
@@ -538,6 +591,14 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("service_period_to=")
 	builder.WriteString(_m.ServicePeriodTo.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("schema_level=")
+	builder.WriteString(fmt.Sprintf("%v", _m.SchemaLevel))
+	builder.WriteString(", ")
+	if v := _m.PriorRunID; v != nil {
+		builder.WriteString("prior_run_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("detailed_lines_present=")
 	builder.WriteString(fmt.Sprintf("%v", _m.DetailedLinesPresent))

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -52,6 +52,10 @@ const (
 	FieldStoredAtLt = "stored_at_lt"
 	// FieldServicePeriodTo holds the string denoting the service_period_to field in the database.
 	FieldServicePeriodTo = "service_period_to"
+	// FieldSchemaLevel holds the string denoting the schema_level field in the database.
+	FieldSchemaLevel = "schema_level"
+	// FieldPriorRunID holds the string denoting the prior_run_id field in the database.
+	FieldPriorRunID = "prior_run_id"
 	// FieldDetailedLinesPresent holds the string denoting the detailed_lines_present field in the database.
 	FieldDetailedLinesPresent = "detailed_lines_present"
 	// FieldDetailedLinesIncludeCreditAllocations holds the string denoting the detailed_lines_include_credit_allocations field in the database.
@@ -74,6 +78,10 @@ const (
 	EdgeBillingInvoiceLine = "billing_invoice_line"
 	// EdgeBillingInvoice holds the string denoting the billing_invoice edge name in mutations.
 	EdgeBillingInvoice = "billing_invoice"
+	// EdgeNextRuns holds the string denoting the next_runs edge name in mutations.
+	EdgeNextRuns = "next_runs"
+	// EdgePriorRun holds the string denoting the prior_run edge name in mutations.
+	EdgePriorRun = "prior_run"
 	// EdgeCreditAllocations holds the string denoting the credit_allocations edge name in mutations.
 	EdgeCreditAllocations = "credit_allocations"
 	// EdgeFiatOverageCreditAllocations holds the string denoting the fiat_overage_credit_allocations edge name in mutations.
@@ -116,6 +124,14 @@ const (
 	BillingInvoiceInverseTable = "billing_invoices"
 	// BillingInvoiceColumn is the table column denoting the billing_invoice relation/edge.
 	BillingInvoiceColumn = "invoice_id"
+	// NextRunsTable is the table that holds the next_runs relation/edge.
+	NextRunsTable = "charge_usage_based_runs"
+	// NextRunsColumn is the table column denoting the next_runs relation/edge.
+	NextRunsColumn = "prior_run_id"
+	// PriorRunTable is the table that holds the prior_run relation/edge.
+	PriorRunTable = "charge_usage_based_runs"
+	// PriorRunColumn is the table column denoting the prior_run relation/edge.
+	PriorRunColumn = "prior_run_id"
 	// CreditAllocationsTable is the table that holds the credit_allocations relation/edge.
 	CreditAllocationsTable = "charge_usage_based_run_credit_allocations"
 	// CreditAllocationsInverseTable is the table name for the ChargeUsageBasedRunCreditAllocations entity.
@@ -181,6 +197,8 @@ var Columns = []string{
 	FieldInitialType,
 	FieldStoredAtLt,
 	FieldServicePeriodTo,
+	FieldSchemaLevel,
+	FieldPriorRunID,
 	FieldDetailedLinesPresent,
 	FieldDetailedLinesIncludeCreditAllocations,
 	FieldLineID,
@@ -211,6 +229,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	FeatureIDValidator func(string) error
+	// DefaultSchemaLevel holds the default value on creation for the "schema_level" field.
+	DefaultSchemaLevel int
 	// DefaultDetailedLinesIncludeCreditAllocations holds the default value on creation for the "detailed_lines_include_credit_allocations" field.
 	DefaultDetailedLinesIncludeCreditAllocations bool
 	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
@@ -341,6 +361,16 @@ func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodTo, opts...).ToFunc()
 }
 
+// BySchemaLevel orders the results by the schema_level field.
+func BySchemaLevel(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSchemaLevel, opts...).ToFunc()
+}
+
+// ByPriorRunID orders the results by the prior_run_id field.
+func ByPriorRunID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPriorRunID, opts...).ToFunc()
+}
+
 // ByDetailedLinesPresent orders the results by the detailed_lines_present field.
 func ByDetailedLinesPresent(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDetailedLinesPresent, opts...).ToFunc()
@@ -401,6 +431,27 @@ func ByBillingInvoiceLineField(field string, opts ...sql.OrderTermOption) OrderO
 func ByBillingInvoiceField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByNextRunsCount orders the results by next_runs count.
+func ByNextRunsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newNextRunsStep(), opts...)
+	}
+}
+
+// ByNextRuns orders the results by next_runs terms.
+func ByNextRuns(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newNextRunsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByPriorRunField orders the results by prior_run field.
+func ByPriorRunField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newPriorRunStep(), sql.OrderByField(field, opts...))
 	}
 }
 
@@ -499,6 +550,20 @@ func newBillingInvoiceStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(BillingInvoiceInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceTable, BillingInvoiceColumn),
+	)
+}
+func newNextRunsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, NextRunsTable, NextRunsColumn),
+	)
+}
+func newPriorRunStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, PriorRunTable, PriorRunColumn),
 	)
 }
 func newCreditAllocationsStep() *sqlgraph.Step {

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -147,6 +147,16 @@ func ServicePeriodTo(v time.Time) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
+// SchemaLevel applies equality check predicate on the "schema_level" field. It's identical to SchemaLevelEQ.
+func SchemaLevel(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldSchemaLevel, v))
+}
+
+// PriorRunID applies equality check predicate on the "prior_run_id" field. It's identical to PriorRunIDEQ.
+func PriorRunID(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldPriorRunID, v))
+}
+
 // DetailedLinesPresent applies equality check predicate on the "detailed_lines_present" field. It's identical to DetailedLinesPresentEQ.
 func DetailedLinesPresent(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesPresent, v))
@@ -967,6 +977,121 @@ func ServicePeriodToLTE(v time.Time) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldServicePeriodTo, v))
 }
 
+// SchemaLevelEQ applies the EQ predicate on the "schema_level" field.
+func SchemaLevelEQ(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldSchemaLevel, v))
+}
+
+// SchemaLevelNEQ applies the NEQ predicate on the "schema_level" field.
+func SchemaLevelNEQ(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldSchemaLevel, v))
+}
+
+// SchemaLevelIn applies the In predicate on the "schema_level" field.
+func SchemaLevelIn(vs ...int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldIn(FieldSchemaLevel, vs...))
+}
+
+// SchemaLevelNotIn applies the NotIn predicate on the "schema_level" field.
+func SchemaLevelNotIn(vs ...int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNotIn(FieldSchemaLevel, vs...))
+}
+
+// SchemaLevelGT applies the GT predicate on the "schema_level" field.
+func SchemaLevelGT(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGT(FieldSchemaLevel, v))
+}
+
+// SchemaLevelGTE applies the GTE predicate on the "schema_level" field.
+func SchemaLevelGTE(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGTE(FieldSchemaLevel, v))
+}
+
+// SchemaLevelLT applies the LT predicate on the "schema_level" field.
+func SchemaLevelLT(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLT(FieldSchemaLevel, v))
+}
+
+// SchemaLevelLTE applies the LTE predicate on the "schema_level" field.
+func SchemaLevelLTE(v int) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldSchemaLevel, v))
+}
+
+// PriorRunIDEQ applies the EQ predicate on the "prior_run_id" field.
+func PriorRunIDEQ(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldPriorRunID, v))
+}
+
+// PriorRunIDNEQ applies the NEQ predicate on the "prior_run_id" field.
+func PriorRunIDNEQ(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldPriorRunID, v))
+}
+
+// PriorRunIDIn applies the In predicate on the "prior_run_id" field.
+func PriorRunIDIn(vs ...string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldIn(FieldPriorRunID, vs...))
+}
+
+// PriorRunIDNotIn applies the NotIn predicate on the "prior_run_id" field.
+func PriorRunIDNotIn(vs ...string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNotIn(FieldPriorRunID, vs...))
+}
+
+// PriorRunIDGT applies the GT predicate on the "prior_run_id" field.
+func PriorRunIDGT(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGT(FieldPriorRunID, v))
+}
+
+// PriorRunIDGTE applies the GTE predicate on the "prior_run_id" field.
+func PriorRunIDGTE(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGTE(FieldPriorRunID, v))
+}
+
+// PriorRunIDLT applies the LT predicate on the "prior_run_id" field.
+func PriorRunIDLT(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLT(FieldPriorRunID, v))
+}
+
+// PriorRunIDLTE applies the LTE predicate on the "prior_run_id" field.
+func PriorRunIDLTE(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldPriorRunID, v))
+}
+
+// PriorRunIDContains applies the Contains predicate on the "prior_run_id" field.
+func PriorRunIDContains(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldContains(FieldPriorRunID, v))
+}
+
+// PriorRunIDHasPrefix applies the HasPrefix predicate on the "prior_run_id" field.
+func PriorRunIDHasPrefix(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldHasPrefix(FieldPriorRunID, v))
+}
+
+// PriorRunIDHasSuffix applies the HasSuffix predicate on the "prior_run_id" field.
+func PriorRunIDHasSuffix(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldHasSuffix(FieldPriorRunID, v))
+}
+
+// PriorRunIDIsNil applies the IsNil predicate on the "prior_run_id" field.
+func PriorRunIDIsNil() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldIsNull(FieldPriorRunID))
+}
+
+// PriorRunIDNotNil applies the NotNil predicate on the "prior_run_id" field.
+func PriorRunIDNotNil() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNotNull(FieldPriorRunID))
+}
+
+// PriorRunIDEqualFold applies the EqualFold predicate on the "prior_run_id" field.
+func PriorRunIDEqualFold(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEqualFold(FieldPriorRunID, v))
+}
+
+// PriorRunIDContainsFold applies the ContainsFold predicate on the "prior_run_id" field.
+func PriorRunIDContainsFold(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldContainsFold(FieldPriorRunID, v))
+}
+
 // DetailedLinesPresentEQ applies the EQ predicate on the "detailed_lines_present" field.
 func DetailedLinesPresentEQ(v bool) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesPresent, v))
@@ -1281,6 +1406,52 @@ func HasBillingInvoice() predicate.ChargeUsageBasedRuns {
 func HasBillingInvoiceWith(preds ...predicate.BillingInvoice) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
 		step := newBillingInvoiceStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasNextRuns applies the HasEdge predicate on the "next_runs" edge.
+func HasNextRuns() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, NextRunsTable, NextRunsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasNextRunsWith applies the HasEdge predicate on the "next_runs" edge with a given conditions (other predicates).
+func HasNextRunsWith(preds ...predicate.ChargeUsageBasedRuns) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := newNextRunsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasPriorRun applies the HasEdge predicate on the "prior_run" edge.
+func HasPriorRun() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, PriorRunTable, PriorRunColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasPriorRunWith applies the HasEdge predicate on the "prior_run" edge with a given conditions (other predicates).
+func HasPriorRunWith(preds ...predicate.ChargeUsageBasedRuns) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := newPriorRunStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -166,6 +166,34 @@ func (_c *ChargeUsageBasedRunsCreate) SetServicePeriodTo(v time.Time) *ChargeUsa
 	return _c
 }
 
+// SetSchemaLevel sets the "schema_level" field.
+func (_c *ChargeUsageBasedRunsCreate) SetSchemaLevel(v int) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetSchemaLevel(v)
+	return _c
+}
+
+// SetNillableSchemaLevel sets the "schema_level" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableSchemaLevel(v *int) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetSchemaLevel(*v)
+	}
+	return _c
+}
+
+// SetPriorRunID sets the "prior_run_id" field.
+func (_c *ChargeUsageBasedRunsCreate) SetPriorRunID(v string) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetPriorRunID(v)
+	return _c
+}
+
+// SetNillablePriorRunID sets the "prior_run_id" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillablePriorRunID(v *string) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetPriorRunID(*v)
+	}
+	return _c
+}
+
 // SetDetailedLinesPresent sets the "detailed_lines_present" field.
 func (_c *ChargeUsageBasedRunsCreate) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetDetailedLinesPresent(v)
@@ -306,6 +334,26 @@ func (_c *ChargeUsageBasedRunsCreate) SetNillableBillingInvoiceID(id *string) *C
 // SetBillingInvoice sets the "billing_invoice" edge to the BillingInvoice entity.
 func (_c *ChargeUsageBasedRunsCreate) SetBillingInvoice(v *BillingInvoice) *ChargeUsageBasedRunsCreate {
 	return _c.SetBillingInvoiceID(v.ID)
+}
+
+// AddNextRunIDs adds the "next_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_c *ChargeUsageBasedRunsCreate) AddNextRunIDs(ids ...string) *ChargeUsageBasedRunsCreate {
+	_c.mutation.AddNextRunIDs(ids...)
+	return _c
+}
+
+// AddNextRuns adds the "next_runs" edges to the ChargeUsageBasedRuns entity.
+func (_c *ChargeUsageBasedRunsCreate) AddNextRuns(v ...*ChargeUsageBasedRuns) *ChargeUsageBasedRunsCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddNextRunIDs(ids...)
+}
+
+// SetPriorRun sets the "prior_run" edge to the ChargeUsageBasedRuns entity.
+func (_c *ChargeUsageBasedRunsCreate) SetPriorRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunsCreate {
+	return _c.SetPriorRunID(v.ID)
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by IDs.
@@ -449,6 +497,10 @@ func (_c *ChargeUsageBasedRunsCreate) defaults() {
 		v := chargeusagebasedruns.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.SchemaLevel(); !ok {
+		v := chargeusagebasedruns.DefaultSchemaLevel
+		_c.mutation.SetSchemaLevel(v)
+	}
 	if _, ok := _c.mutation.DetailedLinesIncludeCreditAllocations(); !ok {
 		v := chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations
 		_c.mutation.SetDetailedLinesIncludeCreditAllocations(v)
@@ -535,6 +587,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	}
 	if _, ok := _c.mutation.ServicePeriodTo(); !ok {
 		return &ValidationError{Name: "service_period_to", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.service_period_to"`)}
+	}
+	if _, ok := _c.mutation.SchemaLevel(); !ok {
+		return &ValidationError{Name: "schema_level", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.schema_level"`)}
 	}
 	if _, ok := _c.mutation.DetailedLinesPresent(); !ok {
 		return &ValidationError{Name: "detailed_lines_present", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.detailed_lines_present"`)}
@@ -667,6 +722,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 		_spec.SetField(chargeusagebasedruns.FieldServicePeriodTo, field.TypeTime, value)
 		_node.ServicePeriodTo = value
 	}
+	if value, ok := _c.mutation.SchemaLevel(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldSchemaLevel, field.TypeInt, value)
+		_node.SchemaLevel = value
+	}
 	if value, ok := _c.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 		_node.DetailedLinesPresent = value
@@ -753,6 +812,39 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.InvoiceID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.NextRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.PriorRunIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedruns.PriorRunTable,
+			Columns: []string{chargeusagebasedruns.PriorRunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.PriorRunID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.CreditAllocationsIDs(); len(nodes) > 0 {
@@ -1053,6 +1145,24 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateStoredAtLt() *ChargeUsageBasedRunsUps
 	return u
 }
 
+// SetSchemaLevel sets the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsert) SetSchemaLevel(v int) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldSchemaLevel, v)
+	return u
+}
+
+// UpdateSchemaLevel sets the "schema_level" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateSchemaLevel() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldSchemaLevel)
+	return u
+}
+
+// AddSchemaLevel adds v to the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsert) AddSchemaLevel(v int) *ChargeUsageBasedRunsUpsert {
+	u.Add(chargeusagebasedruns.FieldSchemaLevel, v)
+	return u
+}
+
 // SetDetailedLinesPresent sets the "detailed_lines_present" field.
 func (u *ChargeUsageBasedRunsUpsert) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpsert {
 	u.Set(chargeusagebasedruns.FieldDetailedLinesPresent, v)
@@ -1165,6 +1275,9 @@ func (u *ChargeUsageBasedRunsUpsertOne) UpdateNewValues() *ChargeUsageBasedRunsU
 		}
 		if _, exists := u.create.mutation.ServicePeriodTo(); exists {
 			s.SetIgnore(chargeusagebasedruns.FieldServicePeriodTo)
+		}
+		if _, exists := u.create.mutation.PriorRunID(); exists {
+			s.SetIgnore(chargeusagebasedruns.FieldPriorRunID)
 		}
 		if _, exists := u.create.mutation.InvoiceID(); exists {
 			s.SetIgnore(chargeusagebasedruns.FieldInvoiceID)
@@ -1372,6 +1485,27 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetStoredAtLt(v time.Time) *ChargeUsageB
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateStoredAtLt() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateStoredAtLt()
+	})
+}
+
+// SetSchemaLevel sets the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetSchemaLevel(v int) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetSchemaLevel(v)
+	})
+}
+
+// AddSchemaLevel adds v to the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsertOne) AddSchemaLevel(v int) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.AddSchemaLevel(v)
+	})
+}
+
+// UpdateSchemaLevel sets the "schema_level" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateSchemaLevel() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateSchemaLevel()
 	})
 }
 
@@ -1667,6 +1801,9 @@ func (u *ChargeUsageBasedRunsUpsertBulk) UpdateNewValues() *ChargeUsageBasedRuns
 			if _, exists := b.mutation.ServicePeriodTo(); exists {
 				s.SetIgnore(chargeusagebasedruns.FieldServicePeriodTo)
 			}
+			if _, exists := b.mutation.PriorRunID(); exists {
+				s.SetIgnore(chargeusagebasedruns.FieldPriorRunID)
+			}
 			if _, exists := b.mutation.InvoiceID(); exists {
 				s.SetIgnore(chargeusagebasedruns.FieldInvoiceID)
 			}
@@ -1874,6 +2011,27 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetStoredAtLt(v time.Time) *ChargeUsage
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateStoredAtLt() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateStoredAtLt()
+	})
+}
+
+// SetSchemaLevel sets the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetSchemaLevel(v int) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetSchemaLevel(v)
+	})
+}
+
+// AddSchemaLevel adds v to the "schema_level" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) AddSchemaLevel(v int) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.AddSchemaLevel(v)
+	})
+}
+
+// UpdateSchemaLevel sets the "schema_level" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateSchemaLevel() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateSchemaLevel()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_query.go
+++ b/openmeter/ent/db/chargeusagebasedruns_query.go
@@ -37,6 +37,8 @@ type ChargeUsageBasedRunsQuery struct {
 	withFeature                      *FeatureQuery
 	withBillingInvoiceLine           *BillingInvoiceLineQuery
 	withBillingInvoice               *BillingInvoiceQuery
+	withNextRuns                     *ChargeUsageBasedRunsQuery
+	withPriorRun                     *ChargeUsageBasedRunsQuery
 	withCreditAllocations            *ChargeUsageBasedRunCreditAllocationsQuery
 	withFiatOverageCreditAllocations *ChargeUsageBasedRunOverageCreditAllocationsQuery
 	withDetailedLines                *ChargeUsageBasedRunDetailedLineQuery
@@ -161,6 +163,50 @@ func (_q *ChargeUsageBasedRunsQuery) QueryBillingInvoice() *BillingInvoiceQuery 
 			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
 			sqlgraph.To(billinginvoice.Table, billinginvoice.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedruns.BillingInvoiceTable, chargeusagebasedruns.BillingInvoiceColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryNextRuns chains the current query on the "next_runs" edge.
+func (_q *ChargeUsageBasedRunsQuery) QueryNextRuns() *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.NextRunsTable, chargeusagebasedruns.NextRunsColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryPriorRun chains the current query on the "prior_run" edge.
+func (_q *ChargeUsageBasedRunsQuery) QueryPriorRun() *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedruns.PriorRunTable, chargeusagebasedruns.PriorRunColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -496,6 +542,8 @@ func (_q *ChargeUsageBasedRunsQuery) Clone() *ChargeUsageBasedRunsQuery {
 		withFeature:                      _q.withFeature.Clone(),
 		withBillingInvoiceLine:           _q.withBillingInvoiceLine.Clone(),
 		withBillingInvoice:               _q.withBillingInvoice.Clone(),
+		withNextRuns:                     _q.withNextRuns.Clone(),
+		withPriorRun:                     _q.withPriorRun.Clone(),
 		withCreditAllocations:            _q.withCreditAllocations.Clone(),
 		withFiatOverageCreditAllocations: _q.withFiatOverageCreditAllocations.Clone(),
 		withDetailedLines:                _q.withDetailedLines.Clone(),
@@ -549,6 +597,28 @@ func (_q *ChargeUsageBasedRunsQuery) WithBillingInvoice(opts ...func(*BillingInv
 		opt(query)
 	}
 	_q.withBillingInvoice = query
+	return _q
+}
+
+// WithNextRuns tells the query-builder to eager-load the nodes that are connected to
+// the "next_runs" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeUsageBasedRunsQuery) WithNextRuns(opts ...func(*ChargeUsageBasedRunsQuery)) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withNextRuns = query
+	return _q
+}
+
+// WithPriorRun tells the query-builder to eager-load the nodes that are connected to
+// the "prior_run" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeUsageBasedRunsQuery) WithPriorRun(opts ...func(*ChargeUsageBasedRunsQuery)) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withPriorRun = query
 	return _q
 }
 
@@ -696,11 +766,13 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 	var (
 		nodes       = []*ChargeUsageBasedRuns{}
 		_spec       = _q.querySpec()
-		loadedTypes = [10]bool{
+		loadedTypes = [12]bool{
 			_q.withUsageBased != nil,
 			_q.withFeature != nil,
 			_q.withBillingInvoiceLine != nil,
 			_q.withBillingInvoice != nil,
+			_q.withNextRuns != nil,
+			_q.withPriorRun != nil,
 			_q.withCreditAllocations != nil,
 			_q.withFiatOverageCreditAllocations != nil,
 			_q.withDetailedLines != nil,
@@ -751,6 +823,19 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 	if query := _q.withBillingInvoice; query != nil {
 		if err := _q.loadBillingInvoice(ctx, query, nodes, nil,
 			func(n *ChargeUsageBasedRuns, e *BillingInvoice) { n.Edges.BillingInvoice = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withNextRuns; query != nil {
+		if err := _q.loadNextRuns(ctx, query, nodes,
+			func(n *ChargeUsageBasedRuns) { n.Edges.NextRuns = []*ChargeUsageBasedRuns{} },
+			func(n *ChargeUsageBasedRuns, e *ChargeUsageBasedRuns) { n.Edges.NextRuns = append(n.Edges.NextRuns, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withPriorRun; query != nil {
+		if err := _q.loadPriorRun(ctx, query, nodes, nil,
+			func(n *ChargeUsageBasedRuns, e *ChargeUsageBasedRuns) { n.Edges.PriorRun = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -922,6 +1007,71 @@ func (_q *ChargeUsageBasedRunsQuery) loadBillingInvoice(ctx context.Context, que
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "invoice_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ChargeUsageBasedRunsQuery) loadNextRuns(ctx context.Context, query *ChargeUsageBasedRunsQuery, nodes []*ChargeUsageBasedRuns, init func(*ChargeUsageBasedRuns), assign func(*ChargeUsageBasedRuns, *ChargeUsageBasedRuns)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*ChargeUsageBasedRuns)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(chargeusagebasedruns.FieldPriorRunID)
+	}
+	query.Where(predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(chargeusagebasedruns.NextRunsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.PriorRunID
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "prior_run_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "prior_run_id" returned %v for node %v`, *fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (_q *ChargeUsageBasedRunsQuery) loadPriorRun(ctx context.Context, query *ChargeUsageBasedRunsQuery, nodes []*ChargeUsageBasedRuns, init func(*ChargeUsageBasedRuns), assign func(*ChargeUsageBasedRuns, *ChargeUsageBasedRuns)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ChargeUsageBasedRuns)
+	for i := range nodes {
+		if nodes[i].PriorRunID == nil {
+			continue
+		}
+		fk := *nodes[i].PriorRunID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(chargeusagebasedruns.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "prior_run_id" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
@@ -1146,6 +1296,9 @@ func (_q *ChargeUsageBasedRunsQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if _q.withBillingInvoice != nil {
 			_spec.Node.AddColumnOnce(chargeusagebasedruns.FieldInvoiceID)
+		}
+		if _q.withPriorRun != nil {
+			_spec.Node.AddColumnOnce(chargeusagebasedruns.FieldPriorRunID)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -202,6 +202,27 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableStoredAtLt(v *time.Time) *Charg
 	return _u
 }
 
+// SetSchemaLevel sets the "schema_level" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetSchemaLevel(v int) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.ResetSchemaLevel()
+	_u.mutation.SetSchemaLevel(v)
+	return _u
+}
+
+// SetNillableSchemaLevel sets the "schema_level" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableSchemaLevel(v *int) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetSchemaLevel(*v)
+	}
+	return _u
+}
+
+// AddSchemaLevel adds value to the "schema_level" field.
+func (_u *ChargeUsageBasedRunsUpdate) AddSchemaLevel(v int) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.AddSchemaLevel(v)
+	return _u
+}
+
 // SetDetailedLinesPresent sets the "detailed_lines_present" field.
 func (_u *ChargeUsageBasedRunsUpdate) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetDetailedLinesPresent(v)
@@ -311,6 +332,21 @@ func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLine(v *BillingInvoiceLin
 	return _u.SetBillingInvoiceLineID(v.ID)
 }
 
+// AddNextRunIDs adds the "next_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_u *ChargeUsageBasedRunsUpdate) AddNextRunIDs(ids ...string) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.AddNextRunIDs(ids...)
+	return _u
+}
+
+// AddNextRuns adds the "next_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunsUpdate) AddNextRuns(v ...*ChargeUsageBasedRuns) *ChargeUsageBasedRunsUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddNextRunIDs(ids...)
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by IDs.
 func (_u *ChargeUsageBasedRunsUpdate) AddCreditAllocationIDs(ids ...string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.AddCreditAllocationIDs(ids...)
@@ -418,6 +454,27 @@ func (_u *ChargeUsageBasedRunsUpdate) Mutation() *ChargeUsageBasedRunsMutation {
 func (_u *ChargeUsageBasedRunsUpdate) ClearBillingInvoiceLine() *ChargeUsageBasedRunsUpdate {
 	_u.mutation.ClearBillingInvoiceLine()
 	return _u
+}
+
+// ClearNextRuns clears all "next_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunsUpdate) ClearNextRuns() *ChargeUsageBasedRunsUpdate {
+	_u.mutation.ClearNextRuns()
+	return _u
+}
+
+// RemoveNextRunIDs removes the "next_runs" edge to ChargeUsageBasedRuns entities by IDs.
+func (_u *ChargeUsageBasedRunsUpdate) RemoveNextRunIDs(ids ...string) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.RemoveNextRunIDs(ids...)
+	return _u
+}
+
+// RemoveNextRuns removes "next_runs" edges to ChargeUsageBasedRuns entities.
+func (_u *ChargeUsageBasedRunsUpdate) RemoveNextRuns(v ...*ChargeUsageBasedRuns) *ChargeUsageBasedRunsUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveNextRunIDs(ids...)
 }
 
 // ClearCreditAllocations clears all "credit_allocations" edges to the ChargeUsageBasedRunCreditAllocations entity.
@@ -624,6 +681,12 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	if value, ok := _u.mutation.StoredAtLt(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldStoredAtLt, field.TypeTime, value)
 	}
+	if value, ok := _u.mutation.SchemaLevel(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldSchemaLevel, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedSchemaLevel(); ok {
+		_spec.AddField(chargeusagebasedruns.FieldSchemaLevel, field.TypeInt, value)
+	}
 	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 	}
@@ -661,6 +724,51 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.NextRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedNextRunsIDs(); len(nodes) > 0 && !_u.mutation.NextRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.NextRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -1092,6 +1200,27 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableStoredAtLt(v *time.Time) *Ch
 	return _u
 }
 
+// SetSchemaLevel sets the "schema_level" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetSchemaLevel(v int) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.ResetSchemaLevel()
+	_u.mutation.SetSchemaLevel(v)
+	return _u
+}
+
+// SetNillableSchemaLevel sets the "schema_level" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableSchemaLevel(v *int) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetSchemaLevel(*v)
+	}
+	return _u
+}
+
+// AddSchemaLevel adds value to the "schema_level" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) AddSchemaLevel(v int) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.AddSchemaLevel(v)
+	return _u
+}
+
 // SetDetailedLinesPresent sets the "detailed_lines_present" field.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetDetailedLinesPresent(v)
@@ -1201,6 +1330,21 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLine(v *BillingInvoice
 	return _u.SetBillingInvoiceLineID(v.ID)
 }
 
+// AddNextRunIDs adds the "next_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_u *ChargeUsageBasedRunsUpdateOne) AddNextRunIDs(ids ...string) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.AddNextRunIDs(ids...)
+	return _u
+}
+
+// AddNextRuns adds the "next_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunsUpdateOne) AddNextRuns(v ...*ChargeUsageBasedRuns) *ChargeUsageBasedRunsUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddNextRunIDs(ids...)
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by IDs.
 func (_u *ChargeUsageBasedRunsUpdateOne) AddCreditAllocationIDs(ids ...string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.AddCreditAllocationIDs(ids...)
@@ -1308,6 +1452,27 @@ func (_u *ChargeUsageBasedRunsUpdateOne) Mutation() *ChargeUsageBasedRunsMutatio
 func (_u *ChargeUsageBasedRunsUpdateOne) ClearBillingInvoiceLine() *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.ClearBillingInvoiceLine()
 	return _u
+}
+
+// ClearNextRuns clears all "next_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunsUpdateOne) ClearNextRuns() *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.ClearNextRuns()
+	return _u
+}
+
+// RemoveNextRunIDs removes the "next_runs" edge to ChargeUsageBasedRuns entities by IDs.
+func (_u *ChargeUsageBasedRunsUpdateOne) RemoveNextRunIDs(ids ...string) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.RemoveNextRunIDs(ids...)
+	return _u
+}
+
+// RemoveNextRuns removes "next_runs" edges to ChargeUsageBasedRuns entities.
+func (_u *ChargeUsageBasedRunsUpdateOne) RemoveNextRuns(v ...*ChargeUsageBasedRuns) *ChargeUsageBasedRunsUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveNextRunIDs(ids...)
 }
 
 // ClearCreditAllocations clears all "credit_allocations" edges to the ChargeUsageBasedRunCreditAllocations entity.
@@ -1544,6 +1709,12 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	if value, ok := _u.mutation.StoredAtLt(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldStoredAtLt, field.TypeTime, value)
 	}
+	if value, ok := _u.mutation.SchemaLevel(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldSchemaLevel, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedSchemaLevel(); ok {
+		_spec.AddField(chargeusagebasedruns.FieldSchemaLevel, field.TypeInt, value)
+	}
 	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 	}
@@ -1581,6 +1752,51 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.NextRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedNextRunsIDs(); len(nodes) > 0 && !_u.mutation.NextRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.NextRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.NextRunsTable,
+			Columns: []string{chargeusagebasedruns.NextRunsColumn},
+			Bidi:    true,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/client.go
+++ b/openmeter/ent/db/client.go
@@ -10567,6 +10567,38 @@ func (c *ChargeUsageBasedRunsClient) QueryBillingInvoice(_m *ChargeUsageBasedRun
 	return query
 }
 
+// QueryNextRuns queries the next_runs edge of a ChargeUsageBasedRuns.
+func (c *ChargeUsageBasedRunsClient) QueryNextRuns(_m *ChargeUsageBasedRuns) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.NextRunsTable, chargeusagebasedruns.NextRunsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryPriorRun queries the prior_run edge of a ChargeUsageBasedRuns.
+func (c *ChargeUsageBasedRunsClient) QueryPriorRun(_m *ChargeUsageBasedRuns) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedruns.PriorRunTable, chargeusagebasedruns.PriorRunColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryCreditAllocations queries the credit_allocations edge of a ChargeUsageBasedRuns.
 func (c *ChargeUsageBasedRunsClient) QueryCreditAllocations(_m *ChargeUsageBasedRuns) *ChargeUsageBasedRunCreditAllocationsQuery {
 	query := (&ChargeUsageBasedRunCreditAllocationsClient{config: c.config}).Query()

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3514,6 +3514,7 @@ var (
 		{Name: "initial_type", Type: field.TypeEnum, Enums: []string{"final_realization", "partial_invoice", "invalid_due_to_unsupported_credit_note"}},
 		{Name: "stored_at_lt", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
+		{Name: "schema_level", Type: field.TypeInt, Default: 1, SchemaType: map[string]string{"postgres": "smallint"}},
 		{Name: "detailed_lines_present", Type: field.TypeBool},
 		{Name: "detailed_lines_include_credit_allocations", Type: field.TypeBool, Default: false},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
@@ -3522,6 +3523,7 @@ var (
 		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "prior_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// ChargeUsageBasedRunsTable holds the schema information for the "charge_usage_based_runs" table.
@@ -3532,25 +3534,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[22]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[23]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[24]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
+				Symbol:     "charge_ub_run_prior_run",
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[26]},
+				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[25]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[27]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3569,7 +3577,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[24]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[25]},
 			},
 		},
 	}
@@ -6419,7 +6427,8 @@ func init() {
 	ChargeUsageBasedRunsTable.ForeignKeys[0].RefTable = BillingInvoicesTable
 	ChargeUsageBasedRunsTable.ForeignKeys[1].RefTable = BillingInvoiceLinesTable
 	ChargeUsageBasedRunsTable.ForeignKeys[2].RefTable = ChargeUsageBasedTable
-	ChargeUsageBasedRunsTable.ForeignKeys[3].RefTable = FeaturesTable
+	ChargeUsageBasedRunsTable.ForeignKeys[3].RefTable = ChargeUsageBasedRunsTable
+	ChargeUsageBasedRunsTable.ForeignKeys[4].RefTable = FeaturesTable
 	CreditRealizationLineagesTable.ForeignKeys[0].RefTable = ChargesTable
 	CreditRealizationLineageSegmentsTable.ForeignKeys[0].RefTable = CreditRealizationLineagesTable
 	CurrencyCostBasesTable.ForeignKeys[0].RefTable = CustomCurrenciesTable

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -77900,6 +77900,8 @@ type ChargeUsageBasedRunsMutation struct {
 	initial_type                              *usagebased.RealizationRunType
 	stored_at_lt                              *time.Time
 	service_period_to                         *time.Time
+	schema_level                              *int
+	addschema_level                           *int
 	detailed_lines_present                    *bool
 	detailed_lines_include_credit_allocations *bool
 	metered_quantity                          *alpacadecimal.Decimal
@@ -77914,6 +77916,11 @@ type ChargeUsageBasedRunsMutation struct {
 	clearedbilling_invoice_line               bool
 	billing_invoice                           *string
 	clearedbilling_invoice                    bool
+	next_runs                                 map[string]struct{}
+	removednext_runs                          map[string]struct{}
+	clearednext_runs                          bool
+	prior_run                                 *string
+	clearedprior_run                          bool
 	credit_allocations                        map[string]struct{}
 	removedcredit_allocations                 map[string]struct{}
 	clearedcredit_allocations                 bool
@@ -78700,6 +78707,111 @@ func (m *ChargeUsageBasedRunsMutation) ResetServicePeriodTo() {
 	m.service_period_to = nil
 }
 
+// SetSchemaLevel sets the "schema_level" field.
+func (m *ChargeUsageBasedRunsMutation) SetSchemaLevel(i int) {
+	m.schema_level = &i
+	m.addschema_level = nil
+}
+
+// SchemaLevel returns the value of the "schema_level" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) SchemaLevel() (r int, exists bool) {
+	v := m.schema_level
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSchemaLevel returns the old "schema_level" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldSchemaLevel(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSchemaLevel is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSchemaLevel requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSchemaLevel: %w", err)
+	}
+	return oldValue.SchemaLevel, nil
+}
+
+// AddSchemaLevel adds i to the "schema_level" field.
+func (m *ChargeUsageBasedRunsMutation) AddSchemaLevel(i int) {
+	if m.addschema_level != nil {
+		*m.addschema_level += i
+	} else {
+		m.addschema_level = &i
+	}
+}
+
+// AddedSchemaLevel returns the value that was added to the "schema_level" field in this mutation.
+func (m *ChargeUsageBasedRunsMutation) AddedSchemaLevel() (r int, exists bool) {
+	v := m.addschema_level
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetSchemaLevel resets all changes to the "schema_level" field.
+func (m *ChargeUsageBasedRunsMutation) ResetSchemaLevel() {
+	m.schema_level = nil
+	m.addschema_level = nil
+}
+
+// SetPriorRunID sets the "prior_run_id" field.
+func (m *ChargeUsageBasedRunsMutation) SetPriorRunID(s string) {
+	m.prior_run = &s
+}
+
+// PriorRunID returns the value of the "prior_run_id" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) PriorRunID() (r string, exists bool) {
+	v := m.prior_run
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPriorRunID returns the old "prior_run_id" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldPriorRunID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPriorRunID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPriorRunID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPriorRunID: %w", err)
+	}
+	return oldValue.PriorRunID, nil
+}
+
+// ClearPriorRunID clears the value of the "prior_run_id" field.
+func (m *ChargeUsageBasedRunsMutation) ClearPriorRunID() {
+	m.prior_run = nil
+	m.clearedFields[chargeusagebasedruns.FieldPriorRunID] = struct{}{}
+}
+
+// PriorRunIDCleared returns if the "prior_run_id" field was cleared in this mutation.
+func (m *ChargeUsageBasedRunsMutation) PriorRunIDCleared() bool {
+	_, ok := m.clearedFields[chargeusagebasedruns.FieldPriorRunID]
+	return ok
+}
+
+// ResetPriorRunID resets all changes to the "prior_run_id" field.
+func (m *ChargeUsageBasedRunsMutation) ResetPriorRunID() {
+	m.prior_run = nil
+	delete(m.clearedFields, chargeusagebasedruns.FieldPriorRunID)
+}
+
 // SetDetailedLinesPresent sets the "detailed_lines_present" field.
 func (m *ChargeUsageBasedRunsMutation) SetDetailedLinesPresent(b bool) {
 	m.detailed_lines_present = &b
@@ -79125,6 +79237,87 @@ func (m *ChargeUsageBasedRunsMutation) ResetBillingInvoice() {
 	m.clearedbilling_invoice = false
 }
 
+// AddNextRunIDs adds the "next_runs" edge to the ChargeUsageBasedRuns entity by ids.
+func (m *ChargeUsageBasedRunsMutation) AddNextRunIDs(ids ...string) {
+	if m.next_runs == nil {
+		m.next_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.next_runs[ids[i]] = struct{}{}
+	}
+}
+
+// ClearNextRuns clears the "next_runs" edge to the ChargeUsageBasedRuns entity.
+func (m *ChargeUsageBasedRunsMutation) ClearNextRuns() {
+	m.clearednext_runs = true
+}
+
+// NextRunsCleared reports if the "next_runs" edge to the ChargeUsageBasedRuns entity was cleared.
+func (m *ChargeUsageBasedRunsMutation) NextRunsCleared() bool {
+	return m.clearednext_runs
+}
+
+// RemoveNextRunIDs removes the "next_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (m *ChargeUsageBasedRunsMutation) RemoveNextRunIDs(ids ...string) {
+	if m.removednext_runs == nil {
+		m.removednext_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.next_runs, ids[i])
+		m.removednext_runs[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedNextRuns returns the removed IDs of the "next_runs" edge to the ChargeUsageBasedRuns entity.
+func (m *ChargeUsageBasedRunsMutation) RemovedNextRunsIDs() (ids []string) {
+	for id := range m.removednext_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// NextRunsIDs returns the "next_runs" edge IDs in the mutation.
+func (m *ChargeUsageBasedRunsMutation) NextRunsIDs() (ids []string) {
+	for id := range m.next_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetNextRuns resets all changes to the "next_runs" edge.
+func (m *ChargeUsageBasedRunsMutation) ResetNextRuns() {
+	m.next_runs = nil
+	m.clearednext_runs = false
+	m.removednext_runs = nil
+}
+
+// ClearPriorRun clears the "prior_run" edge to the ChargeUsageBasedRuns entity.
+func (m *ChargeUsageBasedRunsMutation) ClearPriorRun() {
+	m.clearedprior_run = true
+	m.clearedFields[chargeusagebasedruns.FieldPriorRunID] = struct{}{}
+}
+
+// PriorRunCleared reports if the "prior_run" edge to the ChargeUsageBasedRuns entity was cleared.
+func (m *ChargeUsageBasedRunsMutation) PriorRunCleared() bool {
+	return m.PriorRunIDCleared() || m.clearedprior_run
+}
+
+// PriorRunIDs returns the "prior_run" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// PriorRunID instead. It exists only for internal usage by the builders.
+func (m *ChargeUsageBasedRunsMutation) PriorRunIDs() (ids []string) {
+	if id := m.prior_run; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetPriorRun resets all changes to the "prior_run" edge.
+func (m *ChargeUsageBasedRunsMutation) ResetPriorRun() {
+	m.prior_run = nil
+	m.clearedprior_run = false
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by ids.
 func (m *ChargeUsageBasedRunsMutation) AddCreditAllocationIDs(ids ...string) {
 	if m.credit_allocations == nil {
@@ -79453,7 +79646,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 25)
+	fields := make([]string, 0, 27)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -79507,6 +79700,12 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	}
 	if m.service_period_to != nil {
 		fields = append(fields, chargeusagebasedruns.FieldServicePeriodTo)
+	}
+	if m.schema_level != nil {
+		fields = append(fields, chargeusagebasedruns.FieldSchemaLevel)
+	}
+	if m.prior_run != nil {
+		fields = append(fields, chargeusagebasedruns.FieldPriorRunID)
 	}
 	if m.detailed_lines_present != nil {
 		fields = append(fields, chargeusagebasedruns.FieldDetailedLinesPresent)
@@ -79573,6 +79772,10 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.StoredAtLt()
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		return m.ServicePeriodTo()
+	case chargeusagebasedruns.FieldSchemaLevel:
+		return m.SchemaLevel()
+	case chargeusagebasedruns.FieldPriorRunID:
+		return m.PriorRunID()
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		return m.DetailedLinesPresent()
 	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
@@ -79632,6 +79835,10 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldStoredAtLt(ctx)
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		return m.OldServicePeriodTo(ctx)
+	case chargeusagebasedruns.FieldSchemaLevel:
+		return m.OldSchemaLevel(ctx)
+	case chargeusagebasedruns.FieldPriorRunID:
+		return m.OldPriorRunID(ctx)
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		return m.OldDetailedLinesPresent(ctx)
 	case chargeusagebasedruns.FieldDetailedLinesIncludeCreditAllocations:
@@ -79781,6 +79988,20 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetServicePeriodTo(v)
 		return nil
+	case chargeusagebasedruns.FieldSchemaLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSchemaLevel(v)
+		return nil
+	case chargeusagebasedruns.FieldPriorRunID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPriorRunID(v)
+		return nil
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		v, ok := value.(bool)
 		if !ok {
@@ -79837,13 +80058,21 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *ChargeUsageBasedRunsMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addschema_level != nil {
+		fields = append(fields, chargeusagebasedruns.FieldSchemaLevel)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *ChargeUsageBasedRunsMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case chargeusagebasedruns.FieldSchemaLevel:
+		return m.AddedSchemaLevel()
+	}
 	return nil, false
 }
 
@@ -79852,6 +80081,13 @@ func (m *ChargeUsageBasedRunsMutation) AddedField(name string) (ent.Value, bool)
 // type.
 func (m *ChargeUsageBasedRunsMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case chargeusagebasedruns.FieldSchemaLevel:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddSchemaLevel(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns numeric field %s", name)
 }
@@ -79862,6 +80098,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearedFields() []string {
 	var fields []string
 	if m.FieldCleared(chargeusagebasedruns.FieldDeletedAt) {
 		fields = append(fields, chargeusagebasedruns.FieldDeletedAt)
+	}
+	if m.FieldCleared(chargeusagebasedruns.FieldPriorRunID) {
+		fields = append(fields, chargeusagebasedruns.FieldPriorRunID)
 	}
 	if m.FieldCleared(chargeusagebasedruns.FieldLineID) {
 		fields = append(fields, chargeusagebasedruns.FieldLineID)
@@ -79885,6 +80124,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearField(name string) error {
 	switch name {
 	case chargeusagebasedruns.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case chargeusagebasedruns.FieldPriorRunID:
+		m.ClearPriorRunID()
 		return nil
 	case chargeusagebasedruns.FieldLineID:
 		m.ClearLineID()
@@ -79954,6 +80196,12 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		m.ResetServicePeriodTo()
 		return nil
+	case chargeusagebasedruns.FieldSchemaLevel:
+		m.ResetSchemaLevel()
+		return nil
+	case chargeusagebasedruns.FieldPriorRunID:
+		m.ResetPriorRunID()
+		return nil
 	case chargeusagebasedruns.FieldDetailedLinesPresent:
 		m.ResetDetailedLinesPresent()
 		return nil
@@ -79981,7 +80229,7 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 12)
 	if m.usage_based != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -79993,6 +80241,12 @@ func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
 	}
 	if m.billing_invoice != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoice)
+	}
+	if m.next_runs != nil {
+		edges = append(edges, chargeusagebasedruns.EdgeNextRuns)
+	}
+	if m.prior_run != nil {
+		edges = append(edges, chargeusagebasedruns.EdgePriorRun)
 	}
 	if m.credit_allocations != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
@@ -80035,6 +80289,16 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 		if id := m.billing_invoice; id != nil {
 			return []ent.Value{*id}
 		}
+	case chargeusagebasedruns.EdgeNextRuns:
+		ids := make([]ent.Value, 0, len(m.next_runs))
+		for id := range m.next_runs {
+			ids = append(ids, id)
+		}
+		return ids
+	case chargeusagebasedruns.EdgePriorRun:
+		if id := m.prior_run; id != nil {
+			return []ent.Value{*id}
+		}
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		ids := make([]ent.Value, 0, len(m.credit_allocations))
 		for id := range m.credit_allocations {
@@ -80073,7 +80337,10 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeUsageBasedRunsMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 12)
+	if m.removednext_runs != nil {
+		edges = append(edges, chargeusagebasedruns.EdgeNextRuns)
+	}
 	if m.removedcredit_allocations != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
 	}
@@ -80093,6 +80360,12 @@ func (m *ChargeUsageBasedRunsMutation) RemovedEdges() []string {
 // the given name in this mutation.
 func (m *ChargeUsageBasedRunsMutation) RemovedIDs(name string) []ent.Value {
 	switch name {
+	case chargeusagebasedruns.EdgeNextRuns:
+		ids := make([]ent.Value, 0, len(m.removednext_runs))
+		for id := range m.removednext_runs {
+			ids = append(ids, id)
+		}
+		return ids
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		ids := make([]ent.Value, 0, len(m.removedcredit_allocations))
 		for id := range m.removedcredit_allocations {
@@ -80123,7 +80396,7 @@ func (m *ChargeUsageBasedRunsMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 12)
 	if m.clearedusage_based {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -80135,6 +80408,12 @@ func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
 	}
 	if m.clearedbilling_invoice {
 		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoice)
+	}
+	if m.clearednext_runs {
+		edges = append(edges, chargeusagebasedruns.EdgeNextRuns)
+	}
+	if m.clearedprior_run {
+		edges = append(edges, chargeusagebasedruns.EdgePriorRun)
 	}
 	if m.clearedcredit_allocations {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
@@ -80169,6 +80448,10 @@ func (m *ChargeUsageBasedRunsMutation) EdgeCleared(name string) bool {
 		return m.clearedbilling_invoice_line
 	case chargeusagebasedruns.EdgeBillingInvoice:
 		return m.clearedbilling_invoice
+	case chargeusagebasedruns.EdgeNextRuns:
+		return m.clearednext_runs
+	case chargeusagebasedruns.EdgePriorRun:
+		return m.clearedprior_run
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		return m.clearedcredit_allocations
 	case chargeusagebasedruns.EdgeFiatOverageCreditAllocations:
@@ -80201,6 +80484,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearEdge(name string) error {
 	case chargeusagebasedruns.EdgeBillingInvoice:
 		m.ClearBillingInvoice()
 		return nil
+	case chargeusagebasedruns.EdgePriorRun:
+		m.ClearPriorRun()
+		return nil
 	case chargeusagebasedruns.EdgeInvoicedUsage:
 		m.ClearInvoicedUsage()
 		return nil
@@ -80226,6 +80512,12 @@ func (m *ChargeUsageBasedRunsMutation) ResetEdge(name string) error {
 		return nil
 	case chargeusagebasedruns.EdgeBillingInvoice:
 		m.ResetBillingInvoice()
+		return nil
+	case chargeusagebasedruns.EdgeNextRuns:
+		m.ResetNextRuns()
+		return nil
+	case chargeusagebasedruns.EdgePriorRun:
+		m.ResetPriorRun()
 		return nil
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		m.ResetCreditAllocations()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1829,20 +1829,24 @@ func init() {
 	chargeusagebasedrunsDescFeatureID := chargeusagebasedrunsFields[1].Descriptor()
 	// chargeusagebasedruns.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	chargeusagebasedruns.FeatureIDValidator = chargeusagebasedrunsDescFeatureID.Validators[0].(func(string) error)
+	// chargeusagebasedrunsDescSchemaLevel is the schema descriptor for schema_level field.
+	chargeusagebasedrunsDescSchemaLevel := chargeusagebasedrunsFields[6].Descriptor()
+	// chargeusagebasedruns.DefaultSchemaLevel holds the default value on creation for the schema_level field.
+	chargeusagebasedruns.DefaultSchemaLevel = chargeusagebasedrunsDescSchemaLevel.Default.(int)
 	// chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations is the schema descriptor for detailed_lines_include_credit_allocations field.
-	chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations := chargeusagebasedrunsFields[7].Descriptor()
+	chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations := chargeusagebasedrunsFields[9].Descriptor()
 	// chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations holds the default value on creation for the detailed_lines_include_credit_allocations field.
 	chargeusagebasedruns.DefaultDetailedLinesIncludeCreditAllocations = chargeusagebasedrunsDescDetailedLinesIncludeCreditAllocations.Default.(bool)
 	// chargeusagebasedrunsDescLineID is the schema descriptor for line_id field.
-	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[8].Descriptor()
+	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[10].Descriptor()
 	// chargeusagebasedruns.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	chargeusagebasedruns.LineIDValidator = chargeusagebasedrunsDescLineID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescInvoiceID is the schema descriptor for invoice_id field.
-	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[9].Descriptor()
+	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[11].Descriptor()
 	// chargeusagebasedruns.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
 	chargeusagebasedruns.InvoiceIDValidator = chargeusagebasedrunsDescInvoiceID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescImmutable is the schema descriptor for immutable field.
-	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[12].Descriptor()
+	chargeusagebasedrunsDescImmutable := chargeusagebasedrunsFields[14].Descriptor()
 	// chargeusagebasedruns.DefaultImmutable holds the default value on creation for the immutable field.
 	chargeusagebasedruns.DefaultImmutable = chargeusagebasedrunsDescImmutable.Default.(bool)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -360,6 +360,20 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 		field.Time("service_period_to").
 			Immutable(),
 
+		field.Int("schema_level").
+			Default(usagebased.RealizationRunSchemaLevelLegacy).
+			SchemaType(map[string]string{
+				dialect.Postgres: "smallint",
+			}),
+
+		field.String("prior_run_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			Nillable().
+			Immutable(),
+
 		field.Bool("detailed_lines_present"),
 
 		field.Bool("detailed_lines_include_credit_allocations").
@@ -419,6 +433,13 @@ func (ChargeUsageBasedRuns) Edges() []ent.Edge {
 			Unique().
 			Immutable().
 			Annotations(entsql.OnDelete(entsql.SetNull)),
+		edge.To("next_runs", ChargeUsageBasedRuns.Type).
+			StorageKey(edge.Symbol("charge_ub_run_prior_run")),
+		edge.From("prior_run", ChargeUsageBasedRuns.Type).
+			Ref("next_runs").
+			Field("prior_run_id").
+			Unique().
+			Immutable(),
 		edge.To("credit_allocations", ChargeUsageBasedRunCreditAllocations.Type).
 			StorageKey(edge.Symbol("charge_ub_run_credit_alloc_run")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),

--- a/tools/migrate/migrations/20260825091451_add_usage_based_run_prior_lineage.down.sql
+++ b/tools/migrate/migrations/20260825091451_add_usage_based_run_prior_lineage.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP CONSTRAINT "charge_ub_run_prior_run", DROP COLUMN "prior_run_id", DROP COLUMN "schema_level";

--- a/tools/migrate/migrations/20260825091451_add_usage_based_run_prior_lineage.up.sql
+++ b/tools/migrate/migrations/20260825091451_add_usage_based_run_prior_lineage.up.sql
@@ -1,0 +1,2 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "schema_level" smallint NOT NULL DEFAULT 1, ADD COLUMN "prior_run_id" character(26) NULL, ADD CONSTRAINT "charge_ub_run_prior_run" FOREIGN KEY ("prior_run_id") REFERENCES "charge_usage_based_runs" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
+h1:6mctZw6/94Jm3yWPYQ1udKK78ceHeg+dqOZ9ZXS+JDc=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -270,3 +270,4 @@ h1:l0hjrx9b9W5bxQw4g8VhvwCSj+jb9qf0acfTC8BZD24=
 20260818090123_rate_card_feature_reference_constraints.up.sql h1:VjBtzWp/DPk3Y8uk0B0S6PqfaIzodN3rk0zDKGnnVtE=
 20260824141945_repair_distributed_locks.up.sql h1:2yMrvYEgMu69u2VehzaZMyESZmD/HrwOZaOU1xQsTDY=
 20260825073524_add_usage_based_run_immutable.up.sql h1:gtNDCpb60imuRqnncnjB/xHjAWKUa44SrnJbFl152wo=
+20260825091451_add_usage_based_run_prior_lineage.up.sql h1:2I9axpbf+ph056F3vztIUAAIyX/dtm3Ly+hI6GRjsV8=


### PR DESCRIPTION
## Summary

- add mutable `schema_level` with database default `1` and nullable self-referencing `prior_run_id` to usage-based realization runs
- write schema level `2` for new runs and persist the preceding non-voided run, including an explicit null predecessor for the first run
- derive nominal service-period starts and prior billed usage from persisted run lineage rather than reconstructing predecessors by timestamp
- preserve level-1 representation as unknown lineage for the staged backfill rollout
- document that a run service period is nominal and can include late events from earlier periods

## Deployment

This is PR1 of the OM-471 rollout. Existing and old-writer rows remain schema level 1 through the database default. New adapter writes use schema level 2. Backfill is intentionally excluded from this PR.

## Verification

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/usagebased/... -count=1`
- Atlas desired-state diff: no changes
- `atlas migrate --env local lint --latest 10`
- `atlas migrate --env local validate`
- `golangci-lint run ./openmeter/billing/charges/usagebased/...`

Jira: OM-471


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent lineage tracking between usage-based realization runs.
  - Improved service-period calculation using linked prior runs.
  - Added validation for invalid, missing, cross-namespace, and self-referencing run relationships.
  - Preserved support for legacy runs during migration.
  - Improved handling of late-arriving events and skipped voided runs.

- **Bug Fixes**
  - Billing quantities now use linked prior-run values instead of timestamp inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR persists explicit predecessor lineage for usage-based realization runs while retaining an ordering fallback for unbackfilled legacy rows.
- Adds schema-level and self-referencing predecessor persistence.
- Uses persisted lineage to derive nominal service periods and billed usage.
- Preserves legacy fallback behavior during the staged backfill rollout.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because remapping an unbackfilled equal-boundary run can produce an incorrect invoiced usage quantity.

The legacy lineage fallback excludes same-boundary predecessors even though the run lifecycle orders such runs by creation time, allowing remapping to subtract the wrong previously billed quantity.

**Files Needing Attention:** openmeter/billing/charges/usagebased/realizationrun.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/realizationrun.go | Adds lineage-aware metered-quantity mapping and predecessor selection, but the legacy fallback skips same-boundary predecessors. |
| openmeter/billing/charges/usagebased/charge.go | Derives run service periods from explicit lineage while preserving ordering-based behavior for legacy rows. |
| openmeter/billing/charges/usagebased/adapter/mapping.go | Maps persisted schema levels into known, known-empty, or unknown lineage and rejects inconsistent states. |
| openmeter/billing/charges/usagebased/service/run/create.go | Persists the latest effective realization run as the predecessor of newly created runs. |
| tools/migrate/migrations/20260825091451_add_usage_based_run_prior_lineage.up.sql | Adds the defaulted schema level and nullable self-referencing predecessor column for staged rollout compatibility. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Load[Load realization run] --> Known{PriorRunID state}
  Known -->|Known predecessor| Resolve[Resolve persisted prior run]
  Known -->|Known first run| Zero[Use intent start and zero prior usage]
  Known -->|Unknown legacy lineage| Fallback[Order effective runs by boundary and creation time]
  Resolve --> Map[Map service period and billed usage]
  Zero --> Map
  Fallback --> Map
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235003%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5003&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Frealizationrun.go%3A415-417%0A**Same-boundary%20predecessor%20is%20skipped**%0A%0AWhen%20an%20unbackfilled%20schema-level-1%20run%20is%20remapped%20after%20lifecycle%20processing%20leaves%20multiple%20effective%20runs%20with%20the%20same%20%60ServicePeriodTo%60%2C%20this%20strict%20%60Before%60%20check%20excludes%20the%20actual%20predecessor%20instead%20of%20applying%20the%20%60CreatedAt%60%20tie-break%20used%20elsewhere.%20%60preLinePeriod%60%20then%20comes%20from%20an%20older%20run%20or%20zero%2C%20producing%20an%20incorrect%20invoiced%20line-period%20quantity.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5003&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fom-471-usage-run-lineage%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fom-471-usage-run-lineage%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fusagebased%2Frealizationrun.go%3A415-417%0A**Same-boundary%20predecessor%20is%20skipped**%0A%0AWhen%20an%20unbackfilled%20schema-level-1%20run%20is%20remapped%20after%20lifecycle%20processing%20leaves%20multiple%20effective%20runs%20with%20the%20same%20%60ServicePeriodTo%60%2C%20this%20strict%20%60Before%60%20check%20excludes%20the%20actual%20predecessor%20instead%20of%20applying%20the%20%60CreatedAt%60%20tie-break%20used%20elsewhere.%20%60preLinePeriod%60%20then%20comes%20from%20an%20older%20run%20or%20zero%2C%20producing%20an%20incorrect%20invoiced%20line-period%20quantity.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5003&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(charges): address usage run lineage ..."](https://github.com/openmeterio/openmeter/commit/f04e134d5a6be3b6e719750433644e932ca4a226) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56678366)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->