### PR TITLE
refactor(ingest): use fixed Kafka event topic

### DIFF
--- a/app/common/kafka.go
+++ b/app/common/kafka.go
@@ -23,6 +23,7 @@ var Kafka = wire.NewSet(
 )
 
 var KafkaIngest = wire.NewSet(
+	NewEventTopic,
 	NewKafkaIngestNamespaceHandler,
 )
 
@@ -30,6 +31,21 @@ var KafkaNamespaceResolver = wire.NewSet(
 	NewNamespacedTopicResolver,
 	wire.Bind(new(topicresolver.Resolver), new(*topicresolver.NamespacedTopicResolver)),
 )
+
+type EventTopic string
+
+// NewEventTopic returns the fixed Kafka destination for the ingest pipeline.
+// Existing configurations fall back to the topic assigned to the default namespace.
+func NewEventTopic(
+	ingestConfig config.KafkaIngestConfiguration,
+	namespaceConfig config.NamespaceConfiguration,
+) EventTopic {
+	if ingestConfig.EventsTopic != "" {
+		return EventTopic(ingestConfig.EventsTopic)
+	}
+
+	return EventTopic(fmt.Sprintf(ingestConfig.EventsTopicTemplate, namespaceConfig.Default))
+}
 
 // TODO: add closer function?
 func NewKafkaProducer(conf config.KafkaIngestConfiguration, logger *slog.Logger, meta Metadata) (*kafka.Producer, error) {

--- a/app/common/kafka_test.go
+++ b/app/common/kafka_test.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/app/config"
+)
+
+func TestNewEventTopic(t *testing.T) {
+	tests := []struct {
+		name            string
+		ingestConfig    config.KafkaIngestConfiguration
+		namespaceConfig config.NamespaceConfiguration
+		expected        EventTopic
+	}{
+		{
+			name: "explicit topic",
+			ingestConfig: config.KafkaIngestConfiguration{
+				EventsTopic:         "events",
+				EventsTopicTemplate: "om_%s_events",
+			},
+			namespaceConfig: config.NamespaceConfiguration{Default: "default"},
+			expected:        EventTopic("events"),
+		},
+		{
+			name: "default namespace fallback",
+			ingestConfig: config.KafkaIngestConfiguration{
+				EventsTopicTemplate: "om_%s_events",
+			},
+			namespaceConfig: config.NamespaceConfiguration{Default: "default"},
+			expected:        EventTopic("om_default_events"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, NewEventTopic(test.ingestConfig, test.namespaceConfig))
+		})
+	}
+}

