### PR TITLE
feat(ingest): set explicit buckets on the request event count histogram

### DIFF
--- a/openmeter/ingest/service.go
+++ b/openmeter/ingest/service.go
@@ -56,6 +56,13 @@ func NewService(config Config) (Service, error) {
 		"openmeter.ingest.request.events",
 		metric.WithDescription("Number of events in an ingest request"),
 		metric.WithUnit("{event}"),
+		// The SDK default boundaries are latency-shaped: they start at 0 and jump
+		// straight to 5. In the deployments we have observed, the large majority of
+		// ingest requests carry between one and five events, so that first bucket
+		// swallows the whole distribution and the reported percentiles become
+		// interpolation rather than measurement. Resolve one through five exactly
+		// and keep a coarse tail for clients that batch.
+		metric.WithExplicitBucketBoundaries(0, 1, 2, 3, 4, 5, 10, 25, 100, 1000, 10000),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request event count histogram: %w", err)

--- a/openmeter/ingest/service_test.go
+++ b/openmeter/ingest/service_test.go
@@ -62,4 +62,16 @@ func TestIngestEventsRecordsRequestEventCount(t *testing.T) {
 	namespace, ok := histogram.DataPoints[0].Attributes.Value(attribute.Key("namespace"))
 	require.True(t, ok)
 	require.Equal(t, "default", namespace.AsString())
+
+	require.Equal(
+		t,
+		[]float64{0, 1, 2, 3, 4, 5, 10, 25, 100, 1000, 10000},
+		histogram.DataPoints[0].Bounds,
+	)
+
+	// The one-event and three-event requests must land in separate buckets. Under
+	// the SDK default boundaries both fall into (0, 5], which is what collapses
+	// the distribution.
+	require.Equal(t, uint64(1), histogram.DataPoints[0].BucketCounts[1], "(0, 1] should hold the single-event request")
+	require.Equal(t, uint64(1), histogram.DataPoints[0].BucketCounts[3], "(2, 3] should hold the three-event request")
 }


### PR DESCRIPTION
## What

Set explicit bucket boundaries on the `openmeter.ingest.request.events` histogram added in #5014:

```go
metric.WithExplicitBucketBoundaries(0, 1, 2, 3, 4, 5, 10, 25, 100, 1000, 10000),
```

## Why

The instrument declared no boundaries, so it inherited the OTel SDK defaults — `[0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]`. Those are latency-shaped, but this metric counts events per request, and event counts do not distribute like latencies.

In the deployments we operate, the shape looks like this:

| bucket | share of requests |
|---|---|
| `= 0` | ~0.004% |
| `1–5` | ~99.9% |
| `6–10` | ~0.11% |
| `11–25` | ~0.02% |
| `> 25` | negligible |

A single bucket holds effectively the whole distribution, so any percentile inside it is linear interpolation rather than measurement: `histogram_quantile` returns a p50 pinned near the bucket midpoint (~2.5), while the bucket-independent mean — ingested events divided by request count — is ~1.02.

Other deployments will have their own mix, but the underlying point is not environment-specific: an ingest API that accepts a single event or a batch will see a lot of small requests, and a first bucket spanning 1–5 cannot distinguish them. That defeats the stated purpose of #5014, which was to make single-event vs bulk ingestion patterns observable.

## How

The boundaries are chosen for the shape of this measurement rather than by convention:

- **0** — keeps empty batches distinguishable from single-event requests. An empty `application/cloudevents-batch+json` body is spec-legal (the batch schema has no `minItems`) and does occur.
- **1, 2, 3, 4, 5** — the range where small requests concentrate. Without these boundaries the entire low end is one bucket.
- **10, 25** — the near tail, where light batching shows up.
- **100, 1000, 10000** — sparse coverage so the metric still reads correctly for clients that batch properly.

Eleven boundaries against the default fifteen, so the per-namespace series count drops as well.

## Verification

`go test ./openmeter/ingest/...` passes. The existing test is extended to assert the boundary list and that a one-event and a three-event request land in separate buckets — `(0, 1]` and `(2, 3]` — the distinction the defaults collapsed. Its `Count`/`Sum` assertions are bucket-independent and unaffected.

## Upgrade note

Percentile and heatmap queries spanning the rollout will show a step artifact, since historical data carries the old boundaries. `_sum` and `_count`, and therefore mean events per request, stay continuous. Anyone alerting on percentiles of this metric should re-check their thresholds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR configures event-count-oriented bucket boundaries for the ingest request histogram and extends its test to verify both the exported boundaries and separation of small request sizes.
- Adds explicit boundaries from zero through 10,000 events.
- Distinguishes empty, single-event, and small batch requests.
- Verifies one-event and three-event requests occupy separate histogram buckets.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The explicit boundaries are valid and ordered, their bucket semantics match the new assertions, and no repository metric view overrides the instrument configuration.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ingest/service.go | Adds valid, ordered explicit boundaries tailored to the request event-count distribution. |
| openmeter/ingest/service_test.go | Correctly verifies the exported boundaries and OpenTelemetry bucket placement using the real metric SDK. |

<sub>Reviews (1): Last reviewed commit: ["feat(ingest): set explicit buckets on th..."](https://github.com/openmeterio/openmeter/commit/feec506371b3caa080a7e3b780f21026f24fb60a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59094698)</sub>

**Context used:**

- Knowledge Base — [Event ingestion and collection](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/event-ingestion.md)

<!-- /greptile_comment -->