### PR TITLE
fix(ledger): preserve fiat credit purchase units

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -211,6 +211,11 @@ the standard invoice, the state machine resolves the cost basis before booking
 the credit grant. The line engine then requires that resolution and replaces
 the provisional amount with the resolved fiat value.
 
+Fiat credit remains denominated in nominal credit units throughout ledger
+authorization and settlement; its cost basis carries the amount paid per unit.
+Custom-currency credit instead materializes a fiat-to-custom receivable exchange
+before the fiat payment is authorized.
+
 Persisted credit purchases read settlement and cost basis only from their
 dedicated fields. Fiat purchases persist their scalar rate on the charge row;
 custom-currency purchases reference durable shared cost-basis state. Resolution

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -63,6 +63,35 @@ func NewCreditPurchaseHandler(
 	}, nil
 }
 
+type creditPurchasePaymentPosting struct {
+	amount   alpacadecimal.Decimal
+	currency currencies.CurrencyReference
+}
+
+// resolveCreditPurchasePaymentPosting keeps fiat credit purchases in nominal
+// credit units because their cost basis already carries the amount paid per
+// unit. Custom-currency purchases instead settle the fiat receivable created by
+// their FX transaction.
+func resolveCreditPurchasePaymentPosting(input chargecreditpurchase.PaymentEventInput) (creditPurchasePaymentPosting, error) {
+	charge := input.Charge
+	if !charge.Intent.Currency.IsCustom() {
+		return creditPurchasePaymentPosting{
+			amount:   charge.Intent.CreditAmount,
+			currency: charge.Intent.Currency.Reference(),
+		}, nil
+	}
+
+	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	if err != nil {
+		return creditPurchasePaymentPosting{}, fmt.Errorf("get settlement fiat currency: %w", err)
+	}
+
+	return creditPurchasePaymentPosting{
+		amount:   input.FiatAmount,
+		currency: currencies.NewCurrencyReference(currencyx.Code(fiatCurrency.GetFiatCode())),
+	}, nil
+}
+
 func (h *creditPurchaseHandler) OnPromotionalCreditPurchase(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
 	return h.issueCreditPurchase(ctx, charge)
 }
@@ -83,9 +112,9 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 		)
 	}
 
-	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	paymentPosting, err := resolveCreditPurchasePaymentPosting(input)
 	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+		return ledgertransaction.GroupReference{}, err
 	}
 
 	costBasis := charge.State.ResolvedCostBasis.CostBasis
@@ -97,27 +126,22 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 	featureFilters := charge.Intent.FeatureFilters.Normalize()
 
-	settlementCurrency := currencyx.Code(fiatCurrency.GetFiatCode())
-
 	var templates []transactions.TransactionTemplate
-	if charge.Intent.Currency.IsCustom() || !input.FiatAmount.Equal(charge.Intent.CreditAmount) {
-		// Re-denominate the issued credit receivable into the amount actually
-		// being paid before authorization. For fiat credits, the same-currency
-		// conversion records the cost-basis difference against brokerage.
+	if charge.Intent.Currency.IsCustom() {
 		templates = append(templates, transactions.ConvertCurrencyTemplate{
 			At:             input.EventAt,
-			SourceAmount:   input.FiatAmount,
+			SourceAmount:   paymentPosting.amount,
 			TargetAmount:   charge.Intent.CreditAmount,
 			CostBasis:      costBasis,
-			SourceCurrency: currencies.NewCurrencyReference(settlementCurrency),
+			SourceCurrency: paymentPosting.currency,
 			TargetCurrency: charge.Intent.Currency.Reference(),
 			Features:       featureFilters,
 		})
 	}
 	templates = append(templates, transactions.AuthorizeCustomerReceivablePaymentTemplate{
 		At:             input.EventAt,
-		Amount:         input.FiatAmount,
-		Currency:       currencies.NewCurrencyReference(settlementCurrency),
+		Amount:         paymentPosting.amount,
+		Currency:       paymentPosting.currency,
 		CostBasis:      &costBasis,
 		Features:       featureFilters,
 		SourceChargeID: &charge.ID,
@@ -169,9 +193,9 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 		)
 	}
 
-	fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
+	paymentPosting, err := resolveCreditPurchasePaymentPosting(input)
 	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+		return ledgertransaction.GroupReference{}, err
 	}
 
 	costBasis := charge.State.ResolvedCostBasis.CostBasis
@@ -183,8 +207,6 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 	featureFilters := charge.Intent.FeatureFilters.Normalize()
 
