### PR TITLE
feat(helm): add per-component resources and scheduling values

### DIFF
--- a/deploy/charts/openmeter/README.md
+++ b/deploy/charts/openmeter/README.md
@@ -98,6 +98,44 @@ config:
       debug: true
 ```
 
+## Per-component scheduling and resources
+
+Each OpenMeter component reads its own `resources`, `nodeSelector`, `tolerations`, and `affinity` values. A component value replaces the equivalent chart-wide value. If you do not set a component value, the chart-wide value applies.
+
+The components are `api`, `balanceWorker`, `notificationService`, `sinkWorker`, `billingWorker`, `svix`, `jobs.subscriptionSync`, `jobs.billingCollectInvoices`, and `jobs.billingAdvanceInvoices`.
+
+```yaml
+# Chart-wide default for every component.
+nodeSelector:
+  workload: openmeter
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# The sink worker needs more memory and a dedicated node pool.
+sinkWorker:
+  nodeSelector:
+    workload: openmeter-sink
+  tolerations:
+    - key: openmeter-sink
+      operator: Exists
+      effect: NoSchedule
+  resources:
+    limits:
+      cpu: "2"
+      memory: 4Gi
+    requests:
+      cpu: "1"
+      memory: 2Gi
+
+# The cron jobs run on spot nodes.
+jobs:
+  billingCollectInvoices:
+    nodeSelector:
+      workload: openmeter-batch
+```
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -130,6 +168,10 @@ config:
 | config | object | `{}` | OpenMeter configuration |
 | init | object | `{"busybox":{"tag":"1.37.0"}}` | Defines parameters for the InitContainers |
 | kafka.enabled | bool | `true` | Specifies whether Kafka (using the [Bitnami Kafka](oci://registry-1.docker.io/bitnamicharts)) should be installed. **Not recommended for production environments.** |
+| kafka.image.repository | string | `"bitnamilegacy/kafka"` |  |
+| kafka.externalAccess.autoDiscovery.image.repository | string | `"bitnamilegacy/kubectl"` |  |
+| kafka.volumePermissions.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| kafka.metrics.jmx.image.repository | string | `"bitnamilegacy/jmx-exporter"` |  |
 | kafka.listeners.client.name | string | `"plain"` |  |
 | kafka.listeners.client.containerPort | int | `9092` |  |
 | kafka.listeners.client.protocol | string | `"PLAINTEXT"` |  |
@@ -153,15 +195,66 @@ config:
 | svix.image.tag | string | `"v1.37"` | Image tag to use |
 | svix.service.type | string | `"ClusterIP"` | Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). |
 | svix.service.port | int | `80` | Service port. |
-| svix.resources | object | No requests or limits. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
+| svix.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Svix component. See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details. |
+| svix.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Svix component. |
+| svix.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Svix component. |
+| svix.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Svix component. |
 | redis.enabled | bool | `true` | Specifies whether Redis (using the [Bitnami Redis](oci://registry-1.docker.io/bitnamicharts/redis) chart) should be installed. **Not recommended for production environments.** All further values can be configured in the `redis` section. |
 | redis.auth.enabled | bool | `false` |  |
 | redis.nameOverride | string | `"redis"` |  |
-| postgresql.enabled | bool | `true` | Specifies whether Postgres (using the [Bitnami Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) should be installed. **Not recommended for production environments.** All further values can be configured in the `postgres` section. |
+| redis.image.repository | string | `"bitnamilegacy/redis"` |  |
+| redis.sentinel.image.repository | string | `"bitnamilegacy/redis-sentinel"` |  |
+| redis.metrics.image.repository | string | `"bitnamilegacy/redis-exporter"` |  |
+| redis.volumePermissions.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| redis.sysctl.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| redis.kubectl.image.repository | string | `"bitnamilegacy/kubectl"` |  |
+| postgresql.enabled | bool | `true` | Specifies whether Postgres (using the [Bitnami Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) should be installed. **Not recommended for production environments.** All further values can be configured in the `postgresql` section. |
 | postgresql.nameOverride | string | `"postgres"` |  |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
+| postgresql.volumePermissions.image.repository | string | `"bitnamilegacy/os-shell"` |  |
+| postgresql.metrics.image.repository | string | `"bitnamilegacy/postgres-exporter"` |  |
 | postgresql.primary.initdb.scripts."setup.sql" | string | `"CREATE USER application WITH PASSWORD 'application';\nCREATE DATABASE application;\nGRANT ALL PRIVILEGES ON DATABASE application TO application;\nALTER DATABASE application OWNER TO application;\nCREATE USER svix WITH PASSWORD 'svix';\nCREATE DATABASE svix;\nGRANT ALL PRIVILEGES ON DATABASE svix TO svix;\nALTER DATABASE svix OWNER TO svix;\n"` |  |
 | api.replicaCount | int | `1` | Number of API replicas (pods) to launch. |
+| api.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the API. |
+| api.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the API. |
+| api.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the API. |
+| api.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the API. |
 | balanceWorker.replicaCount | int | `1` | Number of Balance Worker replicas (pods) to launch. |
+| balanceWorker.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Balance Worker. |
+| balanceWorker.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Balance Worker. |
+| balanceWorker.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Balance Worker. |
+| balanceWorker.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Balance Worker. |
 | notificationService.replicaCount | int | `1` | Number of Notification Service replicas (pods) to launch. |
+| notificationService.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Notification Service. |
+| notificationService.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Notification Service. |
+| notificationService.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Notification Service. |
+| notificationService.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Notification Service. |
 | sinkWorker.replicaCount | int | `1` | Number of Sink Worker replicas (pods) to launch. |
+| sinkWorker.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Sink Worker. |
+| sinkWorker.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Sink Worker. |
+| sinkWorker.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Sink Worker. |
+| sinkWorker.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Sink Worker. |
+| billingWorker.replicaCount | int | `1` | Number of Billing Worker replicas (pods) to launch. |
+| billingWorker.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Billing Worker. |
+| billingWorker.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Billing Worker. |
+| billingWorker.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Billing Worker. |
+| billingWorker.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Billing Worker. |
 | caRootCertificates | object | `{}` | List of CA Root certificates to inject into pods at runtime. See [values.yaml](values.yaml) |
+| jobs.subscriptionSync | object | `{"affinity":{},"nodeSelector":{},"resources":{},"schedule":"0 * * * *","tolerations":[]}` | Subscription sync job is a backup reconciler to make sure that all subscriptions are properly billed even if there is some kind of issue with the billing worker. |
+| jobs.subscriptionSync.schedule | string | `"0 * * * *"` | Schedule for the subscription sync job. Default is every hour. |
+| jobs.subscriptionSync.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the subscription sync job. |
+| jobs.subscriptionSync.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the subscription sync job. |
+| jobs.subscriptionSync.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the subscription sync job. |
+| jobs.subscriptionSync.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the subscription sync job. |
+| jobs.billingCollectInvoices | object | `{"affinity":{},"nodeSelector":{},"resources":{},"schedule":"*/5 * * * *","tolerations":[]}` | Collect invoices job creates invoices based on gathering invoices. The job is only used for the second invoice and up. The first invoice is issued as part of the subscription start job immediately. |
+| jobs.billingCollectInvoices.schedule | string | `"*/5 * * * *"` | Schedule for the collect invoices job. Default is every five minutes. |
+| jobs.billingCollectInvoices.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the collect invoices job. |
+| jobs.billingCollectInvoices.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the collect invoices job. |
+| jobs.billingCollectInvoices.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the collect invoices job. |
+| jobs.billingCollectInvoices.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the collect invoices job. |
+| jobs.billingAdvanceInvoices | object | `{"affinity":{},"nodeSelector":{},"resources":{},"schedule":"*/5 * * * *","tolerations":[]}` | Advance invoices job advances automatic approval invoices. |
+| jobs.billingAdvanceInvoices.schedule | string | `"*/5 * * * *"` | Schedule for the advance invoices job. Default is every five minutes. |
+| jobs.billingAdvanceInvoices.resources | object | The chart-wide `resources` value. | Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the advance invoices job. |
+| jobs.billingAdvanceInvoices.nodeSelector | object | The chart-wide `nodeSelector` value. | [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the advance invoices job. |
+| jobs.billingAdvanceInvoices.tolerations | list | The chart-wide `tolerations` value. | [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the advance invoices job. |
+| jobs.billingAdvanceInvoices.affinity | object | The chart-wide `affinity` value. | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the advance invoices job. |

--- a/deploy/charts/openmeter/README.tmpl.md
+++ b/deploy/charts/openmeter/README.tmpl.md
@@ -72,4 +72,42 @@ config:
       debug: true
 ```
 
