### PR TITLE
fix(ci): use self-repository workflow syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -726,7 +726,7 @@ jobs:
 
   trusted-artifacts:
     name: Artifacts
-    uses: ./.github/workflows/artifacts.yaml
+    uses: $/.github/workflows/artifacts.yaml
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       publish: ${{ github.event_name == 'push' }}
@@ -739,7 +739,7 @@ jobs:
   untrusted-artifacts:
     name: Untrusted Artifacts
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-    uses: ./.github/workflows/untrusted-artifacts.yaml
+    uses: $/.github/workflows/untrusted-artifacts.yaml
     permissions:
       contents: read
 
@@ -749,7 +749,7 @@ jobs:
       - trusted-artifacts
       - untrusted-artifacts
     if: ${{ always() }}
-    uses: ./.github/workflows/workflow-result.yaml
+    uses: $/.github/workflows/workflow-result.yaml
     with:
       result: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || !contains(needs.*.result, 'success')) && 'fail' || 'pass' }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Artifacts
     # Artifact publishing (container images, etc.) is tag-only.
     if: github.ref_type == 'tag'
-    uses: ./.github/workflows/artifacts.yaml
+    uses: $/.github/workflows/artifacts.yaml
     with:
       publish: true
     permissions:
@@ -268,7 +268,7 @@ jobs:
     # npm's trusted publisher entry is keyed on caller workflow file + environment,
     # so this single caller must serve both channels.
     needs: [ sdk-javascript-meta ]
-    uses: ./.github/workflows/npm-release.yaml
+    uses: $/.github/workflows/npm-release.yaml
     with:
       version: ${{ needs.sdk-javascript-meta.outputs.version }}
       dist-tag: ${{ needs.sdk-javascript-meta.outputs.dist-tag }}
@@ -284,7 +284,7 @@ jobs:
     # publisher entry is keyed on caller workflow file + environment, so this
     # caller must serve both channels.
     needs: [ sdk-javascript-meta ]
-    uses: ./.github/workflows/aip-npm-release.yaml
+    uses: $/.github/workflows/aip-npm-release.yaml
     with:
       version: ${{ needs.sdk-javascript-meta.outputs.version }}
       dist-tag: ${{ needs.sdk-javascript-meta.outputs.dist-tag }}


### PR DESCRIPTION
## Overview

Update local reusable-workflow references to GitHub's dedicated self-repository syntax. This resolves the `self-repository` findings introduced by zizmor 1.30.0.

No Jira ticket.

## Notes for reviewer

The pinned Kong scanning action installs `zizmor>=v1.2.2`, so its resolved version moved from 1.29.0 to 1.30.0 without a repository change. Version 1.30.0 introduced the `self-repository` audit and flagged the six existing `./.github/workflows/...` references changed here.

## Testing

- `zizmor 1.30.0 --collect=all --persona=regular --no-online-audits .`
  - No findings to report (73 suppressed)
- `git diff --check`



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates six local reusable-workflow references to GitHub’s self-repository syntax.
- Updates artifact workflow calls in `.github/workflows/ci.yaml`.
- Updates artifact and npm release workflow calls in `.github/workflows/release.yaml`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of the provided follow-up review.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Updates three reusable-workflow references for trusted artifacts, untrusted artifacts, and aggregate workflow results. |
| .github/workflows/release.yaml | Updates three reusable-workflow references for artifact publishing and JavaScript SDK releases. |

<sub>Reviews (2): Last reviewed commit: ["fix(ci): use self-repository workflow sy..."](https://github.com/openmeterio/openmeter/commit/196bb89cb5f76efcab1cbf3ce2a6d9883efe90c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58653212)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated validation workflow references.
  - Updated release workflow references for artifact publishing and package releases.
  - No changes to application functionality, user-facing features, or release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->