### PR TITLE
chore(deps): ignore ariga.io/atlas updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,6 +16,8 @@ updates:
       - area/dependencies
       - dependency/go
       - release-note/dependency-update
+    ignore:
+      - dependency-name: "ariga.io/atlas"
     groups:
       k8s:
         patterns:


### PR DESCRIPTION
Ignore ariga.io/atlas in Dependabot so it does not reopen the intentionally closed 1.3.0 upgrade PR.

We don't want to move off the existing atlas version for now.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR configures Dependabot to stop proposing `ariga.io/atlas` updates, preventing the intentionally closed Atlas upgrade from reopening.

- Adds an exact dependency ignore rule to the Go modules update configuration.
- Applies the rule to the existing configured Go module directories containing Atlas.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the ignore rule matches the intended dependency within the relevant Go module update block.

The configuration is valid, the dependency name exactly matches the root and e2e module declarations, and permanently suppressing Atlas update proposals is the explicitly stated behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/dependabot.yaml | Adds a correctly scoped and structurally valid Dependabot ignore entry for `ariga.io/atlas`; no actionable issue was identified. |

<sub>Reviews (1): Last reviewed commit: ["chore(deps): ignore ariga.io/atlas updat..."](https://github.com/openmeterio/openmeter/commit/8f25104c2286b670e1c9613ce6e00564bf65f614) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59096338)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to exclude Atlas from future update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->