### PR TITLE
Revert "fix(productcatalog): make PUT /plans/{planId} replace omitted fields"

### DIFF
--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -53,7 +53,6 @@ func ToAPIBillingPlan(p plan.Plan) (api.BillingPlan, error) {
 		EffectiveTo:      p.EffectiveTo,
 		Id:               p.ID,
 		Key:              p.Key,
-		Labels:           labels.FromMetadata(p.Metadata),
 		Name:             p.Name,
 		UpdatedAt:        p.UpdatedAt,
 		Version:          p.Version,
@@ -569,7 +568,10 @@ func FromAPIUpsertPlanRequest(ns string, planID string, body api.UpsertPlanReque
 		return req, fmt.Errorf("failed to convert label metadata: %w", err)
 	}
 
-	req.Metadata = &meta
+	if body.Labels != nil {
+		m := meta
+		req.Metadata = &m
+	}
 
 	phases := make([]productcatalog.Phase, 0, len(body.Phases))
 	for _, phase := range body.Phases {

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1080,7 +1080,7 @@ func TestToUpdatePlanInput(t *testing.T) {
 		assert.Equal(t, "prod", (*result.Metadata)["env"])
 	})
 
-	t.Run("omitted labels map to empty metadata", func(t *testing.T) {
+	t.Run("nil labels result in nil metadata", func(t *testing.T) {
 		body := api.UpsertPlanRequest{
 			Name:   "Plan",
 			Phases: []api.BillingPlanPhase{},
@@ -1088,19 +1088,7 @@ func TestToUpdatePlanInput(t *testing.T) {
 
 		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
 		require.NoError(t, err)
-		require.NotNil(t, result.Metadata)
-		assert.Empty(t, *result.Metadata)
-	})
-
-	t.Run("omitted description maps to nil", func(t *testing.T) {
-		body := api.UpsertPlanRequest{
-			Name:   "Plan",
-			Phases: []api.BillingPlanPhase{},
-		}
-
-		result, err := FromAPIUpsertPlanRequest("ns", "id", body)
-		require.NoError(t, err)
-		assert.Nil(t, result.Description)
+		assert.Nil(t, result.Metadata)
 	})
 
 	t.Run("pro rating enabled maps correctly", func(t *testing.T) {

--- a/e2e/plans_v3_test.go
+++ b/e2e/plans_v3_test.go
@@ -708,34 +708,3 @@ func TestV3PlanReadTranslatesV1DynamicAndPackagePrices(t *testing.T) {
 		assert.Equal(t, v3sdk.UnitConfigRoundingModeCeiling, *pkgRC.UnitConfig.Rounding)
 	})
 }
-
-func TestV3PlanUpdateClearsOmittedFields(t *testing.T) {
-	c := newV3Client(t)
-
-	createBody := validPlanRequest("test_v3_plan_replace")
-	createBody.Description = lo.ToPtr("Original description")
-	createBody.Labels = &map[string]string{"env": "prod"}
-
-	created, err := c.Plans.Create(t.Context(), createBody)
-	c.requireStatus(http.StatusCreated, err)
-	require.NotNil(t, created)
-	require.NotNil(t, created.Description)
-	require.NotEmpty(t, created.Labels)
-
-	updated, err := c.Plans.Update(t.Context(), created.ID, v3sdk.UpsertPlanRequest{
-		Name:   createBody.Name,
-		Phases: createBody.Phases,
-	})
-	c.requireStatus(http.StatusOK, err)
-	require.NotNil(t, updated)
-
-	assert.Nil(t, updated.Description, "omitted description must be cleared, not carried over")
-	assert.Empty(t, updated.Labels, "omitted labels must be cleared, not carried over")
-
-	fetched, err := c.Plans.Get(t.Context(), created.ID)
-	c.requireStatus(http.StatusOK, err)
-	require.NotNil(t, fetched)
-
-	assert.Nil(t, fetched.Description)
-	assert.Empty(t, fetched.Labels)
-}

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -511,39 +511,6 @@ func TestPostgresAdapter(t *testing.T) {
 			plan.AssertPlanUpdateInputEqual(t, planV1Update, *planV1)
 		})
 
-		t.Run("UpdateClearsOmittedFields", func(t *testing.T) {
-			// given: a plan that carries a description and labels
-			require.NotNilf(t, planV1.Description, "plan must have a description to clear")
-			require.NotEmptyf(t, planV1.Metadata, "plan must have labels to clear")
-
-			// when: an update arrives that names neither of them
-			updated, err := env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{
-				NamespacedID: models.NamespacedID{
-					Namespace: namespace,
-					ID:        planV1.ID,
-				},
-				Name: lo.ToPtr("Pro Published"),
-			})
-			require.NoErrorf(t, err, "updating plan must not fail")
-			require.NotNilf(t, updated, "plan must not be nil")
-
-			// then: both are cleared, in the returned plan and in storage
-			assert.Nilf(t, updated.Description, "omitted description must be cleared")
-			assert.Emptyf(t, updated.Metadata, "omitted labels must be cleared")
-
-			fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
-				NamespacedID: models.NamespacedID{
-					Namespace: namespace,
-					ID:        planV1.ID,
-				},
-			})
-			require.NoErrorf(t, err, "getting plan by id must not fail")
-			assert.Nilf(t, fetched.Description, "cleared description must be persisted")
-			assert.Emptyf(t, fetched.Metadata, "cleared labels must be persisted")
-
-			planV1 = updated
-		})
-
 		t.Run("UpdateSettlementMode", func(t *testing.T) {
 			newMode := productcatalog.CreditOnlySettlementMode
 

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -467,13 +467,16 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 			query := a.db.Plan.UpdateOneID(p.ID).
 				Where(plandb.Namespace(params.Namespace)).
 				SetNillableName(params.Name).
-				SetOrClearDescription(params.Description).
-				SetOrClearMetadata((*map[string]string)(params.Metadata)).
+				SetNillableDescription(params.Description).
 				SetNillableEffectiveFrom(params.EffectiveFrom).
 				SetNillableEffectiveTo(params.EffectiveTo).
 				SetNillableBillingCadence(params.BillingCadence.ISOStringPtrOrNil()).
 				SetNillableProRatingConfig(params.ProRatingConfig).
 				SetNillableSettlementMode(params.SettlementMode)
+
+			if params.Metadata != nil {
+				query = query.SetMetadata(*params.Metadata)
+			}
 
 			err = query.Exec(ctx)
 			if err != nil {
@@ -528,44 +531,6 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 			phases[idx] = *planPhase
 		}
 		p.Phases = phases
-
-		return p, nil
-	}
-
-	return entutils.TransactingRepo[*plan.Plan, *adapter](ctx, a, fn)
-}
-
-func (a *adapter) UpdatePlanEffectivePeriod(ctx context.Context, params plan.UpdatePlanEffectivePeriodInput) (*plan.Plan, error) {
-	fn := func(ctx context.Context, a *adapter) (*plan.Plan, error) {
-		if err := params.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid update Plan effective period parameters: %w", err)
-		}
-
-		err := a.db.Plan.UpdateOneID(params.ID).
-			Where(plandb.Namespace(params.Namespace)).
-			SetNillableEffectiveFrom(params.EffectiveFrom).
-			SetNillableEffectiveTo(params.EffectiveTo).
-			Exec(ctx)
-		if err != nil {
-			if entdb.IsNotFound(err) {
-				return nil, plan.NewNotFoundError(plan.NotFoundErrorParams{
-					Namespace: params.Namespace,
-					ID:        params.ID,
-				})
-			}
-
-			return nil, fmt.Errorf("failed to update Plan effective period: %w", err)
-		}
-
-		p, err := a.GetPlan(ctx, plan.GetPlanInput{
-			NamespacedID: models.NamespacedID{
-				Namespace: params.Namespace,
-				ID:        params.ID,
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get updated Plan: %w", err)
-		}
 
 		return p, nil
 	}

--- a/openmeter/productcatalog/plan/repository.go
+++ b/openmeter/productcatalog/plan/repository.go
@@ -16,5 +16,4 @@ type Repository interface {
 	DeletePlan(ctx context.Context, params DeletePlanInput) error
 	GetPlan(ctx context.Context, params GetPlanInput) (*Plan, error)
 	UpdatePlan(ctx context.Context, params UpdatePlanInput) (*Plan, error)
-	UpdatePlanEffectivePeriod(ctx context.Context, params UpdatePlanEffectivePeriodInput) (*Plan, error)
 }

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -249,11 +249,11 @@ func (i UpdatePlanInput) Equal(p Plan) bool {
 		return false
 	}
 
-	if (i.Description == nil) != (p.Description == nil) || lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
+	if i.Description != nil && lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 
-	if !lo.FromPtr(i.Metadata).Equal(p.Metadata) {
+	if i.Metadata != nil && !i.Metadata.Equal(p.Metadata) {
 		return false
 	}
 
@@ -383,8 +383,13 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 		p.Name = *i.Name
 	}
 
-	p.Description = i.Description
-	p.Metadata = lo.FromPtr(i.Metadata)
+	if i.Description != nil {
+		p.Description = i.Description
+	}
+
+	if i.Metadata != nil {
+		p.Metadata = *i.Metadata
+	}
 
 	if i.BillingCadence != nil {
 		p.BillingCadence = *i.BillingCadence
@@ -403,36 +408,6 @@ func (i UpdatePlanInput) applyTo(p productcatalog.Plan) productcatalog.Plan {
 	}
 
 	return p
-}
-
-var _ models.Validator = (*UpdatePlanEffectivePeriodInput)(nil)
-
-// UpdatePlanEffectivePeriodInput moves only the plan's schedule; a nil boundary is left
-// untouched rather than cleared, so a publish can set EffectiveFrom alone.
-type UpdatePlanEffectivePeriodInput struct {
-	models.NamespacedID
-
-	productcatalog.EffectivePeriod
-}
-
-func (i UpdatePlanEffectivePeriodInput) Validate() error {
-	var errs []error
-
-	if i.Namespace == "" {
-		errs = append(errs, productcatalog.ErrNamespaceEmpty)
-	}
-
-	if i.ID == "" {
-		errs = append(errs, productcatalog.ErrIDEmpty)
-	}
-
-	if i.EffectiveFrom != nil || i.EffectiveTo != nil {
-		if err := i.EffectivePeriod.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid effective period: %w", err))
-		}
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 // ExpandFields defines which fields to expand when returning the Plan.

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -573,7 +573,7 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 			}
 		}
 
-		input := plan.UpdatePlanEffectivePeriodInput{
+		input := plan.UpdatePlanInput{
 			NamespacedID: params.NamespacedID,
 		}
 
@@ -585,7 +585,7 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 			input.EffectiveTo = lo.ToPtr(params.EffectiveTo.UTC())
 		}
 
-		p, err = s.adapter.UpdatePlanEffectivePeriod(ctx, input)
+		p, err = s.adapter.UpdatePlan(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to publish Plan: %w", err)
 		}
@@ -657,7 +657,7 @@ func (s service) ArchivePlan(ctx context.Context, params plan.ArchivePlanInput) 
 		// In other words, modify the surrounding Plans only if the user is allowed it otherwise return a validation error
 		// in case the lifecycle of the Plan is not continuous (there are time gaps between versions).
 
-		p, err = s.adapter.UpdatePlanEffectivePeriod(ctx, plan.UpdatePlanEffectivePeriodInput{
+		p, err = s.adapter.UpdatePlan(ctx, plan.UpdatePlanInput{
 			NamespacedID: models.NamespacedID{
 				Namespace: p.Namespace,
 				ID:        p.ID,

--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -548,9 +548,6 @@ func TestPlanService(t *testing.T) {
 							Namespace: planInput.Namespace,
 							ID:        draftPlanV1.ID,
 						},
-						Name:        lo.ToPtr(draftPlanV1.Name),
-						Description: draftPlanV1.Description,
-						Metadata:    lo.ToPtr(draftPlanV1.Metadata),
 						Phases: lo.ToPtr(lo.Map(draftPlanV1.Phases, func(p plan.Phase, _ int) productcatalog.Phase {
 							return productcatalog.Phase{
 								PhaseMeta: p.PhaseMeta,
@@ -591,10 +588,6 @@ func TestPlanService(t *testing.T) {
 
 				assert.Equalf(t, productcatalog.PlanStatusActive, publishedPlanV1.Status(),
 					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusActive, publishedPlanV1.Status())
-
-				assert.Equalf(t, draftPlanV1.Name, publishedPlanV1.Name, "publishing must preserve the name")
-				assert.Equalf(t, draftPlanV1.Description, publishedPlanV1.Description, "publishing must preserve the description")
-				assert.Equalf(t, draftPlanV1.Metadata, publishedPlanV1.Metadata, "publishing must preserve the labels")
 
 				t.Run("Update", func(t *testing.T) {
 					updateInput := plan.UpdatePlanInput{

--- a/openmeter/productcatalog/plan/service_test.go
+++ b/openmeter/productcatalog/plan/service_test.go
@@ -69,31 +69,3 @@ func TestUpdatePlanInputValidateWithPlanRejectsUnitConfig(t *testing.T) {
 		assert.False(t, rejectedForUnitConfig(in.ValidateWithPlan(planWith(card(nil)))))
 	})
 }
-
-func TestUpdatePlanInputEqualDescriptionPresence(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       *string
-		stored      *string
-		expectEqual bool
-	}{
-		{name: "omitted equals absent", input: nil, stored: nil, expectEqual: true},
-		{name: "omitted must clear a stored value", input: nil, stored: lo.ToPtr("desc"), expectEqual: false},
-		{name: "omitted must clear a stored empty string", input: nil, stored: lo.ToPtr(""), expectEqual: false},
-		{name: "explicit empty differs from absent", input: lo.ToPtr(""), stored: nil, expectEqual: false},
-		{name: "explicit empty matches stored empty string", input: lo.ToPtr(""), stored: lo.ToPtr(""), expectEqual: true},
-		{name: "matching values are equal", input: lo.ToPtr("desc"), stored: lo.ToPtr("desc"), expectEqual: true},
-		{name: "differing values are not equal", input: lo.ToPtr("new"), stored: lo.ToPtr("old"), expectEqual: false},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			p := Plan{}
-			p.Description = tc.stored
-
-			i := UpdatePlanInput{Description: tc.input}
-
-			assert.Equal(t, tc.expectEqual, i.Equal(p))
-		})
-	}
-}


### PR DESCRIPTION
Reverts openmeterio/openmeter#4967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan updates now preserve existing descriptions and metadata when those fields are omitted.
  * Metadata is only changed when labels are explicitly provided.
  * Publishing and archiving continue to maintain effective-period values while using the standard plan update flow.
* **Changes**
  * Plan responses no longer include metadata labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts replacement semantics for omitted fields in plan updates and restores sparse-update behavior across the API, service, and persistence layers.
- Omitted descriptions and labels are preserved during updates.
- Publishing and archiving again use the general plan update path for effective-period changes.
- Replacement-semantics tests and the dedicated effective-period repository operation are removed.
- The response conversion also drops persisted labels, causing all returned plans to omit them.

<h3>Confidence Score: 4/5</h3>

The plan response regression should be fixed before merging because plans with persisted labels are now returned without those labels.

The outbound plan converter no longer assigns metadata to BillingPlan.Labels, and every major plan response path uses that converter, making stored labels disappear from API responses.

**Files Needing Attention:** api/v3/handlers/plans/convert.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/plans/convert.go | Restores sparse metadata updates but also removes the outbound labels mapping, causing plan responses to omit stored labels. |
| openmeter/productcatalog/plan/adapter/plan.go | Restores conditional updates for description and metadata and removes the dedicated effective-period update method. |
| openmeter/productcatalog/plan/service.go | Restores patch-like equality and application semantics for omitted description and metadata. |
| openmeter/productcatalog/plan/service/plan.go | Routes publish and archive effective-period writes through the general repository update without evidence of unrelated state mutation. |
| e2e/plans_v3_test.go | Removes the end-to-end assertion that omitted update fields are cleared, consistent with the intended revert. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/v3/handlers/plans/convert.go`, line 53-60 ([link](https://github.com/openmeterio/openmeter/blob/7a8a9dc69606bcc9205b3d21231a736ea7a19843/api/v3/handlers/plans/convert.go#L53-L60)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Plan labels disappear**

   When a plan containing labels is returned by create, get, list, update, publish, or archive, `ToAPIBillingPlan` leaves `BillingPlan.Labels` unset, causing persisted labels to disappear from API responses.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20api%2Fv3%2Fhandlers%2Fplans%2Fconvert.go%0ALine%3A%2053-60%0A%0AComment%3A%0A**Plan%20labels%20disappear**%0A%0AWhen%20a%20plan%20containing%20labels%20is%20returned%20by%20create%2C%20get%2C%20list%2C%20update%2C%20publish%2C%20or%20archive%2C%20%60ToAPIBillingPlan%60%20leaves%20%60BillingPlan.Labels%60%20unset%2C%20causing%20persisted%20labels%20to%20disappear%20from%20API%20responses.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5010&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22revert-4967-claude%2Fv3-put-replace-plans%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22revert-4967-claude%2Fv3-put-replace-plans%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20api%2Fv3%2Fhandlers%2Fplans%2Fconvert.go%0ALine%3A%2053-60%0A%0AComment%3A%0A**Plan%20labels%20disappear**%0A%0AWhen%20a%20plan%20containing%20labels%20is%20returned%20by%20create%2C%20get%2C%20list%2C%20update%2C%20publish%2C%20or%20archive%2C%20%60ToAPIBillingPlan%60%20leaves%20%60BillingPlan.Labels%60%20unset%2C%20causing%20persisted%20labels%20to%20disappear%20from%20API%20responses.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5010&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235010%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5010&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapi%2Fv3%2Fhandlers%2Fplans%2Fconvert.go%3A53-60%0A**Plan%20labels%20disappear**%0A%0AWhen%20a%20plan%20containing%20labels%20is%20returned%20by%20create%2C%20get%2C%20list%2C%20update%2C%20publish%2C%20or%20archive%2C%20%60ToAPIBillingPlan%60%20leaves%20%60BillingPlan.Labels%60%20unset%2C%20causing%20persisted%20labels%20to%20disappear%20from%20API%20responses.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5010&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22revert-4967-claude%2Fv3-put-replace-plans%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22revert-4967-claude%2Fv3-put-replace-plans%22.%0A%0A%23%23%23%20Issue%201%0Aapi%2Fv3%2Fhandlers%2Fplans%2Fconvert.go%3A53-60%0A**Plan%20labels%20disappear**%0A%0AWhen%20a%20plan%20containing%20labels%20is%20returned%20by%20create%2C%20get%2C%20list%2C%20update%2C%20publish%2C%20or%20archive%2C%20%60ToAPIBillingPlan%60%20leaves%20%60BillingPlan.Labels%60%20unset%2C%20causing%20persisted%20labels%20to%20disappear%20from%20API%20responses.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5010&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(productcatalog): make PUT /p..."](https://github.com/openmeterio/openmeter/commit/7a8a9dc69606bcc9205b3d21231a736ea7a19843) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57025421)</sub>

<!-- /greptile_comment -->