### PR TITLE
feat(ingest): observe events per request

### DIFF
--- a/app/common/openmeter_server.go
+++ b/app/common/openmeter_server.go
@@ -111,9 +111,11 @@ func ServerProvisionTopics(conf config.EventsConfiguration) []pkgkafka.TopicConf
 func NewIngestService(
 	collector ingest.Collector,
 	logger *slog.Logger,
+	meter metric.Meter,
 ) (ingest.Service, error) {
 	return ingest.NewService(ingest.Config{
-		Collector: collector,
-		Logger:    logger,
+		Collector:   collector,
+		Logger:      logger,
+		MetricMeter: meter,
 	})
 }

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -634,7 +634,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	ingestService, err := common.NewIngestService(ingestCollector, logger)
+	ingestService, err := common.NewIngestService(ingestCollector, logger, meter)
 	if err != nil {
 		cleanup8()
 		cleanup7()

--- a/openmeter/ingest/httpdriver/ingest_test.go
+++ b/openmeter/ingest/httpdriver/ingest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/openmeterio/openmeter/openmeter/ingest"
 	"github.com/openmeterio/openmeter/openmeter/ingest/httpdriver"
@@ -24,8 +25,9 @@ func TestIngestEvents(t *testing.T) {
 	collector := ingest.NewInMemoryCollector()
 
 	ingestSvc, err := ingest.NewService(ingest.Config{
-		Collector: collector,
-		Logger:    slog.Default(),
+		Collector:   collector,
+		Logger:      slog.Default(),
+		MetricMeter: metricnoop.NewMeterProvider().Meter("test"),
 	})
 	require.NoError(t, err)
 
@@ -73,8 +75,9 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	collector := ingest.NewInMemoryCollector()
 
 	ingestSvc, err := ingest.NewService(ingest.Config{
-		Collector: collector,
-		Logger:    slog.Default(),
+		Collector:   collector,
+		Logger:      slog.Default(),
+		MetricMeter: metricnoop.NewMeterProvider().Meter("test"),
 	})
 	require.NoError(t, err)
 
@@ -98,8 +101,9 @@ func TestBatchHandler(t *testing.T) {
 	collector := ingest.NewInMemoryCollector()
 
 	ingestSvc, err := ingest.NewService(ingest.Config{
-		Collector: collector,
-		Logger:    slog.Default(),
+		Collector:   collector,
+		Logger:      slog.Default(),
+		MetricMeter: metricnoop.NewMeterProvider().Meter("test"),
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ingest/service.go
+++ b/openmeter/ingest/service.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/event"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type Service interface {
@@ -15,8 +17,9 @@ type Service interface {
 }
 
 type Config struct {
-	Collector Collector
-	Logger    *slog.Logger
+	Collector   Collector
+	Logger      *slog.Logger
+	MetricMeter metric.Meter
 }
 
 func (c Config) Validate() error {
@@ -30,13 +33,18 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("logger is required"))
 	}
 
+	if c.MetricMeter == nil {
+		errs = append(errs, errors.New("metric meter is required"))
+	}
+
 	return errors.Join(errs...)
 }
 
 // service implements the ingestion service.
 type service struct {
-	collector Collector
-	logger    *slog.Logger
+	collector               Collector
+	logger                  *slog.Logger
+	requestEventCountMetric metric.Int64Histogram
 }
 
 func NewService(config Config) (Service, error) {
@@ -44,9 +52,19 @@ func NewService(config Config) (Service, error) {
 		return nil, err
 	}
 
+	requestEventCountMetric, err := config.MetricMeter.Int64Histogram(
+		"openmeter.ingest.request.events",
+		metric.WithDescription("Number of events in an ingest request"),
+		metric.WithUnit("{event}"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request event count histogram: %w", err)
+	}
+
 	return &service{
-		collector: config.Collector,
-		logger:    config.Logger,
+		collector:               config.Collector,
+		logger:                  config.Logger,
+		requestEventCountMetric: requestEventCountMetric,
 	}, nil
 }
 
@@ -56,6 +74,10 @@ type IngestEventsRequest struct {
 }
 
 func (s service) IngestEvents(ctx context.Context, request IngestEventsRequest) (bool, error) {
+	s.requestEventCountMetric.Record(ctx, int64(len(request.Events)), metric.WithAttributes(
+		attribute.String("namespace", request.Namespace),
+	))
+
 	for _, ev := range request.Events {
 		err := s.processEvent(ctx, ev, request.Namespace)
 		if err != nil {

--- a/openmeter/ingest/service_test.go
+++ b/openmeter/ingest/service_test.go
@@ -42,30 +42,24 @@ func TestIngestEventsRecordsRequestEventCount(t *testing.T) {
 	var metrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &metrics))
 
-	histogram := findInt64Histogram(t, metrics, "openmeter.ingest.request.events")
+	var histogram metricdata.Histogram[int64]
+	found := false
+	for _, scopeMetrics := range metrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name == "openmeter.ingest.request.events" {
+				var ok bool
+				histogram, ok = metric.Data.(metricdata.Histogram[int64])
+				require.True(t, ok)
+				found = true
+			}
+		}
+	}
+	require.True(t, found)
+
 	require.Len(t, histogram.DataPoints, 1)
 	require.Equal(t, uint64(2), histogram.DataPoints[0].Count)
 	require.Equal(t, int64(4), histogram.DataPoints[0].Sum)
 	namespace, ok := histogram.DataPoints[0].Attributes.Value(attribute.Key("namespace"))
 	require.True(t, ok)
 	require.Equal(t, "default", namespace.AsString())
-}
-
-func findInt64Histogram(t *testing.T, metrics metricdata.ResourceMetrics, name string) metricdata.Histogram[int64] {
-	t.Helper()
-
-	for _, scopeMetrics := range metrics.ScopeMetrics {
-		for _, metric := range scopeMetrics.Metrics {
-			if metric.Name == name {
-				histogram, ok := metric.Data.(metricdata.Histogram[int64])
-				require.True(t, ok)
-
-				return histogram
-			}
-		}
-	}
-
-	require.FailNow(t, "metric not found", name)
-
-	return metricdata.Histogram[int64]{}
 }

--- a/openmeter/ingest/service_test.go
+++ b/openmeter/ingest/service_test.go
@@ -1,0 +1,71 @@
+package ingest_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/openmeterio/openmeter/openmeter/ingest"
+)
+
+func TestIngestEventsRecordsRequestEventCount(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(t.Context()))
+	})
+
+	service, err := ingest.NewService(ingest.Config{
+		Collector:   ingest.NewInMemoryCollector(),
+		Logger:      slog.Default(),
+		MetricMeter: provider.Meter("ingest-test"),
+	})
+	require.NoError(t, err)
+
+	_, err = service.IngestEvents(t.Context(), ingest.IngestEventsRequest{
+		Namespace: "default",
+		Events:    []event.Event{event.New()},
+	})
+	require.NoError(t, err)
+
+	_, err = service.IngestEvents(t.Context(), ingest.IngestEventsRequest{
+		Namespace: "default",
+		Events:    []event.Event{event.New(), event.New(), event.New()},
+	})
+	require.NoError(t, err)
+
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &metrics))
+
+	histogram := findInt64Histogram(t, metrics, "openmeter.ingest.request.events")
+	require.Len(t, histogram.DataPoints, 1)
+	require.Equal(t, uint64(2), histogram.DataPoints[0].Count)
+	require.Equal(t, int64(4), histogram.DataPoints[0].Sum)
+	namespace, ok := histogram.DataPoints[0].Attributes.Value(attribute.Key("namespace"))
+	require.True(t, ok)
+	require.Equal(t, "default", namespace.AsString())
+}
+
+func findInt64Histogram(t *testing.T, metrics metricdata.ResourceMetrics, name string) metricdata.Histogram[int64] {
+	t.Helper()
+
+	for _, scopeMetrics := range metrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			if metric.Name == name {
+				histogram, ok := metric.Data.(metricdata.Histogram[int64])
+				require.True(t, ok)
+
+				return histogram
+			}
+		}
+	}
+
+	require.FailNow(t, "metric not found", name)
+
+	return metricdata.Histogram[int64]{}
+}