+## Per-component scheduling and resources
+
+Each OpenMeter component reads its own `resources`, `nodeSelector`, `tolerations`, and `affinity` values. A component value replaces the equivalent chart-wide value. If you do not set a component value, the chart-wide value applies.
+
+The components are `api`, `balanceWorker`, `notificationService`, `sinkWorker`, `billingWorker`, `svix`, `jobs.subscriptionSync`, `jobs.billingCollectInvoices`, and `jobs.billingAdvanceInvoices`.
+
+```yaml
+# Chart-wide default for every component.
+nodeSelector:
+  workload: openmeter
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# The sink worker needs more memory and a dedicated node pool.
+sinkWorker:
+  nodeSelector:
+    workload: openmeter-sink
+  tolerations:
+    - key: openmeter-sink
+      operator: Exists
+      effect: NoSchedule
+  resources:
+    limits:
+      cpu: "2"
+      memory: 4Gi
+    requests:
+      cpu: "1"
+      memory: 2Gi
+
+# The cron jobs run on spot nodes.
+jobs:
+  billingCollectInvoices:
+    nodeSelector:
+      workload: openmeter-batch
+```
+
 {{ template "chart.valuesSection" . }}

--- a/deploy/charts/openmeter/templates/deployment.yaml
+++ b/deploy/charts/openmeter/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
               path: /healthz/ready
               port: telemetry-http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.api.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/openmeter
