### PR TITLE
fix(billing): optimize worker database queries

### DIFF
--- a/openmeter/billing/worker/subscriptionsync/adapter/syncstate.go
+++ b/openmeter/billing/worker/subscriptionsync/adapter/syncstate.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionbillingsyncstate"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -27,24 +26,39 @@ func (a *adapter) InvalidateSyncState(ctx context.Context, input subscriptionsyn
 }
 
 func (a *adapter) GetSyncStates(ctx context.Context, input subscriptionsync.GetSyncStatesInput) ([]subscriptionsync.SyncState, error) {
+	if len(input) == 0 {
+		return []subscriptionsync.SyncState{}, nil
+	}
+
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) ([]subscriptionsync.SyncState, error) {
+		requestedIDs := lo.SliceToMap(input, func(id models.NamespacedID) (models.NamespacedID, struct{}) {
+			return id, struct{}{}
+		})
+		subscriptionIDs := lo.Map(input, func(id models.NamespacedID, _ int) string {
+			return id.ID
+		})
+
+		// This is a query optimization: subscription_id is globally unique and indexed,
+		// so fetching by it avoids a large OR expression. The exact namespaced-ID check
+		// below preserves tenant isolation.
 		res, err := tx.db.SubscriptionBillingSyncState.Query().
-			Where(
-				subscriptionbillingsyncstate.Or(
-					lo.Map(input, func(id models.NamespacedID, _ int) predicate.SubscriptionBillingSyncState {
-						return subscriptionbillingsyncstate.And(
-							subscriptionbillingsyncstate.SubscriptionID(id.ID),
-							subscriptionbillingsyncstate.Namespace(id.Namespace),
-						)
-					})...),
-			).All(ctx)
+			Where(subscriptionbillingsyncstate.SubscriptionIDIn(subscriptionIDs...)).
+			All(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		return lo.Map(res, func(state *entdb.SubscriptionBillingSyncState, _ int) subscriptionsync.SyncState {
-			return mapSyncStateFromDB(state)
-		}), nil
+		syncStates := make([]subscriptionsync.SyncState, 0, len(res))
+		for _, state := range res {
+			mappedState := mapSyncStateFromDB(state)
+			if _, ok := requestedIDs[mappedState.SubscriptionID]; !ok {
+				continue
+			}
+
+			syncStates = append(syncStates, mappedState)
+		}
+
+		return syncStates, nil
 	})
 }
 

--- a/openmeter/billing/worker/subscriptionsync/adapter/syncstate.go
+++ b/openmeter/billing/worker/subscriptionsync/adapter/syncstate.go
@@ -48,15 +48,12 @@ func (a *adapter) GetSyncStates(ctx context.Context, input subscriptionsync.GetS
 			return nil, err
 		}
 
-		syncStates := make([]subscriptionsync.SyncState, 0, len(res))
-		for _, state := range res {
+		syncStates := lo.FilterMap(res, func(state *entdb.SubscriptionBillingSyncState, _ int) (subscriptionsync.SyncState, bool) {
 			mappedState := mapSyncStateFromDB(state)
-			if _, ok := requestedIDs[mappedState.SubscriptionID]; !ok {
-				continue
-			}
+			_, requested := requestedIDs[mappedState.SubscriptionID]
 
-			syncStates = append(syncStates, mappedState)
-		}
+			return mappedState, requested
+		})
 
 		return syncStates, nil
 	})

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -4962,6 +4962,17 @@ func (s *SubscriptionHandlerTestSuite) TestSyncStateUpdateNoBillables() {
 		SyncedAt:      clock.Now().UTC(),
 		NextSyncAfter: nil,
 	}, syncStates[0])
+
+	// The optimized lookup fetches by globally unique subscription ID, but must
+	// still conceal sync states from callers requesting that ID in another namespace.
+	syncStates, err = s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
+		{
+			Namespace: "another-namespace",
+			ID:        subsView.Subscription.ID,
+		},
+	})
+	require.NoError(s.T(), err)
+	require.Empty(s.T(), syncStates)
 }
 
 func (s *SubscriptionHandlerTestSuite) TestSyncStateUpdateWithFreePhaseActiveInTheFuture() {

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1109,6 +1109,21 @@ var (
 				Columns: []*schema.Column{BillingInvoiceLinesColumns[44]},
 			},
 			{
+				Name:    "billing_invoice_lines_fee_config_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[36]},
+			},
+			{
+				Name:    "billing_invoice_lines_usage_config_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[37]},
+			},
+			{
+				Name:    "billing_invoice_lines_parent_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[38]},
+			},
+			{
 				Name:    "billinginvoiceline_namespace_invoice_id",
 				Unique:  false,
 				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[35]},
@@ -1174,6 +1189,11 @@ var (
 				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1]},
 			},
 			{
+				Name:    "billing_invoice_line_discounts_line_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[12]},
+			},
+			{
 				Name:    "billinginvoicelinediscount_namespace_line_id",
 				Unique:  false,
 				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1], BillingInvoiceLineDiscountsColumns[12]},
