### PR TITLE
fix(chart): configure bundled PostgreSQL SSL mode

### DIFF
--- a/deploy/charts/openmeter/templates/configmap.yaml
+++ b/deploy/charts/openmeter/templates/configmap.yaml
@@ -21,9 +21,10 @@ aggregation:
 
 {{/* Overwrite postgres config if self-hosted postgres is used */}}
 {{- if .Values.postgresql.enabled -}}
+{{- $postgresTLSEnabled := dig "tls" "enabled" false .Values.postgresql -}}
 postgres:
   autoMigrate: migration
-  url: postgres://application:application@{{ include "openmeter.fullname" . }}-postgres:5432/application
+  url: postgres://application:application@{{ include "openmeter.fullname" . }}-postgres:5432/application?sslmode={{ ternary "require" "disable" $postgresTLSEnabled }}
 {{- end }}
 
 {{/* Overwrite svix config if self-hosted svix is used */}}


### PR DESCRIPTION
## Overview

Configure an explicit PostgreSQL SSL mode in the Helm-generated DSN for the bundled PostgreSQL dependency. The default non-TLS deployment now uses `sslmode=disable`, while deployments that enable the subchart's TLS setting use `sslmode=require`.

Fixes #4951

## Notes for reviewer

Validation:

- `make lint-helm`
- `helm template` with the default values renders `sslmode=disable`
- `helm template` with `postgresql.tls.enabled=true` and certificate values renders `sslmode=require`

This only changes the chart-generated DSN for the bundled PostgreSQL dependency. User-supplied PostgreSQL configuration remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection URLs now automatically use the appropriate SSL mode based on the configured TLS setting.
  * TLS-enabled connections require SSL, while non-TLS connections explicitly disable it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The chart-generated DSN for bundled PostgreSQL now explicitly selects its SSL mode from the subchart’s TLS setting.
- Renders `sslmode=disable` for the default non-TLS deployment.
- Renders `sslmode=require` when bundled PostgreSQL TLS is enabled.
- Leaves user-supplied PostgreSQL configuration unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| deploy/charts/openmeter/templates/configmap.yaml | Adds a safe default lookup for bundled PostgreSQL TLS and maps the supported Boolean setting to the corresponding DSN SSL mode. |

<sub>Reviews (3): Last reviewed commit: ["fix(chart): configure bundled PostgreSQL..."](https://github.com/openmeterio/openmeter/commit/2dcb754f28379ec3c0c203a9ee3a2d723eeb565e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58684877)</sub>

<!-- /greptile_comment -->