### PR DESCRIPTION
## What

Add an `openmeter.ingest.request.events` histogram that records the number of events contained in each ingestion request, partitioned by namespace.

## Why

The existing ingestion metrics count individual successfully ingested events but do not show the distribution of events across HTTP requests. This metric makes single-event and bulk ingestion patterns observable.

## How

Record `len(request.Events)` once at the shared ingestion service boundary before processing individual events. Wire the OpenTelemetry meter into the service and add metric-reader coverage for single and batched requests.

Validated with focused ingestion and HTTP tests, server wiring generation, targeted `go vet`, and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenTelemetry metrics tracking the number of events received in each ingestion request.
  - Included namespace context with ingestion metrics for clearer monitoring and analysis.

- **Bug Fixes**
  - Ingestion setup now validates metric configuration and reports initialization errors clearly.
  - Ingestion requests now record event counts consistently, including requests containing multiple events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an OpenTelemetry histogram that records the number of events in each ingestion request, partitioned by namespace.
- Injects the application meter into the ingestion service.
- Records request event counts at the shared ingestion boundary.
- Adds metric-reader coverage for single-event and batched requests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ingest/service.go | Defines and records the request event-count histogram with a namespace attribute. |
| app/common/openmeter_server.go | Passes the application meter into the ingestion service configuration. |
| cmd/server/wire_gen.go | Updates generated server wiring for the ingestion service’s meter dependency. |
| openmeter/ingest/service_test.go | Verifies histogram count, sum, and namespace attributes while incorporating the requested inline assertion refactor. |
| openmeter/ingest/httpdriver/ingest_test.go | Supplies a no-op meter to existing HTTP ingestion service fixtures. |

<sub>Reviews (2): Last reviewed commit: ["test(ingest): inline request metric asse..."](https://github.com/openmeterio/openmeter/commit/be084525f37e095096938b3e07601f501ac15a9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57432114)</sub>

<!-- /greptile_comment -->