@@ -80,15 +80,15 @@ spec:
           configMap:
             name: ca-certificates
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (.Values.api.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.api.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.api.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -154,7 +154,7 @@ spec:
               path: /healthz/ready
               port: telemetry-http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.balanceWorker.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/openmeter
@@ -172,15 +172,15 @@ spec:
           configMap:
             name: ca-certificates
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (.Values.balanceWorker.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.balanceWorker.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.balanceWorker.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -246,7 +246,7 @@ spec:
               path: /healthz/ready
               port: telemetry-http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.notificationService.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/openmeter
@@ -264,15 +264,15 @@ spec:
           configMap:
             name: ca-certificates
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (.Values.notificationService.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.notificationService.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.notificationService.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -338,7 +338,7 @@ spec:
               path: /healthz/ready
               port: telemetry-http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.sinkWorker.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/openmeter
@@ -356,15 +356,15 @@ spec:
           configMap:
             name: ca-certificates
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (.Values.sinkWorker.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.sinkWorker.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.sinkWorker.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -430,7 +430,7 @@ spec:
               path: /healthz/ready
               port: telemetry-http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml (.Values.billingWorker.resources | default .Values.resources) | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/openmeter
@@ -448,15 +448,15 @@ spec:
           configMap:
             name: ca-certificates
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with (.Values.billingWorker.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.billingWorker.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.billingWorker.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/openmeter/templates/jobs.yaml
+++ b/deploy/charts/openmeter/templates/jobs.yaml
@@ -64,7 +64,7 @@ spec:
                   containerPort: 10000
                   protocol: TCP
               resources:
-                {{- toYaml .Values.resources | nindent 16 }}
+                {{- toYaml (.Values.jobs.subscriptionSync.resources | default .Values.resources) | nindent 16 }}
               volumeMounts:
                 - name: config
                   mountPath: /etc/openmeter
@@ -82,15 +82,15 @@ spec:
               configMap:
                 name: ca-certificates
             {{- end }}
-          {{- with .Values.nodeSelector }}
+          {{- with (.Values.jobs.subscriptionSync.nodeSelector | default .Values.nodeSelector) }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.affinity }}
+          {{- with (.Values.jobs.subscriptionSync.affinity | default .Values.affinity) }}
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.tolerations }}
+          {{- with (.Values.jobs.subscriptionSync.tolerations | default .Values.tolerations) }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -160,7 +160,7 @@ spec:
                   containerPort: 10000
                   protocol: TCP
               resources:
-                {{- toYaml .Values.resources | nindent 16 }}
+                {{- toYaml (.Values.jobs.billingCollectInvoices.resources | default .Values.resources) | nindent 16 }}
               volumeMounts:
                 - name: config
                   mountPath: /etc/openmeter
@@ -178,15 +178,15 @@ spec:
               configMap:
                 name: ca-certificates
             {{- end }}
-          {{- with .Values.nodeSelector }}
+          {{- with (.Values.jobs.billingCollectInvoices.nodeSelector | default .Values.nodeSelector) }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.affinity }}
+          {{- with (.Values.jobs.billingCollectInvoices.affinity | default .Values.affinity) }}
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.tolerations }}
+          {{- with (.Values.jobs.billingCollectInvoices.tolerations | default .Values.tolerations) }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -256,7 +256,7 @@ spec:
                   containerPort: 10000
                   protocol: TCP
               resources:
-                {{- toYaml .Values.resources | nindent 16 }}
+                {{- toYaml (.Values.jobs.billingAdvanceInvoices.resources | default .Values.resources) | nindent 16 }}
               volumeMounts:
                 - name: config
                   mountPath: /etc/openmeter
@@ -274,15 +274,15 @@ spec:
               configMap:
                 name: ca-certificates
             {{- end }}
-          {{- with .Values.nodeSelector }}
+          {{- with (.Values.jobs.billingAdvanceInvoices.nodeSelector | default .Values.nodeSelector) }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.affinity }}
+          {{- with (.Values.jobs.billingAdvanceInvoices.affinity | default .Values.affinity) }}
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.tolerations }}
+          {{- with (.Values.jobs.billingAdvanceInvoices.tolerations | default .Values.tolerations) }}
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/charts/openmeter/templates/svix.yaml
+++ b/deploy/charts/openmeter/templates/svix.yaml
@@ -51,16 +51,16 @@ spec:
               containerPort: 8071
               protocol: TCP
           resources:
