### PR TITLE
fix(customer): improve conflict error diagnostics

### DIFF
--- a/openmeter/customer/adapter/conflict_test.go
+++ b/openmeter/customer/adapter/conflict_test.go
@@ -1,0 +1,299 @@
+package adapter_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func newConflictTestEnv(t *testing.T) (*testEnv, *bytes.Buffer) {
+	t.Helper()
+
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(logs, nil))
+
+	return newTestEnvWithLogger(t, logger), logs
+}
+
+func TestCustomerConflictRedaction(t *testing.T) {
+	t.Run("CreateKeyCustomerIDOverlap", func(t *testing.T) {
+		env, logs := newConflictTestEnv(t)
+		const namespace = "sensitive-create-id-namespace"
+		conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key")
+
+		_, err := env.adapter.CreateCustomer(t.Context(), customer.CreateCustomerInput{
+			Namespace: namespace,
+			CustomerMutate: customer.CustomerMutate{
+				Key:  lo.ToPtr(conflictingCustomerID),
+				Name: "new customer",
+			},
+		})
+
+		assertCustomerConflictResponse(
+			t,
+			err,
+			fmt.Sprintf("customer key %q overlaps with the ID of another customer", conflictingCustomerID),
+			namespace,
+		)
+		assertConflictLog(t, logs, "customer key overlaps with customer ID", map[string]any{
+			"namespace":               namespace,
+			"customer_key":            conflictingCustomerID,
+			"conflicting_customer_id": conflictingCustomerID,
+		})
+	})
+
+	t.Run("CreateKeySubjectOverlap", func(t *testing.T) {
+		env, logs := newConflictTestEnv(t)
+		const namespace = "sensitive-create-subject-namespace"
+		conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key", "existing-subject")
+
+		_, err := env.adapter.CreateCustomer(t.Context(), customer.CreateCustomerInput{
+			Namespace: namespace,
+			CustomerMutate: customer.CustomerMutate{
+				Key:  lo.ToPtr("existing-subject"),
+				Name: "new customer",
+			},
+		})
+
+		assertCustomerConflictResponse(
+			t,
+			err,
+			fmt.Sprintf(`customer key "existing-subject" overlaps with a usage attribution key of another customer: %s`, conflictingCustomerID),
+			namespace,
+		)
+		assertConflictLog(t, logs, "customer key overlaps with customer usage attribution key", map[string]any{
+			"namespace":                         namespace,
+			"customer_key":                      "existing-subject",
+			"conflicting_usage_attribution_key": "existing-subject",
+			"conflicting_customer_id":           conflictingCustomerID,
+		})
+	})
+
+	t.Run("CreateKeyAndSubjectUniqueness", func(t *testing.T) {
+		t.Run("Key", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-create-key-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key")
+
+			_, err := env.adapter.CreateCustomer(t.Context(), customer.CreateCustomerInput{
+				Namespace: namespace,
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("existing-key"),
+					Name: "new customer",
+				},
+			})
+
+			require.True(t, customer.IsKeyConflictError(err))
+			assertCustomerConflictResponse(t, err, `customer key "existing-key" is already in use`, namespace, conflictingCustomerID)
+			assertConflictLog(t, logs, "customer key conflict while creating customer", map[string]any{
+				"namespace":    namespace,
+				"customer_key": "existing-key",
+			}, "db: constraint failed", "customer_namespace_key", "SQLSTATE 23505")
+		})
+
+		t.Run("Subject", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-create-subject-uniqueness-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key", "existing-subject")
+
+			_, err := env.adapter.CreateCustomer(t.Context(), customer.CreateCustomerInput{
+				Namespace: namespace,
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("new-key"),
+					Name: "new customer",
+					UsageAttribution: &customer.CustomerUsageAttribution{
+						SubjectKeys: []string{"existing-subject"},
+					},
+				},
+			})
+
+			require.True(t, customer.IsSubjectKeyConflictError(err))
+			assertCustomerConflictResponse(t, err, `one or more customer usage attribution keys are already in use: ["existing-subject"]`, namespace, conflictingCustomerID)
+			assertConflictLog(t, logs, "customer usage attribution key conflict while creating customer", map[string]any{
+				"namespace":              namespace,
+				"usage_attribution_keys": []string{"existing-subject"},
+			}, "db: constraint failed", "customersubjects_namespace_subject_key", "SQLSTATE 23505")
+		})
+	})
+
+	t.Run("UpdateKeyCustomerIDAndSubjectOverlap", func(t *testing.T) {
+		t.Run("CustomerID", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-update-id-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key")
+			requestedCustomerID := env.seedCustomerWithKey(namespace, "updating-key")
+
+			_, err := env.adapter.UpdateCustomer(t.Context(), customer.UpdateCustomerInput{
+				CustomerID: customer.CustomerID{Namespace: namespace, ID: requestedCustomerID},
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr(conflictingCustomerID),
+					Name: "updated customer",
+				},
+			})
+
+			assertCustomerConflictResponse(
+				t,
+				err,
+				fmt.Sprintf("customer key %q overlaps with the ID of another customer", conflictingCustomerID),
+				namespace,
+				requestedCustomerID,
+			)
+			assertConflictLog(t, logs, "customer key overlaps with customer ID", map[string]any{
+				"namespace":               namespace,
+				"customer_id":             requestedCustomerID,
+				"customer_key":            conflictingCustomerID,
+				"conflicting_customer_id": conflictingCustomerID,
+			})
+		})
+
+		t.Run("Subject", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-update-subject-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key", "existing-subject")
+			requestedCustomerID := env.seedCustomerWithKey(namespace, "updating-key")
+
+			_, err := env.adapter.UpdateCustomer(t.Context(), customer.UpdateCustomerInput{
+				CustomerID: customer.CustomerID{Namespace: namespace, ID: requestedCustomerID},
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("existing-subject"),
+					Name: "updated customer",
+				},
+			})
+
+			assertCustomerConflictResponse(
+				t,
+				err,
+				fmt.Sprintf(`customer key "existing-subject" overlaps with a usage attribution key of another customer: %s`, conflictingCustomerID),
+				namespace,
+				requestedCustomerID,
+			)
+			assertConflictLog(t, logs, "customer key overlaps with customer usage attribution key", map[string]any{
+				"namespace":                         namespace,
+				"customer_id":                       requestedCustomerID,
+				"customer_key":                      "existing-subject",
+				"conflicting_usage_attribution_key": "existing-subject",
+				"conflicting_customer_id":           conflictingCustomerID,
+			})
+		})
+	})
+
+	t.Run("UpdateKeyAndSubjectUniqueness", func(t *testing.T) {
+		t.Run("Key", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-update-key-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key")
+			requestedCustomerID := env.seedCustomerWithKey(namespace, "updating-key")
+
+			_, err := env.adapter.UpdateCustomer(t.Context(), customer.UpdateCustomerInput{
+				CustomerID: customer.CustomerID{Namespace: namespace, ID: requestedCustomerID},
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("existing-key"),
+					Name: "updated customer",
+				},
+			})
+
+			require.True(t, customer.IsKeyConflictError(err))
+			assertCustomerConflictResponse(t, err, `customer key "existing-key" is already in use`, namespace, requestedCustomerID, conflictingCustomerID)
+			assertConflictLog(t, logs, "customer key conflict while updating customer", map[string]any{
+				"namespace":    namespace,
+				"customer_id":  requestedCustomerID,
+				"customer_key": "existing-key",
+			}, "db: constraint failed", "customer_namespace_key", "SQLSTATE 23505")
+		})
+
+		t.Run("Subject", func(t *testing.T) {
+			env, logs := newConflictTestEnv(t)
+			const namespace = "sensitive-update-subject-uniqueness-namespace"
+			conflictingCustomerID := env.seedCustomerWithKey(namespace, "existing-key", "existing-subject")
+			requestedCustomerID := env.seedCustomerWithKey(namespace, "updating-key")
+
+			_, err := env.adapter.UpdateCustomer(t.Context(), customer.UpdateCustomerInput{
+				CustomerID: customer.CustomerID{Namespace: namespace, ID: requestedCustomerID},
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("updating-key"),
+					Name: "updated customer",
+					UsageAttribution: &customer.CustomerUsageAttribution{
+						SubjectKeys: []string{"existing-subject"},
+					},
+				},
+			})
+
+			require.True(t, customer.IsSubjectKeyConflictError(err))
+			assertCustomerConflictResponse(t, err, `one or more customer usage attribution keys are already in use: ["existing-subject"]`, namespace, requestedCustomerID, conflictingCustomerID)
+			assertConflictLog(t, logs, "customer usage attribution key conflict while updating customer", map[string]any{
+				"namespace":              namespace,
+				"customer_id":            requestedCustomerID,
+				"usage_attribution_keys": []string{"existing-subject"},
+			}, "db: constraint failed", "customersubjects_namespace_subject_key", "SQLSTATE 23505")
+		})
+	})
+}
+
+func assertCustomerConflictResponse(t *testing.T, err error, publicMessage string, excludedValues ...string) {
+	t.Helper()
+
+	require.Error(t, err)
+	require.True(t, models.IsGenericConflictError(err))
+	require.EqualError(t, err, "conflict error: "+publicMessage)
+
+	recorder := httptest.NewRecorder()
+	handled := commonhttp.GenericErrorEncoder()(t.Context(), err, recorder, httptest.NewRequest(http.MethodPost, "/", nil))
+	require.True(t, handled)
+	require.Equal(t, http.StatusConflict, recorder.Code)
+
+	response := map[string]any{}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Equal(t, "conflict error: "+publicMessage, response["detail"])
+
+	for _, value := range excludedValues {
+		require.NotContains(t, err.Error(), value)
+		require.NotContains(t, response["detail"], value)
+	}
+}
+
+func assertConflictLog(t *testing.T, logs *bytes.Buffer, message string, expectedFields map[string]any, expectedErrorValues ...string) {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(logs.String()), "\n")
+	require.Len(t, lines, 1)
+
+	logEntry := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &logEntry))
+	require.Equal(t, "WARN", logEntry["level"])
+	require.Equal(t, message, logEntry["msg"])
+
+	for field, expectedValue := range expectedFields {
+		if expectedStrings, ok := expectedValue.([]string); ok {
+			actualValues, ok := logEntry[field].([]any)
+			require.True(t, ok, "log field %q must be an array", field)
+
+			actualStrings := lo.Map(actualValues, func(value any, _ int) string {
+				actualString, ok := value.(string)
+				require.True(t, ok, "log field %q must contain strings", field)
+
+				return actualString
+			})
+			require.Equal(t, expectedStrings, actualStrings)
+
+			continue
+		}
+
+		require.Equal(t, expectedValue, logEntry[field], "unexpected value for log field %q", field)
+	}
+
+	for _, value := range expectedErrorValues {
+		require.Contains(t, logEntry["error"], value)
+	}
+}

