### PR TITLE
test(ledger): cover filtered funded impacts

### DIFF
--- a/e2e/customer_credits_v3_test.go
+++ b/e2e/customer_credits_v3_test.go
@@ -43,6 +43,125 @@ func TestV3CustomerCreditBalanceTimestampParamParsing(t *testing.T) {
 	})
 }
 
+func TestV3CustomerCreditTransactionBalancesAcrossCurrencies(t *testing.T) {
+	c := newV3Client(t)
+	prefix := uniqueKey("credit_transactions_currencies")
+
+	// given:
+	// - one customer receives promotional credits in USD and EUR
+	// - an in-advance credit-only fee then consumes part of each balance
+	customer, err := c.Customers.Create(t.Context(), v3sdk.CreateCustomerRequest{
+		Key:      prefix + "_customer",
+		Name:     "Multi-currency Credit Transaction Customer " + prefix,
+		Currency: lo.ToPtr("USD"),
+	})
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, customer)
+
+	_, err = c.Customers.Credits.Grants.Create(t.Context(), customer.ID, v3sdk.CreateCreditGrantRequest{
+		Name:          "USD promotional credits " + prefix,
+		Amount:        "100",
+		Currency:      v3sdk.BillingCurrencyCode("USD"),
+		FundingMethod: v3sdk.CreditFundingMethodNone,
+	})
+	c.requireStatus(http.StatusCreated, err)
+
+	_, err = c.Customers.Credits.Grants.Create(t.Context(), customer.ID, v3sdk.CreateCreditGrantRequest{
+		Name:          "EUR promotional credits " + prefix,
+		Amount:        "80",
+		Currency:      v3sdk.BillingCurrencyCode("EUR"),
+		FundingMethod: v3sdk.CreditFundingMethodNone,
+	})
+	c.requireStatus(http.StatusCreated, err)
+
+	// Capture the in-advance service start after both grants so the fees are due
+	// immediately while still being booked after the credits they consume.
+	servicePeriodStart := time.Now().UTC().Truncate(time.Microsecond)
+	servicePeriod := v3sdk.ClosedPeriod{
+		From: servicePeriodStart,
+		To:   servicePeriodStart.Add(30 * 24 * time.Hour),
+	}
+
+	usdCharge, err := v3sdk.CreateChargeRequestFromCreateChargeFlatFeeRequest(v3sdk.CreateChargeFlatFeeRequest{
+		Name:           "USD in-advance fee " + prefix,
+		Type:           v3sdk.ChargeTypeFlatFee,
+		Currency:       "USD",
+		InvoiceAt:      servicePeriod.From,
+		ServicePeriod:  servicePeriod,
+		SettlementMode: v3sdk.SettlementModeCreditOnly,
+		PaymentTerm:    v3sdk.PricePaymentTermInAdvance,
+		ProrationConfiguration: v3sdk.RateCardProrationConfiguration{
+			Mode: v3sdk.RateCardProrationModeNoProration,
+		},
+		AmountBeforeProration: v3sdk.CurrencyAmount{Amount: "30", Currency: "USD"},
+	})
+	require.NoError(t, err)
+	createdUSDCharge, err := c.Customers.Charges.Create(t.Context(), customer.ID, usdCharge)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, createdUSDCharge)
+	createdUSDFlatFee, err := createdUSDCharge.AsChargeFlatFee()
+	require.NoError(t, err)
+	require.Equal(t, v3sdk.ChargeStatusFinal, createdUSDFlatFee.Status)
+
+	eurCharge, err := v3sdk.CreateChargeRequestFromCreateChargeFlatFeeRequest(v3sdk.CreateChargeFlatFeeRequest{
+		Name:           "EUR in-advance fee " + prefix,
+		Type:           v3sdk.ChargeTypeFlatFee,
+		Currency:       "EUR",
+		InvoiceAt:      servicePeriod.From,
+		ServicePeriod:  servicePeriod,
+		SettlementMode: v3sdk.SettlementModeCreditOnly,
+		PaymentTerm:    v3sdk.PricePaymentTermInAdvance,
+		ProrationConfiguration: v3sdk.RateCardProrationConfiguration{
+			Mode: v3sdk.RateCardProrationModeNoProration,
+		},
+		AmountBeforeProration: v3sdk.CurrencyAmount{Amount: "20", Currency: "EUR"},
+	})
+	require.NoError(t, err)
+	createdEURCharge, err := c.Customers.Charges.Create(t.Context(), customer.ID, eurCharge)
+	c.requireStatus(http.StatusCreated, err)
+	require.NotNil(t, createdEURCharge)
+	createdEURFlatFee, err := createdEURCharge.AsChargeFlatFee()
+	require.NoError(t, err)
+	require.Equal(t, v3sdk.ChargeStatusFinal, createdEURFlatFee.Status)
+
+	// when:
+	// - the customer's complete transaction history is listed without a currency filter
+	transactions, err := c.Customers.Credits.Transactions.List(t.Context(), customer.ID, v3sdk.CreditTransactionListParams{})
+	c.requireStatus(http.StatusOK, err)
+	require.NotNil(t, transactions)
+	require.Len(t, transactions.Data, 4)
+
+	// then:
+	// - the shared chronological stream reconstructs an independent balance chain for each currency
+	type transactionBalance struct {
+		Type   v3sdk.CreditTransactionType
+		Amount v3sdk.Numeric
+		Before v3sdk.Numeric
+		After  v3sdk.Numeric
+	}
+
+	byCurrency := map[v3sdk.BillingCurrencyCode][]transactionBalance{}
+	for _, transaction := range transactions.Data {
+		byCurrency[transaction.Currency] = append(byCurrency[transaction.Currency], transactionBalance{
+			Type:   transaction.Type,
+			Amount: transaction.Amount,
+			Before: transaction.AvailableBalance.Before,
+			After:  transaction.AvailableBalance.After,
+		})
+	}
+
+	require.Equal(t, map[v3sdk.BillingCurrencyCode][]transactionBalance{
+		"USD": {
+			{Type: v3sdk.CreditTransactionTypeConsumed, Amount: "-30", Before: "100", After: "70"},
+			{Type: v3sdk.CreditTransactionTypeFunded, Amount: "100", Before: "0", After: "100"},
+		},
+		"EUR": {
+			{Type: v3sdk.CreditTransactionTypeConsumed, Amount: "-20", Before: "80", After: "60"},
+			{Type: v3sdk.CreditTransactionTypeFunded, Amount: "80", Before: "0", After: "80"},
+		},
+	}, byCurrency)
+}
+
 // TestV3CreateCreditGrantMissingTaxCode verifies the documented contract for
 // create-credit-grant: referencing a tax code that does not exist is rejected
 // with HTTP 400 (a validation error), not a 412/500. The OpenAPI spec documents

--- a/openmeter/ledger/customerbalance/README.md
+++ b/openmeter/ledger/customerbalance/README.md
@@ -76,7 +76,14 @@ expired  => negative FBO impact
 
 This matters when a purchase covers an existing advance. Its funded amount can
 be split between clearing the advance receivable and issuing the remainder to
-FBO, while the customer-visible balance still increases by the full purchase.
+FBO. Impacts at the same effective time are shown as one funded row. If the
+remainder is scheduled for later, the history shows separate rows when each
+part affects the balance:
+
+```text
+@T1 funded +40  (advance attribution)
+@T2 funded +60  (scheduled FBO issuance)
+```
 
 ## Listing Example: Funded, Consumed, Expired
 

--- a/openmeter/ledger/customerbalance/README.md
+++ b/openmeter/ledger/customerbalance/README.md
@@ -66,13 +66,17 @@ Visible types:
 - `consumed`: credit was used.
 - `expired`: unused credit expired.
 
-The visible amount is the customer FBO impact:
+The visible amount is the customer balance impact:
 
 ```text
-funded   => positive
-consumed => negative
-expired  => negative
+funded   => positive FBO issuance + positive nil-cost-basis receivable attribution
+consumed => negative FBO impact
+expired  => negative FBO impact
 ```
+
+This matters when a purchase covers an existing advance. Its funded amount can
+be split between clearing the advance receivable and issuing the remainder to
+FBO, while the customer-visible balance still increases by the full purchase.
 
 ## Listing Example: Funded, Consumed, Expired
 
@@ -199,7 +203,7 @@ This package may:
 - merge funded, consumed, and expired views;
 - apply customer-facing labels and balances;
 - page and cursor the result set;
