### PR TITLE
build(nix): split development shells

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,11 +248,11 @@ jobs:
       - name: Validate Node version file
         run: |
           FILE_NODE_VERSION="$(tr -d '\r\n' < .nvmrc)"
-          NIX_NODE_VERSION="$(nix develop --impure .#ci -c node -v)"
+          NIX_NODE_VERSION="$(nix develop --impure .#api -c node -v)"
 
           if [ "$NIX_NODE_VERSION" != "$FILE_NODE_VERSION" ]; then
-            echo ".nvmrc is out of sync with the Nix CI shell"
-            echo "nix develop --impure .#ci -c node -v => $NIX_NODE_VERSION"
+            echo ".nvmrc is out of sync with the Nix API shell"
+            echo "nix develop --impure .#api -c node -v => $NIX_NODE_VERSION"
             echo ".nvmrc => $FILE_NODE_VERSION"
             exit 1
           fi
@@ -323,7 +323,7 @@ jobs:
 
       - name: Ensure code generators are run
         run: |
-          nix develop --impure .#ci -c make update-openapi
+          nix develop --impure .#api -c make update-openapi
 
           # does not detect new files
           if [ -n "$(git diff --exit-code)" ]; then
@@ -343,7 +343,7 @@ jobs:
 
       - name: Run TypeSpec Go emitter checks
         run: |
-          nix develop --impure .#ci -c pnpm -C api/spec --filter @openmeter/typespec-go run check
+          nix develop --impure .#api -c pnpm -C api/spec --filter @openmeter/typespec-go run check
 
   generators-javascript-sdk:
     name: Code Generators / JavaScript SDK
@@ -440,8 +440,8 @@ jobs:
 
       - name: Ensure code generators are run
         run: |
