### PR TITLE
fix(ci): add GitHub-hosted runner fallback

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,0 +1,25 @@
+name: Set up Go for CI
+description: Install the Go toolchain used by CI and restore its native caches.
+
+inputs:
+  cache:
+    description: Whether setup-go should restore and save Go caches.
+    default: "true"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        # Keep this explicit: go.mod expresses the minimum supported Go version,
+        # while CI intentionally follows the newer version from the Nix shell.
+        go-version: "1.27.0"
+        check-latest: false
+        cache: ${{ inputs.cache }}
+        cache-dependency-path: |
+          go.sum
+          collector/go.sum
+          api/v3/client/go.sum
+          e2e/go.sum

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,0 +1,26 @@
+name: Set up Node.js for CI
+description: Install the repository Node.js and package-manager versions.
+
+inputs:
+  package-json-file:
+    description: package.json containing the packageManager version for pnpm.
+    required: true
+  cache-dependency-path:
+    description: pnpm lockfile used to key the dependency cache.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+      with:
+        package_json_file: ${{ inputs.package-json-file }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        # .nvmrc remains shared by Nix and GitHub-native development paths.
+        node-version-file: .nvmrc
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   container-image:
     name: Container image
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -107,7 +107,7 @@ jobs:
 
   benthos-collector-container-image:
     name: Benthos Collector Container image
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -21,9 +21,6 @@ on:
       container-image-ref:
         description: Container image ref
         value: ${{ jobs.container-image.outputs.ref }}
-      container-image-url-depot:
-        description: Container image URL from Depot
-        value: ${{ jobs.container-image.outputs.depot-image-url }}
 
 permissions:
   contents: read
@@ -31,7 +28,7 @@ permissions:
 jobs:
   container-image:
     name: Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
 
     permissions:
       contents: read
@@ -44,7 +41,6 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       tag: ${{ steps.meta.outputs.version }}
       ref: ${{ steps.image-ref.outputs.value }}
-      depot-image-url: "registry.depot.dev/${{ steps.build.outputs.project-id }}@${{ steps.build.outputs.imageid }}"
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -57,9 +53,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Set up Depot CLI
-        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Set image name
         id: image-name
@@ -80,71 +73,41 @@ jobs:
             type=ref,event=branch,suffix=-{{sha}}-{{date 'X'}},enable={{is_default_branch}}
 
       - name: Login to GitHub Container Registry
+        if: inputs.publish
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-        if: inputs.publish
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push image
         id: build
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           build-args: |
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
-          platforms: linux/amd64,linux/arm64 # The confluent library doesn't support ARMv7
+          platforms: linux/amd64,linux/arm64 # The confluent library does not support ARMv7.
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ inputs.publish }}
-          save: true
-          project: ${{ vars.DEPOT_PROJECT }}
 
       - name: Set image ref
         id: image-ref
-        run: echo "value=${STEPS_IMAGE_NAME_OUTPUTS_VALUE}@${STEPS_BUILD_OUTPUTS_DIGEST}" >> "$GITHUB_OUTPUT"
+        run: echo "value=${IMAGE_NAME}@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
         env:
-          STEPS_IMAGE_NAME_OUTPUTS_VALUE: ${{ steps.image-name.outputs.value }}
-          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
-
-      - name: Retrieve pull token
-        id: pull-token
-        run: |
-          PULL_TOKEN="$(depot pull-token --project "${VARS_DEPOT_PROJECT}")"
-          echo "token=$PULL_TOKEN" >> "$GITHUB_OUTPUT"
-          echo "::add-mask::$PULL_TOKEN"
-        env:
-          VARS_DEPOT_PROJECT: ${{ vars.DEPOT_PROJECT }}
-
-      ### Trivy is comporomised
-      #
-      # - name: Run Trivy vulnerability scanner
-      #   uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-      #   with:
-      #     image-ref: registry.depot.dev/${{ vars.DEPOT_PROJECT }}:${{ steps.build.outputs.build-id }}
-      #     format: sarif
-      #     output: trivy-results.sarif
-      #   env:
-      #     TRIVY_USERNAME: x-token
-      #     TRIVY_PASSWORD: ${{ steps.pull-token.outputs.token }}
-      #     TRIVY_DB_REPOSITORY: ghcr.io/openmeterio/trivy-db:2
-
-      # - name: Upload Trivy scan results as artifact
-      #   uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      #   with:
-      #     name: "[${{ github.job }}] Trivy scan results"
-      #     path: trivy-results.sarif
-      #     retention-days: 5
-
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v3.29.5
-      #   with:
-      #     sarif_file: trivy-results.sarif
+          IMAGE_NAME: ${{ steps.image-name.outputs.value }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
 
   benthos-collector-container-image:
     name: Benthos Collector Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
 
     permissions:
       contents: read
@@ -170,9 +133,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Depot CLI
-        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
-
       - name: Set image name
         id: image-name
         run: echo "value=ghcr.io/openmeterio/benthos-collector" >> "$GITHUB_OUTPUT"
@@ -192,16 +152,22 @@ jobs:
             type=ref,event=branch,suffix=-{{sha}}-{{date 'X'}},enable={{is_default_branch}}
 
       - name: Login to GitHub Container Registry
+        if: inputs.publish
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-        if: inputs.publish
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push image
         id: build
-        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: benthos-collector.Dockerfile
@@ -211,44 +177,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ inputs.publish }}
-          save: true
-          project: ${{ vars.DEPOT_PROJECT }}
 
       - name: Set image ref
         id: image-ref