-	settlementCurrency := currencyx.Code(fiatCurrency.GetFiatCode())
-
 	inputs, err := transactions.ResolveTransactions(
 		ctx,
 		h.resolverDependencies(),
@@ -194,8 +216,8 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:             input.EventAt,
-			Amount:         input.FiatAmount,
-			Currency:       currencies.NewCurrencyReference(settlementCurrency),
+			Amount:         paymentPosting.amount,
+			Currency:       paymentPosting.currency,
 			CostBasis:      &costBasis,
 			Features:       featureFilters,
 			SourceChargeID: &charge.ID,

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -593,29 +593,32 @@ func TestOnCreditPurchasePaymentSettled(t *testing.T) {
 	}
 }
 
-func TestOnCreditPurchasePaymentLifecycleRevaluesFiatAmount(t *testing.T) {
+func TestOnCreditPurchasePaymentLifecyclePreservesFiatCreditUnits(t *testing.T) {
 	env := newCreditPurchaseHandlerTestEnv(t)
-	costBasis := mustDecimal(t, "0.5")
+	costBasis := mustDecimal(t, "0.25")
 	charge := env.newExternalCharge(alpacadecimal.NewFromInt(100), costBasis)
-	fiatAmount := alpacadecimal.NewFromInt(99)
+	fiatAmount := alpacadecimal.NewFromInt(25)
 
 	_, err := env.handler.OnCreditPurchaseInitiated(t.Context(), charge)
 	require.NoError(t, err)
 
-	_, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
+	authorizedRef, err := env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
 		Charge:     charge,
 		EventAt:    charge.CreatedAt.Add(15 * time.Minute),
 		FiatAmount: fiatAmount,
 	})
 	require.NoError(t, err)
+	require.Equal(t, []string{
+		transactions.TemplateCode(transactions.AuthorizeCustomerReceivablePaymentTemplate{}),
+	}, env.transactionTemplateCodes(t, authorizedRef.TransactionGroupID))
 	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(fiatAmount.Neg()))
+	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(charge.Intent.CreditAmount.Neg()))
 	brokerage, err := env.BusinessAccounts.BrokerageAccount.GetSubAccountForRoute(t.Context(), ledger.BusinessRouteParams{
 		Currency:  env.CurrencyReference(),
 		CostBasis: &costBasis,
 	})
 	require.NoError(t, err)