-          nix develop --impure .#ci -c make patch-oapi-templates
-          nix develop --impure .#ci -c go generate ./...
+          nix develop --impure .#go -c make patch-oapi-templates
+          nix develop --impure .#go -c go generate ./...
 
           # does not detect new files
           if [ -n "$(git diff --exit-code)" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,18 @@
 ## Repository tooling
 
 - Use the `Makefile` for common development tasks. The `justfile` is secondary.
-- When tools are missing from the ambient shell, use:
+- When tools are missing from the ambient shell, use the smallest shell that
+  covers the task:
 
   ```bash
-  nix develop --impure .#ci -c <command>
+  nix develop --impure .#go -c make generate
+  nix develop --impure .#api -c make generate-all
+  nix develop --impure .#ci -c <full-environment-command>
   ```
+
+  `.#go` contains the Go code-generation toolchain without Node. `.#api` adds
+  Node, pnpm, and API/JavaScript generation tools. `.#ci` remains the complete
+  compatibility shell for broad workflows.
 
 - Always invoke `nix develop` from the repository root. Entering from a
   subdirectory writes CWD-relative devenv files and can break formatting or the
@@ -19,7 +26,7 @@
   Existing worktree module caches are not migrated or removed automatically;
   clean them up separately after confirming no active shell uses them.
 - `.nvmrc` is the GitHub Actions source of truth for Node. Keep it aligned with
-  `node -v` in the Nix `.#ci` shell.
+  `node -v` in the Nix `.#api` and `.#ci` shells.
 - For slow or noisy commands, save complete output to a temporary log outside the repository, preserve and report the exit status and log path, inspect bounded slices, and never rerun solely because displayed output was truncated.
 
 ## Repository invariants

--- a/flake.nix
+++ b/flake.nix
@@ -21,156 +21,51 @@
 
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
 
-      perSystem = { config, self', inputs', pkgs, lib, system, ... }: rec {
-        _module.args.pkgs = import inputs.nixpkgs {
-          inherit system;
+      perSystem = { config, self', inputs', pkgs, lib, system, ... }:
+        let
+          # The Nixpkgs Go package can retain a build-time loader that is not represented in
+          # its store identity. Wrap cmd/link with the active loader as an explicit argument
+          # and derivation input so every internal link, including Nix checks, uses it.
+          goPackage =
+            if pkgs.stdenv.hostPlatform.isLinux then
+              pkgs.symlinkJoin
+                {
+                  name = "${pkgs.go_1_27.name}-openmeter";
+                  paths = [ pkgs.go_1_27 ];
+                  inherit (pkgs.go_1_27) CGO_ENABLED GOARCH GOOS meta passthru version;
+                  nativeBuildInputs = [ pkgs.makeWrapper ];
+                  postBuild = ''
+                    linkTool="share/go/pkg/tool/${pkgs.go_1_27.GOOS}_${pkgs.go_1_27.GOARCH}/link"
+                    rm "$out/$linkTool"
+                    makeWrapper "${pkgs.go_1_27}/$linkTool" "$out/$linkTool" \
+                      --add-flags "-I=${pkgs.stdenv.cc.bintools.dynamicLinker}"
 
-          overlays = [
-            inputs.llm-agents.overlays.shared-nixpkgs
-          ];
-        };
+                    wrapProgram "$out/bin/go" \
+                      --set-default GO_LDSO ${pkgs.stdenv.cc.bintools.dynamicLinker}
+                  '';
+                }
+            else
+              pkgs.go_1_27;
 
-        devenv.shells = {
-          default = {
-            languages = {
-              go = {
-                enable = true;
-                # The Nixpkgs Go package can retain a build-time loader that is not represented in
-                # its store identity. Wrap cmd/link with the active loader as an explicit argument
-                # and derivation input so every internal link, including Nix checks, uses it.
-                package =
-                  if pkgs.stdenv.hostPlatform.isLinux then
-                    pkgs.symlinkJoin
-                      {
-                        name = "${pkgs.go_1_27.name}-openmeter";
-                        paths = [ pkgs.go_1_27 ];
-                        inherit (pkgs.go_1_27) CGO_ENABLED GOARCH GOOS meta passthru version;
-                        nativeBuildInputs = [ pkgs.makeWrapper ];
-                        postBuild = ''
-                          linkTool="share/go/pkg/tool/${pkgs.go_1_27.GOOS}_${pkgs.go_1_27.GOARCH}/link"
-                          rm "$out/$linkTool"
-                          makeWrapper "${pkgs.go_1_27}/$linkTool" "$out/$linkTool" \
-                            --add-flags "-I=${pkgs.stdenv.cc.bintools.dynamicLinker}"
+          goShell = shellName: {
+            languages.go = {
+              enable = true;
+              package = goPackage;
 
-                          wrapProgram "$out/bin/go" \
-                            --set-default GO_LDSO ${pkgs.stdenv.cc.bintools.dynamicLinker}
-                        '';
-                      }
-                  else
-                    pkgs.go_1_27;
-
-                delve.package = pkgs.delve.overrideAttrs (old: {
-                  # Delve runs these generator checks only with the latest Go release. They invoke
-                  # `go run ...@latest`, which cannot query modules while buildGoModule uses -mod=vendor.
-                  # Keep the remaining Delve tests enabled until upstream packaging skips these checks.
-                  checkFlags = (old.checkFlags or [ ]) ++ [
-                    "-skip=TestGeneratedDoc|TestTypecheckRPC"
-                  ];
-                });
-              };
-
-              python = {
-                enable = true;
-                package = pkgs.python314;
-                uv = {
-                  enable = true;
-                };
-              };
-
-              javascript = {
-                enable = true;
-                package = inputs'.nixpkgs-node.legacyPackages.nodejs-slim_26;
-                pnpm = {
-                  enable = true;
-                };
-              };
+              delve.package = pkgs.delve.overrideAttrs (old: {
+                # Delve runs these generator checks only with the latest Go release. They invoke
+                # `go run ...@latest`, which cannot query modules while buildGoModule uses -mod=vendor.
+                # Keep the remaining Delve tests enabled until upstream packaging skips these checks.
+                checkFlags = (old.checkFlags or [ ]) ++ [
+                  "-skip=TestGeneratedDoc|TestTypecheckRPC"
+                ];
+              });
             };
-
-            git-hooks.hooks = {
-              nixpkgs-fmt.enable = true;
-              commitizen.enable = true;
-
-              commitizen-branch = {
-                enable = true;
-                name = "commitizen-branch check";
-                description = ''
-                  Check whether commit messages on the current HEAD follows committing rules.
-                '';
-                entry = "${pkgs.commitizen}/bin/cz check --allow-abort --rev-range origin/HEAD..HEAD";
-                pass_filenames = false;
-                stages = [ "manual" ];
-              };
-            };
-
-            # Use alternative pre-commit implementations
-            git-hooks.package = pkgs.prek;
 
             packages = with pkgs; [
               git
               gnumake
-              mage
-
-              # Kafka build dependencies
-              # https://github.com/confluentinc/confluent-kafka-go#librdkafka
-              # Check actual version via:
-              # $ pkg-config --modversion rdkafka++
-              # Getting sha256 hash for git ref:
-              # $ nix-shell -p nix-prefetch-git jq --run "nix hash convert sha256:\$(nix-prefetch-git --url https://github.com/confluentinc/librdkafka.git --quiet --rev v2.15.0 | jq -r '.sha256')"
-              (rdkafka.overrideAttrs (_: rec {
-                src = fetchFromGitHub {
-                  owner = "confluentinc";
-                  repo = "librdkafka";
-                  rev = "v2.15.0";
-                  sha256 = "sha256-WW64fwh0xR4lEVwmrv00tP9mo6b49aCNgLLH/P0YS8k=";
-                };
-              }))
-
-              cyrus_sasl
-              pkg-config
-              # confluent-platform
-
-              golangci-lint
-              goreleaser
-              gotestsum
-              air
-
-              curl
-              jq
-              yq-go
-              minikube
-              kind
-              kubectl
-              helm-docs
-              kubernetes-helm
-
-              benthos
-
-              # We should use a custom light-weight derivation, see this thread https://discourse.nixos.org/t/installing-postgresql-client/948/15
-              # Multi-platform support makes this a bit more difficult
-              postgresql
-
-              # node: pnpm (from javascript.pnpm) provides `pnpm dlx` as the
-              # npx-style runner for these one-off CLIs. The invoked bin runs
-              # under the dev shell's `node` (nodejs-slim_26) via its env-node
-              # shebang, so no separate corepack/Node runtime is needed.
-              # We can consider adding a pkgs.buildNpmPackage for spectral-cli if build takes a lot of time, but for now
-              # this is a quick fix to get it working.
-              (writeShellScriptBin "spectral" ''
-                exec ${pkgs.pnpm}/bin/pnpm dlx @stoplight/spectral-cli@6.16.0 "$@"
-              '')
-              self'.packages.codegraph
-
-              # python
-              poetry
-
-              self'.packages.atlasx
-
-              just
-              semver-tool
-
-              go-migrate
-
-              sqlc
+              gnupatch
             ];
 
             env = {
@@ -179,20 +74,14 @@
               # rebuild nor a stdenv/glibc update can reuse link results from another generation.
               GOCACHE =
                 let
-                  goToolchainID = builtins.baseNameOf (toString config.devenv.shells.default.languages.go.package);
+                  goToolchainID = builtins.baseNameOf (toString goPackage);
                   runtimeLinkerID =
                     if pkgs.stdenv.hostPlatform.isLinux then
                       builtins.elemAt (builtins.match "/nix/store/([^/]+)/.*" pkgs.stdenv.cc.bintools.dynamicLinker) 0
                     else
                       "native";
                 in
-                "${config.devenv.shells.default.env.DEVENV_STATE}/go/build-cache/${goToolchainID}/${runtimeLinkerID}";
-              KUBECONFIG = "${config.devenv.shells.default.env.DEVENV_STATE}/kube/config";
-              KIND_CLUSTER_NAME = "openmeter";
-
-              HELM_CACHE_HOME = "${config.devenv.shells.default.env.DEVENV_STATE}/helm/cache";
-              HELM_CONFIG_HOME = "${config.devenv.shells.default.env.DEVENV_STATE}/helm/config";
-              HELM_DATA_HOME = "${config.devenv.shells.default.env.DEVENV_STATE}/helm/data";
+                "${config.devenv.shells.${shellName}.env.DEVENV_STATE}/go/build-cache/${goToolchainID}/${runtimeLinkerID}";
             } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
               # Keep GO_LDSO visible for patched Go linkers and diagnostics. The wrapped cmd/link
               # above also passes -I explicitly because the cached Nix binary can retain its stale
@@ -213,24 +102,158 @@
                 unset DEVELOPER_DIR
                 # End of workaround
               ''}
-
-              # Keep GitHub-hosted Node jobs aligned with the Nix shell.
-              node -v > .nvmrc
             '';
 
             # https://github.com/cachix/devenv/issues/528#issuecomment-1556108767
             containers = pkgs.lib.mkForce { };
           };
 
-          ci = devenv.shells.default;
-        };
+          apiShell = shellName:
+            let
+              base = goShell shellName;
+            in
+            lib.recursiveUpdate base {
+              languages.javascript = {
+                enable = true;
+                package = inputs'.nixpkgs-node.legacyPackages.nodejs-slim_26;
+                pnpm.enable = true;
+              };
 
-        packages = {
-          # CodeGraph 1.5.0 aborts while indexing on macOS with Node 24.
-          codegraph = pkgs.llm-agents.codegraph.override {
-            buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
+              packages = base.packages ++ [ pkgs.yq-go ];
+
+              enterShell = base.enterShell + ''
+                # Keep GitHub-hosted Node jobs aligned with the Nix shell.
+                node -v > .nvmrc
+              '';
+            };
+
+          fullShell = shellName:
+            let
+              base = apiShell shellName;
+            in
+            lib.recursiveUpdate base {
+              languages.python = {
+                enable = true;
+                package = pkgs.python314;
+                uv.enable = true;
+              };
+
+              git-hooks.hooks = {
+                nixpkgs-fmt.enable = true;
+                commitizen.enable = true;
+
+                commitizen-branch = {
+                  enable = true;
+                  name = "commitizen-branch check";
+                  description = ''
+                    Check whether commit messages on the current HEAD follows committing rules.
+                  '';
+                  entry = "${pkgs.commitizen}/bin/cz check --allow-abort --rev-range origin/HEAD..HEAD";
+                  pass_filenames = false;
+                  stages = [ "manual" ];
+                };
+              };
+
+              # Use alternative pre-commit implementations
+              git-hooks.package = pkgs.prek;
+
+              packages = base.packages ++ (with pkgs; [
+                mage
+
+                # Kafka build dependencies
+                # https://github.com/confluentinc/confluent-kafka-go#librdkafka
+                # Check actual version via:
+                # $ pkg-config --modversion rdkafka++
+                # Getting sha256 hash for git ref:
+                # $ nix-shell -p nix-prefetch-git jq --run "nix hash convert sha256:\$(nix-prefetch-git --url https://github.com/confluentinc/librdkafka.git --quiet --rev v2.15.0 | jq -r '.sha256')"
+                (rdkafka.overrideAttrs (_: rec {
+                  src = fetchFromGitHub {
+                    owner = "confluentinc";
+                    repo = "librdkafka";
+                    rev = "v2.15.0";
+                    sha256 = "sha256-WW64fwh0xR4lEVwmrv00tP9mo6b49aCNgLLH/P0YS8k=";
+                  };
+                }))
+
+                cyrus_sasl
+                pkg-config
+                # confluent-platform
+
+                golangci-lint
+                goreleaser
+                gotestsum
+                air
+
+                curl
+                jq
+                minikube
+                kind
+                kubectl
+                helm-docs
+                kubernetes-helm
+
+                benthos
+
+                # We should use a custom light-weight derivation, see this thread https://discourse.nixos.org/t/installing-postgresql-client/948/15
+                # Multi-platform support makes this a bit more difficult
+                postgresql
+
+                # node: pnpm (from javascript.pnpm) provides `pnpm dlx` as the
+                # npx-style runner for these one-off CLIs. The invoked bin runs
+                # under the dev shell's `node` (nodejs-slim_26) via its env-node
+                # shebang, so no separate corepack/Node runtime is needed.
+                # We can consider adding a pkgs.buildNpmPackage for spectral-cli if build takes a lot of time, but for now
+                # this is a quick fix to get it working.
+                (writeShellScriptBin "spectral" ''
+                  exec ${pkgs.pnpm}/bin/pnpm dlx @stoplight/spectral-cli@6.16.0 "$@"
+                '')
+                self'.packages.codegraph
+
+                # python
+                poetry
+
+                self'.packages.atlasx
+
+                just
+                semver-tool
+
+                go-migrate
+
+                sqlc
+              ]);
+
+              env = {
+                KUBECONFIG = "${config.devenv.shells.${shellName}.env.DEVENV_STATE}/kube/config";
+                KIND_CLUSTER_NAME = "openmeter";
+
+                HELM_CACHE_HOME = "${config.devenv.shells.${shellName}.env.DEVENV_STATE}/helm/cache";
+                HELM_CONFIG_HOME = "${config.devenv.shells.${shellName}.env.DEVENV_STATE}/helm/config";
+                HELM_DATA_HOME = "${config.devenv.shells.${shellName}.env.DEVENV_STATE}/helm/data";
+              };
+            };
+        in
+        rec {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+
+            overlays = [
+              inputs.llm-agents.overlays.shared-nixpkgs
+            ];
           };
-        } // import ./custom-packages.nix { inherit pkgs; };
-      };
+
+          devenv.shells = {
+            go = goShell "go";
+            api = apiShell "api";
+            default = fullShell "default";
+            ci = devenv.shells.default;
+          };
+
+          packages = {
+            # CodeGraph 1.5.0 aborts while indexing on macOS with Node 24.
+            codegraph = pkgs.llm-agents.codegraph.override {
+              buildNpmPackage = pkgs.buildNpmPackage.override { nodejs = pkgs.nodejs_22; };
+            };
+          } // import ./custom-packages.nix { inherit pkgs; };
+        };
     };
 }


