### PR TITLE
fix(subscription): validate custom rate card features

### DIFF
--- a/app/common/subscription.go
+++ b/app/common/subscription.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/google/wire"
@@ -10,6 +11,7 @@ import (
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
@@ -60,6 +62,11 @@ func NewSubscriptionServices(
 	featureFlags ffx.Service,
 	taxCodeService taxcode.Service,
 ) (SubscriptionServiceWithWorkflow, error) {
+	featureResolver, err := featureresolver.New(featureConnector)
+	if err != nil {
+		return SubscriptionServiceWithWorkflow{}, fmt.Errorf("failed to initialize feature resolver: %w", err)
+	}
+
 	subscriptionRepo := subscriptionrepo.NewSubscriptionRepo(db)
 	subscriptionPhaseRepo := subscriptionrepo.NewSubscriptionPhaseRepo(db)
 	subscriptionItemRepo := subscriptionrepo.NewSubscriptionItemRepo(db)
@@ -110,6 +117,7 @@ func NewSubscriptionServices(
 		Service:            subscriptionService,
 		CustomerService:    customerService,
 		CurrencyResolver:   currencyResolver,
+		FeatureResolver:    featureResolver,
 		TransactionManager: subscriptionRepo,
 		AddonService:       subAddSvc,
 		Logger:             logger.With("subsystem", "subscription.workflow.service"),
@@ -124,6 +132,7 @@ func NewSubscriptionServices(
 		WorkflowService:     subscriptionWorkflowService,
 		SubscriptionService: subscriptionService,
 		PlanService:         planService,
+		FeatureResolver:     featureResolver,
 		CurrencyResolver:    currencyResolver,
 		CustomerService:     customerService,
 		Logger:              logger.With("subsystem", "subscription.change.service"),

--- a/openmeter/productcatalog/subscription/service/change.go
+++ b/openmeter/productcatalog/subscription/service/change.go
@@ -25,6 +25,11 @@ func (s *service) Change(ctx context.Context, request plansubscription.ChangeSub
 		if request.SettlementMode != nil {
 			planInput.SettlementMode = *request.SettlementMode
 		}
+
+		if err := s.resolveCustomPlanFeatures(ctx, request.ID.Namespace, &planInput); err != nil {
+			return def, err
+		}
+
 		if err := productcatalogcurrencyresolver.ResolveCurrenciesForPlan(ctx, s.CurrencyResolver.WithNamespace(request.ID.Namespace), &planInput.Plan); err != nil {
 			return def, fmt.Errorf("invalid plan currencies: %w", err)
 		}

--- a/openmeter/productcatalog/subscription/service/change_test.go
+++ b/openmeter/productcatalog/subscription/service/change_test.go
@@ -511,3 +511,70 @@ func TestChange(t *testing.T) {
 		})
 	})
 }
+
+func TestChangeInlineCustomPlanRejectsMissingFeature(t *testing.T) {
+	// given:
+	// - a running subscription and an inline replacement plan whose rate card
+	//   references a feature that does not exist
+	// when:
+	// - the subscription is changed to the inline plan
+	// then:
+	// - the change fails with the product catalog's missing-feature validation error
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+	svc := newPlanSubscriptionService(t, deps, testutils.NewLogger(t))
+	customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+	deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	currentPlanInput := subscriptiontestutils.GetExamplePlanInput(t)
+	currentPlanInput.Plan.Key = ""
+	currentPlanInput.Plan.Version = 0
+	currentPlan := plansubscription.PlanInput{}
+	currentPlan.FromInput(&currentPlanInput)
+
+	sub, err := svc.Create(t.Context(), plansubscription.CreateSubscriptionRequest{
+		PlanInput: currentPlan,
+		WorkflowInput: subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Name:   "subscription before invalid plan change",
+				Timing: subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)},
+			},
+			Namespace:  customer.Namespace,
+			CustomerID: customer.ID,
+		},
+	})
+	require.NoError(t, err)
+
+	const missingFeatureKey = "missing-change-feature"
+	replacementPlanInput := subscriptiontestutils.GetExamplePlanInput(t)
+	replacementPlanInput.Plan.Key = ""
+	replacementPlanInput.Plan.Version = 0
+	require.NoError(t, replacementPlanInput.Plan.Phases[0].RateCards[0].ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+		meta.Key = missingFeatureKey
+		meta.Feature = productcatalog.NewFeatureReference(nil, lo.ToPtr(missingFeatureKey))
+
+		return meta, nil
+	}))
+	replacementPlan := plansubscription.PlanInput{}
+	replacementPlan.FromInput(&replacementPlanInput)
+
+	_, err = svc.Change(t.Context(), plansubscription.ChangeSubscriptionRequest{
+		ID:        sub.NamespacedID,
+		PlanInput: replacementPlan,
+		WorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Name:   sub.Name,
+			Timing: subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)},
+		},
+	})
+	require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureNotFound)
+	require.ErrorContains(t, err, missingFeatureKey)
+	issues, systemErr := models.AsValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.NotEmpty(t, issues)
+}