--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -243,8 +243,16 @@ func (a *adapter) CreateCustomer(ctx context.Context, input customer.CreateCusto
 			}
 
 			if count > 0 {
+				repo.logger.WarnContext(
+					ctx,
+					"customer key overlaps with customer ID",
+					"namespace", input.Namespace,
+					"customer_key", *input.Key,
+					"conflicting_customer_id", *input.Key,
+				)
+
 				return nil, models.NewGenericConflictError(
-					fmt.Errorf("key %s overlaps with id of another customer", *input.Key),
+					fmt.Errorf("customer key %q overlaps with the ID of another customer", *input.Key),
 				)
 			}
 		}
@@ -262,8 +270,18 @@ func (a *adapter) CreateCustomer(ctx context.Context, input customer.CreateCusto
 			}
 
 			if len(conflictingCustomerIDs) > 0 {
+				conflictingCustomerID := conflictingCustomerIDs[0].CustomerID
+				repo.logger.WarnContext(
+					ctx,
+					"customer key overlaps with customer usage attribution key",
+					"namespace", input.Namespace,
+					"customer_key", *input.Key,
+					"conflicting_usage_attribution_key", *input.Key,
+					"conflicting_customer_id", conflictingCustomerID,
+				)
+
 				return nil, models.NewGenericConflictError(
-					fmt.Errorf("key %s overlaps with subject of another customer: %s", *input.Key, conflictingCustomerIDs[0].CustomerID),
+					fmt.Errorf("customer key %q overlaps with a usage attribution key of another customer: %s", *input.Key, conflictingCustomerID),
 				)
 			}
 		}