@@ -1227,6 +1247,11 @@ var (
 				Name:    "billinginvoicelineusagediscount_namespace",
 				Unique:  false,
 				Columns: []*schema.Column{BillingInvoiceLineUsageDiscountsColumns[1]},
+			},
+			{
+				Name:    "billing_invoice_line_usage_discounts_line_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLineUsageDiscountsColumns[12]},
 			},
 			{
 				Name:    "billinginvoicelineusagediscount_namespace_line_id",
@@ -1604,6 +1629,11 @@ var (
 				Columns: []*schema.Column{BillingStandardInvoiceDetailedLinesColumns[13], BillingStandardInvoiceDetailedLinesColumns[0]},
 			},
 			{
+				Name:    "billing_std_invoice_detailed_lines_parent_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingStandardInvoiceDetailedLinesColumns[29]},
+			},
+			{
 				Name:    "billingstandardinvoicedetailedline_namespace_invoice_id",
 				Unique:  false,
 				Columns: []*schema.Column{BillingStandardInvoiceDetailedLinesColumns[13], BillingStandardInvoiceDetailedLinesColumns[28]},
@@ -1662,6 +1692,11 @@ var (
 				Name:    "billingstandardinvoicedetailedlineamountdiscount_namespace",
 				Unique:  false,
 				Columns: []*schema.Column{BillingStandardInvoiceDetailedLineAmountDiscountsColumns[1]},
+			},
+			{
+				Name:    "billing_std_invoice_detail_amount_discounts_line_id_idx",
+				Unique:  false,
+				Columns: []*schema.Column{BillingStandardInvoiceDetailedLineAmountDiscountsColumns[12]},
 			},
 			{
 				Name:    "billingstandardinvoicedetailedlineamountdiscount_namespace_line_id",

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -519,6 +519,16 @@ func (BillingInvoiceLine) Fields() []ent.Field {
 
 func (BillingInvoiceLine) Indexes() []ent.Index {
 	return []ent.Index{
+		// PostgreSQL looks up child rows by the foreign-key column alone when a line
+		// config is deleted, so these indexes prevent a scan of all invoice lines.
+		index.Edges("flat_fee_line").
+			StorageKey("billing_invoice_lines_fee_config_id_idx"),
+		index.Edges("usage_based_line").
+			StorageKey("billing_invoice_lines_usage_config_id_idx"),
+		// Self-referencing foreign-key actions filter by parent_line_id without the
+		// namespace, so the namespace-prefixed index below cannot serve them.
+		index.Fields("parent_line_id").
+			StorageKey("billing_invoice_lines_parent_id_idx"),
 		index.Fields("namespace", "invoice_id"),
 		index.Fields("namespace", "parent_line_id"),
 		index.Fields("namespace", "parent_line_id", "child_unique_reference_id").
@@ -959,6 +969,10 @@ func (BillingInvoiceLineDiscount) Fields() []ent.Field {
 
 func (BillingInvoiceLineDiscount) Indexes() []ent.Index {
 	return []ent.Index{
+		// Invoice-line deletion cascades by line_id alone, so the namespace-prefixed
+		// indexes below cannot prevent a scan of all amount discounts.
+		index.Fields("line_id").
+			StorageKey("billing_invoice_line_discounts_line_id_idx"),
 		index.Fields("namespace", "line_id"),
 		index.Fields("namespace", "line_id", "child_unique_reference_id").
 			Annotations(
@@ -1019,6 +1033,10 @@ func (BillingInvoiceLineUsageDiscount) Fields() []ent.Field {
 
 func (BillingInvoiceLineUsageDiscount) Indexes() []ent.Index {
 	return []ent.Index{
+		// Invoice-line deletion cascades by line_id alone, so the namespace-prefixed
+		// indexes below cannot prevent a scan of all usage discounts.
+		index.Fields("line_id").
+			StorageKey("billing_invoice_line_usage_discounts_line_id_idx"),
 		index.Fields("namespace", "line_id"),
 		index.Fields("namespace", "line_id", "child_unique_reference_id").
 			Annotations(
@@ -1064,6 +1082,10 @@ func (BillingStandardInvoiceDetailedLine) Fields() []ent.Field {
 
 func (BillingStandardInvoiceDetailedLine) Indexes() []ent.Index {
 	return []ent.Index{
+		// Invoice-line deletion cascades by parent_line_id alone, so the
+		// namespace-prefixed indexes below cannot prevent a scan of detailed lines.
+		index.Fields("parent_line_id").
+			StorageKey("billing_std_invoice_detailed_lines_parent_id_idx"),
 		index.Fields("namespace", "invoice_id"),
 		index.Fields("namespace", "parent_line_id"),
 		index.Fields("namespace", "parent_line_id", "child_unique_reference_id").
@@ -1134,6 +1156,10 @@ func (BillingStandardInvoiceDetailedLineAmountDiscount) Fields() []ent.Field {
 
 func (BillingStandardInvoiceDetailedLineAmountDiscount) Indexes() []ent.Index {
 	return []ent.Index{
+		// Detailed-line deletion cascades by line_id alone, so the namespace-prefixed
+		// indexes below cannot prevent a scan of all amount discounts.
+		index.Fields("line_id").
+			StorageKey("billing_std_invoice_detail_amount_discounts_line_id_idx"),
 		index.Fields("namespace", "line_id"),
 		index.Fields("namespace", "line_id", "child_unique_reference_id").
 			Annotations(

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
@@ -1,16 +1,14 @@
--- atlas:txmode none
-
 -- reverse: create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
-DROP INDEX CONCURRENTLY "billing_std_invoice_detailed_lines_parent_id_idx";
+DROP INDEX "billing_std_invoice_detailed_lines_parent_id_idx";
 -- reverse: create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
-DROP INDEX CONCURRENTLY "billing_std_invoice_detail_amount_discounts_line_id_idx";
+DROP INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx";
 -- reverse: create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
-DROP INDEX CONCURRENTLY "billing_invoice_lines_usage_config_id_idx";
+DROP INDEX "billing_invoice_lines_usage_config_id_idx";
 -- reverse: create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
-DROP INDEX CONCURRENTLY "billing_invoice_lines_parent_id_idx";
+DROP INDEX "billing_invoice_lines_parent_id_idx";
 -- reverse: create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
-DROP INDEX CONCURRENTLY "billing_invoice_lines_fee_config_id_idx";
+DROP INDEX "billing_invoice_lines_fee_config_id_idx";
 -- reverse: create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
-DROP INDEX CONCURRENTLY "billing_invoice_line_usage_discounts_line_id_idx";
+DROP INDEX "billing_invoice_line_usage_discounts_line_id_idx";
 -- reverse: create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
-DROP INDEX CONCURRENTLY "billing_invoice_line_discounts_line_id_idx";
+DROP INDEX "billing_invoice_line_discounts_line_id_idx";

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
@@ -1,14 +1,16 @@
+-- atlas:txmode none
+
 -- reverse: create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
-DROP INDEX "billing_std_invoice_detailed_lines_parent_id_idx";
+DROP INDEX CONCURRENTLY "billing_std_invoice_detailed_lines_parent_id_idx";
 -- reverse: create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
-DROP INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx";
+DROP INDEX CONCURRENTLY "billing_std_invoice_detail_amount_discounts_line_id_idx";
 -- reverse: create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
-DROP INDEX "billing_invoice_lines_usage_config_id_idx";
+DROP INDEX CONCURRENTLY "billing_invoice_lines_usage_config_id_idx";
 -- reverse: create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
-DROP INDEX "billing_invoice_lines_parent_id_idx";
+DROP INDEX CONCURRENTLY "billing_invoice_lines_parent_id_idx";
 -- reverse: create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
-DROP INDEX "billing_invoice_lines_fee_config_id_idx";
+DROP INDEX CONCURRENTLY "billing_invoice_lines_fee_config_id_idx";
 -- reverse: create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
-DROP INDEX "billing_invoice_line_usage_discounts_line_id_idx";
+DROP INDEX CONCURRENTLY "billing_invoice_line_usage_discounts_line_id_idx";
 -- reverse: create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
-DROP INDEX "billing_invoice_line_discounts_line_id_idx";
+DROP INDEX CONCURRENTLY "billing_invoice_line_discounts_line_id_idx";

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql
@@ -1,0 +1,14 @@
+-- reverse: create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
+DROP INDEX "billing_std_invoice_detailed_lines_parent_id_idx";
+-- reverse: create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
+DROP INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx";
+-- reverse: create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
+DROP INDEX "billing_invoice_lines_usage_config_id_idx";
+-- reverse: create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
+DROP INDEX "billing_invoice_lines_parent_id_idx";
+-- reverse: create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
+DROP INDEX "billing_invoice_lines_fee_config_id_idx";
+-- reverse: create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
+DROP INDEX "billing_invoice_line_usage_discounts_line_id_idx";
+-- reverse: create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
+DROP INDEX "billing_invoice_line_discounts_line_id_idx";

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
@@ -1,14 +1,16 @@
+-- atlas:txmode none
+
 -- create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
-CREATE INDEX "billing_invoice_line_discounts_line_id_idx" ON "billing_invoice_line_discounts" ("line_id");
+CREATE INDEX CONCURRENTLY "billing_invoice_line_discounts_line_id_idx" ON "billing_invoice_line_discounts" ("line_id");
 -- create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
-CREATE INDEX "billing_invoice_line_usage_discounts_line_id_idx" ON "billing_invoice_line_usage_discounts" ("line_id");
+CREATE INDEX CONCURRENTLY "billing_invoice_line_usage_discounts_line_id_idx" ON "billing_invoice_line_usage_discounts" ("line_id");
 -- create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX "billing_invoice_lines_fee_config_id_idx" ON "billing_invoice_lines" ("fee_line_config_id");
+CREATE INDEX CONCURRENTLY "billing_invoice_lines_fee_config_id_idx" ON "billing_invoice_lines" ("fee_line_config_id");
 -- create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX "billing_invoice_lines_parent_id_idx" ON "billing_invoice_lines" ("parent_line_id");
+CREATE INDEX CONCURRENTLY "billing_invoice_lines_parent_id_idx" ON "billing_invoice_lines" ("parent_line_id");
 -- create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX "billing_invoice_lines_usage_config_id_idx" ON "billing_invoice_lines" ("usage_based_line_config_id");
+CREATE INDEX CONCURRENTLY "billing_invoice_lines_usage_config_id_idx" ON "billing_invoice_lines" ("usage_based_line_config_id");
 -- create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
-CREATE INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx" ON "billing_standard_invoice_detailed_line_amount_discounts" ("line_id");
+CREATE INDEX CONCURRENTLY "billing_std_invoice_detail_amount_discounts_line_id_idx" ON "billing_standard_invoice_detailed_line_amount_discounts" ("line_id");
 -- create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
-CREATE INDEX "billing_std_invoice_detailed_lines_parent_id_idx" ON "billing_standard_invoice_detailed_lines" ("parent_line_id");
+CREATE INDEX CONCURRENTLY "billing_std_invoice_detailed_lines_parent_id_idx" ON "billing_standard_invoice_detailed_lines" ("parent_line_id");

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
@@ -1,16 +1,14 @@
--- atlas:txmode none
-
 -- create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
-CREATE INDEX CONCURRENTLY "billing_invoice_line_discounts_line_id_idx" ON "billing_invoice_line_discounts" ("line_id");
+CREATE INDEX "billing_invoice_line_discounts_line_id_idx" ON "billing_invoice_line_discounts" ("line_id");
 -- create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
-CREATE INDEX CONCURRENTLY "billing_invoice_line_usage_discounts_line_id_idx" ON "billing_invoice_line_usage_discounts" ("line_id");
+CREATE INDEX "billing_invoice_line_usage_discounts_line_id_idx" ON "billing_invoice_line_usage_discounts" ("line_id");
 -- create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX CONCURRENTLY "billing_invoice_lines_fee_config_id_idx" ON "billing_invoice_lines" ("fee_line_config_id");
+CREATE INDEX "billing_invoice_lines_fee_config_id_idx" ON "billing_invoice_lines" ("fee_line_config_id");
 -- create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX CONCURRENTLY "billing_invoice_lines_parent_id_idx" ON "billing_invoice_lines" ("parent_line_id");
+CREATE INDEX "billing_invoice_lines_parent_id_idx" ON "billing_invoice_lines" ("parent_line_id");
 -- create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
-CREATE INDEX CONCURRENTLY "billing_invoice_lines_usage_config_id_idx" ON "billing_invoice_lines" ("usage_based_line_config_id");
+CREATE INDEX "billing_invoice_lines_usage_config_id_idx" ON "billing_invoice_lines" ("usage_based_line_config_id");
 -- create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
-CREATE INDEX CONCURRENTLY "billing_std_invoice_detail_amount_discounts_line_id_idx" ON "billing_standard_invoice_detailed_line_amount_discounts" ("line_id");
+CREATE INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx" ON "billing_standard_invoice_detailed_line_amount_discounts" ("line_id");
 -- create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
-CREATE INDEX CONCURRENTLY "billing_std_invoice_detailed_lines_parent_id_idx" ON "billing_standard_invoice_detailed_lines" ("parent_line_id");
+CREATE INDEX "billing_std_invoice_detailed_lines_parent_id_idx" ON "billing_standard_invoice_detailed_lines" ("parent_line_id");

--- a/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
+++ b/tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql
@@ -1,0 +1,14 @@
+-- create index "billing_invoice_line_discounts_line_id_idx" to table: "billing_invoice_line_discounts"
+CREATE INDEX "billing_invoice_line_discounts_line_id_idx" ON "billing_invoice_line_discounts" ("line_id");
+-- create index "billing_invoice_line_usage_discounts_line_id_idx" to table: "billing_invoice_line_usage_discounts"
+CREATE INDEX "billing_invoice_line_usage_discounts_line_id_idx" ON "billing_invoice_line_usage_discounts" ("line_id");
+-- create index "billing_invoice_lines_fee_config_id_idx" to table: "billing_invoice_lines"
+CREATE INDEX "billing_invoice_lines_fee_config_id_idx" ON "billing_invoice_lines" ("fee_line_config_id");
+-- create index "billing_invoice_lines_parent_id_idx" to table: "billing_invoice_lines"
+CREATE INDEX "billing_invoice_lines_parent_id_idx" ON "billing_invoice_lines" ("parent_line_id");
+-- create index "billing_invoice_lines_usage_config_id_idx" to table: "billing_invoice_lines"
+CREATE INDEX "billing_invoice_lines_usage_config_id_idx" ON "billing_invoice_lines" ("usage_based_line_config_id");
+-- create index "billing_std_invoice_detail_amount_discounts_line_id_idx" to table: "billing_standard_invoice_detailed_line_amount_discounts"
+CREATE INDEX "billing_std_invoice_detail_amount_discounts_line_id_idx" ON "billing_standard_invoice_detailed_line_amount_discounts" ("line_id");
+-- create index "billing_std_invoice_detailed_lines_parent_id_idx" to table: "billing_standard_invoice_detailed_lines"
+CREATE INDEX "billing_std_invoice_detailed_lines_parent_id_idx" ON "billing_standard_invoice_detailed_lines" ("parent_line_id");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:NJkByX7l8bxNbBh1hdcAAvD27fowunB8rdRv/wsInQs=
+h1:9V4Ep3kwIkoLCF5N5RM66XJrd4psvz1A64BBsQpsAHo=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -275,3 +275,4 @@ h1:NJkByX7l8bxNbBh1hdcAAvD27fowunB8rdRv/wsInQs=
 20260826120555_backfill_usage_based_run_prior_lineage.up.sql h1:6WJ8jhOtRTCNDa01cCTuyiq777slyDS+PgydKK40dfQ=
 20260826131456_usage_based_run_schema_level_2_only.up.sql h1:t6pW+zlYNcF/nR4hdXHoLsEKxyDledrehUaVxXNxshM=
 20260827103408_add_charge_overage_preparation_state.up.sql h1:BmCUpvxwwWOPo4OhPJoB32kELVamexLpaOlGQqbvRPc=
+20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:9V4Ep3kwIkoLCF5N5RM66XJrd4psvz1A64BBsQpsAHo=
+h1:rcJUGlDdf2Et+Mvrsy3oP3G2D59vZ9a1ut/NCPnW784=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -275,4 +275,4 @@ h1:9V4Ep3kwIkoLCF5N5RM66XJrd4psvz1A64BBsQpsAHo=
 20260826120555_backfill_usage_based_run_prior_lineage.up.sql h1:6WJ8jhOtRTCNDa01cCTuyiq777slyDS+PgydKK40dfQ=
 20260826131456_usage_based_run_schema_level_2_only.up.sql h1:t6pW+zlYNcF/nR4hdXHoLsEKxyDledrehUaVxXNxshM=
 20260827103408_add_charge_overage_preparation_state.up.sql h1:BmCUpvxwwWOPo4OhPJoB32kELVamexLpaOlGQqbvRPc=
-20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=
+20260901065710_add_billing_foreign_key_indexes.up.sql h1:/vD57mpqwaIWpg+X+SiOeSeD7+FC9m4YjReAhFTC1tE=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:rcJUGlDdf2Et+Mvrsy3oP3G2D59vZ9a1ut/NCPnW784=
+h1:9V4Ep3kwIkoLCF5N5RM66XJrd4psvz1A64BBsQpsAHo=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -275,4 +275,4 @@ h1:rcJUGlDdf2Et+Mvrsy3oP3G2D59vZ9a1ut/NCPnW784=
 20260826120555_backfill_usage_based_run_prior_lineage.up.sql h1:6WJ8jhOtRTCNDa01cCTuyiq777slyDS+PgydKK40dfQ=
 20260826131456_usage_based_run_schema_level_2_only.up.sql h1:t6pW+zlYNcF/nR4hdXHoLsEKxyDledrehUaVxXNxshM=
 20260827103408_add_charge_overage_preparation_state.up.sql h1:BmCUpvxwwWOPo4OhPJoB32kELVamexLpaOlGQqbvRPc=
-20260901065710_add_billing_foreign_key_indexes.up.sql h1:/vD57mpqwaIWpg+X+SiOeSeD7+FC9m4YjReAhFTC1tE=
+20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=


### PR DESCRIPTION
## Overview

Optimizes the billing worker database queries identified from the last two days of Dash0 traces.

- add seven billing-table indexes used by foreign-key cascade and delete lookups
- replace the large subscription billing sync-state OR query with an indexed subscription ID lookup
- validate the exact namespace and subscription ID pair before returning sync states to preserve tenant isolation
- document why the indexes and sync-state lookup are query optimization measures

## Notes for reviewer

The new billing indexes cover child foreign-key columns that PostgreSQL filters independently of the existing namespace-prefixed indexes. Charge tables are intentionally unchanged.

The sync-state lookup relies on subscription IDs being globally unique, but still filters fetched rows against the requested namespaced IDs before returning them.

## Verification

- `make lint-go-fast`
- focused PostgreSQL-backed subscription sync-state test
- `make migrate-check`
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription synchronization lookups to prevent sync states from appearing across namespaces.
  * Empty subscription queries now return no results immediately.

* **Performance**
  * Added billing database indexes to improve invoice, discount, and line-item operations.

* **Database**
  * Added migration support to create and safely remove the new indexes within transactions, helping maintain reliable database updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimizes billing-worker database access while preserving namespace isolation.
- Replaces the subscription sync-state OR query with an indexed subscription-ID lookup followed by exact namespaced-ID filtering.
- Adds coverage for cross-namespace sync-state requests and empty inputs.
- Adds seven indexes supporting billing foreign-key and deletion lookups, including matching Ent schema and migration updates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/worker/subscriptionsync/adapter/syncstate.go | Optimizes sync-state retrieval while filtering fetched rows against exact requested namespace-and-ID pairs. |
| openmeter/billing/worker/subscriptionsync/service/sync_test.go | Adds tenant-isolation coverage using a context already derived from the active test. |
| openmeter/ent/schema/billing.go | Declares seven single-column indexes for billing foreign-key lookup paths. |
| openmeter/ent/db/migrate/schema.go | Updates the generated Ent migration schema to include the new indexes. |
| tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.up.sql | Creates the seven billing indexes represented in the Ent schema. |
| tools/migrate/migrations/20260901065710_add_billing_foreign_key_indexes.down.sql | Drops all seven indexes during rollback. |

<sub>Reviews (4): Last reviewed commit: ["fix(billing): use single index migration"](https://github.com/openmeterio/openmeter/commit/750a4657f4334540ce860dd1996b98927989f1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58970091)</sub>

<!-- /greptile_comment -->