-- expose FBO impact as customer-visible amount.
+- expose customer balance impact as the customer-visible amount.
 
 This package should not:
 

--- a/openmeter/ledger/customerbalance/README.md
+++ b/openmeter/ledger/customerbalance/README.md
@@ -74,6 +74,9 @@ consumed => negative FBO impact
 expired  => negative FBO impact
 ```
 
+In a mixed-currency listing, `available_balance` is reconstructed independently
+for each currency identity even though the rows share one chronological stream.
+
 This matters when a purchase covers an existing advance. Its funded amount can
 be split between clearing the advance receivable and issuing the remainder to
 FBO. Impacts at the same effective time are shown as one funded row. If the

--- a/openmeter/ledger/customerbalance/funded_loader.go
+++ b/openmeter/ledger/customerbalance/funded_loader.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -81,10 +82,13 @@ func (l *fundedCreditTransactionLoader) resolveBalances(
 		return nil, fmt.Errorf("get funded credit transaction group %s: %w", item.fundedTransactionGroupID, err)
 	}
 
-	impacts := fundedCreditTransactionBalanceImpacts(group, GetBalanceServiceInput{
+	impacts, err := fundedCreditTransactionBalanceImpacts(group, GetBalanceServiceInput{
 		Currency:      item.Currency,
 		FeatureFilter: input.FeatureFilter,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve funded credit transaction group %s balance impacts: %w", item.fundedTransactionGroupID, err)
+	}
 	if len(impacts) == 0 {
 		return nil, fmt.Errorf("funded credit transaction group %s has no customer balance impact", item.fundedTransactionGroupID)
 	}
@@ -113,6 +117,7 @@ func (l *fundedCreditTransactionLoader) resolveBalances(
 		resolvedItem.Amount = impact.Amount
 		resolvedItem.balanceCursor = &impact.Cursor
 		resolvedItem.balanceImpact = &impact.Amount
+		resolvedItem.currencyReference = impact.CurrencyReference
 		items = append(items, resolvedItem)
 	}
 
@@ -120,31 +125,35 @@ func (l *fundedCreditTransactionLoader) resolveBalances(
 }
 
 type fundedCreditTransactionBalanceImpact struct {
-	Amount alpacadecimal.Decimal
-	Cursor ledger.TransactionCursor
+	Amount            alpacadecimal.Decimal
+	Cursor            ledger.TransactionCursor
+	CurrencyReference currencies.CurrencyReference
 }
 
 // fundedCreditTransactionBalanceImpacts follows the same two ledger components
 // as settled balance and groups them by the time they affect that balance.
 // Looking at the actual scoped entries keeps legacy credit purchase groups
 // readable without relying on transaction template annotations.
-func fundedCreditTransactionBalanceImpacts(group ledger.TransactionGroup, input GetBalanceServiceInput) []fundedCreditTransactionBalanceImpact {
+func fundedCreditTransactionBalanceImpacts(group ledger.TransactionGroup, input GetBalanceServiceInput) ([]fundedCreditTransactionBalanceImpact, error) {
 	impactsByBookedAt := make(map[time.Time]fundedCreditTransactionBalanceImpact)
+	var groupCurrency currencies.CurrencyReference
 
 	for _, tx := range group.Transactions() {
 		if tx.Annotations()[ledger.AnnotationCollectionType] == ledger.CollectionTypeBreakage {
 			continue
 		}
 
-		impact := ledger.TransactionImpact(tx, ledger.ImpactFilter{
-			AccountType: ledger.AccountTypeCustomerFBO,
-			Route:       input.bookedRoute(),
-		}).Add(ledger.TransactionImpact(tx, ledger.ImpactFilter{
-			AccountType: ledger.AccountTypeCustomerReceivable,
-			Route:       input.advanceRoute(),
-		}))
+		impact, currencyReference, err := fundedCreditTransactionImpact(tx, input)
+		if err != nil {
+			return nil, err
+		}
 		if impact.IsZero() {
 			continue
+		}
+		if groupCurrency.Code == "" {
+			groupCurrency = currencyReference
+		} else if !groupCurrency.Equal(currencyReference) {
+			return nil, fmt.Errorf("transactions have multiple customer balance currencies")
 		}
 
 		cursor := tx.Cursor()
@@ -152,6 +161,7 @@ func fundedCreditTransactionBalanceImpacts(group ledger.TransactionGroup, input 
 		groupedImpact, ok := impactsByBookedAt[bookedAt]
 		if !ok {
 			groupedImpact.Amount = alpacadecimal.Zero
+			groupedImpact.CurrencyReference = currencyReference
 		}
 		groupedImpact.Amount = groupedImpact.Amount.Add(impact)
 		if groupedImpact.Cursor.BookedAt.IsZero() || groupedImpact.Cursor.Compare(cursor) < 0 {
@@ -170,7 +180,36 @@ func fundedCreditTransactionBalanceImpacts(group ledger.TransactionGroup, input 
 		return b.Cursor.Compare(a.Cursor)
 	})
 
-	return impacts
+	return impacts, nil
+}
+
+func fundedCreditTransactionImpact(tx ledger.Transaction, input GetBalanceServiceInput) (alpacadecimal.Decimal, currencies.CurrencyReference, error) {
+	bookedFilter := ledger.ImpactFilter{
+		AccountType: ledger.AccountTypeCustomerFBO,
+		Route:       input.bookedRoute(),
+	}
+	advanceFilter := ledger.ImpactFilter{
+		AccountType: ledger.AccountTypeCustomerReceivable,
+		Route:       input.advanceRoute(),
+	}
+
+	impact := alpacadecimal.Zero
+	var currencyReference currencies.CurrencyReference
+	for _, entry := range tx.Entries() {
+		if !ledger.EntryMatchesImpactFilter(entry, bookedFilter) && !ledger.EntryMatchesImpactFilter(entry, advanceFilter) {
+			continue
+		}
+
+		entryCurrency := entry.PostingAddress().Route().Route().Currency
+		if currencyReference.Code == "" {
+			currencyReference = entryCurrency
+		} else if !currencyReference.Equal(entryCurrency) {
+			return alpacadecimal.Zero, currencies.CurrencyReference{}, fmt.Errorf("transaction %s has multiple customer balance currencies", tx.ID().ID)
+		}
+		impact = impact.Add(entry.Amount())
+	}
+
+	return impact, currencyReference, nil
 }
 
 func toFundedCreditActivityCursor(cursor *ledger.TransactionCursor) *creditpurchase.FundedCreditActivityCursor {

--- a/openmeter/ledger/customerbalance/funded_loader.go
+++ b/openmeter/ledger/customerbalance/funded_loader.go
@@ -3,6 +3,8 @@ package customerbalance
 import (
 	"context"
 	"fmt"
+	"slices"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 
@@ -60,13 +62,15 @@ func (l *fundedCreditTransactionLoader) Load(ctx context.Context, input creditTr
 	}, nil
 }
 
-func (l *fundedCreditTransactionLoader) resolveBalance(
+// resolveBalances splits a funded transaction into separate balance movements
+// when its ledger impacts have different booked times.
+func (l *fundedCreditTransactionLoader) resolveBalances(
 	ctx context.Context,
 	input creditTransactionLoaderInput,
-	item *CreditTransaction,
-) error {
+	item CreditTransaction,
+) ([]CreditTransaction, error) {
 	if item.fundedTransactionGroupID == "" {
-		return nil
+		return []CreditTransaction{item}, nil
 	}
 
 	group, err := l.service.Ledger.GetTransactionGroup(ctx, models.NamespacedID{
@@ -74,37 +78,58 @@ func (l *fundedCreditTransactionLoader) resolveBalance(
 		ID:        item.fundedTransactionGroupID,
 	})
 	if err != nil {
-		return fmt.Errorf("get funded credit transaction group %s: %w", item.fundedTransactionGroupID, err)
+		return nil, fmt.Errorf("get funded credit transaction group %s: %w", item.fundedTransactionGroupID, err)
 	}
 
-	impact, cursor := fundedCreditTransactionBalanceImpact(group, GetBalanceServiceInput{
+	impacts := fundedCreditTransactionBalanceImpacts(group, GetBalanceServiceInput{
 		Currency:      item.Currency,
 		FeatureFilter: input.FeatureFilter,
 	})
-	if cursor == nil {
-		return fmt.Errorf("funded credit transaction group %s has no customer balance impact", item.fundedTransactionGroupID)
+	if len(impacts) == 0 {
+		return nil, fmt.Errorf("funded credit transaction group %s has no customer balance impact", item.fundedTransactionGroupID)
 	}
-	if !impact.Equal(item.Amount) {
-		return fmt.Errorf(
+
+	total := alpacadecimal.Zero
+	for _, impact := range impacts {
+		total = total.Add(impact.Amount)
+	}
+	if !total.Equal(item.Amount) {
+		return nil, fmt.Errorf(
 			"funded credit transaction group %s customer balance impact %s does not match funded amount %s",
 			item.fundedTransactionGroupID,
-			impact,
+			total,
 			item.Amount,
 		)
 	}
 
-	item.balanceCursor = cursor
-	item.balanceImpact = &impact
+	items := make([]CreditTransaction, 0, len(impacts))
+	for _, impact := range impacts {
+		if impact.Cursor.BookedAt.After(input.AsOf) {
+			continue
+		}
 
-	return nil
+		resolvedItem := item
+		resolvedItem.BookedAt = impact.Cursor.BookedAt
+		resolvedItem.Amount = impact.Amount
+		resolvedItem.balanceCursor = &impact.Cursor
+		resolvedItem.balanceImpact = &impact.Amount
+		items = append(items, resolvedItem)
+	}
+
+	return items, nil
 }
 
-// fundedCreditTransactionBalanceImpact follows the same two ledger components
-// as settled balance. Looking at the actual scoped entries keeps legacy credit
-// purchase groups readable without relying on transaction template annotations.
-func fundedCreditTransactionBalanceImpact(group ledger.TransactionGroup, input GetBalanceServiceInput) (alpacadecimal.Decimal, *ledger.TransactionCursor) {
-	total := alpacadecimal.Zero
-	var latestCursor *ledger.TransactionCursor
+type fundedCreditTransactionBalanceImpact struct {
+	Amount alpacadecimal.Decimal
+	Cursor ledger.TransactionCursor
+}
+
+// fundedCreditTransactionBalanceImpacts follows the same two ledger components
+// as settled balance and groups them by the time they affect that balance.
+// Looking at the actual scoped entries keeps legacy credit purchase groups
+// readable without relying on transaction template annotations.
+func fundedCreditTransactionBalanceImpacts(group ledger.TransactionGroup, input GetBalanceServiceInput) []fundedCreditTransactionBalanceImpact {
+	impactsByBookedAt := make(map[time.Time]fundedCreditTransactionBalanceImpact)
 
 	for _, tx := range group.Transactions() {
 		if tx.Annotations()[ledger.AnnotationCollectionType] == ledger.CollectionTypeBreakage {
@@ -122,14 +147,30 @@ func fundedCreditTransactionBalanceImpact(group ledger.TransactionGroup, input G
 			continue
 		}
 
-		total = total.Add(impact)
 		cursor := tx.Cursor()
-		if latestCursor == nil || latestCursor.Compare(cursor) < 0 {
-			latestCursor = &cursor
+		bookedAt := cursor.BookedAt.UTC()
+		groupedImpact, ok := impactsByBookedAt[bookedAt]
+		if !ok {
+			groupedImpact.Amount = alpacadecimal.Zero
 		}
+		groupedImpact.Amount = groupedImpact.Amount.Add(impact)
+		if groupedImpact.Cursor.BookedAt.IsZero() || groupedImpact.Cursor.Compare(cursor) < 0 {
+			groupedImpact.Cursor = cursor
+		}
+		impactsByBookedAt[bookedAt] = groupedImpact
 	}
 
-	return total, latestCursor
+	impacts := make([]fundedCreditTransactionBalanceImpact, 0, len(impactsByBookedAt))
+	for _, impact := range impactsByBookedAt {
+		if !impact.Amount.IsZero() {
+			impacts = append(impacts, impact)
+		}
+	}
+	slices.SortFunc(impacts, func(a, b fundedCreditTransactionBalanceImpact) int {
+		return b.Cursor.Compare(a.Cursor)
+	})
+
+	return impacts
 }
 
 func toFundedCreditActivityCursor(cursor *ledger.TransactionCursor) *creditpurchase.FundedCreditActivityCursor {

--- a/openmeter/ledger/customerbalance/funded_loader.go
+++ b/openmeter/ledger/customerbalance/funded_loader.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/alpacahq/alpacadecimal"
+
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -34,30 +36,21 @@ func (l *fundedCreditTransactionLoader) Load(ctx context.Context, input creditTr
 
 	items := make([]CreditTransaction, 0, len(result.Items))
 	for _, activity := range result.Items {
-		// FIXME: this is an N+1 group lookup on the listing path. Keep it as a
-		// temporary bridge because the funded activity query does not expose the
-		// exact balance cursor yet; replace it with a batched lookup or query-side
-		// cursor projection when this path is hardened.
-		balanceCursor, err := l.balanceCursorForFundedActivity(ctx, input.CustomerID.Namespace, activity)
-		if err != nil {
-			return creditTransactionLoaderResult{}, err
-		}
-
 		annotations := models.Annotations{
 			ledger.AnnotationChargeID: activity.ChargeID.ID,
 		}
 
 		items = append(items, CreditTransaction{
-			ID:            models.NamespacedID(activity.ChargeID),
-			CreatedAt:     activity.ChargeCreatedAt,
-			BookedAt:      activity.FundedAt,
-			Type:          CreditTransactionTypeFunded,
-			Currency:      activity.Currency,
-			Amount:        activity.Amount,
-			Name:          activity.Name,
-			Description:   activity.Description,
-			Annotations:   annotations,
-			balanceCursor: balanceCursor,
+			ID:                       models.NamespacedID(activity.ChargeID),
+			CreatedAt:                activity.ChargeCreatedAt,
+			BookedAt:                 activity.FundedAt,
+			Type:                     CreditTransactionTypeFunded,
+			Currency:                 activity.Currency,
+			Amount:                   activity.Amount,
+			Name:                     activity.Name,
+			Description:              activity.Description,
+			Annotations:              annotations,
+			fundedTransactionGroupID: activity.TransactionGroupID,
 		})
 	}
 
@@ -67,36 +60,76 @@ func (l *fundedCreditTransactionLoader) Load(ctx context.Context, input creditTr
 	}, nil
 }
 
-func (l *fundedCreditTransactionLoader) balanceCursorForFundedActivity(
+func (l *fundedCreditTransactionLoader) resolveBalance(
 	ctx context.Context,
-	namespace string,
-	activity creditpurchase.FundedCreditActivity,
-) (*ledger.TransactionCursor, error) {
-	if activity.TransactionGroupID == "" {
-		return nil, nil
+	input creditTransactionLoaderInput,
+	item *CreditTransaction,
+) error {
+	if item.fundedTransactionGroupID == "" {
+		return nil
 	}
 
 	group, err := l.service.Ledger.GetTransactionGroup(ctx, models.NamespacedID{
-		Namespace: namespace,
-		ID:        activity.TransactionGroupID,
+		Namespace: input.CustomerID.Namespace,
+		ID:        item.fundedTransactionGroupID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("get funded credit transaction group %s: %w", activity.TransactionGroupID, err)
+		return fmt.Errorf("get funded credit transaction group %s: %w", item.fundedTransactionGroupID, err)
 	}
 
+	impact, cursor := fundedCreditTransactionBalanceImpact(group, GetBalanceServiceInput{
+		Currency:      item.Currency,
+		FeatureFilter: input.FeatureFilter,
+	})
+	if cursor == nil {
+		return fmt.Errorf("funded credit transaction group %s has no customer balance impact", item.fundedTransactionGroupID)
+	}
+	if !impact.Equal(item.Amount) {
+		return fmt.Errorf(
+			"funded credit transaction group %s customer balance impact %s does not match funded amount %s",
+			item.fundedTransactionGroupID,
+			impact,
+			item.Amount,
+		)
+	}
+
+	item.balanceCursor = cursor
+	item.balanceImpact = &impact
+
+	return nil
+}
+
+// fundedCreditTransactionBalanceImpact follows the same two ledger components
+// as settled balance. Looking at the actual scoped entries keeps legacy credit
+// purchase groups readable without relying on transaction template annotations.
+func fundedCreditTransactionBalanceImpact(group ledger.TransactionGroup, input GetBalanceServiceInput) (alpacadecimal.Decimal, *ledger.TransactionCursor) {
+	total := alpacadecimal.Zero
+	var latestCursor *ledger.TransactionCursor
+
 	for _, tx := range group.Transactions() {
-		impact, currency, err := creditTransactionFBOImpact(tx)
-		if err != nil {
+		if tx.Annotations()[ledger.AnnotationCollectionType] == ledger.CollectionTypeBreakage {
 			continue
 		}
 
-		if currency == activity.Currency && impact.Equal(activity.Amount) {
-			cursor := tx.Cursor()
-			return &cursor, nil
+		impact := ledger.TransactionImpact(tx, ledger.ImpactFilter{
+			AccountType: ledger.AccountTypeCustomerFBO,
+			Route:       input.bookedRoute(),
+		}).Add(ledger.TransactionImpact(tx, ledger.ImpactFilter{
+			AccountType: ledger.AccountTypeCustomerReceivable,
+			Route:       input.advanceRoute(),
+		}))
+		if impact.IsZero() {
+			continue
+		}
+
+		total = total.Add(impact)
+		cursor := tx.Cursor()
+		if latestCursor == nil || latestCursor.Compare(cursor) < 0 {
+			latestCursor = &cursor
 		}
 	}
 
-	return nil, fmt.Errorf("funded credit transaction group %s has no matching customer FBO transaction", activity.TransactionGroupID)
+	return total, latestCursor
 }
 
 func toFundedCreditActivityCursor(cursor *ledger.TransactionCursor) *creditpurchase.FundedCreditActivityCursor {

--- a/openmeter/ledger/customerbalance/funded_loader_test.go
+++ b/openmeter/ledger/customerbalance/funded_loader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
 func TestListCreditTransactionsFundedBalanceCoalescesSameEffectiveTime(t *testing.T) {
@@ -214,4 +215,69 @@ func TestListCreditTransactionsFundedBalanceUsesEffectiveTimes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListCreditTransactionsFundedEffectiveTimesAcrossCurrencies(t *testing.T) {
+	env := newTestEnv(t)
+
+	// given:
+	// - USD has an outstanding advance and a future-effective purchase
+	servicePeriod := env.sp()
+	charge := env.createFlatFeeCharge(
+		t,
+		alpacadecimal.NewFromInt(40),
+		productcatalog.CreditOnlySettlementMode,
+		servicePeriod,
+	)
+	env.passTimeAfterServicePeriod(t, servicePeriod)
+	env.advanceFlatFeeCharge(t, charge)
+
+	fundedAt := clock.Now()
+	effectiveAt := fundedAt.Add(2 * time.Hour)
+	env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(100), env.Currency, &effectiveAt)
+
+	// and:
+	// - EUR funding becomes effective between the two USD balance movements
+	eurFundedAt := fundedAt.Add(time.Hour)
+	clock.FreezeTime(eurFundedAt)
+	t.Cleanup(clock.UnFreeze)
+	env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(200), "EUR", nil)
+
+	// when:
+	// - the unfiltered history is listed after the scheduled USD issuance
+	afterEffectiveAt := effectiveAt.Add(time.Second)
+	result, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID:    env.CustomerID,
+		Limit:         10,
+		AsOf:          &afterEffectiveAt,
+		FeatureFilter: AllFeatureFilter(),
+	})
+	require.NoError(t, err)
+
+	// then:
+	// - the global order follows effective time while each currency keeps its own balance chain
+	require.Len(t, result.Items, 4)
+	require.Equal(t, currencyx.Code("USD"), result.Items[0].Currency)
+	require.True(t, effectiveAt.Equal(result.Items[0].BookedAt))
+	require.Equal(t, float64(60), result.Items[0].Amount.InexactFloat64())
+	require.Equal(t, float64(0), result.Items[0].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(60), result.Items[0].Balance.After.InexactFloat64())
+
+	require.Equal(t, currencyx.Code("EUR"), result.Items[1].Currency)
+	require.True(t, eurFundedAt.Equal(result.Items[1].BookedAt))
+	require.Equal(t, float64(200), result.Items[1].Amount.InexactFloat64())
+	require.Equal(t, float64(0), result.Items[1].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(200), result.Items[1].Balance.After.InexactFloat64())
+
+	require.Equal(t, currencyx.Code("USD"), result.Items[2].Currency)
+	require.True(t, fundedAt.Equal(result.Items[2].BookedAt))
+	require.Equal(t, float64(40), result.Items[2].Amount.InexactFloat64())
+	require.Equal(t, float64(-40), result.Items[2].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(0), result.Items[2].Balance.After.InexactFloat64())
+
+	require.Equal(t, currencyx.Code("USD"), result.Items[3].Currency)
+	require.Equal(t, CreditTransactionTypeConsumed, result.Items[3].Type)
+	require.Equal(t, float64(-40), result.Items[3].Amount.InexactFloat64())
+	require.Equal(t, float64(0), result.Items[3].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(-40), result.Items[3].Balance.After.InexactFloat64())
 }

--- a/openmeter/ledger/customerbalance/funded_loader_test.go
+++ b/openmeter/ledger/customerbalance/funded_loader_test.go
@@ -2,15 +2,17 @@ package customerbalance
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
-func TestListCreditTransactionsFundedBalanceIncludesAdvanceAttribution(t *testing.T) {
+func TestListCreditTransactionsFundedBalanceCoalescesSameEffectiveTime(t *testing.T) {
 	tests := []struct {
 		name          string
 		advanceAmount int64
@@ -88,6 +90,127 @@ func TestListCreditTransactionsFundedBalanceIncludesAdvanceAttribution(t *testin
 				require.Equal(t, float64(-tt.advanceAmount), advance.Amount.InexactFloat64())
 				require.Equal(t, float64(0), advance.Balance.Before.InexactFloat64())
 				require.Equal(t, float64(-tt.advanceAmount), advance.Balance.After.InexactFloat64())
+			}
+		})
+	}
+}
+
+func TestListCreditTransactionsFundedBalanceUsesEffectiveTimes(t *testing.T) {
+	// Each scenario issues one future-effective credit purchase, then lists its
+	// funded history both before and after the purchase becomes effective.
+	type expectedTransaction struct {
+		bookedAfter time.Duration
+		amount      int64
+		before      int64
+		after       int64
+	}
+
+	tests := []struct {
+		name          string
+		advanceAmount int64
+		before        []expectedTransaction
+		after         []expectedTransaction
+	}{
+		{
+			name:   "ordinary future issuance",
+			before: []expectedTransaction{},
+			after: []expectedTransaction{
+				{bookedAfter: time.Hour, amount: 100, before: 0, after: 100},
+			},
+		},
+		{
+			name:          "future issuance partially covers advance",
+			advanceAmount: 40,
+			before: []expectedTransaction{
+				{amount: 40, before: -40, after: 0},
+			},
+			after: []expectedTransaction{
+				{bookedAfter: time.Hour, amount: 60, before: 0, after: 60},
+				{amount: 40, before: -40, after: 0},
+			},
+		},
+		{
+			name:          "future issuance fully covers advance",
+			advanceAmount: 100,
+			before: []expectedTransaction{
+				{amount: 100, before: -100, after: 0},
+			},
+			after: []expectedTransaction{
+				{amount: 100, before: -100, after: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+
+			// given:
+			// - a customer may have an outstanding advance when a future-effective
+			//   credit purchase is funded
+			if tt.advanceAmount > 0 {
+				servicePeriod := env.sp()
+				charge := env.createFlatFeeCharge(
+					t,
+					alpacadecimal.NewFromInt(tt.advanceAmount),
+					productcatalog.CreditOnlySettlementMode,
+					servicePeriod,
+				)
+				env.passTimeAfterServicePeriod(t, servicePeriod)
+				env.advanceFlatFeeCharge(t, charge)
+			}
+
+			fundedAt := clock.Now()
+			effectiveAt := fundedAt.Add(time.Hour)
+			charge := env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(100), env.Currency, &effectiveAt)
+
+			// when:
+			// - funded history is listed before the scheduled issuance is effective
+			before, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+				CustomerID:    env.CustomerID,
+				Limit:         10,
+				Type:          lo.ToPtr(CreditTransactionTypeFunded),
+				Currency:      &env.Currency,
+				AsOf:          &fundedAt,
+				FeatureFilter: AllFeatureFilter(),
+			})
+			require.NoError(t, err)
+
+			// then:
+			// - only the advance attribution that already affected balance is visible
+			require.Len(t, before.Items, len(tt.before))
+			for i, want := range tt.before {
+				item := before.Items[i]
+				require.Equal(t, charge.ID, item.ID.ID)
+				require.True(t, fundedAt.Add(want.bookedAfter).Equal(item.BookedAt))
+				require.Equal(t, float64(want.amount), item.Amount.InexactFloat64())
+				require.Equal(t, float64(want.before), item.Balance.Before.InexactFloat64())
+				require.Equal(t, float64(want.after), item.Balance.After.InexactFloat64())
+			}
+
+			// when:
+			// - funded history is listed after the scheduled issuance is effective
+			afterEffectiveAt := effectiveAt.Add(time.Second)
+			after, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+				CustomerID:    env.CustomerID,
+				Limit:         10,
+				Type:          lo.ToPtr(CreditTransactionTypeFunded),
+				Currency:      &env.Currency,
+				AsOf:          &afterEffectiveAt,
+				FeatureFilter: AllFeatureFilter(),
+			})
+			require.NoError(t, err)
+
+			// then:
+			// - each distinct effective time has its own correctly ordered balance line
+			require.Len(t, after.Items, len(tt.after))
+			for i, want := range tt.after {
+				item := after.Items[i]
+				require.Equal(t, charge.ID, item.ID.ID)
+				require.True(t, fundedAt.Add(want.bookedAfter).Equal(item.BookedAt))
+				require.Equal(t, float64(want.amount), item.Amount.InexactFloat64())
+				require.Equal(t, float64(want.before), item.Balance.Before.InexactFloat64())
+				require.Equal(t, float64(want.after), item.Balance.After.InexactFloat64())
 			}
 		})
 	}

--- a/openmeter/ledger/customerbalance/funded_loader_test.go
+++ b/openmeter/ledger/customerbalance/funded_loader_test.go
@@ -1,0 +1,94 @@
+package customerbalance
+
+import (
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+)
+
+func TestListCreditTransactionsFundedBalanceIncludesAdvanceAttribution(t *testing.T) {
+	tests := []struct {
+		name          string
+		advanceAmount int64
+		wantBefore    int64
+		wantAfter     int64
+	}{
+		{
+			name:       "ordinary issuance",
+			wantBefore: 0,
+			wantAfter:  100,
+		},
+		{
+			name:          "partially covered advance",
+			advanceAmount: 40,
+			wantBefore:    -40,
+			wantAfter:     60,
+		},
+		{
+			name:          "fully covered advance without issuance",
+			advanceAmount: 100,
+			wantBefore:    -100,
+			wantAfter:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+
+			// given:
+			// - the customer may already have settled advance usage
+			if tt.advanceAmount > 0 {
+				servicePeriod := env.sp()
+				charge := env.createFlatFeeCharge(
+					t,
+					alpacadecimal.NewFromInt(tt.advanceAmount),
+					productcatalog.CreditOnlySettlementMode,
+					servicePeriod,
+				)
+				env.passTimeAfterServicePeriod(t, servicePeriod)
+				env.advanceFlatFeeCharge(t, charge)
+			}
+
+			fundedAt := clock.Now()
+			env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(100), env.Currency, nil)
+
+			// when:
+			// - merged transaction history reconstructs the balance around the purchase
+			result, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+				CustomerID:    env.CustomerID,
+				Limit:         10,
+				Currency:      &env.Currency,
+				FeatureFilter: AllFeatureFilter(),
+			})
+			require.NoError(t, err)
+
+			// then:
+			// - the full purchase is visible and its before/after balance includes both
+			//   issued FBO and cleared advance receivable value
+			expectedItems := 1
+			if tt.advanceAmount > 0 {
+				expectedItems++
+			}
+			require.Len(t, result.Items, expectedItems)
+			item := result.Items[0]
+			require.Equal(t, CreditTransactionTypeFunded, item.Type)
+			require.True(t, fundedAt.Equal(item.BookedAt))
+			require.Equal(t, float64(100), item.Amount.InexactFloat64())
+			require.Equal(t, float64(tt.wantBefore), item.Balance.Before.InexactFloat64())
+			require.Equal(t, float64(tt.wantAfter), item.Balance.After.InexactFloat64())
+
+			if tt.advanceAmount > 0 {
+				advance := result.Items[1]
+				require.Equal(t, CreditTransactionTypeConsumed, advance.Type)
+				require.Equal(t, float64(-tt.advanceAmount), advance.Amount.InexactFloat64())
+				require.Equal(t, float64(0), advance.Balance.Before.InexactFloat64())
+				require.Equal(t, float64(-tt.advanceAmount), advance.Balance.After.InexactFloat64())
+			}
+		})
+	}
+}

--- a/openmeter/ledger/customerbalance/funded_loader_test.go
+++ b/openmeter/ledger/customerbalance/funded_loader_test.go
@@ -96,6 +96,45 @@ func TestListCreditTransactionsFundedBalanceCoalescesSameEffectiveTime(t *testin
 	}
 }
 
+func TestListCreditTransactionsFundedBalanceProjectsFeatureFilteredImpact(t *testing.T) {
+	env := newTestEnv(t)
+
+	// given:
+	// - feature-restricted usage has created a 40-credit advance
+	// - an unrestricted 100-credit purchase covers that advance and issues the remaining 60
+	servicePeriod := env.sp()
+	charge := env.createFlatFeeCharge(
+		t,
+		alpacadecimal.NewFromInt(40),
+		productcatalog.CreditOnlySettlementMode,
+		servicePeriod,
+		testFeatureKey,
+	)
+	env.passTimeAfterServicePeriod(t, servicePeriod)
+	env.advanceFlatFeeCharge(t, charge)
+	env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(100), env.Currency, nil)
+
+	// when:
+	// - funded history is projected onto the unrestricted-only balance
+	result, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID:    env.CustomerID,
+		Limit:         10,
+		Type:          lo.ToPtr(CreditTransactionTypeFunded),
+		Currency:      &env.Currency,
+		FeatureFilter: NewUnrestrictedFeatureFilter(),
+	})
+	require.NoError(t, err)
+
+	// then:
+	// - only the residual unrestricted issuance is visible; the restricted advance
+	//   attribution does not affect this filtered balance
+	require.Len(t, result.Items, 1)
+	item := result.Items[0]
+	require.Equal(t, float64(60), item.Amount.InexactFloat64())
+	require.Equal(t, float64(0), item.Balance.Before.InexactFloat64())
+	require.Equal(t, float64(60), item.Balance.After.InexactFloat64())
+}
+
 func TestListCreditTransactionsFundedBalanceUsesEffectiveTimes(t *testing.T) {
 	// Each scenario issues one future-effective credit purchase, then lists its
 	// funded history both before and after the purchase becomes effective.

--- a/openmeter/ledger/customerbalance/loaders.go
+++ b/openmeter/ledger/customerbalance/loaders.go
@@ -33,7 +33,7 @@ type creditTransactionLoader interface {
 }
 
 type creditTransactionBalanceResolver interface {
-	resolveBalance(ctx context.Context, input creditTransactionLoaderInput, item *CreditTransaction) error
+	resolveBalances(ctx context.Context, input creditTransactionLoaderInput, item CreditTransaction) ([]CreditTransaction, error)
 }
 
 type creditTransactionLoaderFactory func(*service) creditTransactionLoader
@@ -76,16 +76,16 @@ func (s *service) creditTransactionLoaders(txType *CreditTransactionType) ([]cre
 	return []creditTransactionLoader{factory(s)}, nil
 }
 
-func (s *service) resolveCreditTransactionBalance(ctx context.Context, input creditTransactionLoaderInput, item *CreditTransaction) error {
+func (s *service) resolveCreditTransactionBalances(ctx context.Context, input creditTransactionLoaderInput, item CreditTransaction) ([]CreditTransaction, error) {
 	factory, ok := creditTransactionLoaderFactories[item.Type]
 	if !ok {
-		return item.Type.Validate()
+		return nil, item.Type.Validate()
 	}
 
 	resolver, ok := factory(s).(creditTransactionBalanceResolver)
 	if !ok {
-		return nil
+		return []CreditTransaction{item}, nil
 	}
 
-	return resolver.resolveBalance(ctx, input, item)
+	return resolver.resolveBalances(ctx, input, item)
 }

--- a/openmeter/ledger/customerbalance/loaders.go
+++ b/openmeter/ledger/customerbalance/loaders.go
@@ -32,6 +32,10 @@ type creditTransactionLoader interface {
 	Load(ctx context.Context, input creditTransactionLoaderInput) (creditTransactionLoaderResult, error)
 }
 
+type creditTransactionBalanceResolver interface {
+	resolveBalance(ctx context.Context, input creditTransactionLoaderInput, item *CreditTransaction) error
+}
+
 type creditTransactionLoaderFactory func(*service) creditTransactionLoader
 
 var creditTransactionLoaderOrder = []CreditTransactionType{
@@ -70,4 +74,18 @@ func (s *service) creditTransactionLoaders(txType *CreditTransactionType) ([]cre
 	}
 
 	return []creditTransactionLoader{factory(s)}, nil
+}
+
+func (s *service) resolveCreditTransactionBalance(ctx context.Context, input creditTransactionLoaderInput, item *CreditTransaction) error {
+	factory, ok := creditTransactionLoaderFactories[item.Type]
+	if !ok {
+		return item.Type.Validate()
+	}
+
+	resolver, ok := factory(s).(creditTransactionBalanceResolver)
+	if !ok {
+		return nil
+	}
+
+	return resolver.resolveBalance(ctx, input, item)
 }

--- a/openmeter/ledger/customerbalance/merge.go
+++ b/openmeter/ledger/customerbalance/merge.go
@@ -10,6 +10,10 @@ func compareCreditTransactionsByCursor(a, b CreditTransaction) int {
 	return creditTransactionCursor(a).Compare(creditTransactionCursor(b))
 }
 
+func compareCreditTransactionsByBalanceCursor(a, b CreditTransaction) int {
+	return creditTransactionBalanceCursor(a).Compare(creditTransactionBalanceCursor(b))
+}
+
 type mergeListState struct {
 	items []CreditTransaction
 	next  int
@@ -103,4 +107,12 @@ func creditTransactionCursor(tx CreditTransaction) ledger.TransactionCursor {
 		CreatedAt: tx.CreatedAt,
 		ID:        tx.ID,
 	}
+}
+
+func creditTransactionBalanceCursor(tx CreditTransaction) ledger.TransactionCursor {
+	if tx.balanceCursor != nil {
+		return *tx.balanceCursor
+	}
+
+	return creditTransactionCursor(tx)
 }

--- a/openmeter/ledger/customerbalance/service.go
+++ b/openmeter/ledger/customerbalance/service.go
@@ -101,10 +101,11 @@ type Config struct {
 }
 
 type GetBalanceServiceInput struct {
-	CustomerID    customer.CustomerID
-	Currency      currencyx.Code
-	FeatureFilter mo.Option[creditpurchase.FeatureFilters]
-	BalanceQuery  ledger.BalanceQuery
+	CustomerID        customer.CustomerID
+	Currency          currencyx.Code
+	FeatureFilter     mo.Option[creditpurchase.FeatureFilters]
+	BalanceQuery      ledger.BalanceQuery
+	currencyReference currencies.CurrencyReference
 }
 
 type GetBalanceCurrenciesInput struct {
@@ -194,14 +195,14 @@ func (i GetBalanceCurrenciesInput) pendingGrantAsOf() time.Time {
 
 func (i GetBalanceServiceInput) bookedRoute() ledger.RouteFilter {
 	route := i.featureRoute()
-	route.Currency = currencies.NewCurrencyReference(i.Currency)
+	route.Currency = i.ledgerCurrencyReference()
 
 	return route
 }
 
 func (i GetBalanceServiceInput) advanceRoute() ledger.RouteFilter {
 	route := i.featureRoute()
-	route.Currency = currencies.NewCurrencyReference(i.Currency)
+	route.Currency = i.ledgerCurrencyReference()
 	route.CostBasis = mo.Some[*alpacadecimal.Decimal](nil)
 
 	return route
@@ -209,6 +210,14 @@ func (i GetBalanceServiceInput) advanceRoute() ledger.RouteFilter {
 
 func (i GetBalanceServiceInput) featureRoute() ledger.RouteFilter {
 	return featureFilterRoute(normalizeFeatureFilter(i.FeatureFilter))
+}
+
+func (i GetBalanceServiceInput) ledgerCurrencyReference() currencies.CurrencyReference {
+	if i.currencyReference.Code != "" {
+		return i.currencyReference.Clone()
+	}
+
+	return currencies.NewCurrencyReference(i.Currency)
 }
 
 func (c Config) Validate() error {

--- a/openmeter/ledger/customerbalance/transactions.go
+++ b/openmeter/ledger/customerbalance/transactions.go
@@ -115,9 +115,10 @@ type CreditTransaction struct {
 	Description *string
 	Annotations models.Annotations
 
-	balanceCursor *ledger.TransactionCursor
-	balanceAsOf   *time.Time
-	balanceImpact *alpacadecimal.Decimal
+	balanceCursor     *ledger.TransactionCursor
+	balanceAsOf       *time.Time
+	balanceImpact     *alpacadecimal.Decimal
+	currencyReference currencies.CurrencyReference
 
 	fundedTransactionGroupID string
 }
@@ -199,19 +200,30 @@ func (s *service) ListCreditTransactions(ctx context.Context, input ListCreditTr
 
 	s.applyChargeMetadataToCreditTransactions(ctx, input.CustomerID.Namespace, items)
 
-	if len(items) > 0 {
-		runningBalance, err := s.GetSettledBalance(ctx, GetBalanceServiceInput{
-			CustomerID:    input.CustomerID,
-			Currency:      items[0].Currency,
-			FeatureFilter: normalizeFeatureFilter(input.FeatureFilter),
-			BalanceQuery:  items[0].balanceQuery(),
-		})
-		if err != nil {
-			return ListCreditTransactionsResult{}, fmt.Errorf("get FBO balance after transaction %s: %w", items[0].ID.ID, err)
+	// CurrencyReference.IdentityKey keeps custom currency IDs distinct without
+	// using pointer-bearing references as map keys.
+	runningBalancesByCurrency := make(map[string]alpacadecimal.Decimal)
+	for _, item := range items {
+		currencyReference := item.balanceCurrencyReference()
+		currencyKey := currencyReference.IdentityKey()
+		if _, ok := runningBalancesByCurrency[currencyKey]; ok {
+			continue
 		}
 
-		applyCreditTransactionBalances(items, runningBalance)
+		runningBalance, err := s.GetSettledBalance(ctx, GetBalanceServiceInput{
+			CustomerID:        input.CustomerID,
+			Currency:          currencyReference.GetCode(),
+			FeatureFilter:     normalizeFeatureFilter(input.FeatureFilter),
+			BalanceQuery:      item.balanceQuery(),
+			currencyReference: currencyReference,
+		})
+		if err != nil {
+			return ListCreditTransactionsResult{}, fmt.Errorf("get FBO balance after transaction %s: %w", item.ID.ID, err)
+		}
+
+		runningBalancesByCurrency[currencyKey] = runningBalance
 	}
+	applyCreditTransactionBalances(items, runningBalancesByCurrency)
 
 	var (
 		nextCursor     *ledger.TransactionCursor
@@ -280,26 +292,27 @@ func creditTransactionsFromLedgerTransactions(txs []ledger.Transaction) ([]Credi
 }
 
 func creditTransactionFromLedgerTransaction(tx ledger.Transaction) (CreditTransaction, error) {
-	fboImpact, currency, err := creditTransactionFBOImpact(tx)
+	fboImpact, currencyReference, err := creditTransactionFBOImpact(tx)
 	if err != nil {
 		return CreditTransaction{}, err
 	}
 	cursor := tx.Cursor()
 
 	return CreditTransaction{
-		ID:            tx.ID(),
-		CreatedAt:     tx.Cursor().CreatedAt,
-		BookedAt:      tx.BookedAt(),
-		Type:          creditTransactionType(fboImpact),
-		Currency:      currency,
-		Amount:        fboImpact,
-		Name:          "",
-		Annotations:   tx.Annotations(),
-		balanceCursor: &cursor,
+		ID:                tx.ID(),
+		CreatedAt:         tx.Cursor().CreatedAt,
+		BookedAt:          tx.BookedAt(),
+		Type:              creditTransactionType(fboImpact),
+		Currency:          currencyReference.GetCode(),
+		Amount:            fboImpact,
+		Name:              "",
+		Annotations:       tx.Annotations(),
+		balanceCursor:     &cursor,
+		currencyReference: currencyReference,
 	}, nil
 }
 
-func creditTransactionFBOImpact(tx ledger.Transaction) (alpacadecimal.Decimal, currencyx.Code, error) {
+func creditTransactionFBOImpact(tx ledger.Transaction) (alpacadecimal.Decimal, currencies.CurrencyReference, error) {
 	amount := ledger.TransactionImpact(tx, ledger.ImpactFilter{
 		AccountType: ledger.AccountTypeCustomerFBO,
 	})
@@ -315,26 +328,34 @@ func creditTransactionFBOImpact(tx ledger.Transaction) (alpacadecimal.Decimal, c
 			currency = entryCurrency
 		}
 		if !currency.Equal(entryCurrency) {
-			return alpacadecimal.Decimal{}, "", fmt.Errorf("transaction %s has multiple customer FBO currencies", tx.ID().ID)
+			return alpacadecimal.Decimal{}, currencies.CurrencyReference{}, fmt.Errorf("transaction %s has multiple customer FBO currencies", tx.ID().ID)
 		}
 	}
 
 	if currency.Code == "" {
-		return alpacadecimal.Decimal{}, "", fmt.Errorf("no customer FBO entry found in transaction %s", tx.ID().ID)
+		return alpacadecimal.Decimal{}, currencies.CurrencyReference{}, fmt.Errorf("no customer FBO entry found in transaction %s", tx.ID().ID)
 	}
 
-	return amount, currency.Code, nil
+	return amount, currency, nil
 }
 
-func applyCreditTransactionBalances(items []CreditTransaction, after alpacadecimal.Decimal) {
-	runningBalance := after
-
+func applyCreditTransactionBalances(items []CreditTransaction, runningBalancesByCurrency map[string]alpacadecimal.Decimal) {
 	for i := range items {
+		currencyKey := items[i].balanceCurrencyReference().IdentityKey()
+		runningBalance := runningBalancesByCurrency[currencyKey]
 		items[i].Balance.After = runningBalance
 		impact := lo.FromPtrOr(items[i].balanceImpact, items[i].Amount)
 		items[i].Balance.Before = runningBalance.Sub(impact)
-		runningBalance = runningBalance.Sub(impact)
+		runningBalancesByCurrency[currencyKey] = runningBalance.Sub(impact)
 	}
+}
+
+func (tx CreditTransaction) balanceCurrencyReference() currencies.CurrencyReference {
+	if tx.currencyReference.Code != "" {
+		return tx.currencyReference.Clone()
+	}
+
+	return currencies.NewCurrencyReference(tx.Currency)
 }
 
 func (tx CreditTransaction) balanceQuery() ledger.BalanceQuery {

--- a/openmeter/ledger/customerbalance/transactions.go
+++ b/openmeter/ledger/customerbalance/transactions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -182,14 +183,21 @@ func (s *service) ListCreditTransactions(ctx context.Context, input ListCreditTr
 	// loadersHaveMore captures additional records in the requested cursor direction beyond each loader's in-memory window.
 	hasMoreInQueryDirection := bufferedHasMore || loadersHaveMore
 
-	items := mergedItems
-	s.applyChargeMetadataToCreditTransactions(ctx, input.CustomerID.Namespace, items)
-
-	for i := range items {
-		if err := s.resolveCreditTransactionBalance(ctx, loaderInput, &items[i]); err != nil {
-			return ListCreditTransactionsResult{}, fmt.Errorf("resolve balance for transaction %s: %w", items[i].ID.ID, err)
+	items := make([]CreditTransaction, 0, len(mergedItems))
+	for _, item := range mergedItems {
+		resolvedItems, err := s.resolveCreditTransactionBalances(ctx, loaderInput, item)
+		if err != nil {
+			return ListCreditTransactionsResult{}, fmt.Errorf("resolve balance for transaction %s: %w", item.ID.ID, err)
 		}
+
+		items = append(items, resolvedItems...)
 	}
+	// Resolved balances need sorting again because funded transactions can split by booked time.
+	slices.SortStableFunc(items, func(a, b CreditTransaction) int {
+		return compareCreditTransactionsByBalanceCursor(b, a)
+	})
+
+	s.applyChargeMetadataToCreditTransactions(ctx, input.CustomerID.Namespace, items)
 
 	if len(items) > 0 {
 		runningBalance, err := s.GetSettledBalance(ctx, GetBalanceServiceInput{

--- a/openmeter/ledger/customerbalance/transactions.go
+++ b/openmeter/ledger/customerbalance/transactions.go
@@ -116,6 +116,9 @@ type CreditTransaction struct {
 
 	balanceCursor *ledger.TransactionCursor
 	balanceAsOf   *time.Time
+	balanceImpact *alpacadecimal.Decimal
+
+	fundedTransactionGroupID string
 }
 
 type CreditTransactionBalance struct {
@@ -181,6 +184,12 @@ func (s *service) ListCreditTransactions(ctx context.Context, input ListCreditTr
 
 	items := mergedItems
 	s.applyChargeMetadataToCreditTransactions(ctx, input.CustomerID.Namespace, items)
+
+	for i := range items {
+		if err := s.resolveCreditTransactionBalance(ctx, loaderInput, &items[i]); err != nil {
+			return ListCreditTransactionsResult{}, fmt.Errorf("resolve balance for transaction %s: %w", items[i].ID.ID, err)
+		}
+	}
 
 	if len(items) > 0 {
 		runningBalance, err := s.GetSettledBalance(ctx, GetBalanceServiceInput{
@@ -314,8 +323,9 @@ func applyCreditTransactionBalances(items []CreditTransaction, after alpacadecim
 
 	for i := range items {
 		items[i].Balance.After = runningBalance
-		items[i].Balance.Before = runningBalance.Sub(items[i].Amount)
-		runningBalance = runningBalance.Sub(items[i].Amount)
+		impact := lo.FromPtrOr(items[i].balanceImpact, items[i].Amount)
+		items[i].Balance.Before = runningBalance.Sub(impact)
+		runningBalance = runningBalance.Sub(impact)
 	}
 }
 

--- a/openmeter/ledger/customerbalance/transactions_test.go
+++ b/openmeter/ledger/customerbalance/transactions_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	ledgerhistorical "github.com/openmeterio/openmeter/openmeter/ledger/historical"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestCreditTransactionLoaders_InvalidType(t *testing.T) {
@@ -60,17 +63,145 @@ func TestCreditTransactionFromLedgerTransaction_AggregatesScopedFBOEntries(t *te
 
 func TestApplyCreditTransactionBalances(t *testing.T) {
 	balanceImpact := alpacadecimal.NewFromInt(-7)
+	currencyReference := currencies.NewCurrencyReference("USD")
 	items := []CreditTransaction{
 		{
-			Amount:        alpacadecimal.NewFromInt(-10),
-			balanceImpact: &balanceImpact,
+			Currency:          "USD",
+			Amount:            alpacadecimal.NewFromInt(-10),
+			balanceImpact:     &balanceImpact,
+			currencyReference: currencyReference,
 		},
 	}
 
-	applyCreditTransactionBalances(items, alpacadecimal.NewFromInt(42))
+	applyCreditTransactionBalances(items, map[string]alpacadecimal.Decimal{
+		currencyReference.IdentityKey(): alpacadecimal.NewFromInt(42),
+	})
 
 	require.True(t, items[0].Balance.After.Equal(alpacadecimal.NewFromInt(42)))
 	require.True(t, items[0].Balance.Before.Equal(alpacadecimal.NewFromInt(49)))
+}
+
+func TestApplyCreditTransactionBalancesSeparatesCustomCurrencyIdentities(t *testing.T) {
+	alpha, err := currencies.ParseCurrencyReference([]byte("custom|v1|CREDITS|currency-alpha|2"))
+	require.NoError(t, err)
+	beta, err := currencies.ParseCurrencyReference([]byte("custom|v1|CREDITS|currency-beta|2"))
+	require.NoError(t, err)
+
+	items := []CreditTransaction{
+		{Currency: "CREDITS", Amount: alpacadecimal.NewFromInt(10), currencyReference: alpha},
+		{Currency: "CREDITS", Amount: alpacadecimal.NewFromInt(20), currencyReference: beta},
+		{Currency: "CREDITS", Amount: alpacadecimal.NewFromInt(30), currencyReference: alpha},
+	}
+
+	applyCreditTransactionBalances(items, map[string]alpacadecimal.Decimal{
+		alpha.IdentityKey(): alpacadecimal.NewFromInt(100),
+		beta.IdentityKey():  alpacadecimal.NewFromInt(200),
+	})
+
+	require.Equal(t, float64(90), items[0].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(100), items[0].Balance.After.InexactFloat64())
+	require.Equal(t, float64(180), items[1].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(200), items[1].Balance.After.InexactFloat64())
+	require.Equal(t, float64(60), items[2].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(90), items[2].Balance.After.InexactFloat64())
+}
+
+func TestListCreditTransactionsBalancesByCurrency(t *testing.T) {
+	env := newTestEnv(t)
+
+	// given:
+	// - funded and consumed USD/EUR movements are interleaved by booked time
+	issuedAt := clock.Now()
+	env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(100), "USD", nil)
+
+	eurFundedAt := issuedAt.Add(time.Hour)
+	clock.FreezeTime(eurFundedAt)
+	t.Cleanup(clock.UnFreeze)
+	env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(200), "EUR", nil)
+
+	usdConsumedAt := issuedAt.Add(2 * time.Hour)
+	clock.FreezeTime(usdConsumedAt.Add(-time.Minute))
+	t.Cleanup(clock.UnFreeze)
+	usdCharge := env.createFlatFeeChargeInCurrency(
+		t,
+		alpacadecimal.NewFromInt(30),
+		productcatalog.CreditOnlySettlementMode,
+		timeutil.ClosedPeriod{From: usdConsumedAt, To: usdConsumedAt},
+		"USD",
+	)
+	clock.FreezeTime(usdConsumedAt.Add(time.Second))
+	t.Cleanup(clock.UnFreeze)
+	env.advanceFlatFeeCharge(t, usdCharge)
+
+	eurConsumedAt := issuedAt.Add(3 * time.Hour)
+	clock.FreezeTime(eurConsumedAt.Add(-time.Minute))
+	t.Cleanup(clock.UnFreeze)
+	eurCharge := env.createFlatFeeChargeInCurrency(
+		t,
+		alpacadecimal.NewFromInt(50),
+		productcatalog.CreditOnlySettlementMode,
+		timeutil.ClosedPeriod{From: eurConsumedAt, To: eurConsumedAt},
+		"EUR",
+	)
+	clock.FreezeTime(eurConsumedAt.Add(time.Second))
+	t.Cleanup(clock.UnFreeze)
+	env.advanceFlatFeeCharge(t, eurCharge)
+
+	// when:
+	// - an unfiltered history interleaves two currency balance chains
+	result, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID:    env.CustomerID,
+		Limit:         10,
+		FeatureFilter: AllFeatureFilter(),
+	})
+	require.NoError(t, err)
+
+	// then:
+	// - rows stay globally ordered while balances advance only within their currency
+	expected := []struct {
+		currency currencyx.Code
+		txType   CreditTransactionType
+		bookedAt time.Time
+		amount   int64
+		before   int64
+		after    int64
+	}{
+		{currency: "EUR", txType: CreditTransactionTypeConsumed, bookedAt: eurConsumedAt, amount: -50, before: 200, after: 150},
+		{currency: "USD", txType: CreditTransactionTypeConsumed, bookedAt: usdConsumedAt, amount: -30, before: 100, after: 70},
+		{currency: "EUR", txType: CreditTransactionTypeFunded, bookedAt: eurFundedAt, amount: 200, before: 0, after: 200},
+		{currency: "USD", txType: CreditTransactionTypeFunded, bookedAt: issuedAt, amount: 100, before: 0, after: 100},
+	}
+	require.Len(t, result.Items, len(expected))
+	for i, want := range expected {
+		item := result.Items[i]
+		require.Equal(t, want.currency, item.Currency)
+		require.Equal(t, want.txType, item.Type)
+		require.True(t, want.bookedAt.Equal(item.BookedAt))
+		require.Equal(t, float64(want.amount), item.Amount.InexactFloat64())
+		require.Equal(t, float64(want.before), item.Balance.Before.InexactFloat64())
+		require.Equal(t, float64(want.after), item.Balance.After.InexactFloat64())
+	}
+
+	// when:
+	// - the same history is filtered to one currency
+	usd := currencyx.Code("USD")
+	filtered, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID:    env.CustomerID,
+		Limit:         10,
+		Currency:      &usd,
+		FeatureFilter: AllFeatureFilter(),
+	})
+	require.NoError(t, err)
+
+	// then:
+	// - the filtered rows retain the same USD balance chain
+	require.Len(t, filtered.Items, 2)
+	require.Equal(t, CreditTransactionTypeConsumed, filtered.Items[0].Type)
+	require.Equal(t, float64(100), filtered.Items[0].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(70), filtered.Items[0].Balance.After.InexactFloat64())
+	require.Equal(t, CreditTransactionTypeFunded, filtered.Items[1].Type)
+	require.Equal(t, float64(0), filtered.Items[1].Balance.Before.InexactFloat64())
+	require.Equal(t, float64(100), filtered.Items[1].Balance.After.InexactFloat64())
 }
 
 func TestApplyChargeMetadataToCreditTransactions(t *testing.T) {

--- a/openmeter/ledger/customerbalance/transactions_test.go
+++ b/openmeter/ledger/customerbalance/transactions_test.go
@@ -59,16 +59,18 @@ func TestCreditTransactionFromLedgerTransaction_AggregatesScopedFBOEntries(t *te
 }
 
 func TestApplyCreditTransactionBalances(t *testing.T) {
+	balanceImpact := alpacadecimal.NewFromInt(-7)
 	items := []CreditTransaction{
 		{
-			Amount: alpacadecimal.NewFromInt(-10),
+			Amount:        alpacadecimal.NewFromInt(-10),
+			balanceImpact: &balanceImpact,
 		},
 	}
 
 	applyCreditTransactionBalances(items, alpacadecimal.NewFromInt(42))
 
 	require.True(t, items[0].Balance.After.Equal(alpacadecimal.NewFromInt(42)))
-	require.True(t, items[0].Balance.Before.Equal(alpacadecimal.NewFromInt(52)))
+	require.True(t, items[0].Balance.Before.Equal(alpacadecimal.NewFromInt(49)))
 }
 
 func TestApplyChargeMetadataToCreditTransactions(t *testing.T) {


### PR DESCRIPTION
## Overview

Adds a focused regression test for feature-filtered funded transaction reconstruction.

The scenario creates a feature-restricted 40-credit advance, then funds the customer with an unrestricted 100-credit purchase. An unrestricted-only listing should expose only the residual 60-credit FBO issuance with a 0 to 60 balance transition.

This PR is stacked on #5040.

## Current result

The test intentionally fails against the parent implementation because the filtered 60-credit balance impact is compared with the unfiltered 100-credit purchase amount:

    customer balance impact 60 does not match funded amount 100

## Validation

    POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/ledger/customerbalance -run ^TestListCreditTransactionsFundedBalanceProjectsFeatureFilteredImpact$ -count=1

Expected on the parent implementation: failure demonstrating the regression.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds focused regression coverage for reconstructing funded credit transactions under an unrestricted feature filter.
- Creates a feature-restricted 40-credit advance followed by an unrestricted 100-credit purchase.
- Verifies that the filtered history exposes the residual 60-credit issuance with a 0-to-60 balance transition.

<h3>Confidence Score: 5/5</h3>

The test-only change appears safe to merge, with no unacknowledged actionable issues in the added coverage.

The new scenario consistently exercises restricted advance attribution followed by unrestricted funding and asserts the intended filtered transaction amount and balance projection.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ledger/customerbalance/funded_loader_test.go | Adds a clearly structured dynamic regression test for feature-filtered funded transaction reconstruction without changing production behavior. |

<sub>Reviews (1): Last reviewed commit: ["test(ledger): cover filtered funded impa..."](https://github.com/openmeterio/openmeter/commit/611e8b091f9a41407efca842bf4b95ca9b1b817e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59094115)</sub>

<!-- /greptile_comment -->