### PR TITLE
feat(charges): backfill usage run lineage

### DIFF
--- a/tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.down.sql
+++ b/tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.down.sql
@@ -1,0 +1,2 @@
+-- Intentionally no-op. Demoting schema-level-2 runs would discard known
+-- lineage and could also overwrite realization runs created after the backfill.

--- a/tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.up.sql
+++ b/tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.up.sql
@@ -1,0 +1,62 @@
+BEGIN;
+
+-- Capture the schema-level-1 rows and their approximate predecessors before
+-- updating them. Voided history is intentionally included: ordering all runs
+-- by creation time per charge is the accepted approximation for this backfill.
+CREATE TEMP TABLE "om_usage_based_run_prior_lineage_backfill" (
+  "id" character(26) PRIMARY KEY,
+  "prior_run_id" character(26) NULL
+) ON COMMIT DROP;
+
+INSERT INTO "om_usage_based_run_prior_lineage_backfill" ("id", "prior_run_id")
+SELECT "id", "prior_run_id"
+FROM (
+  SELECT
+    "id",
+    "schema_level",
+    LAG("id") OVER (
+      PARTITION BY "namespace", "charge_id"
+      ORDER BY "created_at", "id"
+    ) AS "prior_run_id"
+  FROM "charge_usage_based_runs"
+) AS "ordered_runs"
+WHERE "schema_level" = 1
+ORDER BY "id";
+
+-- schema_level is the commit marker and is promoted only together with the
+-- lineage value captured above. Existing schema-level-2 rows are untouched.
+UPDATE "charge_usage_based_runs" AS "run"
+SET
+  "prior_run_id" = "backfill"."prior_run_id",
+  "schema_level" = 2
+FROM "om_usage_based_run_prior_lineage_backfill" AS "backfill"
+WHERE "run"."id" = "backfill"."id"
+  AND "run"."schema_level" = 1;
+
+DO $migration$
+DECLARE
+  invalid_ids TEXT;
+BEGIN
+  SELECT string_agg("run"."id"::text, ', ' ORDER BY "run"."id")
+  INTO invalid_ids
+  FROM "om_usage_based_run_prior_lineage_backfill" AS "backfill"
+  JOIN "charge_usage_based_runs" AS "run" ON "run"."id" = "backfill"."id"
+  WHERE "run"."schema_level" IS DISTINCT FROM 2
+    OR "run"."prior_run_id" IS DISTINCT FROM "backfill"."prior_run_id";
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'usage-based realization run lineage backfill is incomplete [ids=%]', invalid_ids;
+  END IF;
+
+  SELECT string_agg("id"::text, ', ' ORDER BY "id")
+  INTO invalid_ids
+  FROM "charge_usage_based_runs"
+  WHERE "schema_level" = 1;
+
+  IF invalid_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'usage-based realization runs remain at schema level 1 [ids=%]', invalid_ids;
+  END IF;
+END
+$migration$;
+
+COMMIT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:YFEqyc0ZS26SrWFw+1zBijJ9IaurnKhQJOIEdCAoOXY=
+h1:Zbm+IN8nnd5MIJpHsJaNRIEhW3Yu+YiuZKsmojOc+Sc=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -272,3 +272,4 @@ h1:YFEqyc0ZS26SrWFw+1zBijJ9IaurnKhQJOIEdCAoOXY=
 20260825073524_add_usage_based_run_immutable.up.sql h1:gtNDCpb60imuRqnncnjB/xHjAWKUa44SrnJbFl152wo=
 20260825091451_add_usage_based_run_prior_lineage.up.sql h1:2I9axpbf+ph056F3vztIUAAIyX/dtm3Ly+hI6GRjsV8=
 20260826113408_backfill_usage_based_run_immutable.up.sql h1:D0b69QdV15gKaqoQ5PEKvw60rtNWEHMk1Iv/rign4kI=
+20260826120555_backfill_usage_based_run_prior_lineage.up.sql h1:6WJ8jhOtRTCNDa01cCTuyiq777slyDS+PgydKK40dfQ=