--- a/openmeter/productcatalog/subscription/service/create.go
+++ b/openmeter/productcatalog/subscription/service/create.go
@@ -27,6 +27,11 @@ func (s *service) Create(ctx context.Context, request plansubscription.CreateSub
 		if request.SettlementMode != nil {
 			planInput.SettlementMode = *request.SettlementMode
 		}
+
+		if err := s.resolveCustomPlanFeatures(ctx, request.WorkflowInput.Namespace, &planInput); err != nil {
+			return def, err
+		}
+
 		if err := productcatalogcurrencyresolver.ResolveCurrenciesForPlan(ctx, s.CurrencyResolver.WithNamespace(request.WorkflowInput.Namespace), &planInput.Plan); err != nil {
 			return def, fmt.Errorf("invalid plan currencies: %w", err)
 		}

--- a/openmeter/productcatalog/subscription/service/create_test.go
+++ b/openmeter/productcatalog/subscription/service/create_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -24,17 +25,67 @@ import (
 func newPlanSubscriptionService(t *testing.T, deps subscriptiontestutils.SubscriptionDependencies, logger *slog.Logger) plansubscription.PlanSubscriptionService {
 	t.Helper()
 
+	featureResolver, err := featureresolver.New(deps.FeatureConnector)
+	require.NoError(t, err)
+
 	svc, err := service.New(service.Config{
 		SubscriptionService: deps.SubscriptionService,
 		WorkflowService:     deps.WorkflowService,
 		Logger:              logger,
 		PlanService:         deps.PlanService,
+		FeatureResolver:     featureResolver,
 		CurrencyResolver:    deps.CurrencyResolver,
 		CustomerService:     deps.CustomerService,
 	})
 	require.NoError(t, err)
 
 	return svc
+}
+
+func TestCreateInlineCustomPlanRejectsMissingFeature(t *testing.T) {
+	// given:
+	// - an inline custom plan whose rate card references a feature that does not exist
+	// when:
+	// - the plan subscription service creates the subscription
+	// then:
+	// - creation fails with the product catalog's missing-feature validation error
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+	svc := newPlanSubscriptionService(t, deps, testutils.NewLogger(t))
+	customer := deps.CustomerAdapter.CreateExampleCustomer(t)
+	deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	const missingFeatureKey = "missing-feature"
+	planInput := subscriptiontestutils.GetExamplePlanInput(t)
+	planInput.Plan.Key = ""
+	planInput.Plan.Version = 0
+	require.NoError(t, planInput.Plan.Phases[0].RateCards[0].ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+		meta.Key = missingFeatureKey
+		meta.Feature = productcatalog.NewFeatureReference(nil, lo.ToPtr(missingFeatureKey))
+
+		return meta, nil
+	}))
+
+	requestPlan := plansubscription.PlanInput{}
+	requestPlan.FromInput(&planInput)
+
+	_, err := svc.Create(t.Context(), plansubscription.CreateSubscriptionRequest{
+		PlanInput: requestPlan,
+		WorkflowInput: subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Name: "inline plan with missing feature",
+				Timing: subscription.Timing{
+					Enum: lo.ToPtr(subscription.TimingImmediate),
+				},
+			},
+			Namespace:  customer.Namespace,
+			CustomerID: customer.ID,
+		},
+	})
+	require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureNotFound)
+	require.ErrorContains(t, err, missingFeatureKey)
 }
 
 func TestCreateSettlementModeOverride(t *testing.T) {

--- a/openmeter/productcatalog/subscription/service/plan.go
+++ b/openmeter/productcatalog/subscription/service/plan.go
@@ -7,12 +7,35 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+// resolveCustomPlanFeatures canonicalizes feature references before an inline
+// plan is converted into a subscription-owned spec.
+func (s *service) resolveCustomPlanFeatures(ctx context.Context, namespace string, input *plan.CreatePlanInput) error {
+	for idx := range input.Phases {
+		phaseFieldSelector := models.NewFieldSelectorGroup(
+			models.NewFieldSelector("plan"),
+			models.NewFieldSelector("phases").WithExpression(
+				models.NewFieldAttrValue("key", input.Phases[idx].Key),
+			),
+		)
+
+		if err := featureresolver.ResolveFeaturesForRateCards(ctx, s.FeatureResolver, namespace, &input.Phases[idx].RateCards); err != nil {
+			return models.ErrorWithFieldPrefix(
+				phaseFieldSelector,
+				fmt.Errorf("failed to resolve features for ratecards in custom plan phase [plan.phase.key=%s]: %w", input.Phases[idx].Key, err),
+			)
+		}
+	}
+
+	return nil
+}
 
 // TODO: this method is mostly redundant if the APIs are matched
 func (s *service) getPlanByVersion(ctx context.Context, namespace string, ref plansubscription.PlanRefInput) (*plan.Plan, error) {

--- a/openmeter/productcatalog/subscription/service/service.go
+++ b/openmeter/productcatalog/subscription/service/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	plansubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -23,6 +24,7 @@ type Config struct {
 	WorkflowService     subscriptionworkflow.Service
 	SubscriptionService subscription.Service
 	PlanService         plan.Service
+	FeatureResolver     productcatalog.FeatureResolver
 	CurrencyResolver    currencies.CurrencyResolver
 	Logger              *slog.Logger
 	CustomerService     customer.Service
@@ -41,6 +43,10 @@ func (c Config) Validate() error {
 
 	if c.PlanService == nil {
 		errs = append(errs, errors.New("plan service is required"))
+	}
+
+	if c.FeatureResolver == nil {
+		errs = append(errs, errors.New("feature resolver is required"))
 	}
 
 	if c.CurrencyResolver == nil {

--- a/openmeter/subscription/README.md
+++ b/openmeter/subscription/README.md
@@ -123,6 +123,10 @@ and phase; do not persist a derived absolute end as independent source truth.
   this snapshot
 - customer and subscription invoice currencies must match whenever the spec has
   priced items; unpriced items have no materialized currency
+- customer-authored rate cards in inline custom plans and add-item edits must
+  resolve every feature in the subscription namespace before building the
+  target spec; they enforce the same feature existence and archival rules as
+  persisted plans
 - item and entitlement cadences cannot escape their phase or subscription
 - downstream work must be derived from the committed view and tolerate event
   retries

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -289,6 +289,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		Service:            svc,
 		CustomerService:    customerService,
 		CurrencyResolver:   currencyResolver,
+		FeatureResolver:    featureResolver,
 		TransactionManager: subItemRepo,
 		AddonService:       subAddSvc,
 		Logger:             logger.With("subsystem", "subscription.workflow.service"),

--- a/openmeter/subscription/workflow/service/service.go
+++ b/openmeter/subscription/workflow/service/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
@@ -22,6 +23,7 @@ type WorkflowServiceConfig struct {
 	// connectors
 	CustomerService  customer.Service
 	CurrencyResolver currencies.CurrencyResolver
+	FeatureResolver  productcatalog.FeatureResolver
 	// framework
 	TransactionManager transaction.Creator
 	Logger             *slog.Logger
@@ -46,6 +48,10 @@ func (c WorkflowServiceConfig) Validate() error {
 
 	if c.CurrencyResolver == nil {
 		errs = append(errs, errors.New("currency resolver is required"))
+	}
+
+	if c.FeatureResolver == nil {
+		errs = append(errs, errors.New("feature resolver is required"))
 	}
 
 	if c.TransactionManager == nil {

--- a/openmeter/subscription/workflow/service/service_test.go
+++ b/openmeter/subscription/workflow/service/service_test.go
@@ -13,6 +13,7 @@ func TestNewWorkflowServiceValidatesConfig(t *testing.T) {
 	require.ErrorContains(t, err, "subscription add-on service is required")
 	require.ErrorContains(t, err, "customer service is required")
 	require.ErrorContains(t, err, "currency resolver is required")
+	require.ErrorContains(t, err, "feature resolver is required")
 	require.ErrorContains(t, err, "transaction manager is required")
 	require.ErrorContains(t, err, "logger is required")
 	require.ErrorContains(t, err, "locker is required")

--- a/openmeter/subscription/workflow/service/subscription.go
+++ b/openmeter/subscription/workflow/service/subscription.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	productcatalogcurrencyresolver "github.com/openmeterio/openmeter/openmeter/productcatalog/currencyresolver"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
@@ -132,9 +133,9 @@ func resolveSubscriptionInvoiceCurrency(cus customer.Customer, plan subscription
 	return *cus.Currency, nil
 }
 
-// resolveEditPatchCurrency resolves the currency of a newly authored priced
-// item before patch validation requires a persisted custom-currency identity.
-func (s *service) resolveEditPatchCurrency(ctx context.Context, namespace string, invoiceCurrency currencyx.Code, customization subscription.Patch) (subscription.Patch, error) {
+// resolveEditPatchRateCardReferences canonicalizes the feature and currency of
+// a newly authored item before the patch is applied to the subscription spec.
+func (s *service) resolveEditPatchRateCardReferences(ctx context.Context, namespace string, invoiceCurrency currencyx.Code, customization subscription.Patch) (subscription.Patch, error) {
 	var addItem *patch.PatchAddItem
 	returnsPointer := false
 
@@ -152,25 +153,35 @@ func (s *service) resolveEditPatchCurrency(ctx context.Context, namespace string
 	}
 
 	rateCard := addItem.CreateInput.RateCard
-	if rateCard == nil || rateCard.AsMeta().Price == nil {
+	if rateCard == nil {
 		return customization, nil
 	}
 
 	rateCard = rateCard.Clone()
-	if rateCard.AsMeta().Currency == nil {
-		if err := rateCard.ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
-			meta.Currency = lo.ToPtr(currencies.NewCurrencyReference(invoiceCurrency))
-			return meta, nil
-		}); err != nil {
-			return nil, fmt.Errorf("defaulting add-item currency: %w", err)
+	rateCards := productcatalog.RateCards{rateCard}
+	if err := featureresolver.ResolveFeaturesForRateCards(ctx, s.FeatureResolver, namespace, &rateCards); err != nil {
+		return nil, fmt.Errorf("resolving add-item feature: %w", err)
+	}
+	rateCard = rateCards[0]
+
+	if rateCard.AsMeta().Price != nil {
+		if rateCard.AsMeta().Currency == nil {
+			if err := rateCard.ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+				meta.Currency = lo.ToPtr(currencies.NewCurrencyReference(invoiceCurrency))
+				return meta, nil
+			}); err != nil {
+				return nil, fmt.Errorf("defaulting add-item currency: %w", err)
+			}
 		}
+
+		rateCards[0] = rateCard
+		if err := productcatalogcurrencyresolver.ResolveCurrenciesForRateCards(ctx, s.CurrencyResolver.WithNamespace(namespace), &rateCards); err != nil {
+			return nil, fmt.Errorf("resolving add-item currency: %w", err)
+		}
+		rateCard = rateCards[0]
 	}
 
-	rateCards := productcatalog.RateCards{rateCard}
-	if err := productcatalogcurrencyresolver.ResolveCurrenciesForRateCards(ctx, s.CurrencyResolver.WithNamespace(namespace), &rateCards); err != nil {
-		return nil, fmt.Errorf("resolving add-item currency: %w", err)
-	}
-	addItem.CreateInput.RateCard = rateCards[0]
+	addItem.CreateInput.RateCard = rateCard
 
 	if returnsPointer {
 		return addItem, nil
@@ -234,7 +245,7 @@ func (s *service) EditRunning(ctx context.Context, subscriptionID models.Namespa
 		}
 
 		for i, customization := range customizations {
-			resolved, err := s.resolveEditPatchCurrency(ctx, subscriptionID.Namespace, curr.Spec.InvoiceCurrency, customization)
+			resolved, err := s.resolveEditPatchRateCardReferences(ctx, subscriptionID.Namespace, curr.Spec.InvoiceCurrency, customization)
 			if err != nil {
 				return subscription.SubscriptionView{}, models.ErrorWithComponent(models.ComponentName(fmt.Sprintf("patch[%d]", i)), err)
 			}

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -335,6 +336,98 @@ func TestEditRunning(t *testing.T) {
 			},
 		},
 		{
+			Name: "Should resolve feature references on a newly authored item",
+			Handler: func(t *testing.T, deps testCaseDeps) {
+				// given:
+				// - an unpriced add-item patch identifying an existing feature by key
+				// when:
+				// - it is added through the running-subscription edit workflow
+				// then:
+				// - the persisted rate card carries the canonical feature ID and key
+				const phaseKey = "test_phase_1"
+				itemKey := subscriptiontestutils.ExampleFeatureKey2
+
+				rateCard := &productcatalog.FlatFeeRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:     itemKey,
+						Name:    itemKey,
+						Feature: productcatalog.NewFeatureReference(nil, &itemKey),
+					},
+				}
+
+				subView, err := deps.WorkflowService.EditRunning(t.Context(), deps.SubView.Subscription.NamespacedID, []subscription.Patch{
+					patch.PatchAddItem{
+						PhaseKey: phaseKey,
+						ItemKey:  itemKey,
+						CreateInput: subscription.SubscriptionItemSpec{
+							CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+								CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+									PhaseKey: phaseKey,
+									ItemKey:  itemKey,
+									RateCard: rateCard,
+								},
+							},
+						},
+					},
+				}, immediate)
+				require.NoError(t, err)
+
+				phase, ok := subView.GetPhaseByKey(phaseKey)
+				require.True(t, ok)
+				require.Len(t, phase.ItemsByKey[itemKey], 1)
+
+				featureReference := phase.ItemsByKey[itemKey][0].Spec.RateCard.AsMeta().Feature
+				require.NotNil(t, featureReference)
+				require.NotNil(t, featureReference.ID)
+				require.NotNil(t, featureReference.Key)
+				require.Equal(t, itemKey, *featureReference.Key)
+			},
+		},
+		{
+			Name: "Should reject a newly authored item with a missing feature",
+			Handler: func(t *testing.T, deps testCaseDeps) {
+				// given:
+				// - an unpriced add-item patch referencing a feature that does not exist
+				// when:
+				// - it is submitted through the running-subscription edit workflow
+				// then:
+				// - the edit fails with the product catalog's missing-feature validation error
+				const (
+					phaseKey = "test_phase_1"
+					itemKey  = "missing-edit-feature"
+				)
+
+				rateCard := &productcatalog.FlatFeeRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:     itemKey,
+						Name:    itemKey,
+						Feature: productcatalog.NewFeatureReference(nil, lo.ToPtr(itemKey)),
+					},
+				}
+
+				_, err := deps.WorkflowService.EditRunning(t.Context(), deps.SubView.Subscription.NamespacedID, []subscription.Patch{
+					patch.PatchAddItem{
+						PhaseKey: phaseKey,
+						ItemKey:  itemKey,
+						CreateInput: subscription.SubscriptionItemSpec{
+							CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+								CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+									PhaseKey: phaseKey,
+									ItemKey:  itemKey,
+									RateCard: rateCard,
+								},
+							},
+						},
+					},
+				}, immediate)
+				require.ErrorIs(t, err, productcatalog.ErrRateCardFeatureNotFound)
+				require.ErrorContains(t, err, itemKey)
+				issues, systemErr := models.AsValidationIssues(err)
+				require.NoError(t, systemErr)
+				require.NotEmpty(t, issues)
+			},
+		},
+		{
 			Name: "Should preserve patch field paths when a priced item is invalid",
 			Handler: func(t *testing.T, deps testCaseDeps) {
 				// given:
@@ -500,6 +593,8 @@ func TestEditRunning(t *testing.T) {
 				}
 
 				tuDeps := subscriptiontestutils.NewService(t, deps.DBDeps)
+				featureResolver, err := featureresolver.New(tuDeps.FeatureConnector)
+				require.NoError(t, err)
 
 				lockr, err := lockr.NewLocker(&lockr.LockerConfig{Logger: slog.Default()})
 				require.NoError(t, err)
@@ -507,6 +602,7 @@ func TestEditRunning(t *testing.T) {
 					Service:            &mSvc,
 					CustomerService:    tuDeps.CustomerService,
 					CurrencyResolver:   tuDeps.CurrencyResolver,
+					FeatureResolver:    featureResolver,
 					TransactionManager: tuDeps.CustomerAdapter,
 					AddonService:       tuDeps.SubscriptionAddonService,
 					Logger:             slog.Default(),

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -245,6 +245,7 @@ func TestEditRunning(t *testing.T) {
 		CurrentTime     time.Time
 		SubView         subscription.SubscriptionView
 		Customer        customer.Customer
+		FeatureIDsByKey map[string]string
 		WorkflowService subscriptionworkflow.Service
 		Service         subscription.Service
 		DBDeps          *subscriptiontestutils.DBDeps
@@ -381,6 +382,10 @@ func TestEditRunning(t *testing.T) {
 				require.NotNil(t, featureReference.ID)
 				require.NotNil(t, featureReference.Key)
 				require.Equal(t, itemKey, *featureReference.Key)
+
+				expectedFeatureID, ok := deps.FeatureIDsByKey[itemKey]
+				require.True(t, ok)
+				require.Equal(t, expectedFeatureID, *featureReference.ID)
 			},
 		},
 		{
@@ -634,10 +639,15 @@ func TestEditRunning(t *testing.T) {
 			defer dbDeps.Cleanup(t)
 
 			deps := subscriptiontestutils.NewService(t, dbDeps)
-			deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+			features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
 			plan := deps.PlanHelper.CreatePlan(t, subscriptiontestutils.GetExamplePlanInput(t))
 			cust := deps.CustomerAdapter.CreateExampleCustomer(t)
 			require.NotNil(t, cust)
+
+			featureIDsByKey := make(map[string]string, len(features))
+			for _, feature := range features {
+				featureIDsByKey[feature.Key] = feature.ID
+			}
 
 			// Let's create an example subscription
 			sub, err := deps.WorkflowService.CreateFromPlan(context.Background(), subscriptionworkflow.CreateSubscriptionWorkflowInput{
@@ -654,6 +664,7 @@ func TestEditRunning(t *testing.T) {
 
 			tcDeps.SubView = sub
 			tcDeps.Customer = *cust
+			tcDeps.FeatureIDsByKey = featureIDsByKey
 			tcDeps.DBDeps = dbDeps
 			tcDeps.Service = deps.SubscriptionService
 			tcDeps.WorkflowService = deps.WorkflowService

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -241,6 +241,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		AddonService:       s.SubscriptionAddonService,
 		CustomerService:    deps.CustomerService,
 		CurrencyResolver:   currencyResolver,
+		FeatureResolver:    featureResolver,
 		TransactionManager: subsRepo,
 		Logger:             slog.Default(),
 		Lockr:              lockr,

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -409,6 +409,7 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Service:            svc,
 		CustomerService:    customerService,
 		CurrencyResolver:   currencyResolver,
+		FeatureResolver:    featureResolver,
 		TransactionManager: subItemRepo,
 		AddonService:       subAddSvc,
 		Logger:             logger.With("subsystem", "subscription.workflow.service"),

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	subscriptionsyncadapter "github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/adapter"
 	subscriptionsyncservice "github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	pcsubscriptionservice "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
 	subscription "github.com/openmeterio/openmeter/openmeter/subscription"
@@ -63,10 +64,14 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 
 	deps := subscriptiontestutils.NewService(t, dbDeps)
 
+	featureResolver, err := featureresolver.New(deps.FeatureConnector)
+	require.NoError(t, err)
+
 	pcSubsService, err := pcsubscriptionservice.New(pcsubscriptionservice.Config{
 		WorkflowService:     deps.WorkflowService,
 		SubscriptionService: deps.SubscriptionService,
 		PlanService:         deps.PlanService,
+		FeatureResolver:     featureResolver,
 		CurrencyResolver:    deps.CurrencyResolver,
 		Logger:              testutils.NewLogger(t),
 		CustomerService:     deps.CustomerService,


### PR DESCRIPTION
## Summary

- resolve and canonicalize feature references before creating or changing subscriptions from inline custom plans
- validate feature references introduced by running-subscription add-item edits, including unpriced items
- return missing, archived, or conflicting feature references as product catalog validation errors before materialization
- document the subscription authoring invariant and cover creation, change, and edit paths with regression tests

## Testing

- `make test-nocache`
- `make lint-go-fast`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/productcatalog/subscription/service ./openmeter/subscription/workflow/service -count=1`





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline custom plans now resolve and validate referenced features during subscription creation and plan changes.
  * Subscription edits resolve authored feature keys and apply the same feature existence and archival rules as persisted plans.
  * Rate cards retain appropriate currency handling while feature references are resolved.

* **Bug Fixes**
  * Missing feature references now return clear validation errors, including the affected feature key.

* **Documentation**
  * Documented feature-resolution requirements for inline plans and subscription edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves and validates feature references before inline custom plans and newly added subscription items are materialized.
- Adds namespace-scoped feature canonicalization to inline subscription creation and plan changes.
- Resolves features for priced and unpriced add-item edits while preserving currency resolution for priced items.
- Makes the feature resolver an explicit dependency of subscription services and adds regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/productcatalog/subscription/service/plan.go | Adds per-phase feature resolution and field-prefixed validation errors for inline custom plans. |
| openmeter/productcatalog/subscription/service/create.go | Resolves custom-plan feature references before currency resolution and subscription creation. |
| openmeter/productcatalog/subscription/service/change.go | Applies the same feature canonicalization before changing a subscription to an inline plan. |
| openmeter/subscription/workflow/service/subscription.go | Canonicalizes add-item feature references for priced and unpriced rate cards, then resolves currency when pricing requires it. |
| app/common/subscription.go | Constructs and injects a shared feature resolver into both subscription services. |
| openmeter/productcatalog/subscription/service/service.go | Makes feature resolution a validated dependency of the product-catalog subscription service. |
| openmeter/subscription/workflow/service/service.go | Makes feature resolution a validated dependency of the subscription workflow service. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant SubscriptionService
    participant FeatureResolver
    participant Workflow
    Client->>SubscriptionService: Create, change, or add item
    SubscriptionService->>FeatureResolver: Resolve feature in namespace
    alt Feature is valid
        FeatureResolver-->>SubscriptionService: Canonical ID and key
        SubscriptionService->>Workflow: Materialize subscription spec
        Workflow-->>Client: Updated subscription
    else Missing, archived, or conflicting
        FeatureResolver-->>SubscriptionService: Validation error
        SubscriptionService-->>Client: Reject request
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: assert canonical feature ID after ..."](https://github.com/openmeterio/openmeter/commit/7ba605c62848b9b8fc077d582f5f4f3b4b530e97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58971036)</sub>

<!-- /greptile_comment -->