--- a/app/common/openmeter_server.go
+++ b/app/common/openmeter_server.go
@@ -15,15 +15,14 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ingest/ingestadapter"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
-	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/topicresolver"
 	watermillkafka "github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
 )
 
 func NewKafkaIngestCollector(
-	config config.KafkaIngestConfiguration,
+	ingestConfig config.KafkaIngestConfiguration,
+	eventTopic EventTopic,
 	producer *kafka.Producer,
-	topicResolver topicresolver.Resolver,
 	topicProvisioner pkgkafka.TopicProvisioner,
 	logger *slog.Logger,
 	tracer trace.Tracer,
@@ -31,9 +30,9 @@ func NewKafkaIngestCollector(
 	collector, err := kafkaingest.NewCollector(
 		producer,
 		serializer.NewJSONSerializer(),
-		topicResolver,
+		string(eventTopic),
 		topicProvisioner,
-		config.Partitions,
+		ingestConfig.Partitions,
 		logger,
 		tracer,
 	)

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -122,6 +122,7 @@ func TestComplete(t *testing.T) {
 					},
 				},
 				Partitions:          1,
+				EventsTopic:         "om_explicit_events",
 				EventsTopicTemplate: "om_%s_events",
 				TopicProvisioner: TopicProvisionerConfig{
 					Enabled:   true,

--- a/app/config/ingest.go
+++ b/app/config/ingest.go
@@ -33,6 +33,7 @@ type KafkaIngestConfiguration struct {
 	TopicProvisioner TopicProvisionerConfig
 
 	Partitions          int
+	EventsTopic         string
 	EventsTopicTemplate string
 
 	// NamespaceDeletionEnabled defines whether deleting namespaces are allowed or not.
@@ -177,6 +178,7 @@ func ConfigureIngestKafkaConfiguration(v *viper.Viper, prefixes ...string) {
 // Configure configures some defaults in the Viper instance.
 func ConfigureIngest(v *viper.Viper) {
 	v.SetDefault("ingest.kafka.partitions", 1)
+	v.SetDefault("ingest.kafka.eventsTopic", "")
 	v.SetDefault("ingest.kafka.eventsTopicTemplate", "om_%s_events")
 	v.SetDefault("ingest.kafka.namespaceDeletionEnabled", false)
 

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -40,6 +40,7 @@ ingest:
     saslUsername: user
     saslPassword: pass
     partitions: 1
+    eventsTopic: om_explicit_events
     statsInterval: 5s
     brokerAddressFamily: any
     socketKeepAliveEnabled: true

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -590,6 +590,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	dedupeConfiguration := conf.Dedupe
+	eventTopic := common.NewEventTopic(kafkaIngestConfiguration, namespaceConfiguration)
 	producer, err := common.NewKafkaProducer(kafkaIngestConfiguration, logger, commonMetadata)
 	if err != nil {
 		cleanup7()
@@ -601,18 +602,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	namespacedTopicResolver, err := common.NewNamespacedTopicResolver(kafkaIngestConfiguration)
-	if err != nil {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return Application{}, nil, err
-	}
-	collector, err := common.NewKafkaIngestCollector(kafkaIngestConfiguration, producer, namespacedTopicResolver, topicProvisioner, logger, tracer)
+	collector, err := common.NewKafkaIngestCollector(kafkaIngestConfiguration, eventTopic, producer, topicProvisioner, logger, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -647,6 +637,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	metrics, err := common.NewKafkaMetrics(meter)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	namespacedTopicResolver, err := common.NewNamespacedTopicResolver(kafkaIngestConfiguration)
 	if err != nil {
 		cleanup8()
 		cleanup7()

--- a/openmeter/ingest/kafkaingest/collector.go
+++ b/openmeter/ingest/kafkaingest/collector.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
-	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/topicresolver"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
 	kafkametrics "github.com/openmeterio/openmeter/pkg/kafka/metrics"
@@ -40,7 +39,7 @@ func FromIngestedAt(s string) (time.Time, error) {
 type Collector struct {
 	Producer         *kafka.Producer
 	Serializer       serializer.Serializer
-	TopicResolver    topicresolver.Resolver
+	Topic            string
 	TopicProvisioner pkgkafka.TopicProvisioner
 	TopicPartitions  int
 
@@ -51,7 +50,7 @@ type Collector struct {
 func NewCollector(
 	producer *kafka.Producer,
 	serializer serializer.Serializer,
-	resolver topicresolver.Resolver,
+	topic string,
 	provisioner pkgkafka.TopicProvisioner,
 	partitions int,
 	logger *slog.Logger,
@@ -63,8 +62,8 @@ func NewCollector(
 	if serializer == nil {
 		return nil, fmt.Errorf("serializer is required")
 	}
-	if resolver == nil {
-		return nil, fmt.Errorf("topic name resolver is required")
+	if topic == "" {
+		return nil, fmt.Errorf("topic is required")
 	}
 
 	if provisioner == nil {
@@ -80,7 +79,7 @@ func NewCollector(
 	return &Collector{
 		Producer:         producer,
 		Serializer:       serializer,
-		TopicResolver:    resolver,
+		Topic:            topic,
 		TopicProvisioner: provisioner,
 		TopicPartitions:  partitions,
 		Logger:           logger,
@@ -105,12 +104,7 @@ func (s Collector) Ingest(ctx context.Context, namespace string, ev event.Event)
 		span.End()
 	}()
 
-	span.AddEvent("resolved namespace to kafka topic")
-	topicName, err := s.TopicResolver.Resolve(ctx, namespace)
-	if err != nil {
-		err = fmt.Errorf("failed to resolve namespace to topic name: %w", err)
-		return err
-	}
+	topicName := s.Topic
 	span.SetAttributes(semconv.MessagingDestinationName(topicName))
 
 	// Make sure topic is provisioned

--- a/openmeter/ingest/kafkaingest/collector_test.go
+++ b/openmeter/ingest/kafkaingest/collector_test.go
@@ -1,0 +1,103 @@
+package kafkaingest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
+)
+
+type recordingSerializer struct {
+	topics []string
+	err    error
+}
+
+func (s *recordingSerializer) SerializeKey(topic string, _ string, _ cloudevents.Event) ([]byte, error) {
+	s.topics = append(s.topics, topic)
+
+	return nil, s.err
+}
+
+func (s *recordingSerializer) SerializeValue(_ string, _ cloudevents.Event) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *recordingSerializer) GetFormat() string {
+	return ""
+}
+
+func (s *recordingSerializer) GetKeySchemaId() int {
+	return 0
+}
+
+func (s *recordingSerializer) GetValueSchemaId() int {
+	return 0
+}
+
+type recordingTopicProvisioner struct {
+	topics []pkgkafka.TopicConfig
+}
+
+func (p *recordingTopicProvisioner) Provision(_ context.Context, topics ...pkgkafka.TopicConfig) error {
+	p.topics = append(p.topics, topics...)
+
+	return nil
+}
+
+func (p *recordingTopicProvisioner) DeProvision(_ context.Context, _ ...string) error {
+	return nil
+}
+
+func TestCollectorUsesFixedTopic(t *testing.T) {
+	serializerError := errors.New("stop before producing")
+	serializer := &recordingSerializer{err: serializerError}
+	provisioner := &recordingTopicProvisioner{}
+
+	collector, err := NewCollector(
+		&kafka.Producer{},
+		serializer,
+		"om_default_events",
+		provisioner,
+		1,
+		testutils.NewDiscardLogger(t),
+		noop.NewTracerProvider().Tracer("test"),
+	)
+	require.NoError(t, err)
+
+	ev := cloudevents.New()
+	ev.SetID("event-id")
+
+	for _, namespace := range []string{"default", "customer"} {
+		err = collector.Ingest(t.Context(), namespace, ev)
+		require.ErrorIs(t, err, serializerError)
+	}
+
+	assert.Equal(t, []string{"om_default_events", "om_default_events"}, serializer.topics)
+	assert.Equal(t, []pkgkafka.TopicConfig{
+		{Name: "om_default_events", Partitions: 1},
+		{Name: "om_default_events", Partitions: 1},
+	}, provisioner.topics)
+}
+
+func TestNewCollectorRequiresTopic(t *testing.T) {
+	collector, err := NewCollector(
+		&kafka.Producer{},
+		&recordingSerializer{},
+		"",
+		&recordingTopicProvisioner{},
+		1,
+		testutils.NewDiscardLogger(t),
+		noop.NewTracerProvider().Tracer("test"),
+	)
+
+	require.EqualError(t, err, "topic is required")
+	assert.Nil(t, collector)
+}


### PR DESCRIPTION
## What

- Replaced per-request Kafka topic resolution in the ingest collector with a fixed event topic.
- Added the optional `ingest.kafka.eventsTopic` configuration parameter.
- Preserved the existing fallback: when unset, the topic template is evaluated with the default namespace, producing `om_default_events`.
- Kept the topic resolver for namespace lifecycle management; it was removed only from event ingestion.
- No Helm chart changes are included.

## Why

The ingest pipeline no longer needs to resolve a Kafka topic for every event based on its namespace. Using one fixed destination removes unnecessary runtime work and simplifies the path from HTTP ingestion to Kafka while retaining backward compatibility for existing deployments.

## How

- Added an `EventTopic` type and constructor that selects the explicit topic or calculates the default fallback.
- Injected the resolved topic into `NewKafkaIngestCollector`.
- Updated the collector to validate, provision, serialize, and produce against the fixed topic.
- Extended the complete configuration test with an explicit topic.
- Added tests covering explicit selection, fallback selection, required-topic validation, and consistent topic use across namespaces.
- Verified the full Go test suite and E2E ingestion with both fallback and explicit topic configuration.

JIRA: OM-487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated Kafka events topic.
  * Automatically uses the configured topic, or a namespace-based default when none is provided.

* **Bug Fixes**
  * Kafka event ingestion now consistently publishes to the selected events topic, preventing unexpected topic changes based on request namespace.
  * Added validation to prevent starting ingestion without a valid events topic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Kafka ingestion from per-namespace topic resolution to a single configured event topic, with a default derived from the default namespace.

- Adds `ingest.kafka.eventsTopic` and fixed-topic dependency injection.
- Updates provisioning, serialization, and production to consistently use the fixed topic.
- Retains the namespaced resolver for namespace lifecycle handling and adds focused configuration and collector tests.

<h3>Confidence Score: 4/5</h3>

The explicit-topic path needs coordination with sink topic discovery before merging, otherwise valid configurations can silently leave ingested events unprocessed.

The producer now accepts arbitrary fixed topic names, while the existing sink subscribes only to names matching its namespace-topic regexp; no validation ensures those independently configured values are compatible.

**Files Needing Attention:** app/common/kafka.go, app/config/ingest.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/common/kafka.go | Introduces fixed-topic selection but accepts explicit topics that the sink may not discover. |
| app/config/ingest.go | Adds the optional event-topic setting and fallback default without cross-validating consumer subscription configuration. |
| app/common/openmeter_server.go | Replaces resolver injection with the resolved fixed topic in collector construction. |
| openmeter/ingest/kafkaingest/collector.go | Provisions, serializes, and produces all namespace events against one topic while retaining namespace headers. |
| cmd/server/wire_gen.go | Updates generated dependency wiring and preserves cleanup behavior after provider reordering. |
| openmeter/ingest/kafkaingest/collector_test.go | Covers fixed-topic consistency and required-topic validation but not compatibility with sink discovery. |
| app/common/kafka_test.go | Covers explicit and fallback selection, including an explicit example incompatible with the sink's default regexp. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Ingest request] --> Collector[Kafka ingest collector]
  Config[eventsTopic or default fallback] --> Collector
  Collector --> FixedTopic[Fixed Kafka event topic]
  FixedTopic --> Discovery{Matches sink namespaceTopicRegexp?}
  Discovery -->|Yes| Sink[Sink worker]
  Discovery -->|No| Unconsumed[Events remain unprocessed]
  Sink --> Usage[Event storage and usage processing]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235017%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5017&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapp%2Fcommon%2Fkafka.go%3A43-44%0A**Topics%20bypass%20sink%20discovery**%0A%0AIf%20%60ingest.kafka.eventsTopic%60%20is%20set%20to%20a%20valid%20Kafka%20topic%20such%20as%20%60events%60%20or%20%60om_events%60%2C%20%60NewEventTopic%60%20returns%20it%20unchanged%20while%20the%20sink%20subscribes%20only%20to%20topics%20matching%20its%20namespace-topic%20regexp.%20Events%20are%20accepted%20and%20queued%20in%20Kafka%2C%20but%20the%20sink%20never%20consumes%20them%20for%20storage%20or%20usage%20aggregation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5017&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22refactor%2Fingest-v2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2Fingest-v2%22.%0A%0A%23%23%23%20Issue%201%0Aapp%2Fcommon%2Fkafka.go%3A43-44%0A**Topics%20bypass%20sink%20discovery**%0A%0AIf%20%60ingest.kafka.eventsTopic%60%20is%20set%20to%20a%20valid%20Kafka%20topic%20such%20as%20%60events%60%20or%20%60om_events%60%2C%20%60NewEventTopic%60%20returns%20it%20unchanged%20while%20the%20sink%20subscribes%20only%20to%20topics%20matching%20its%20namespace-topic%20regexp.%20Events%20are%20accepted%20and%20queued%20in%20Kafka%2C%20but%20the%20sink%20never%20consumes%20them%20for%20storage%20or%20usage%20aggregation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5017&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/common/kafka.go:43-44
**Topics bypass sink discovery**

If `ingest.kafka.eventsTopic` is set to a valid Kafka topic such as `events` or `om_events`, `NewEventTopic` returns it unchanged while the sink subscribes only to topics matching its namespace-topic regexp. Events are accepted and queued in Kafka, but the sink never consumes them for storage or usage aggregation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(ingest): use fixed Kafka event ..."](https://github.com/openmeterio/openmeter/commit/7de4e06120db786619a461adb52624bedecffb5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57805077)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->