### PR TITLE
chore: bump min Go version to 1.26

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/openmeterio/openmeter/e2e
 
-go 1.25.6
+go 1.26
 
 replace github.com/openmeterio/openmeter => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openmeterio/openmeter
 
-go 1.25.6
+go 1.26
 
 // ee: https://github.com/oklog/run/pull/35
 replace github.com/oklog/run => github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634


### PR DESCRIPTION
## Overview

Bump minimum Go version to 1.26. This intentionally leaves out the Go version upgrade for the Go SDK package.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises the minimum Go version from 1.25.6 to 1.26 for the root and end-to-end test modules while intentionally leaving the Go SDK module unchanged.
- Updates the root module’s Go directive.
- Updates the end-to-end module’s Go directive.
- Aligns both changed modules with existing Go 1.26 build and CI environments.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the affected build environments already use Go 1.26 or newer.

The change only updates two module Go directives, leaves dependency resolution unchanged, and remains compatible with the repository’s relevant CI and container toolchains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| go.mod | Raises the root module’s minimum Go version to 1.26; existing build targets are compatible and no dependency versions change. |
| e2e/go.mod | Raises the end-to-end test module’s minimum Go version to 1.26 consistently with the root module and current CI environment. |

<sub>Reviews (1): Last reviewed commit: ["chore: bump min Go version to 1.26"](https://github.com/openmeterio/openmeter/commit/0a74d24cfa8e1ce56e3c8ec4c60ff188b9b529fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56975177)</sub>

<!-- /greptile_comment -->