--- a/tools/migrate/usage_based_run_prior_lineage_backfill_test.go
+++ b/tools/migrate/usage_based_run_prior_lineage_backfill_test.go
@@ -1,0 +1,212 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+type usageBasedRunPriorLineageState struct {
+	SchemaLevel int
+	PriorRunID  sql.NullString
+}
+
+func queryUsageBasedRunPriorLineageStates(t testing.TB, db *sql.DB) map[string]usageBasedRunPriorLineageState {
+	t.Helper()
+
+	rows, err := db.QueryContext(t.Context(), `
+		SELECT id, schema_level, prior_run_id
+		FROM charge_usage_based_runs
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	states := map[string]usageBasedRunPriorLineageState{}
+	for rows.Next() {
+		var (
+			id    string
+			state usageBasedRunPriorLineageState
+		)
+
+		require.NoError(t, rows.Scan(&id, &state.SchemaLevel, &state.PriorRunID))
+		states[id] = state
+	}
+	require.NoError(t, rows.Err())
+
+	return states
+}
+
+func TestBackfillUsageBasedRunPriorLineageMigration(t *testing.T) {
+	const (
+		namespace       = "default"
+		previousVersion = uint(20260826113408)
+		targetVersion   = uint(20260826120555)
+	)
+
+	// given:
+	// - legacy runs from two charges with interleaved creation times
+	// - same-created-at runs inserted out of ID order, including voided history
+	// - an existing schema-level-2 run
+	// when:
+	// - the lineage backfill is migrated up and then down
+	// then:
+	// - only legacy runs are linked by creation time and ID per charge
+	// - all legacy runs are promoted, existing level-2 lineage is preserved, and rollback is non-destructive
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEmpty)
+	t.Cleanup(func() { testDB.Close(t) })
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           testutils.NewLogger(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sourceErr, databaseErr := migrator.Close()
+		require.NoError(t, errors.Join(sourceErr, databaseErr))
+	})
+	require.NoError(t, migrator.Migrate(previousVersion))
+
+	db := testDB.PGDriver.DB()
+	now := time.Date(2026, 8, 26, 8, 0, 0, 0, time.UTC)
+	customerID := ulid.Make().String()
+	taxCodeID := ulid.Make().String()
+	featureID := ulid.Make().String()
+	chargeAID := ulid.Make().String()
+	chargeBID := ulid.Make().String()
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO customers (
+			id, namespace, metadata, created_at, updated_at, key, name, currency
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'lineage-customer', 'Lineage Customer', 'EUR'
+		)
+	`, customerID, namespace, now)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO tax_codes (
+			id, namespace, metadata, created_at, updated_at, name, key
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Lineage tax code', 'lineage-tax-code'
+		)
+	`, taxCodeID, namespace, now)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO features (
+			id, namespace, metadata, created_at, updated_at, name, key
+		) VALUES (
+			$1, $2, '{}'::jsonb, $3, $3, 'Lineage feature', 'lineage-feature'
+		)
+	`, featureID, namespace, now)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO charge_usage_based (
+			id, namespace, invoice_at, settlement_mode, discounts, feature_key, price,
+			service_period_from, service_period_to, billing_period_from, billing_period_to,
+			full_service_period_from, full_service_period_to, unique_reference_id, currency,
+			managed_by, annotations, metadata, created_at, updated_at, name, status,
+			status_detailed, customer_id, tax_code_id, feature_id, rating_engine,
+			current_realization_run_id
+		) VALUES
+			(
+				$1, $3, $4, 'credit_then_invoice', '{}'::jsonb, 'lineage-feature',
+				'{"type":"unit","amount":"1"}'::jsonb,
+				$4, $5, $4, $5, $4, $5, 'lineage-charge-a', 'EUR',
+				'subscription', '{}'::jsonb, '{}'::jsonb, $4, $4, 'Lineage Charge A', 'active',
+				'active', $6, $7, $8, 'delta', NULL
+			),
+			(
+				$2, $3, $4, 'credit_then_invoice', '{}'::jsonb, 'lineage-feature',
+				'{"type":"unit","amount":"1"}'::jsonb,
+				$4, $5, $4, $5, $4, $5, 'lineage-charge-b', 'EUR',
+				'subscription', '{}'::jsonb, '{}'::jsonb, $4, $4, 'Lineage Charge B', 'active',
+				'active', $6, $7, $8, 'delta', NULL
+			)
+	`, chargeAID, chargeBID, namespace, now, now.Add(24*time.Hour), customerID, taxCodeID, featureID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO charges (id, namespace, created_at, type, charge_usage_based_id)
+		VALUES
+			($1, $3, $4, 'usage_based', $1),
+			($2, $3, $4, 'usage_based', $2)
+	`, chargeAID, chargeBID, namespace, now)
+	require.NoError(t, err)
+
+	tiedRunIDs := []string{ulid.Make().String(), ulid.Make().String(), ulid.Make().String()}
+	slices.Sort(tiedRunIDs)
+	chargeAFirstRunID := tiedRunIDs[0]
+	chargeAVoidedRunID := tiedRunIDs[1]
+	chargeAThirdRunID := tiedRunIDs[2]
+	chargeAFourthRunID := ulid.Make().String()
+	chargeALevel2RunID := ulid.Make().String()
+	chargeBFirstRunID := ulid.Make().String()
+	chargeBSecondRunID := ulid.Make().String()
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO charge_usage_based_runs (
+			id, namespace, created_at, updated_at, deleted_at, type, initial_type,
+			stored_at_lt, service_period_to, detailed_lines_present, metered_quantity,
+			no_fiat_transaction_required, charge_id, feature_id, amount, taxes_total,
+			taxes_inclusive_total, taxes_exclusive_total, charges_total, discounts_total,
+			credits_total, total, schema_level, prior_run_id
+		) VALUES
+			($3, $1, $10, $10, NULL, 'partial_invoice', 'partial_invoice', $10, $11, false, 1, true, $2, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL),
+			($5, $1, $10, $10, NULL, 'partial_invoice', 'partial_invoice', $10, $11, false, 3, true, $2, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL),
+			($4, $1, $10, $10, NULL, 'invalid_due_to_unsupported_credit_note', 'partial_invoice', $10, $11, false, 2, true, $2, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL),
+			($6, $1, $12, $12, NULL, 'partial_invoice', 'partial_invoice', $12, $13, false, 4, true, $2, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL),
+			($7, $1, $14, $14, NULL, 'final_realization', 'final_realization', $14, $15, false, 5, true, $2, $9, 0, 0, 0, 0, 0, 0, 0, 0, 2, $6),
+			($16, $1, $17, $17, NULL, 'partial_invoice', 'partial_invoice', $17, $18, false, 1, true, $8, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL),
+			($19, $1, $20, $20, NULL, 'final_realization', 'final_realization', $20, $21, false, 2, true, $8, $9, 0, 0, 0, 0, 0, 0, 0, 0, 1, NULL)
+	`,
+		namespace,
+		chargeAID,
+		chargeAFirstRunID,
+		chargeAVoidedRunID,
+		chargeAThirdRunID,
+		chargeAFourthRunID,
+		chargeALevel2RunID,
+		chargeBID,
+		featureID,
+		now,
+		now.Add(time.Hour),
+		now.Add(2*time.Hour),
+		now.Add(3*time.Hour),
+		now.Add(4*time.Hour),
+		now.Add(5*time.Hour),
+		chargeBFirstRunID,
+		now.Add(30*time.Minute),
+		now.Add(90*time.Minute),
+		chargeBSecondRunID,
+		now.Add(3*time.Hour),
+		now.Add(4*time.Hour),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, migrator.Migrate(targetVersion))
+
+	wantStates := map[string]usageBasedRunPriorLineageState{
+		chargeAFirstRunID:  {SchemaLevel: 2},
+		chargeAVoidedRunID: {SchemaLevel: 2, PriorRunID: sql.NullString{String: chargeAFirstRunID, Valid: true}},
+		chargeAThirdRunID:  {SchemaLevel: 2, PriorRunID: sql.NullString{String: chargeAVoidedRunID, Valid: true}},
+		chargeAFourthRunID: {SchemaLevel: 2, PriorRunID: sql.NullString{String: chargeAThirdRunID, Valid: true}},
+		chargeALevel2RunID: {SchemaLevel: 2, PriorRunID: sql.NullString{String: chargeAFourthRunID, Valid: true}},
+		chargeBFirstRunID:  {SchemaLevel: 2},
+		chargeBSecondRunID: {SchemaLevel: 2, PriorRunID: sql.NullString{String: chargeBFirstRunID, Valid: true}},
+	}
+	require.Equal(t, wantStates, queryUsageBasedRunPriorLineageStates(t, db))
+
+	require.NoError(t, migrator.Migrate(previousVersion))
+	require.Equal(t, wantStates, queryUsageBasedRunPriorLineageStates(t, db))
+}


### PR DESCRIPTION
## Summary

- backfill schema-level-1 usage-based realization runs with prior-run lineage
- derive predecessors per namespace and charge using creation time with an ID tie-break
- promote backfilled rows to schema level 2 while preserving existing level-2 lineage
- keep rollback non-destructive

## Deployment

This is PR2 of the staged OM-471 rollout and follows #5003. Merge and deploy it only after PR1 has reached production.

The backfill intentionally includes voided history. Ordering by creation time per charge is the accepted approximation because voiding is rare.

## Testing

- focused PostgreSQL migration integration test
- full tools/migrate test package
- Atlas migration validation and lint
- targeted Go lint and formatting checks

Jira: OM-471



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineage tracking for usage-based runs by backfilling prior-run relationships.
  * Preserved existing lineage and newer run records during migration rollback.

* **Tests**
  * Added comprehensive validation covering voided runs, interleaved run history, existing lineage, and non-destructive rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a transactional migration that derives prior-run lineage for schema-level-1 usage-based realization runs and promotes them to schema level 2.
- Derives predecessors by namespace and charge using creation time and an ID tie-break.
- Preserves existing schema-level-2 lineage and makes rollback non-destructive.
- Adds a PostgreSQL migration test covering charge isolation, tied timestamps, voided history, existing level-2 rows, and rollback behavior.

<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until the outstanding voided-predecessor lineage defect is resolved.

The migration still promotes valid legacy runs with prior_run_id values that can reference voided history, after which level-2 quantity and service-period calculations consume those references directly rather than applying the non-voided predecessor semantics used by current writes and legacy fallback.

**Files Needing Attention:** tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.up.sql and tools/migrate/usage_based_run_prior_lineage_backfill_test.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.up.sql | Adds transactional lineage derivation, promotion, and verification; the previously reported voided-predecessor inconsistency remains. |
| tools/migrate/migrations/20260826120555_backfill_usage_based_run_prior_lineage.down.sql | Intentionally leaves promoted lineage unchanged to avoid destructive rollback. |
| tools/migrate/usage_based_run_prior_lineage_backfill_test.go | Covers ordering, charge partitioning, preservation, and rollback, while encoding voided runs into the resulting lineage. |
| tools/migrate/migrations/atlas.sum | Registers the new migration in the Atlas checksum manifest. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  L1[Schema-level-1 runs] --> Order[Order by namespace, charge, created_at, and ID]
  L2[Existing schema-level-2 runs] --> Order
  Order --> Lag[Derive predecessor with LAG]
  Lag --> Snapshot[Store lineage for level-1 rows]
  Snapshot --> Update[Set prior_run_id and promote to schema level 2]
  Update --> Verify[Verify lineage and promotion]
  Verify --> Commit[Commit transaction]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(charges): backfill usage run lineag..."](https://github.com/openmeterio/openmeter/commit/67fff937af0b083512befc9ac0bba1df166f2608) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57009325)</sub>

<!-- /greptile_comment -->