-        run: echo "value=${STEPS_IMAGE_NAME_OUTPUTS_VALUE}@${STEPS_BUILD_OUTPUTS_DIGEST}" >> "$GITHUB_OUTPUT"
+        run: echo "value=${IMAGE_NAME}@${IMAGE_DIGEST}" >> "$GITHUB_OUTPUT"
         env:
-          STEPS_IMAGE_NAME_OUTPUTS_VALUE: ${{ steps.image-name.outputs.value }}
-          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
-
-      - name: Retrieve pull token
-        id: pull-token
-        run: |
-          PULL_TOKEN="$(depot pull-token --project "${VARS_DEPOT_PROJECT}")"
-          echo "token=$PULL_TOKEN" >> "$GITHUB_OUTPUT"
-          echo "::add-mask::$PULL_TOKEN"
-        env:
-          VARS_DEPOT_PROJECT: ${{ vars.DEPOT_PROJECT }}
-
-      # - name: Run Trivy vulnerability scanner
-      #   uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-      #   with:
-      #     image-ref: registry.depot.dev/${{ vars.DEPOT_PROJECT }}:${{ steps.build.outputs.build-id }}
-      #     format: sarif
-      #     output: trivy-results.sarif
-      #   env:
-      #     TRIVY_USERNAME: x-token
-      #     TRIVY_PASSWORD: ${{ steps.pull-token.outputs.token }}
-      #     TRIVY_DB_REPOSITORY: ghcr.io/openmeterio/trivy-db:2
-
-      # - name: Upload Trivy scan results as artifact
-      #   uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-      #   with:
-      #     name: "[${{ github.job }}] Trivy scan results"
-      #     path: trivy-results.sarif
-      #     retention-days: 5
-
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v3.29.5
-      #   with:
-      #     sarif_file: trivy-results.sarif
+          IMAGE_NAME: ${{ steps.image-name.outputs.value }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,198 +9,14 @@ permissions:
   contents: read
 
 concurrency:
-  # Supersede stale pull request runs, but never let a queued main run block a
-  # later push from rebuilding the shared caches.
+  # Supersede stale pull request runs without cancelling an unrelated main run.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  cache-rebuild:
-    name: Select or rebuild Nix cache
-    runs-on: depot-ubuntu-latest-16
-    outputs:
-      cache-key: ${{ steps.cache-key.outputs.cache-key }}
-
-    steps:
-      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
-        with:
-          egress-policy: audit
-          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
-          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 2
-          persist-credentials: false
-
-      - name: Detect Nix input changes
-        id: changed-files
-        uses: kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
-        with:
-          files_yaml: |
-            nix:
-              # flake.lock captures remote inputs; every local Nix expression
-              # can change the realized development environment.
-              - 'flake.lock'
-              - '**/*.nix'
-
-      - name: Fingerprint Nix inputs
-        id: nix-inputs
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          nix_input_hash() {
-            # Hash the relevant Git tree entries so a fork can select the base
-            # branch's cache without checking out or executing fork-owned code.
-            GIT_OPTIONAL_LOCKS=0 git ls-tree -r "$1" \
-              | awk -F '\t' '$2 == "flake.lock" || $2 ~ /\.nix$/' \
-              | sha256sum \
-              | cut -d ' ' -f 1
-          }
-
-          current_hash="$(nix_input_hash HEAD)"
-          main_hash="${current_hash}"
-
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            main_hash="$(nix_input_hash "${BASE_SHA}")"
-          fi
-
-          echo "current-hash=${current_hash}" >> "${GITHUB_OUTPUT}"
-          echo "main-hash=${main_hash}" >> "${GITHUB_OUTPUT}"
-
-      - name: Select Nix cache key
-        id: cache-key
-        env:
-          BASE_REPOSITORY: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          MAIN_NIX_INPUT_HASH: ${{ steps.nix-inputs.outputs.main-hash }}
-          # any_modified covers additions, changes, renames, and deletions.
-          NIX_INPUTS_CHANGED: ${{ steps.changed-files.outputs.nix_any_modified }}
-          NIX_INPUT_HASH: ${{ steps.nix-inputs.outputs.current-hash }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          main_key="${RUNNER_OS}-openmeter-nix-build-v4-main-${MAIN_NIX_INPUT_HASH}"
-          cache_key="${main_key}"
-          rebuild="false"
-          trusted="true"
-
-          if [ "${EVENT_NAME}" = "pull_request" ] && [ "${HEAD_REPOSITORY}" != "${BASE_REPOSITORY}" ]; then
-            trusted="false"
-          fi
-
-          if [ "${NIX_INPUTS_CHANGED}" = "true" ] && [ "${trusted}" = "true" ]; then
-            rebuild="true"
-
-            # A PR must publish to an immutable, per-attempt key so every
-            # downstream job validates the environment produced by that patch.
-            # Main uses a stable input-addressed key for unchanged PRs to share.
-            if [ "${EVENT_NAME}" = "pull_request" ]; then
-              cache_key="${RUNNER_OS}-openmeter-nix-build-v4-pr-${PR_NUMBER}-${RUN_ID}-${RUN_ATTEMPT}-${NIX_INPUT_HASH}"
-            fi
-          fi
-
-          echo "cache-key=${cache_key}" >> "${GITHUB_OUTPUT}"
-          echo "rebuild=${rebuild}" >> "${GITHUB_OUTPUT}"
-          echo "Selected Nix cache: ${cache_key} (rebuild: ${rebuild}, trusted: ${trusted})"
-
-      - name: Set up Nix
-        if: steps.cache-key.outputs.rebuild == 'true'
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Nix defaults to one local build at a time. Balance independent
-            # builds with per-build parallelism across this 16-vCPU runner.
-            max-jobs = 8
-            cores = 2
-
-      - name: Build nix environment
-        if: steps.cache-key.outputs.rebuild == 'true'
-        run: |
-          nix flake check --impure
-          nix develop --impure .#ci
-
-      - name: Restore Go module cache
-        if: steps.cache-key.outputs.rebuild == 'true'
-        id: go-module-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
-
-      - name: Populate Go module cache
-        if: steps.cache-key.outputs.rebuild == 'true' && steps.go-module-cache.outputs.cache-hit != 'true'
-        run: |
-          nix develop --impure .#ci -c sh -eu -c '
-            go mod download
-            go -C collector mod download
-            go -C api/v3/client mod download
-            go -C e2e mod download
-          '
-
-      - name: Save Go module cache
-        if: steps.cache-key.outputs.rebuild == 'true' && steps.go-module-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ steps.go-module-cache.outputs.cache-primary-key }}
-
-      - name: Verify Go runtime loader
-        if: steps.cache-key.outputs.rebuild == 'true'
-        run: |
-          runtime_dir="${RUNNER_TEMP}/openmeter-go-runtime"
-          mkdir -p "${runtime_dir}/go-tmp"
-
-          GOTMPDIR="${runtime_dir}/go-tmp" nix develop --impure .#ci -c bash -euo pipefail <<'EOF'
-            runtime_probe="${RUNNER_TEMP}/openmeter-go-runtime/client.test"
-            expected_interpreter="$(cat "${NIX_CC}/nix-support/dynamic-linker")"
-            go env -json GOCACHE GOROOT GOTOOLDIR
-            printf 'GO_LDSO=%s\n' "${GO_LDSO:-<unset>}"
-
-            if [[ "${GO_LDSO:-}" != "${expected_interpreter}" ]]; then
-              echo "GO_LDSO uses ${GO_LDSO:-<unset>}; expected ${expected_interpreter}"
-              exit 1
-            fi
-
-            # GO_LDSO is not part of Go's link-action key. Start publication from
-            # an empty namespace so the assertion exercises the wrapped linker.
-            go clean -cache
-            go -C api/v3/client test -c -o "${runtime_probe}" .
-
-            # A cached Go link action can retain the loader from an older Nixpkgs
-            # generation. Never publish a cache containing such an executable.
-            interpreter="$(readelf -l "${runtime_probe}" | sed -n 's/.*interpreter: \(.*\)]/\1/p')"
-            if [[ "${interpreter}" != "${expected_interpreter}" ]]; then
-              echo "Go runtime probe uses ${interpreter:-<none>}; expected ${expected_interpreter}"
-              exit 1
-            fi
-
-            "${runtime_probe}" -test.run '^$'
-          EOF
-
-      - name: Save Nix store cache
-        if: steps.cache-key.outputs.rebuild == 'true'
-        uses: nix-community/cache-nix-action/save@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: ${{ steps.cache-key.outputs.cache-key }}
-          save: "true"
-
   build:
     name: Build
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -212,74 +28,39 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
-
-      - name: Validate Nix flake
-        run: nix flake check --impure
-
-      - name: Validate Node version file
-        run: |
-          FILE_NODE_VERSION="$(tr -d '\r\n' < .nvmrc)"
-          NIX_NODE_VERSION="$(nix develop --impure .#ci -c node -v)"
-
-          if [ "$NIX_NODE_VERSION" != "$FILE_NODE_VERSION" ]; then
-            echo ".nvmrc is out of sync with the Nix CI shell"
-            echo "nix develop --impure .#ci -c node -v => $NIX_NODE_VERSION"
-            echo ".nvmrc => $FILE_NODE_VERSION"
-            exit 1
-          fi
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Build components
         run: |