-	require.True(t, env.sumBalance(t, brokerage).Equal(alpacadecimal.NewFromInt(-1)))
+	require.True(t, env.sumBalance(t, brokerage).IsZero())
 
 	_, err = env.handler.OnCreditPurchasePaymentSettled(t.Context(), chargecreditpurchase.PaymentEventInput{
 		Charge:     charge,
@@ -624,7 +627,7 @@ func TestOnCreditPurchasePaymentLifecycleRevaluesFiatAmount(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
-	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(fiatAmount.Neg()))
+	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(charge.Intent.CreditAmount.Neg()))
 }
 
 func TestOnCreditPurchasePaymentSettled_BacksAdvanceBeforeTopUp(t *testing.T) {

--- a/openmeter/ledger/transactions/fx.go
+++ b/openmeter/ledger/transactions/fx.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
@@ -15,6 +14,8 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
+// ConvertCurrencyTemplate materializes a fiat-funded custom-currency
+// receivable exchange. The source is fiat and the target is custom currency.
 type ConvertCurrencyTemplate struct {
 	At           time.Time
 	SourceAmount alpacadecimal.Decimal
@@ -59,12 +60,10 @@ func (t ConvertCurrencyTemplate) Validate() error {
 
 	if err := t.TargetCurrency.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("target currency: %w", err))
-	} else if t.TargetCurrency.IsCustom() {
-		if !t.TargetCurrency.IsResolved() {
-			errs = append(errs, errors.New("target custom currency must be resolved"))
-		}
-	} else if !t.TargetCurrency.IsFiat() || t.TargetCurrency.Code != t.SourceCurrency.Code {
-		errs = append(errs, errors.New("target currency must be custom or match the source fiat currency"))
+	} else if !t.TargetCurrency.IsCustom() {
+		errs = append(errs, errors.New("target currency must be custom"))
+	} else if !t.TargetCurrency.IsResolved() {
+		errs = append(errs, errors.New("target custom currency must be resolved"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -86,10 +85,7 @@ func (t ConvertCurrencyTemplate) code() TransactionTemplateCode {
 
 func (t ConvertCurrencyTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
 	costBasis := t.CostBasis
-	targetCostBasisCurrency := lo.ToPtr(t.SourceCurrency.Code)
-	if t.TargetCurrency.IsFiat() {
-		targetCostBasisCurrency = nil
-	}
+	targetCostBasisCurrency := t.SourceCurrency.Code
 	customerAccounts, err := resolvers.AccountService.GetCustomerAccounts(ctx, customerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get customer accounts: %w", err)
@@ -107,7 +103,7 @@ func (t ConvertCurrencyTemplate) resolve(ctx context.Context, customerID custome
 
 	targetAccount, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.TargetCurrency,
-		CostBasisCurrency:              targetCostBasisCurrency,
+		CostBasisCurrency:              &targetCostBasisCurrency,
 		CostBasis:                      &costBasis,
 		Features:                       t.Features,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
@@ -131,27 +127,11 @@ func (t ConvertCurrencyTemplate) resolve(ctx context.Context, customerID custome
 
 	brokerageTarget, err := businessAccounts.BrokerageAccount.GetSubAccountForRoute(ctx, ledger.BusinessRouteParams{
 		Currency:          t.TargetCurrency,
-		CostBasisCurrency: targetCostBasisCurrency,
+		CostBasisCurrency: &targetCostBasisCurrency,
 		CostBasis:         &costBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get brokerage target sub-account: %w", err)
-	}
-
-	if t.TargetCurrency.IsFiat() {
-		return &TransactionInput{
-			bookedAt: t.At,
-			entryInputs: []*EntryInput{
-				{
-					address: sourceAccount.Address(),
-					amount:  t.TargetAmount.Sub(t.SourceAmount),
-				},
-				{
-					address: brokerageSource.Address(),
-					amount:  t.SourceAmount.Sub(t.TargetAmount),
-				},
-			},
-		}, nil
 	}
 
 	return &TransactionInput{

--- a/openmeter/ledger/transactions/fx_test.go
+++ b/openmeter/ledger/transactions/fx_test.go
@@ -90,9 +90,9 @@ func TestConvertCurrencyTemplate(t *testing.T) {
 				name: "fiat to custom",
 			},
 			{
-				name: "fiat to fiat",
+				name: "rejects same fiat to fiat",
 				mutate: func(input *ConvertCurrencyTemplate) {
-					input.TargetCurrency = currencies.NewCurrencyReference(currencyx.Code("EUR"))
+					input.TargetCurrency = currencies.NewCurrencyReference(currencyx.Code("USD"))
 				},
 			},
 			{
@@ -168,38 +168,6 @@ func TestConvertCurrencyTemplate(t *testing.T) {
 				require.Error(t, err)
 			})
 		}
-	})
-
-	t.Run("revalues a fiat receivable through brokerage", func(t *testing.T) {
-		// given:
-		// - a 100 USD credit receivable with a 0.25 USD cost basis
-		// when:
-		// - it is re-denominated into a 25 USD external payment
-		// then:
-		// - the 75 USD difference is balanced through brokerage
-		env := newTransactionsTestEnv(t)
-		costBasis := alpacadecimal.NewFromFloat(0.25)
-		inputs := env.resolve(t, ConvertCurrencyTemplate{
-			At:             env.Now(),
-			SourceAmount:   alpacadecimal.NewFromInt(25),
-			TargetAmount:   alpacadecimal.NewFromInt(100),
-			CostBasis:      costBasis,
-			SourceCurrency: currencies.NewCurrencyReference(currencyx.Code("USD")),
-			TargetCurrency: currencies.NewCurrencyReference(currencyx.Code("USD")),
-		})
-
-		require.Len(t, inputs, 1)
-		require.Len(t, inputs[0].EntryInputs(), 2)
-
-		amountsByAccountType := map[ledger.AccountType]float64{}
-		for _, entry := range inputs[0].EntryInputs() {
-			amountsByAccountType[entry.PostingAddress().AccountType()] = entry.Amount().InexactFloat64()
-		}
-
-		require.Equal(t, map[ledger.AccountType]float64{
-			ledger.AccountTypeCustomerReceivable: 75,
-			ledger.AccountTypeBrokerage:          -75,
-		}, amountsByAccountType)
 	})
 
 	t.Run("accepts the exact source amount supplied by the charge layer", func(t *testing.T) {

--- a/openmeter/ledger/transactions/fx_test.go
+++ b/openmeter/ledger/transactions/fx_test.go
@@ -83,8 +83,9 @@ func TestConvertCurrencyTemplate(t *testing.T) {
 		}
 
 		tests := []struct {
-			name   string
-			mutate func(*ConvertCurrencyTemplate)
+			name          string
+			mutate        func(*ConvertCurrencyTemplate)
+			errorContains string
 		}{
 			{
 				name: "fiat to custom",
@@ -94,6 +95,13 @@ func TestConvertCurrencyTemplate(t *testing.T) {
 				mutate: func(input *ConvertCurrencyTemplate) {
 					input.TargetCurrency = currencies.NewCurrencyReference(currencyx.Code("USD"))
 				},
+			},
+			{
+				name: "rejects unresolved custom target",
+				mutate: func(input *ConvertCurrencyTemplate) {
+					input.TargetCurrency = currencies.NewCurrencyReference(currencyx.Code("ACME"))
+				},
+				errorContains: "target custom currency must be resolved",
 			},
 			{
 				name: "custom to custom",
@@ -166,6 +174,9 @@ func TestConvertCurrencyTemplate(t *testing.T) {
 				}
 
 				require.Error(t, err)
+				if tt.errorContains != "" {
+					require.ErrorContains(t, err, tt.errorContains)
+				}
 			})
 		}
 	})

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -379,7 +379,8 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSet
 	// when:
 	// - the external payment is authorized
 	// then:
-	// - the receivable moves from open to authorized while credits stay allocated
+	// - the payment realization stores the rounded fiat amount
+	// - the nominal credit receivable moves from open to authorized while credits stay allocated
 	grant, err = s.CreditGrantService.UpdateExternalSettlement(ctx, creditgrant.UpdateExternalSettlementInput{
 		Namespace:    ns,
 		CustomerID:   cust.ID,
@@ -393,13 +394,13 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSet
 	s.AssertDecimalEqual(fiatAmount, grant.Realizations.ExternalPaymentSettlement.FiatAmount, "authorized grant should persist the rounded fiat payment amount")
 	s.AssertDecimalEqual(creditAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&costBasis), int(priority)), "authorized grant should keep credits allocated")
 	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen), "authorized grant should clear open receivable")
-	s.AssertDecimalEqual(fiatAmount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "authorized grant should book the rounded fiat receivable")
+	s.AssertDecimalEqual(creditAmount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "authorized grant should book the nominal credit receivable")
 	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "authorized grant should not book wash")
 
 	// when:
 	// - the external payment is settled
 	// then:
-	// - the charge finalizes and the receivable is funded from wash
+	// - the charge finalizes and the nominal receivable clears through its cost-basis-qualified wash route
 	grant, err = s.CreditGrantService.UpdateExternalSettlement(ctx, creditgrant.UpdateExternalSettlementInput{
 		Namespace:    ns,
 		CustomerID:   cust.ID,
@@ -415,7 +416,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSet
 	s.AssertDecimalEqual(creditAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&costBasis), int(priority)), "settled grant should keep credits allocated")
 	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen), "settled grant should keep open receivable cleared")
 	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "settled grant should clear authorized receivable")
-	s.AssertDecimalEqual(fiatAmount.Neg(), s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "settled grant should book the rounded fiat payment in wash")
+	s.AssertDecimalEqual(creditAmount.Neg(), s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "settled grant should book the nominal credit amount in wash")
 }
 
 func (s *CreditGrantTestSuite) TestListCreditGrants() {

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2441,8 +2441,9 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
-		s.Equal(float64(-25), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
+		s.Equal(float64(-50), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
 	})
 
 	s.Run("the customer settles the credit purchase payment", func() {
@@ -2457,6 +2458,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusSettled, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
 	})
 
@@ -3204,8 +3206,9 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
-		s.Equal(float64(-25), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
+		s.Equal(float64(-50), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
 	})
 
 	s.Run("the customer settles the credit purchase payment", func() {
@@ -3217,6 +3220,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusSettled, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
 	})
 
@@ -3461,12 +3465,13 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 		})
 		s.NoError(err)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 