-            {{- toYaml .Values.svix.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+            {{- toYaml (.Values.svix.resources | default .Values.resources) | nindent 12 }}
+      {{- with (.Values.svix.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.svix.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with (.Values.svix.tolerations | default .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -207,9 +207,9 @@ svix:
     # -- Service port.
     port: 80
 
-  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Svix component.
   # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
-  # @default -- No requests or limits.
+  # @default -- The chart-wide `resources` value.
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -221,6 +221,18 @@ svix:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Svix component.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Svix component.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Svix component.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
 
 redis:
   # -- Specifies whether Redis (using the [Bitnami Redis](oci://registry-1.docker.io/bitnamicharts/redis) chart) should be installed.
@@ -258,7 +270,7 @@ redis:
 postgresql:
   # -- Specifies whether Postgres (using the [Bitnami Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) should be installed.
   # **Not recommended for production environments.**
-  # All further values can be configured in the `postgres` section.
+  # All further values can be configured in the `postgresql` section.
   enabled: true
 
   nameOverride: postgres
@@ -293,21 +305,101 @@ api:
   # -- Number of API replicas (pods) to launch.
   replicaCount: 1
 
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the API.
+  # @default -- The chart-wide `resources` value.
+  resources: {}
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the API.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the API.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the API.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
+
 balanceWorker:
   # -- Number of Balance Worker replicas (pods) to launch.
   replicaCount: 1
+
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Balance Worker.
+  # @default -- The chart-wide `resources` value.
+  resources: {}
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Balance Worker.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Balance Worker.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Balance Worker.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
 
 notificationService:
   # -- Number of Notification Service replicas (pods) to launch.
   replicaCount: 1
 
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Notification Service.
+  # @default -- The chart-wide `resources` value.
+  resources: {}
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Notification Service.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Notification Service.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Notification Service.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
+
 sinkWorker:
   # -- Number of Sink Worker replicas (pods) to launch.
   replicaCount: 1
 
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Sink Worker.
+  # @default -- The chart-wide `resources` value.
+  resources: {}
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Sink Worker.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Sink Worker.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Sink Worker.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
+
 billingWorker:
   # -- Number of Billing Worker replicas (pods) to launch.
   replicaCount: 1
+
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the Billing Worker.
+  # @default -- The chart-wide `resources` value.
+  resources: {}
+
+  # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the Billing Worker.
+  # @default -- The chart-wide `nodeSelector` value.
+  nodeSelector: {}
+
+  # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the Billing Worker.
+  # @default -- The chart-wide `tolerations` value.
+  tolerations: []
+
+  # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the Billing Worker.
+  # @default -- The chart-wide `affinity` value.
+  affinity: {}
 
 # -- List of CA Root certificates to inject into pods at runtime.
 # See [values.yaml](values.yaml)
@@ -324,15 +416,63 @@ jobs:
     # -- Schedule for the subscription sync job.
     # Default is every hour.
     schedule: "0 * * * *"
+
+    # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the subscription sync job.
+    # @default -- The chart-wide `resources` value.
+    resources: {}
+
+    # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the subscription sync job.
+    # @default -- The chart-wide `nodeSelector` value.
+    nodeSelector: {}
+
+    # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the subscription sync job.
+    # @default -- The chart-wide `tolerations` value.
+    tolerations: []
+
+    # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the subscription sync job.
+    # @default -- The chart-wide `affinity` value.
+    affinity: {}
   # -- Collect invoices job creates invoices based on gathering invoices. The job is only used
-  # for the second invoice and up. The first invoice is issued as part of the subscription start job immidately.
+  # for the second invoice and up. The first invoice is issued as part of the subscription start job immediately.
   billingCollectInvoices:
     # -- Schedule for the collect invoices job.
     # Default is every five minutes.
     schedule: "*/5 * * * *"
+
+    # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the collect invoices job.
+    # @default -- The chart-wide `resources` value.
+    resources: {}
+
+    # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the collect invoices job.
+    # @default -- The chart-wide `nodeSelector` value.
+    nodeSelector: {}
+
+    # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the collect invoices job.
+    # @default -- The chart-wide `tolerations` value.
+    tolerations: []
+
+    # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the collect invoices job.
+    # @default -- The chart-wide `affinity` value.
+    affinity: {}
 
   # -- Advance invoices job advances automatic approval invoices.
   billingAdvanceInvoices:
     # -- Schedule for the advance invoices job.
     # Default is every five minutes.
     schedule: "*/5 * * * *"
+
+    # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the advance invoices job.
+    # @default -- The chart-wide `resources` value.
+    resources: {}
+
+    # -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the advance invoices job.
+    # @default -- The chart-wide `nodeSelector` value.
+    nodeSelector: {}
+
+    # -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for the advance invoices job.
+    # @default -- The chart-wide `tolerations` value.
+    tolerations: []
+
+    # -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for the advance invoices job.
+    # @default -- The chart-wide `affinity` value.
+    affinity: {}


### PR DESCRIPTION
## Overview

Every internal component read the chart-wide `resources`, `nodeSelector`, `tolerations`, and `affinity` values. An operator could not give more memory to the sink worker alone, or move only the cron jobs to a spot node pool.

Add the four values to each of the nine components: `api`, `balanceWorker`, `notificationService`, `sinkWorker`, `billingWorker`, `svix`, `jobs.subscriptionSync`, `jobs.billingCollectInvoices`, and `jobs.billingAdvanceInvoices`.

A component value replaces the equivalent chart-wide value. Each field falls back on its own. A component can set only `nodeSelector` and keep the chart-wide `tolerations`.

Each pod spec reads its own value and falls back inline, for example `.Values.api.nodeSelector | default .Values.nodeSelector`. The chart already writes out every Deployment in full, so an inline fallback keeps the rule visible where it applies.

`svix.resources` now falls back to the chart-wide `resources` value. Before, it ignored that value. Both defaults are empty, so the rendered output stays the same unless you set the chart-wide `resources` value.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->


## Checklist

- [x] I updated the relevant README,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-component resource and Kubernetes scheduling settings for services and billing jobs.
  * Component-specific settings can override chart-wide defaults, with automatic fallback when unspecified.

* **Documentation**
  * Expanded Helm chart documentation with configuration examples and scheduling details.
  * Added image repository references for bundled Kafka, Redis, and PostgreSQL charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds independently configurable resources and scheduling values for each OpenMeter Helm component, with field-level fallback to chart-wide settings.
- Adds component-specific resources, node selectors, tolerations, and affinity for five deployments, Svix, and three CronJobs.
- Documents inheritance semantics and the new values in the chart README.
- Corrects related generated chart documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| deploy/charts/openmeter/templates/deployment.yaml | Applies component-specific resource and scheduling values to the five OpenMeter deployments with chart-wide fallback. |
| deploy/charts/openmeter/templates/jobs.yaml | Applies independent resource and scheduling values to each of the three CronJobs. |
| deploy/charts/openmeter/templates/svix.yaml | Adds Svix scheduling overrides and makes its resources inherit the chart-wide value when unset. |
| deploy/charts/openmeter/values.yaml | Defines and documents the new per-component configuration values and inheritance defaults. |
| deploy/charts/openmeter/README.tmpl.md | Documents per-component configuration and chart-wide fallback behavior. |
| deploy/charts/openmeter/README.md | Updates generated values documentation and provides a per-component scheduling example. |

<sub>Reviews (4): Last reviewed commit: ["feat(helm): add per-component resources ..."](https://github.com/openmeterio/openmeter/commit/ad3c2161a21a10e5e41f255add786b4af4c4517e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57980969)</sub>

<!-- /greptile_comment -->