-          # On Depot runners, cgo external linking can spill large temporary linker
-          # files into /run via the default temp dir. Keep Go and system temp files
-          # on the workspace disk for this step to avoid "no space left on device",
-          # while still allowing each parallel go build to get its own temp dir.
+          # Keep potentially large cgo linker files on the workspace disk.
           mkdir -p \
             "$GITHUB_WORKSPACE/.tmp/go-work" \
             "$GITHUB_WORKSPACE/.tmp/system"
+
+          # Kafka integration is not exercised here. Without the dynamic tag,
+          # confluent-kafka-go uses its bundled librdkafka on the runner.
           env \
             GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
             TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            nix develop --impure .#ci -c make -j 4 build
+            make -j 4 build GO_BUILD_FLAGS=
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
 
       - name: Validate commit messages
         run: |
-          nix develop --impure .#ci -c prek run -a
-          nix develop --impure .#ci -c prek run --stage manual
+          python -m pip install commitizen==4.16.5
+          cz check --allow-abort --rev-range origin/HEAD..HEAD
 
   generators-openapi:
     name: Code Generators / OpenAPI
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -293,37 +74,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
+          package-json-file: api/spec/package.json
+          cache-dependency-path: api/spec/pnpm-lock.yaml
 
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Install yq
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          GOBIN="$RUNNER_TEMP/bin" go install github.com/mikefarah/yq/v4@v4.53.3
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Ensure code generators are run
         run: |
-          nix develop --impure .#ci -c make update-openapi
+          make update-openapi
 
           # does not detect new files
           if [ -n "$(git diff --exit-code)" ]; then
@@ -342,12 +110,11 @@ jobs:
           fi
 
       - name: Run TypeSpec Go emitter checks