### PR DESCRIPTION
## Summary

- add a lightweight `.#go` shell for root Go code generation without Node
- add an `.#api` shell that layers the pinned Node runtime, pnpm, and API generation tools on the Go shell
- keep `default` and `.#ci` as the complete compatibility environment, while moving generator CI commands and developer guidance to the purpose-specific shells

## Validation

- `nix flake check --impure`
- `nix develop --impure .#go` smoke test and full `make generate`
- verified the realized `.#go` closure contains no Node, pnpm, or V8 derivations
- `nix develop --impure .#api` smoke test: Node `v26.8.1` matches `.nvmrc`; pnpm, yq, Go, and make are available
- `nix develop --impure .#ci` compatibility smoke test for the existing broad toolset
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated development environments for Go-only and API/JavaScript workflows.
  * Improved tooling setup by providing only the dependencies needed for each workflow.

* **Documentation**
  * Updated repository guidance with instructions for selecting the smallest suitable development environment.

* **Chores**
  * Updated automated checks and code-generation tasks to use the appropriate development environments.
  * Added required patching tools to Go-focused workflows and aligned Node.js version validation with the API environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR splits the Nix development environment into purpose-specific Go and API shells while retaining the complete default/CI environment.
- Adds lightweight `go` and layered `api` development shells.
- Moves generator CI commands to the smallest shell containing their required tools.
- Updates contributor guidance for selecting development shells.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| flake.nix | Factors the existing environment into Go, API, and full shells while preserving the default and CI compatibility toolsets. |
| .github/workflows/ci.yaml | Routes Node/API and Go generation checks through their corresponding purpose-specific Nix shells. |
| AGENTS.md | Documents shell selection and maintains the Node-version synchronization guidance. |

<sub>Reviews (3): Last reviewed commit: ["build(nix): split development shells"](https://github.com/openmeterio/openmeter/commit/b52dca3133ed0afda5338c29b321e30e2713bdad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58608556)</sub>

<!-- /greptile_comment -->