### PR TITLE
test(ci): benchmark package shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,7 +227,9 @@ jobs:
 
   test:
     name: Test
-    needs: test-shards
+    needs:
+      - test-shards
+      - migration-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
 
@@ -238,12 +240,14 @@ jobs:
           use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
-      - name: Check test shards
+      - name: Check test results
         env:
+          MIGRATION_TESTS_RESULT: ${{ needs.migration-tests.result }}
           TEST_SHARDS_RESULT: ${{ needs.test-shards.result }}
         run: |
-          if [ "$TEST_SHARDS_RESULT" != "success" ]; then
+          if [ "$TEST_SHARDS_RESULT" != "success" ] || [ "$MIGRATION_TESTS_RESULT" != "success" ]; then
             echo "Test shards finished with result: $TEST_SHARDS_RESULT"
+            echo "Migration tests finished with result: $MIGRATION_TESTS_RESULT"
             exit 1
           fi
 
@@ -276,7 +280,10 @@ jobs:
         id: packages
         run: |
           matrix="$(
-            go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... |
+            # The migration suite performs enough concurrent database work to
+            # starve when it shares a runner with other packages. Run it in its
+            # own job below instead of assigning it to a general-purpose shard.
+            go list -f '{{if and (or .TestGoFiles .XTestGoFiles) (ne .ImportPath "github.com/openmeterio/openmeter/tools/migrate")}}{{.ImportPath}}{{end}}' ./... |
               sort |
               jq --raw-input --slurp --compact-output '
                 split("\n") | map(select(length > 0)) as $packages |
@@ -355,6 +362,52 @@ jobs:
               -p 8 -parallel 16 -count=1 "${packages[@]}"
 
       - name: Stop docker-compose dependencies
+        if: always()
+        run: |
+          docker compose down -v
+
+  migration-tests:
+    name: Migration tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
+          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Start PostgreSQL
+        run: |
+          docker compose up postgres -d
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Wait for PostgreSQL to be ready
+        run: |
+          ./tools/wait-for-compose.sh postgres
+
+      - name: Run migration tests
+        run: |
+          # Keep potentially large cgo files on the workspace disk and isolate
+          # this database-heavy package from the parallel package shards.
+          mkdir -p \
+            "$GITHUB_WORKSPACE/.tmp/go-work" \
+            "$GITHUB_WORKSPACE/.tmp/system"
+          env \
+            GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
+            TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
+            POSTGRES_HOST=127.0.0.1 \
+            go tool gotestsum --format pkgname-and-test-fails --hide-summary=skipped -- \
+              -p 1 -parallel 16 -count=1 ./tools/migrate
+
+      - name: Stop PostgreSQL
         if: always()
         run: |
           docker compose down -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,6 +278,117 @@ jobs:
         run: |
           docker compose down -v
 
+  # Temporary benchmark for measuring package-level sharding on the
+  # GitHub-hosted fallback. Keep the regular Test job as the required check.
+  test-packages:
+    name: Plan test shards
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.packages.outputs.matrix }}
+
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
+          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          cache: "false"
+
+      - name: Split test packages
+        id: packages
+        run: |
+          matrix="$(
+            go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... |
+              jq --raw-input --slurp --compact-output '
+                split("\n") | map(select(length > 0)) as $packages |
+                ($packages | length) as $count |
+                (($count + 2) / 3 | floor) as $chunk_size |
+                {
+                  include: [
+                    range(0; 3) as $index |
+                    {
+                      shard: ($index + 1),
+                      packages: $packages[
+                        ($index * $chunk_size):(($index + 1) * $chunk_size)
+                      ]
+                    }
+                  ]
+                }
+              '
+          )"
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix" |
+            jq --raw-output '.include[] | "Shard \(.shard): \(.packages | length) packages"'
+
+  test-shards:
+    name: Test shard ${{ matrix.shard }}/3
+    needs: test-packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.test-packages.outputs.matrix) }}
+
+    steps:
+      - uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+          use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
+          api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Start dependencies early so their health checks progress during Go setup.
+      - name: Start docker-compose dependencies
+        run: |
+          docker compose up postgres svix redis clickhouse -d
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Wait for dependencies to be ready
+        run: |
+          ./tools/wait-for-compose.sh postgres svix redis clickhouse
+
+      - name: Run tests
+        env:
+          TEST_PACKAGES: ${{ toJSON(matrix.packages) }}
+          SVIX_HOST: localhost
+          TEST_CLICKHOUSE_DSN: ${{ vars.TEST_CLICKHOUSE_DSN }}
+          # Dev JWT secret, non-sensitive
+          SVIX_JWT_SECRET: DUMMY_JWT_SECRET
+        # count=1 is needed to force retest
+        run: |
+          # Keep potentially large cgo files on the workspace disk. Kafka is not
+          # covered by this suite, so use confluent-kafka-go's bundled library.
+          mkdir -p \
+            "$GITHUB_WORKSPACE/.tmp/go-work" \
+            "$GITHUB_WORKSPACE/.tmp/system"
+          mapfile -t packages < <(jq --raw-output '.[]' <<< "$TEST_PACKAGES")
+          env \
+            GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
+            TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
+            POSTGRES_HOST=127.0.0.1 \
+            go tool gotestsum --format pkgname-and-test-fails --hide-summary=skipped -- \
+              -p 8 -parallel 16 -count=1 "${packages[@]}"
+
+      - name: Stop docker-compose dependencies
+        if: always()
+        run: |
+          docker compose down -v
+
   migrations:
     name: Migration Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,6 +227,8 @@ jobs:
 
   test:
     name: Test