-		// Authorization only moves the purchased receivable into the authorized bucket;
-		// attribution already happened during purchase initiation.
+		// Authorization only moves the nominal purchased receivable into the
+		// authorized bucket; attribution already happened during purchase initiation.
 		s.True(
-			s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromInt(-25)),
-			"the cost-basis payment amount should be visible in the exact authorized receivable route before settlement",
+			s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromInt(-50)),
+			"the nominal purchased amount should be visible in the exact authorized receivable route before settlement",
 		)
 		s.True(
 			s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusAuthorized).Equal(start.advanceAuthorized),
@@ -3479,9 +3484,11 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 		})
 		s.NoError(err)
 		s.Equal(payment.StatusSettled, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
+		s.Equal(float64(25), updatedCharge.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
 
-		// Settlement is the cash movement from wash that clears the authorized receivable.
-		// The earlier attribution stays intact, and the purchased receivable fully nets out here.
+		// Settlement clears the nominal authorized receivable through its
+		// cost-basis-qualified wash route. The payment realization separately
+		// retains the actual fiat amount paid.
 		s.True(
 			s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero),
 			"the exact open advance receivable bucket should stay cleared after initiation-time attribution",
@@ -3514,7 +3521,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 			s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()).Equal(start.totalAccrued),
 			"settlement should only translate accrued between buckets, not change the total accrued amount",
 		)