@@ -302,10 +320,16 @@ func (a *adapter) CreateCustomer(ctx context.Context, input customer.CreateCusto
 		customerEntity, err := query.Save(ctx)
 		if err != nil {
 			if entdb.IsConstraintError(err) {
-				return nil, customer.NewKeyConflictError(
-					input.Namespace,
-					*lo.CoalesceOrEmpty(input.Key),
+				customerKey := *lo.CoalesceOrEmpty(input.Key)
+				repo.logger.WarnContext(
+					ctx,
+					"customer key conflict while creating customer",
+					"namespace", input.Namespace,
+					"customer_key", customerKey,
+					"error", err,
 				)
+
+				return nil, customer.NewKeyConflictError(customerKey)
 			}
 
 			return nil, fmt.Errorf("failed to create customer: %w", err)
@@ -335,10 +359,16 @@ func (a *adapter) CreateCustomer(ctx context.Context, input customer.CreateCusto
 				Save(ctx)
 			if err != nil {
 				if entdb.IsConstraintError(err) {
-					return nil, customer.NewSubjectKeyConflictError(
-						input.Namespace,
-						input.UsageAttribution.SubjectKeys,
+					repo.logger.WarnContext(
+						ctx,
+						"customer usage attribution key conflict while creating customer",
+						"namespace", input.Namespace,
+						"customer_id", customerEntity.ID,
+						"usage_attribution_keys", input.UsageAttribution.SubjectKeys,
+						"error", err,
 					)
+
+					return nil, customer.NewSubjectKeyConflictError(input.UsageAttribution.SubjectKeys)
 				}
 
 				return nil, fmt.Errorf("failed to create customer: failed to add subject keys: %w", err)
@@ -660,8 +690,17 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 			}
 
 			if count > 0 {
+				repo.logger.WarnContext(
+					ctx,
+					"customer key overlaps with customer ID",
+					"namespace", input.CustomerID.Namespace,
+					"customer_id", input.CustomerID.ID,
+					"customer_key", *input.Key,
+					"conflicting_customer_id", *input.Key,
+				)
+
 				return nil, models.NewGenericConflictError(
-					fmt.Errorf("key %s overlaps with id of another customer", *input.Key),
+					fmt.Errorf("customer key %q overlaps with the ID of another customer", *input.Key),
 				)
 			}
 		}
@@ -680,8 +719,19 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 			}
 
 			if len(conflictingCustomerIDs) > 0 {
+				conflictingCustomerID := conflictingCustomerIDs[0].CustomerID
+				repo.logger.WarnContext(
+					ctx,
+					"customer key overlaps with customer usage attribution key",
+					"namespace", input.CustomerID.Namespace,
+					"customer_id", input.CustomerID.ID,
+					"customer_key", *input.Key,
+					"conflicting_usage_attribution_key", *input.Key,
+					"conflicting_customer_id", conflictingCustomerID,
+				)
+
 				return nil, models.NewGenericConflictError(
-					fmt.Errorf("key %s overlaps with subject of another customer: %s", *input.Key, conflictingCustomerIDs[0].CustomerID),
+					fmt.Errorf("customer key %q overlaps with a usage attribution key of another customer: %s", *input.Key, conflictingCustomerID),
 				)
 			}
 		}
@@ -738,10 +788,17 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 			}
 
 			if entdb.IsConstraintError(err) {
-				return nil, customer.NewKeyConflictError(
-					input.CustomerID.Namespace,
-					*lo.CoalesceOrEmpty(input.Key),
+				customerKey := *lo.CoalesceOrEmpty(input.Key)
+				repo.logger.WarnContext(
+					ctx,
+					"customer key conflict while updating customer",
+					"namespace", input.CustomerID.Namespace,
+					"customer_id", input.CustomerID.ID,
+					"customer_key", customerKey,
+					"error", err,
 				)
+
+				return nil, customer.NewKeyConflictError(customerKey)
 			}
 
 			return nil, fmt.Errorf("failed to update customer: %w", err)
@@ -784,10 +841,16 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 				Save(ctx)
 			if err != nil {
 				if entdb.IsConstraintError(err) {
-					return nil, customer.NewSubjectKeyConflictError(
-						input.CustomerID.Namespace,
-						subKeysToAdd,
+					repo.logger.WarnContext(
+						ctx,
+						"customer usage attribution key conflict while updating customer",
+						"namespace", input.CustomerID.Namespace,
+						"customer_id", input.CustomerID.ID,
+						"usage_attribution_keys", subKeysToAdd,
+						"error", err,
 					)
+
+					return nil, customer.NewSubjectKeyConflictError(subKeysToAdd)
 				}
 
 				return nil, fmt.Errorf("failed to add customer subjects: %w", err)
@@ -806,10 +869,16 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 				Exec(ctx)
 			if err != nil {
 				if entdb.IsConstraintError(err) {
-					return nil, customer.NewSubjectKeyConflictError(
-						input.CustomerID.Namespace,
-						subKeysToRemove,
+					repo.logger.WarnContext(
+						ctx,
+						"customer usage attribution key conflict while updating customer",
+						"namespace", input.CustomerID.Namespace,
+						"customer_id", input.CustomerID.ID,
+						"usage_attribution_keys", subKeysToRemove,
+						"error", err,
 					)
+
+					return nil, customer.NewSubjectKeyConflictError(subKeysToRemove)
 				}
 
 				return nil, fmt.Errorf("failed to remove customer subjects: %w", err)

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -1,6 +1,7 @@
 package adapter_test
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -40,6 +41,10 @@ type testEnv struct {
 }
 
 func newTestEnv(t *testing.T) *testEnv {
+	return newTestEnvWithLogger(t, testutils.NewDiscardLogger(t))
+}
+
+func newTestEnvWithLogger(t *testing.T, logger *slog.Logger) *testEnv {
 	t.Helper()
 
 	testdb := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
@@ -52,7 +57,7 @@ func newTestEnv(t *testing.T) *testEnv {
 
 	adapter, err := customeradapter.New(customeradapter.Config{
 		Client: dbClient,
-		Logger: testutils.NewDiscardLogger(t),
+		Logger: logger,
 	})
 	require.NoError(t, err, "constructing customer adapter must not fail")
 

--- a/openmeter/customer/errors.go
+++ b/openmeter/customer/errors.go
@@ -3,7 +3,6 @@ package customer
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -31,16 +30,16 @@ func (e UpdateAfterDeleteError) Unwrap() error {
 	return e.err
 }
 
-// NewKeyConflictError creates a new KeyConflictError
-func NewKeyConflictError(namespace, key string) *KeyConflictError {
+// NewKeyConflictError creates a new KeyConflictError.
+func NewKeyConflictError(key string) *KeyConflictError {
 	return &KeyConflictError{
-		err: models.NewGenericConflictError(fmt.Errorf("key \"%s\" is already used by an another customer in the namespace %s", key, namespace)),
+		err: models.NewGenericConflictError(fmt.Errorf("customer key %q is already in use", key)),
 	}
 }
 
 var _ models.GenericError = &KeyConflictError{}
 
-// KeyConflictError represents an error when a subject key is already associated with a customer
+// KeyConflictError represents an error when a customer key is already associated with a customer.
 type KeyConflictError struct {
 	err error
 }
@@ -63,16 +62,16 @@ func IsKeyConflictError(err error) bool {
 	return errors.As(err, &e)
 }
 
-// NewSubjectKeyConflictError creates a new SubjectKeyConflictError
-func NewSubjectKeyConflictError(namespace string, subjectKeys []string) *SubjectKeyConflictError {
+// NewSubjectKeyConflictError creates a new SubjectKeyConflictError.
+func NewSubjectKeyConflictError(subjectKeys []string) *SubjectKeyConflictError {
 	return &SubjectKeyConflictError{
-		err: models.NewGenericConflictError(fmt.Errorf("one or multiple subject keys of [%s] are already associated with an different customer in the namespace %s", strings.Join(subjectKeys, ", "), namespace)),
+		err: models.NewGenericConflictError(fmt.Errorf("one or more customer usage attribution keys are already in use: %q", subjectKeys)),
 	}
 }
 
 var _ models.GenericError = &SubjectKeyConflictError{}
 
-// SubjectKeyConflictError represents an error when a subject key is already associated with a customer
+// SubjectKeyConflictError represents an error when a usage attribution key is already associated with a customer.
 type SubjectKeyConflictError struct {
 	err error
 }

--- a/test/customer/customer.go
+++ b/test/customer/customer.go
@@ -201,6 +201,41 @@ func (s *CustomerHandlerTestSuite) TestCreate(ctx context.Context, t *testing.T)
 	})
 }
 
+func (s *CustomerHandlerTestSuite) TestCreateSameKeyAndSubjectAcrossNamespaces(ctx context.Context, t *testing.T) {
+	service := s.Env.Customer()
+	namespaceA := ulid.Make().String()
+	namespaceB := ulid.Make().String()
+	const sharedKey = "turip-test"
+
+	// Given a customer whose key and usage-attribution subject are identical in namespace A.
+	createdCustomerA, err := service.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespaceA,
+		CustomerMutate: customer.CustomerMutate{
+			Key:  lo.ToPtr(sharedKey),
+			Name: "Customer A",
+			UsageAttribution: &customer.CustomerUsageAttribution{
+				SubjectKeys: []string{sharedKey},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, namespaceA, createdCustomerA.Namespace)
+
+	// When another customer uses the same key and subject in namespace B, then namespace isolation allows it.
+	createdCustomerB, err := service.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespaceB,
+		CustomerMutate: customer.CustomerMutate{
+			Key:  lo.ToPtr(sharedKey),
+			Name: "Customer B",
+			UsageAttribution: &customer.CustomerUsageAttribution{
+				SubjectKeys: []string{sharedKey},
+			},
+		},
+	})
+	require.NoError(t, err, "customer keys and subjects must be unique within a namespace, not across namespaces")
+	require.Equal(t, namespaceB, createdCustomerB.Namespace)
+}
+
 // TestUpdate tests the updating of a customer
 func (s *CustomerHandlerTestSuite) TestUpdate(ctx context.Context, t *testing.T) {
 	s.setupNamespace(t)

--- a/test/customer/customer_test.go
+++ b/test/customer/customer_test.go
@@ -31,6 +31,10 @@ func TestCustomer(t *testing.T) {
 			testSuite.TestCreate(ctx, t)
 		})
 
+		t.Run("TestCreateSameKeyAndSubjectAcrossNamespaces", func(t *testing.T) {
+			testSuite.TestCreateSameKeyAndSubjectAcrossNamespaces(ctx, t)
+		})
+
 		t.Run("TestList", func(t *testing.T) {
 			testSuite.TestList(ctx, t)
 		})


### PR DESCRIPTION
## Summary

- remove namespaces from caller-facing customer key and subject conflict errors
- add structured warning logs with namespace, customer, key, and conflicting entity details
- preserve complete Ent constraint errors in logs while returning typed HTTP 409 responses
- add adapter conflict coverage and an Atlas-backed cross-namespace regression test

## Testing

- POSTGRES_HOST=127.0.0.1 go test ./openmeter/customer/... -count=1
- POSTGRES_HOST=127.0.0.1 go test ./test/customer -run ^TestCustomer$/^Customer$/^TestCreateSameKeyAndSubjectAcrossNamespaces$ -count=1
- direnv exec . golangci-lint run ./openmeter/customer/... ./test/customer/...


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves customer-conflict diagnostics while preserving namespace-scoped identity behavior.
- Removes namespace values from caller-facing key and usage-attribution conflict messages.
- Adds structured warning logs containing tenant and conflicting-entity context while retaining complete Ent constraint errors.
- Adds adapter-level conflict coverage and a cross-namespace regression test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

The changed conflict paths retain namespace-scoped enforcement, all constructor callers were migrated, and the new tests cover both public error details and internal structured diagnostics.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/customer/adapter/customer.go | Adds structured diagnostics to create and update conflict paths and returns namespace-free typed conflict errors without changing conflict enforcement. |
| openmeter/customer/errors.go | Simplifies conflict-error constructors and improves caller-facing messages; all repository call sites were updated. |
| openmeter/customer/adapter/conflict_test.go | Covers HTTP conflict redaction, typed errors, structured fields, and preservation of underlying database diagnostics. |
| test/customer/customer.go | Adds service-backed coverage confirming equal customer and subject keys remain isolated across namespaces. |

<sub>Reviews (1): Last reviewed commit: ["fix(customer): improve conflict error di..."](https://github.com/openmeterio/openmeter/commit/a69547e924602b3c48ca0176f51e016251edc243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59087210)</sub>

**Context used:**

- Knowledge Base — [Customers and tenant boundaries](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/customers-and-tenant-boundaries.md)
- Knowledge Base — [Customer, namespace, and portal services](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/customer-namespace-and-portal.md)

<!-- /greptile_comment -->