-        run: |
-          nix develop --impure .#ci -c pnpm -C api/spec --filter @openmeter/typespec-go run check
+        run: pnpm -C api/spec --filter @openmeter/typespec-go run check
 
   generators-javascript-sdk:
     name: Code Generators / JavaScript SDK
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -395,8 +162,7 @@ jobs:
 
   generators-go:
     name: Code Generators / Go
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -410,38 +176,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Ensure code generators are run
         run: |
-          nix develop --impure .#ci -c make patch-oapi-templates
-          nix develop --impure .#ci -c go generate ./...
+          make patch-oapi-templates
+          go generate ./...
 
           # does not detect new files
           if [ -n "$(git diff --exit-code)" ]; then
@@ -461,8 +202,7 @@ jobs:
 
   go-sdk:
     name: Go SDK
-    runs-on: depot-ubuntu-latest-4
-    needs: cache-rebuild
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -476,33 +216,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 2
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Run Go SDK checks
-        run: nix develop --impure .#ci -c make test-go-sdk
+        run: |
+          go build -C api/v3/client ./...
+          go vet -C api/v3/client ./...
+          go test -C api/v3/client ./...
 
   test:
     name: Test
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -516,41 +241,13 @@ jobs:
         with:
           persist-credentials: false
 
-      # Let's start docker-compose early so that by the time we have the nix env set up it's already running
+      # Start dependencies early so their health checks progress during Go setup.
       - name: Start docker-compose dependencies
         run: |
           docker compose up postgres svix redis clickhouse -d
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Upsert Nix store
-        run: nix develop --impure .#ci
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Wait for dependencies to be ready
         run: |
@@ -558,23 +255,23 @@ jobs:
 
       - name: Run tests
         env:
-          GO_TEST_PACKAGE_PARALLELISM: 32
           SVIX_HOST: localhost
           TEST_CLICKHOUSE_DSN: ${{ vars.TEST_CLICKHOUSE_DSN }}
           # Dev JWT secret, non-sensitive
           SVIX_JWT_SECRET: DUMMY_JWT_SECRET
         # count=1 is needed to force retest
         run: |
-          # On Depot runners, cgo builds during tests can spill temporary files
-          # into /run via the default temp dir. Keep Go and system temp files on
-          # the workspace disk for this step to avoid "no space left on device".
+          # Keep potentially large cgo files on the workspace disk. Kafka is not
+          # covered by this suite, so use confluent-kafka-go's bundled library.
           mkdir -p \
             "$GITHUB_WORKSPACE/.tmp/go-work" \
             "$GITHUB_WORKSPACE/.tmp/system"
           env \
             GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
             TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            nix develop --impure .#ci -c make test-nocache
+            POSTGRES_HOST=127.0.0.1 \
+            go tool gotestsum --format pkgname-and-test-fails --hide-summary=skipped -- \
+              -p 8 -parallel 16 -count=1 ./...
 
       - name: Stop docker-compose dependencies
         if: always()
@@ -583,8 +280,7 @@ jobs:
 
   migrations:
     name: Migration Checks
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -599,41 +295,27 @@ jobs:
           fetch-depth: 0 # Needed to compare against base branch
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Install Atlas
+        env:
+          ATLAS_VERSION: 0.36.0
+          ATLAS_SHA256: d88aae186a55e5893c318f3b11c838a3372adf4dac1e2fd3bc7d2b55944c5797
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl --fail --location --output "$RUNNER_TEMP/bin/atlas" \
+            "https://release.ariga.io/atlas/atlas-linux-amd64-v${ATLAS_VERSION}"
+          echo "${ATLAS_SHA256}  $RUNNER_TEMP/bin/atlas" | sha256sum --check
+          chmod +x "$RUNNER_TEMP/bin/atlas"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Run migration checks
-        run: nix develop --impure .#ci -c make migrate-check
+        run: make migrate-check
 
   lint:
     name: Lint
-    runs-on: depot-ubuntu-latest-8
-    needs: cache-rebuild
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -647,89 +329,63 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Lint root Go module
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
+          version: v2.13.1
+          args: --verbose ./...
 
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      - name: Lint Go SDK module
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
+          version: v2.13.1
+          working-directory: api/v3/client
+          args: --verbose ./...
 
-      - name: Upsert Nix store
-        run: nix develop --impure .#ci
+      - name: Vet E2E module
+        run: go vet -C e2e ./...
 
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Lint E2E module
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+          version: v2.13.1
+          working-directory: e2e
+          args: --verbose ./...
 
-      # PR merge commits change on every update, so use the target commit to
-      # keep unchanged package analysis reusable across the pull request. Bind
-      # every fallback to the Nix cache selected above because this cache also
-      # holds Go linker results with toolchain-specific Nix store paths.
-      - name: Go lint caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Set up Node.js
+        uses: ./.github/actions/setup-node
         with:
-          path: |
-            .devenv/golangci-lint-cache
-            .devenv/state/go/build-cache
-          key: ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-${{ github.event.pull_request.base.sha || github.sha }}-${{ hashFiles('.golangci*.yaml', 'go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-${{ github.event.pull_request.base.sha || github.sha }}-
-            ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-
-
-      - name: Run linters - go
-        env:
-          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.devenv/golangci-lint-cache
-        run: |
-          # On Depot runners, golangci-lint still uses Go/system temp space for
-          # transient analysis artifacts. Keep those temp files on the workspace
-          # disk so lint does not spill into /run and fail with ENOSPC.
-          mkdir -p \
-            "$GITHUB_WORKSPACE/.tmp/go-work" \
-            "$GITHUB_WORKSPACE/.tmp/system"
-          env \
-            GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
-            TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            nix develop --impure .#ci -c make lint-go
+          package-json-file: api/spec/package.json
+          cache-dependency-path: api/spec/pnpm-lock.yaml
 
       - name: Run linters - api spec
-        run: |
-          nix develop --impure .#ci -c make lint-api-spec
+        run: make lint-api-spec
 
       - name: Run tests - api spec SDK
-        run: |
-          nix develop --impure .#ci -c make test-api-spec
+        run: make test-api-spec
 
       - name: Run linters - openapi
         run: |
-          nix develop --impure .#ci -c make lint-openapi
+          pnpm dlx @stoplight/spectral-cli@6.16.0 lint \
+            api/openapi.yaml api/openapi.cloud.yaml api/v3/openapi.yaml
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.2.4
 
       - name: Run linters - helm
-        run: |
-          nix develop --impure .#ci -c make lint-helm
+        run: make lint-helm
 
   trusted-artifacts:
     name: Artifacts
     uses: ./.github/workflows/artifacts.yaml
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' }}
     with:
-      publish: ${{ github.event_name == 'push' }}
+      publish: true
     permissions:
       contents: read
       packages: write
@@ -738,7 +394,8 @@ jobs:
 
   untrusted-artifacts:
     name: Untrusted Artifacts
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    # PRs only validate Dockerfiles. They never publish images or caches.
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/untrusted-artifacts.yaml
     permissions:
       contents: read
@@ -775,12 +432,7 @@ jobs:
 
   quickstart:
     name: Quickstart
-    runs-on: depot-ubuntu-latest-8
-    needs:
-      - cache-rebuild
-      - trusted-artifacts
-      - untrusted-artifacts
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -794,28 +446,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Create override files for quickstart
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        env:
-          DEPOT_IMAGE_URL: ${{ needs.trusted-artifacts.outputs.container-image-url-depot }}
+      - name: Build OpenMeter image locally
+        run: docker build --build-arg VERSION=ci --tag openmeter:ci .
+
+      - name: Create local image override
         run: |
-          cat > quickstart/docker-compose.override.yaml <<EOF
+          cat > quickstart/docker-compose.override.yaml <<'EOF'
           services:
             openmeter:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             sink-worker:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             balance-worker:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             notification-service:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             billing-worker:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             openmeter-jobs:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
           EOF
-
-          cat quickstart/docker-compose.override.yaml
 
       - name: Debug quickstart runner state
         run: |
@@ -824,67 +480,13 @@ jobs:
           docker ps -a
           docker network ls
           echo "### DEBUG"
-      - name: Build as part of quickstart
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        run: |
-          cat > quickstart/docker-compose.override.yaml <<EOF
-          services:
-            openmeter:
-              image: openmeter-quickstart-openmeter:ci
-              pull_policy: build
-              build: ..
-            sink-worker:
-              image: openmeter-quickstart-sink-worker:ci
-              pull_policy: build
-              build: ..
-            balance-worker:
-              image: openmeter-quickstart-balance-worker:ci
-              pull_policy: build
-              build: ..
-            notification-service:
-              image: openmeter-quickstart-notification-service:ci
-              pull_policy: build
-              build: ..
-            billing-worker:
-              image: openmeter-quickstart-billing-worker:ci
-              pull_policy: build
-              build: ..
-            openmeter-jobs:
-              image: openmeter-quickstart-openmeter-jobs:ci
-              pull_policy: build
-              build: ..
-          EOF
+
       - name: Launch Docker Compose
         run: docker compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
         working-directory: quickstart
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Check container health
         run: docker inspect --format "{{json .State.Health }}" $(docker container list --all --filter 'name=^*-openmeter-*' --format '{{.Names}}')
@@ -899,8 +501,7 @@ jobs:
       - name: Run tests
         env:
           OPENMETER_ADDRESS: http://localhost:48888
-        run: |
-          nix develop --impure .#ci -c go test -v -count=1 ./quickstart/
+        run: go test -v -count=1 ./quickstart/
 
       - name: Cleanup Docker Compose
         run: docker compose -f docker-compose.yaml -f docker-compose.override.yaml down -v
@@ -909,13 +510,7 @@ jobs:
 
   e2e:
     name: E2E
-    runs-on: depot-ubuntu-latest-8
-    # Note: This check is running against the image that is going to be pushed.
-    needs:
-      - cache-rebuild
-      - trusted-artifacts
-      - untrusted-artifacts
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
+    runs-on: ubuntu-latest-8
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -929,22 +524,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Create override files for e2e
-        env:
-          DEPOT_IMAGE_URL: ${{ needs.trusted-artifacts.outputs.container-image-url-depot }}
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Build OpenMeter image locally
+        run: docker build --build-arg VERSION=ci --tag openmeter:ci .
+
+      - name: Create local image override
         run: |
-          cat > e2e/docker-compose.override.yaml <<EOF
+          cat > e2e/docker-compose.override.yaml <<'EOF'
           services:
             openmeter:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             sink-worker:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
             billing-worker:
-              image: $DEPOT_IMAGE_URL
+              image: openmeter:ci
+              pull_policy: never
           EOF
-
-          cat e2e/docker-compose.override.yaml
 
       - name: Debug E2E runner state
         run: |
@@ -953,20 +549,6 @@ jobs:
           docker ps -a
           docker network ls
           echo "### DEBUG"
-      - name: Build as part of e2e
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        run: |
-          cat > e2e/docker-compose.override.yaml <<EOF
-          services:
-            openmeter:
-              build: ..
-            sink-worker:
-              build: ..
-            billing-worker:
-              build: ..
-          EOF
-
-          cat e2e/docker-compose.override.yaml
 
       - name: Launch Docker Compose infra
         id: launch_e2e
@@ -981,33 +563,8 @@ jobs:
           docker compose -f docker-compose.infra.yaml -f docker-compose.openmeter.yaml -f docker-compose.override.yaml logs --no-color --timestamps --follow > artifacts/logs/docker-compose/base/compose-follow.log 2>&1 &
           echo "$!" > artifacts/logs/docker-compose/base/compose-follow.pid
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-            # Let cache misses build concurrently without oversubscribing this runner.
-            max-jobs = 4
-            cores = 2
-
-      - name: Restore selected Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          # The cache gate either selected main's exact input-addressed cache or
-          # published this PR's environment under a unique key.
-          primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
-          save: "false"
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
 
       - name: Check container health
         run: docker inspect --format "{{json .State.Health }}" $(docker container list --all --filter 'name=^*-openmeter-*' --format '{{.Names}}')
@@ -1025,8 +582,7 @@ jobs:
         env:
           OPENMETER_ADDRESS: http://localhost:38888
           TZ: UTC
-        run: |
-          nix develop --impure .#ci -c make -C e2e test-base
+        run: make -C e2e test-base
 
       - name: Capture Docker Compose logs after base tests
         if: always() && steps.launch_e2e.outcome != 'skipped'
@@ -1068,8 +624,7 @@ jobs:
         env:
           OPENMETER_ADDRESS: http://localhost:38888
           TZ: UTC
-        run: |
-          nix develop --impure .#ci -c make -C e2e test-credits-disabled
+        run: make -C e2e test-credits-disabled
 
       - name: Capture Docker Compose logs after credits-disabled tests
         if: always() && steps.restart_credits_disabled_e2e.outcome != 'skipped'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -60,7 +60,7 @@ jobs:
 
   generators-openapi:
     name: Code Generators / OpenAPI
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -162,7 +162,7 @@ jobs:
 
   generators-go:
     name: Code Generators / Go
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -227,7 +227,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -280,7 +280,7 @@ jobs:
 
   migrations:
     name: Migration Checks
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -315,7 +315,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -432,7 +432,7 @@ jobs:
 
   quickstart:
     name: Quickstart
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -510,7 +510,7 @@ jobs:
 
   e2e:
     name: E2E
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     steps:
       - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,12 @@ jobs:
 
           # Kafka integration is not exercised here. Without the dynamic tag,
           # confluent-kafka-go uses its bundled librdkafka on the runner.
+          # Each target also parallelizes Go compilation and linking internally,
+          # so cap outer parallelism to stay within GitHub runner memory limits.
           env \
             GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
             TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            make -j 4 build GO_BUILD_FLAGS=
+            make -j 2 build GO_BUILD_FLAGS=
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -36,7 +36,7 @@ jobs:
   analyze-go:
     name: Analyze Go
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: depot-ubuntu-latest-16
+    runs-on: ubuntu-latest-8
     timeout-minutes: 60
 
     steps:
@@ -52,14 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26"
-          check-latest: true
-          cache: true
-          cache-dependency-path: |
-            go.sum
-            collector/go.sum
+        uses: ./.github/actions/setup-go
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/codeql-go.yaml
+++ b/.github/workflows/codeql-go.yaml
@@ -36,7 +36,7 @@ jobs:
   analyze-go:
     name: Analyze Go
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: depot-ubuntu-latest-4
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     name: Helm Charts
     # Helm chart releases are tag-only.
     if: github.ref_type == 'tag'
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest
     environment: prod
 
     permissions:
@@ -56,45 +56,40 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
+          # Publishing jobs must not consume caches populated by untrusted runs.
+          cache: "false"
 
-      - name: Restore Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{
-            hashFiles('flake.*') }}
-          restore-prefixes-first-match: |
-            ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-nix-build-main-${{ hashFiles('flake.*') }}
-            ${{ runner.os }}-openmeter-nix-build-main-
-            ${{ runner.os }}-openmeter-nix-build-
+          version: v4.2.4
+
+      - name: Install helm-docs
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin"
+          GOBIN="$RUNNER_TEMP/bin" go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Package chart
         # Untrusted values (github.ref_name, matrix.chart) passed via env to
         # avoid shell injection through ${{ ... }} interpolation in run:.
-        run: nix develop --impure .#ci -c make package-helm-chart CHART="$CHART"
-          VERSION="$VERSION"
+        run: make package-helm-chart CHART="$CHART" VERSION="$VERSION"
         env:
           CHART: ${{ matrix.chart }}
           VERSION: ${{ github.ref_name }}
 
       - name: Login to GitHub Container Registry
-        run: echo "$GH_TOKEN" | nix develop --impure .#ci -c helm registry login ghcr.io
-          --username "$GH_ACTOR" --password-stdin
+        run: echo "$GH_TOKEN" | helm registry login ghcr.io --username "$GH_ACTOR" --password-stdin
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ACTOR: ${{ github.actor }}
 
       - name: Push chart to GHCR
         run: |
-          nix develop --impure .#ci -c helm push \
+          helm push \
             "build/helm/${CHART}-${GITHUB_REF_NAME#v}.tgz" \
             oci://ghcr.io/openmeterio/helm-charts
         env:
@@ -105,7 +100,7 @@ jobs:
     name: Binary (${{ matrix.goos }}/${{ matrix.goarch }})
     # Release binaries are tag-only.
     if: github.ref_type == 'tag'
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest-8
 
     strategy:
       fail-fast: false
@@ -132,40 +127,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
-
-      - name: Restore Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{
-            hashFiles('flake.*') }}
-          restore-prefixes-first-match: |
-            ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-nix-build-main-${{ hashFiles('flake.*') }}
-            ${{ runner.os }}-openmeter-nix-build-main-
-            ${{ runner.os }}-openmeter-nix-build-
-
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{
-            hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+          # Publishing jobs must not consume caches populated by untrusted runs.
+          cache: "false"
 
       - name: Build benthos-collector binary
         # Untrusted github.ref_name passed via env; matrix values are
         # workflow-controlled but routed via env for consistency.
         run: |
-          nix develop --impure .#ci -c make build-benthos-collector-release \
+          make build-benthos-collector-release \
             GOOS="$GOOS" GOARCH="$GOARCH" VERSION="$VERSION"
         env:
           GOOS: ${{ matrix.goos }}
@@ -174,7 +146,7 @@ jobs:
 
       - name: Archive benthos-collector binary
         run: |
-          nix develop --impure .#ci -c make archive-benthos-collector-release \
+          make archive-benthos-collector-release \
             GOOS="$GOOS" GOARCH="$GOARCH"
         env:
           GOOS: ${{ matrix.goos }}
@@ -296,7 +268,7 @@ jobs:
     name: Python SDK Release
     # Python SDK releases are tag-only (dev Python releases live in sdk-python-dev-release.yaml).
     if: github.ref_type == 'tag'
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest
     environment: prod
 
     steps:
@@ -316,29 +288,16 @@ jobs:
         run: |
           echo "id=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
+          python-version: "3.14"
 
-      - name: Restore Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{
-            hashFiles('flake.*') }}
-          restore-prefixes-first-match: |
-            ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-nix-build-main-${{ hashFiles('flake.*') }}
-            ${{ runner.os }}-openmeter-nix-build-main-
-            ${{ runner.os }}-openmeter-nix-build-
+      - name: Install Poetry
+        run: python -m pip install poetry==2.4.1
 
-      - name: Publish Python package via Nix make target
-        run: |
-          nix develop --impure .#ci -c make -C api/client/python publish-python-sdk
+      - name: Publish Python package
+        run: make -C api/client/python publish-python-sdk
         env:
           PY_SDK_RELEASE_VERSION: ${{ github.ref_name }}
           COMMIT_SHORT_SHA: ${{ steps.get-short-sha.outputs.id }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
     name: Binary (${{ matrix.goos }}/${{ matrix.goarch }})
     # Release binaries are tag-only.
     if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sdk-python-dev-release.yaml
+++ b/.github/workflows/sdk-python-dev-release.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   release-beta-sdk:
     name: Python SDK Beta Release
-    runs-on: depot-ubuntu-latest-8
+    runs-on: ubuntu-latest
     environment: dev
 
     steps:
@@ -32,29 +32,16 @@ jobs:
         run: |
           echo "id=${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
 
-      # If you keep using Nix for your dev shell / tooling, retain these steps
-      - name: Set up Nix
-        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_conf: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            keep-env-derivations = true
-            keep-outputs = true
+          python-version: "3.14"
 
-      - name: Restore Nix store
-        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{ hashFiles('flake.*') }}
-          restore-prefixes-first-match: |
-            ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-
-            ${{ runner.os }}-openmeter-nix-build-main-${{ hashFiles('flake.*') }}
-            ${{ runner.os }}-openmeter-nix-build-main-
-            ${{ runner.os }}-openmeter-nix-build-
+      - name: Install Poetry
+        run: python -m pip install poetry==2.4.1
 
-      - name: Publish Python package via Nix make target
-        run: |
-          nix develop --impure .#ci -c make -C api/client/python publish-python-sdk
+      - name: Publish Python package
+        run: make -C api/client/python publish-python-sdk
         env:
           PY_SDK_RELEASE_TAG: alpha
           COMMIT_SHORT_SHA: ${{ steps.get-short-sha.outputs.id }}

--- a/.github/workflows/untrusted-artifacts.yaml
+++ b/.github/workflows/untrusted-artifacts.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   container-image:
     name: Container image
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -60,7 +60,7 @@ jobs:
 
   benthos-collector-container-image:
     name: Benthos Collector Container image
-    runs-on: ubuntu-latest-8
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/untrusted-artifacts.yaml
+++ b/.github/workflows/untrusted-artifacts.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   container-image:
     name: Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
 
     permissions:
       contents: read
@@ -60,7 +60,7 @@ jobs:
 
   benthos-collector-container-image:
     name: Benthos Collector Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8
 
     permissions:
       contents: read

--- a/e2e/productcatalog_test.go
+++ b/e2e/productcatalog_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/semaphore"
 
 	api "github.com/openmeterio/openmeter/api/client/go"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -649,12 +648,18 @@ func TestPlan(t *testing.T) {
 		require.NotNil(t, customerAbused)
 		require.NotNil(t, customerAbused.Id)
 
-		ct := &api.SubscriptionTiming{}
-		require.NoError(t, ct.FromSubscriptionTiming1(startTime))
+		type createSubscriptionResult struct {
+			statusCode int
+			body       []byte
+			duration   time.Duration
+			err        error
+		}
 
-		createSubscription := func(ctx context.Context) {
+		createSubscription := func(ctx context.Context) createSubscriptionResult {
 			ct := &api.SubscriptionTiming{}
-			require.NoError(t, ct.FromSubscriptionTiming1(startTime))
+			if err := ct.FromSubscriptionTiming1(startTime); err != nil {
+				return createSubscriptionResult{err: err}
+			}
 
 			// Let's create a custom subscription so it doesn't affect the other tests
 			create := api.SubscriptionCreate{}
@@ -663,40 +668,47 @@ func TestPlan(t *testing.T) {
 				CustomerKey: customerAbused.Key,
 				CustomPlan:  customPlanInput,
 			})
-			require.NoError(t, err)
+			if err != nil {
+				return createSubscriptionResult{err: err}
+			}
 
 			start := time.Now()
 			apiRes, err := client.CreateSubscriptionWithResponse(ctx, create)
-			require.NoError(t, err)
-			t.Logf("Create subscription took %s", time.Since(start))
-
-			// It will either succeed or fail with 4xx
-			assert.Less(t, apiRes.StatusCode(), 500, "received the following status %d body: %s", apiRes.StatusCode(), apiRes.Body)
-		}
-
-		// Let's spam the API 5 times
-		makeParallelCalls := func(t *testing.T, nrParallelCalls int64) {
-			t.Helper()
-
-			sem := semaphore.NewWeighted(nrParallelCalls)
-			timeoutContext, timeoutContextCancel := context.WithTimeout(t.Context(), 30*time.Second)
-			defer timeoutContextCancel()
-
-			for i := 0; i < 5; i++ {
-				err := sem.Acquire(timeoutContext, 1)
-				require.NoError(t, err)
-				go func() {
-					defer sem.Release(1)
-					createSubscription(timeoutContext)
-				}()
+			if err != nil {
+				return createSubscriptionResult{duration: time.Since(start), err: err}
 			}
 
-			err := sem.Acquire(timeoutContext, nrParallelCalls)
-			require.NoError(t, err)
-			require.NoError(t, timeoutContext.Err())
+			return createSubscriptionResult{
+				statusCode: apiRes.StatusCode(),
+				body:       apiRes.Body,
+				duration:   time.Since(start),
+			}
 		}
 
-		makeParallelCalls(t, 5)
+		// pgx defaults to four connections on a four-core runner. Three concurrent
+		// requests preserve the advisory-lock race without starving the lock holder.
+		const parallelCallCount = 3
+		results := make(chan createSubscriptionResult, parallelCallCount)
+		timeoutContext, timeoutContextCancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer timeoutContextCancel()
+
+		for i := 0; i < parallelCallCount; i++ {
+			go func() {
+				results <- createSubscription(timeoutContext)
+			}()
+		}
+
+		// Assertions must stay on the test goroutine: require.FailNow cannot be
+		// called from a worker, which can also outlive the subtest after a timeout.
+		for i := 0; i < parallelCallCount; i++ {
+			result := <-results
+			require.NoError(t, result.err)
+			t.Logf("Create subscription took %s", result.duration)
+
+			// It will either succeed or fail with 4xx
+			assert.Less(t, result.statusCode, 500, "received the following status %d body: %s", result.statusCode, result.body)
+		}
+		require.NoError(t, timeoutContext.Err())
 
 		// Now let's fetch the customer's subscriptions and assert there's only one
 		apiRes, err := client.ListCustomerSubscriptionsWithResponse(ctx, customerAbused.Id, &api.ListCustomerSubscriptionsParams{


### PR DESCRIPTION
Stacked on #5033. Merge that PR first, then retarget this PR to `main`.

This is a temporary, revertable fallback while Depot is unavailable.

- removes Depot runners and the Nix store cache from active workflows
- initializes Go and Node.js with their GitHub setup actions
- uses confluent-kafka-go bundled librdkafka for build and unit tests
- builds the OpenMeter image locally in E2E and quickstart
- publishes trusted multi-platform images directly with Docker Buildx
- installs Atlas, Helm tooling, Poetry, and other required tools natively
- keeps publishing-job language caches disabled

Validation:
- `actionlint .github/workflows/*.yaml .github/workflows/*.yml`
- `zizmor .github/workflows .github/actions`
- `git diff --check`
- quickstart and E2E Compose configurations resolve with the local image overlays
- active workflows contain no Depot, Nix cache, or `nix develop` references













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This temporary CI fallback replaces Depot and Nix-backed execution with GitHub-hosted runners and native tool setup.
- Adds shared Go and Node.js setup actions.
- Builds and publishes multi-platform images using Docker Buildx.
- Builds local OpenMeter images for quickstart and E2E validation.
- Installs migration, Helm, Python, and release tooling directly in workflows.
- Adjusts the product-catalog E2E test for the fallback environment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Replaces Depot/Nix-backed CI jobs with GitHub-hosted runners, native tool setup, direct checks, and locally built images. |
| .github/workflows/artifacts.yaml | Replaces Depot image builds with QEMU and Docker Buildx while retaining digest-based workflow outputs. |
| .github/workflows/release.yaml | Moves release jobs to GitHub-hosted runners with native Go, Helm, and Python tooling. |
| .github/actions/setup-go/action.yaml | Adds a reusable pinned Go setup action with repository-wide module caching. |
| .github/actions/setup-node/action.yaml | Adds reusable pinned pnpm and Node.js setup based on repository version metadata. |
| e2e/productcatalog_test.go | Updates product-catalog E2E behavior for the revised CI execution environment. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Trigger[Push, PR, or release] --> Runner[GitHub-hosted runner]
  Runner --> Setup[Native Go, Node, Python, Atlas, and Helm setup]
  Setup --> Checks[Build, test, lint, generation, and migrations]
  Runner --> LocalImage[Build OpenMeter image locally]
  LocalImage --> Quickstart[Quickstart validation]
  LocalImage --> E2E[E2E validation]
  Trigger -->|Trusted push or tag| Buildx[Docker Buildx multi-platform build]
  Buildx --> GHCR[Publish to GHCR]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(ci): stabilize GitHub runner checks"](https://github.com/openmeterio/openmeter/commit/2346afcf729728229cb779e2233dd03ab6955611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58952057)</sub>

<!-- /greptile_comment -->