-		assertDelta("external wash after later purchase settlement", start.externalWash, alpacadecimal.NewFromInt(-25), s.MustWashBalance(ns, USD, mo.Some(&externalCostBasis)))
+		assertDelta("external wash after later purchase settlement", start.externalWash, alpacadecimal.NewFromInt(-50), s.MustWashBalance(ns, USD, mo.Some(&externalCostBasis)))
 		s.requireCustomerFBOSourceBalanceBuckets(cust.GetID(), ledger.RouteFilter{
 			Currency:  currencies.NewCurrencyReference(USD),
 			CostBasis: mo.Some(&externalCostBasis),


### PR DESCRIPTION
## Summary

- keep fiat credit-purchase authorization and settlement in nominal credit units while payment realizations retain the actual fiat amount paid
- restrict currency conversion transactions to fiat-to-custom exchanges and remove same-fiat brokerage postings
- document the denomination contract and cover the non-unit-cost fiat lifecycle with a ledger regression test

## Why

A fiat purchase of 100 USD credits at a 0.25 cost basis already records 100 nominal units on a cost-basis-qualified route. Re-denominating that receivable to 25 units through brokerage applies the purchase price twice. Authorization and settlement should move the original 100 units; the 0.25 cost basis carries their paid value.

Custom-currency purchases still materialize the required fiat-to-custom receivable exchange before payment authorization.

## Validation

- go test -tags=dynamic ./openmeter/ledger/transactions ./openmeter/ledger/chargeadapter
- go test -tags=dynamic ./openmeter/billing/charges/creditpurchase/... ./openmeter/ledger/collector
- go test -tags=dynamic ./test/credits -run ^TestCreditPurchaseCostBasisSuite$


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Billing**
  * Fiat credit purchases preserve the full nominal credit amount during payment authorization and settlement, even when the fiat payment is lower.
  * Custom-currency purchases convert the fiat payment into the selected custom currency before settlement.
  * Currency conversion validation and ledger handling now consistently distinguish fiat purchases from custom-currency exchanges.

* **Documentation**
  * Clarified settlement semantics for fiat and custom-currency credit purchases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR keeps fiat credit purchases in nominal credit units through ledger authorization and settlement while retaining the actual amount paid in the payment realization.

- Uses nominal credit amounts for fiat receivable authorization and settlement.
- Retains fiat-to-custom conversion for custom-currency purchases.
- Restricts `ConvertCurrencyTemplate` to resolved custom-currency targets.
- Adds regression coverage and documents the denomination contract.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ledger/chargeadapter/creditpurchase.go | Separates fiat nominal-unit postings from custom-currency settlement-fiat postings across authorization and settlement. |
| openmeter/ledger/transactions/fx.go | Narrows currency conversion transactions to resolved fiat-to-custom exchanges and removes same-fiat brokerage revaluation. |
| openmeter/ledger/chargeadapter/creditpurchase_test.go | Verifies that non-unit-cost fiat purchases move nominal units without a brokerage posting. |
| test/credits/creditgrant_test.go | Updates lifecycle expectations so payment realization retains fiat while ledger balances retain nominal units. |
| test/credits/sanity_test.go | Extends end-to-end assertions for nominal receivable balances and actual fiat realization amounts. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Credit purchase] --> T{Credit currency}
    T -->|Fiat| N[Keep nominal credit units]
    T -->|Custom| X[Convert settlement fiat to custom units]
    N --> A[Authorize receivable]
    X --> A
    A --> S[Settle receivable through wash]
    F[Actual fiat amount paid] --> R[Payment realization]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ledger): align fiat purchase lifecy..."](https://github.com/openmeterio/openmeter/commit/ef421be60f1afa3198554bc31cf505de9aed7f61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59475424)</sub>

**Context used:**

- Knowledge Base — [Entitlements, credits, and ledger](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/entitlements-and-credit.md)
- Knowledge Base — [Credit and ledger accounting](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-and-ledger-accounting.md)

<!-- /greptile_comment -->