### PR TITLE
ci: add improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -639,29 +639,6 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
-  fossa-scan:
-    name: FOSSA Scan
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    environment: prod
-
-    steps:
-      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
-        with:
-          egress-policy: audit
-          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
-          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Run FOSSA Scan
-        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
-        with:
-          api-key: ${{secrets.FOSSA_API_KEY}}
-
   quickstart:
     name: Quickstart
     runs-on: depot-ubuntu-latest-8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,13 +46,18 @@ jobs:
         run: |
           nix flake check --impure
           nix develop --impure .#ci
-      - name: Save Nix store cache
-        uses: nix-community/cache-nix-action/save@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+
+      - name: Restore Go module cache
+        id: go-module-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{ hashFiles('flake.*') }}
-          save: "true"
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
+          restore-keys: |
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Populate Go module cache
+        if: steps.go-module-cache.outputs.cache-hit != 'true'
         run: |
           nix develop --impure .#ci -c sh -eu -c '
             go mod download
@@ -62,10 +67,17 @@ jobs:
           '
 
       - name: Save Go module cache
+        if: steps.go-module-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
+          key: ${{ steps.go-module-cache.outputs.cache-primary-key }}
+
+      - name: Save Nix store cache
+        uses: nix-community/cache-nix-action/save@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{ hashFiles('flake.*') }}
+          save: "true"
 
   build:
     name: Build
@@ -106,13 +118,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Validate Nix flake
         run: nix flake check --impure
@@ -187,13 +195,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Ensure code generators are run
         run: |
@@ -306,13 +310,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Ensure code generators are run
         run: |
@@ -420,13 +420,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Wait for dependencies to be ready
         run: |
@@ -497,12 +493,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Run migration checks
         run: nix develop --impure .#ci -c make migrate-check
@@ -549,13 +542,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       # PR merge commits change on every update, so use the target commit to
       # keep unchanged package analysis reusable across the pull request.
@@ -780,12 +769,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Check container health
         run: docker inspect --format "{{json .State.Health }}" $(docker container list --all --filter 'name=^*-openmeter-*' --format '{{.Names}}')
@@ -904,12 +890,9 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          # Prefer to restore the branch cache over the main cache
+          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Check container health
         run: docker inspect --format "{{json .State.Health }}" $(docker container list --all --filter 'name=^*-openmeter-*' --format '{{.Names}}')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main') && !contains(github.ref, 'refs/tags/') }}
+  # Supersede stale pull request runs, but never let a queued main run block a
+  # later push from rebuilding the shared caches.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   cache-rebuild:

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,35 @@
+name: FOSSA
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: FOSSA Scan
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
+          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,17 +152,14 @@ jobs:
             ${{ runner.os }}-openmeter-nix-build-main-
             ${{ runner.os }}-openmeter-nix-build-
 
-      - name: Restore go.mod cache if exists
+      - name: Restore Go module cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .devenv/state/go
-          key: ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{
-            hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-openmeter-go-modules-${{
+            hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
           restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
-            ${{ runner.os }}-openmeter-go-modules-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-go-modules-main-${{ hashFiles('flake.*', 'go.*', '.github/workflows/*.yaml') }}
-            ${{ runner.os }}-openmeter-go-modules-main
+            ${{ runner.os }}-openmeter-go-modules-
 
       - name: Build benthos-collector binary
         # Untrusted github.ref_name passed via env; matrix values are


### PR DESCRIPTION
## What

- Isolate CI concurrency so pull requests supersede stale runs without one main-branch run blocking subsequent pushes.
- Standardize Go module caching across CI and release workflows.
- Move the FOSSA scan into a standalone workflow with independent concurrency.

## Why

- The FOSSA job uses the protected `prod` environment and can remain queued for approval. Because it previously lived inside the main CI workflow, that queued job kept the workflow's concurrency group occupied. Subsequent main pushes could then cancel one another before rebuilding the shared caches.
- Go module cache keys included branch names and unrelated Nix flake inputs, producing unnecessary cache misses and duplicate caches for identical module dependencies.
- The cache producer downloaded every module even on an exact cache hit and saved the module cache only after the much larger Nix cache, making cache publication slower and less reliable.
- The release workflow restored `.devenv/state/go`, while the shared Go module cache actually lives at `~/go/pkg/mod`, preventing effective reuse.

## How

- Give pull requests stable PR-scoped concurrency groups while giving each main push its own run-scoped group.
- Restore `~/go/pkg/mod` before downloading dependencies, skip population and saving on exact hits, and save using the restore action's primary key.
- Base module cache keys only on the manifests of all four Go modules and use a branch-independent restore prefix.
- Align every CI and release cache consumer with the same cache path and key contract.
- Save the Go module cache before publishing the Nix store cache.
- Run FOSSA on main pushes in its own workflow so environment approval and cancellation no longer affect the main CI pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Improved workflow concurrency to cancel outdated runs automatically.
  * Streamlined Go module caching for more reliable build and release workflows.
  * Added a dedicated dependency scanning workflow with hardened permissions and runner security.
  * Updated release builds to use consistent Go module cache restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates FOSSA scanning from the main CI workflow and standardizes Go module caching and concurrency behavior.
- Uses stable PR-scoped concurrency while allowing main pushes to execute independently.
- Restores and publishes a shared, manifest-keyed Go module cache before the Nix cache.
- Aligns release builds with the shared `~/go/pkg/mod` cache.
- Moves FOSSA into an independently cancellable main-branch workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue remains.

The changed concurrency expressions match the declared PR and main-push triggers, cache population covers every Go module and safely handles partial restores, and FOSSA remains reachable through its dedicated main-branch workflow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Introduces event-aware concurrency, centralizes Go module cache production and consumption, and removes the FOSSA job without an identified correctness issue. |
| .github/workflows/fossa.yaml | Adds a main-only standalone FOSSA workflow with independent latest-run concurrency and the existing protected environment. |
| .github/workflows/release.yaml | Aligns release cache restoration with the shared Go module path and manifest-derived key used by CI. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Pull request update] --> PRGroup[Stable PR-scoped CI group]
  PRGroup --> Cancel[Cancel stale PR run]
  Main[Push to main] --> RunGroup[Run-scoped CI group]
  RunGroup --> Restore[Restore Go module cache]
  Restore -->|Miss or partial hit| Populate[Download all four modules]
  Populate --> SaveGo[Save Go module cache]
  Restore -->|Exact hit| Build[Build and test jobs]
  SaveGo --> SaveNix[Save Nix store cache]
  SaveNix --> Build
  Main --> FOSSA[Standalone FOSSA workflow]
  FOSSA --> Approval[Protected prod environment]
  Approval --> Scan[FOSSA scan]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: isolate FOSSA scan workflow"](https://github.com/openmeterio/openmeter/commit/5fb32e6cf4814dd93c319516fddcfce9d213a2bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57010240)</sub>

<!-- /greptile_comment -->