+    needs: test-shards
+    if: ${{ always() }}
     runs-on: ubuntu-latest
 
     steps:
@@ -236,50 +238,17 @@ jobs:
           use-policy-store: ${{ secrets.STEP_SECURITY_API_KEY != '' }}
           api-key: ${{ secrets.STEP_SECURITY_API_KEY }}
 
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      # Start dependencies early so their health checks progress during Go setup.
-      - name: Start docker-compose dependencies
-        run: |
-          docker compose up postgres svix redis clickhouse -d
-
-      - name: Set up Go
-        uses: ./.github/actions/setup-go
-
-      - name: Wait for dependencies to be ready
-        run: |
-          ./tools/wait-for-compose.sh postgres svix redis clickhouse
-
-      - name: Run tests
+      - name: Check test shards
         env:
-          SVIX_HOST: localhost
-          TEST_CLICKHOUSE_DSN: ${{ vars.TEST_CLICKHOUSE_DSN }}
-          # Dev JWT secret, non-sensitive
-          SVIX_JWT_SECRET: DUMMY_JWT_SECRET
-        # count=1 is needed to force retest
+          TEST_SHARDS_RESULT: ${{ needs.test-shards.result }}
         run: |
-          # Keep potentially large cgo files on the workspace disk. Kafka is not
-          # covered by this suite, so use confluent-kafka-go's bundled library.
-          mkdir -p \
-            "$GITHUB_WORKSPACE/.tmp/go-work" \
-            "$GITHUB_WORKSPACE/.tmp/system"
-          env \
-            GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
-            TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            POSTGRES_HOST=127.0.0.1 \
-            go tool gotestsum --format pkgname-and-test-fails --hide-summary=skipped -- \
-              -p 8 -parallel 16 -count=1 ./...
-
-      - name: Stop docker-compose dependencies
-        if: always()
-        run: |
-          docker compose down -v
+          if [ "$TEST_SHARDS_RESULT" != "success" ]; then
+            echo "Test shards finished with result: $TEST_SHARDS_RESULT"
+            exit 1
+          fi
 
   # Temporary benchmark for measuring package-level sharding on the
-  # GitHub-hosted fallback. Keep the regular Test job as the required check.
+  # GitHub-hosted fallback. The Test job above keeps the required check stable.
   test-packages:
     name: Plan test shards
     runs-on: ubuntu-latest
@@ -308,6 +277,7 @@ jobs:
         run: |
           matrix="$(
             go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... |
+              sort |
               jq --raw-input --slurp --compact-output '
                 split("\n") | map(select(length > 0)) as $packages |
                 ($packages | length) as $count |


### PR DESCRIPTION
## Summary

- add a temporary package discovery job for root-module packages containing tests
- split the discovered packages into three simple matrix shards
- run every shard with Go package parallelism 8 and test parallelism 16
- keep the existing Test job unchanged as the stable required check

Stacked on #5035.

No Jira ticket.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the root-module test run with package-level sharding while preserving the stable `Test` check as an aggregate gate.
- Discovers root-module packages containing tests and divides them across three matrix shards.
- Runs each shard with package parallelism 8 and test parallelism 16.
- Isolates the database-heavy migration package in a dedicated PostgreSQL-backed job.
- Requires both shard and migration jobs to succeed before the stable `Test` check passes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Adds package discovery, three matrix test shards, isolated migration tests, and a stable aggregate Test gate without an accepted follow-up finding. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P[Plan test shards] --> S1[Test shard 1]
  P --> S2[Test shard 2]
  P --> S3[Test shard 3]
  M[Migration tests] --> T[Stable Test check]
  S1 --> TS[Test-shards matrix result]
  S2 --> TS
  S3 --> TS
  TS --> T
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): isolate migration tests"](https://github.com/openmeterio/openmeter/commit/31e953749a289b682850a10919e42b02c414e746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58969436)</sub>

<!-- /greptile_comment -->