### PR TITLE
fix(billing): register the custom invoicing app in the jobs binary

### DIFF
--- a/cmd/jobs/internal/wire.go
+++ b/cmd/jobs/internal/wire.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/app/common"
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
+	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	chargesworkeradvance "github.com/openmeterio/openmeter/openmeter/billing/charges/worker/advance"
 	billingworkerautoadvance "github.com/openmeterio/openmeter/openmeter/billing/worker/advance"
@@ -41,6 +42,11 @@ type Application struct {
 
 	App                           app.Service
 	AppStripe                     appstripe.Service
+	// Constructing the custom invoicing service registers its marketplace
+	// listing; without it the subscription sync reconciler cannot resolve
+	// a billing profile driven by the custom_invoicing app
+	// ("listing with type not found: custom_invoicing").
+	AppCustomInvoicing            appcustominvoicing.Service
 	AppSandboxProvisioner         common.AppSandboxProvisioner
 	Customer                      customer.Service
 	BillingRegistry               common.BillingRegistry

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/app/common"
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	"github.com/openmeterio/openmeter/openmeter/app/stripe"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/worker/advance"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/advance"
@@ -418,6 +419,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	appcustominvoicingService, err := common.NewAppCustomInvoicingService(logger, client, appsConfiguration, service, customerService, secretserviceService, billingRegistry, eventbusPublisher)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	factory, err := common.NewAppSandboxFactory(appsConfiguration, service, billingRegistry)
 	if err != nil {
 		cleanup7()
@@ -613,6 +625,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Migrator:                      migrator,
 		App:                           service,
 		AppStripe:                     appstripeService,
+		AppCustomInvoicing:            appcustominvoicingService,
 		AppSandboxProvisioner:         appSandboxProvisioner,
 		Customer:                      customerService,
 		BillingRegistry:               billingRegistry,
@@ -655,8 +668,13 @@ type Application struct {
 	common.GlobalInitializer
 	common.Migrator
 
-	App                           app.Service
-	AppStripe                     appstripe.Service
+	App       app.Service
+	AppStripe appstripe.Service
+	// Constructing the custom invoicing service registers its marketplace
+	// listing; without it the subscription sync reconciler cannot resolve
+	// a billing profile driven by the custom_invoicing app
+	// ("listing with type not found: custom_invoicing").
+	AppCustomInvoicing            appcustominvoicing.Service
 	AppSandboxProvisioner         common.AppSandboxProvisioner
 	Customer                      customer.Service
 	BillingRegistry               common.BillingRegistry


### PR DESCRIPTION
The jobs binary (subscription sync cronjob) cannot resolve a billing profile driven by the custom_invoicing app:

    getting billing profile: cannot resolve tax app: failed to get listing for app <id>: not found error: listing with type not found: custom_invoicing

Marketplace listings are registered as a side effect of constructing each app service, and wire only constructs what a binary's Application struct demands. cmd/jobs demands the sandbox and stripe apps but not custom invoicing; the server and cmd/billing-worker construct it, which is why the same app resolves fine on every other surface.

Repro: install custom_invoicing, create a default billing profile with it in all three slots, subscribe a customer to a paid plan, run `openmeter-jobs billing subscriptionsync all`. Free-plan subscriptions skip on "no billables" before profile resolution, so the failure only shows on paid ones.

Fix: demand the service from cmd/jobs as well; wire_gen.go regenerated. Verified against v1.0.0-beta.231 and .232 — the stock binary fails as above, the patched one reconciles the paid subscription into a gathering invoice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom invoicing services.
  * Custom invoicing billing profiles can now be recognized during subscription reconciliation.
  * Marketplace listings required for custom invoicing are registered automatically during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the custom invoicing service to the jobs binary’s dependency graph so its marketplace listing is registered before subscription synchronization resolves billing profiles.
- Adds `appcustominvoicing.Service` to the jobs `Application`.
- Regenerates the Wire graph to construct and retain the service.
- Preserves existing provider error cleanup and initialization ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the jobs dependency graph now consistently registering the custom invoicing marketplace listing.

The added provider uses dependencies already available in the jobs graph, matches existing server and billing-worker composition, and preserves generated initialization and cleanup behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/jobs/internal/wire.go | Adds the custom invoicing service to the jobs application graph, making its registration side effect part of process initialization. |
| cmd/jobs/internal/wire_gen.go | Regenerates the jobs provider graph to construct and retain the custom invoicing service with consistent error cleanup. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Start[Jobs application initialization] --> Construct[Construct custom invoicing service]
  Construct --> Register[Register custom_invoicing marketplace listing]
  Register --> Sync[Run paid subscription synchronization]
  Sync --> Resolve[Resolve custom invoicing billing profile]
  Resolve --> Invoice[Reconcile gathering invoice]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): register the custom invoic..."](https://github.com/openmeterio/openmeter/commit/3af4df4da991c7de7a78f5489de4efa59c4f3347) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56868033)</sub>

**Context used:**

- Knowledge Base — [API and runtime composition](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/api-and-runtime-composition.md)
- Knowledge Base — [Server and worker processes](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/server-and-worker-processes.md)

<!-- /greptile_comment -->