### PR TITLE
feat(ledger): label voided funded transactions

### DIFF
--- a/api/v3/handlers/customers/credits/convert.go
+++ b/api/v3/handlers/customers/credits/convert.go
@@ -528,6 +528,9 @@ func toAPIBillingCreditTransaction(tx customerbalance.CreditTransaction) api.Bil
 	}
 
 	labels := creditTransactionLabels(tx.Annotations)
+	if tx.Type == customerbalance.CreditTransactionTypeFunded && tx.GrantVoided {
+		labels["voided"] = "true"
+	}
 	if len(labels) > 0 {
 		apiLabels := api.Labels(labels)
 		apiTx.Labels = &apiLabels

--- a/api/v3/handlers/customers/credits/list_transactions_test.go
+++ b/api/v3/handlers/customers/credits/list_transactions_test.go
@@ -42,11 +42,12 @@ func TestToAPIBillingCreditTransaction(t *testing.T) {
 			Namespace: "ns",
 			ID:        "tx-1",
 		},
-		CreatedAt: createdAt,
-		BookedAt:  bookedAt,
-		Type:      customerbalance.CreditTransactionTypeConsumed,
-		Currency:  currencyx.Code("USD"),
-		Amount:    alpacadecimal.NewFromInt(-10),
+		CreatedAt:   createdAt,
+		BookedAt:    bookedAt,
+		Type:        customerbalance.CreditTransactionTypeConsumed,
+		GrantVoided: true,
+		Currency:    currencyx.Code("USD"),
+		Amount:      alpacadecimal.NewFromInt(-10),
 		Balance: customerbalance.CreditTransactionBalance{
 			Before: alpacadecimal.NewFromInt(52),
 			After:  alpacadecimal.NewFromInt(42),
@@ -68,6 +69,25 @@ func TestToAPIBillingCreditTransaction(t *testing.T) {
 	require.Equal(t, description, *tx.Description)
 	require.NotNil(t, tx.Labels)
 	require.Equal(t, "charge-1", (*tx.Labels)["charge_id"])
+	require.NotContains(t, *tx.Labels, "voided")
+}
+
+func TestToAPIBillingCreditTransaction_VoidedFundedLabel(t *testing.T) {
+	tx := toAPIBillingCreditTransaction(customerbalance.CreditTransaction{
+		ID: models.NamespacedID{
+			Namespace: "ns",
+			ID:        "tx-1",
+		},
+		CreatedAt:   time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC),
+		BookedAt:    time.Date(2026, 4, 10, 9, 0, 1, 0, time.UTC),
+		Type:        customerbalance.CreditTransactionTypeFunded,
+		GrantVoided: true,
+		Currency:    currencyx.Code("USD"),
+		Amount:      alpacadecimal.NewFromInt(10),
+	})
+
+	require.NotNil(t, tx.Labels)
+	require.Equal(t, "true", (*tx.Labels)["voided"])
 }
 
 func TestToAPIBillingCreditTransaction_Expired(t *testing.T) {

--- a/e2e/customer_credits_v3_test.go
+++ b/e2e/customer_credits_v3_test.go
@@ -409,11 +409,25 @@ func TestV3VoidCreditGrant(t *testing.T) {
 		require.NotNil(t, all)
 
 		typeCounts := map[v3sdk.CreditTransactionType]int{}
+		fundedByID := map[string]v3sdk.CreditTransaction{}
 		for _, tx := range all.Data {
 			typeCounts[tx.Type]++
+			if tx.Type == v3sdk.CreditTransactionTypeFunded {
+				fundedByID[tx.ID] = tx
+			}
 		}
 		assert.Equal(t, 2, typeCounts[v3sdk.CreditTransactionTypeFunded])
 		assert.Equal(t, 1, typeCounts[txType])
+
+		voidedFunding, ok := fundedByID[grant.ID]
+		require.True(t, ok)
+		require.NotNil(t, voidedFunding.Labels)
+		assert.Equal(t, "true", voidedFunding.Labels["voided"])
+
+		activeFunding, ok := fundedByID[keptGrant.ID]
+		require.True(t, ok)
+		require.NotNil(t, activeFunding.Labels)
+		assert.NotContains(t, activeFunding.Labels, "voided")
 	})
 
 	t.Run("voiding an unknown grant is a 404", func(t *testing.T) {

--- a/openmeter/ledger/customerbalance/README.md
+++ b/openmeter/ledger/customerbalance/README.md
@@ -65,6 +65,11 @@ Visible types:
 - `funded`: credit became available.
 - `consumed`: credit was used.
 - `expired`: unused credit expired.
+- `voided`: unused credit was forfeited by voiding its grant.
+
+Funded rows include the response label `voided: "true"` when the backing grant
+has since been voided. The label is absent from active funded rows and from
+other transaction types.
 
 The visible amount is the customer balance impact:
 

--- a/openmeter/ledger/customerbalance/funded_loader.go
+++ b/openmeter/ledger/customerbalance/funded_loader.go
@@ -262,6 +262,7 @@ func fundedCreditTransactionFromCharge(charge creditpurchase.Charge) (CreditTran
 		CreatedAt:   charge.CreatedAt,
 		BookedAt:    grant.Time,
 		Type:        CreditTransactionTypeFunded,
+		GrantVoided: charge.State.VoidedAt != nil,
 		Currency:    charge.Intent.Currency.GetCode(),
 		Amount:      charge.Intent.CreditAmount,
 		Name:        charge.Intent.Name,

--- a/openmeter/ledger/customerbalance/funded_loader_test.go
+++ b/openmeter/ledger/customerbalance/funded_loader_test.go
@@ -100,6 +100,43 @@ func TestListCreditTransactionsFundedBalanceCoalescesSameEffectiveTime(t *testin
 	}
 }
 
+func TestListCreditTransactionsFundedMarksVoidedGrant(t *testing.T) {
+	env := newTestEnv(t)
+
+	// given:
+	// - one funded grant has been voided and another remains active
+	voidedCharge := env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(25), env.Currency, nil)
+	activeCharge := env.createPromotionalCreditGrant(t, alpacadecimal.NewFromInt(40), env.Currency, nil)
+	_, err := env.creditPurchase.MarkVoided(t.Context(), creditpurchase.MarkVoidedInput{
+		ChargeID: voidedCharge.GetChargeID(),
+		VoidedAt: clock.Now(),
+	})
+	require.NoError(t, err)
+
+	// when:
+	// - funded transaction history is listed after the void
+	result, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID:    env.CustomerID,
+		Limit:         10,
+		Type:          lo.ToPtr(CreditTransactionTypeFunded),
+		Currency:      &env.Currency,
+		FeatureFilter: AllFeatureFilter(),
+	})
+	require.NoError(t, err)
+
+	// then:
+	// - only the funding backed by the voided grant carries the marker
+	itemsByID := make(map[string]CreditTransaction, len(result.Items))
+	for _, item := range result.Items {
+		itemsByID[item.ID.ID] = item
+	}
+
+	require.Contains(t, itemsByID, voidedCharge.ID)
+	require.True(t, itemsByID[voidedCharge.ID].GrantVoided)
+	require.Contains(t, itemsByID, activeCharge.ID)
+	require.False(t, itemsByID[activeCharge.ID].GrantVoided)
+}
+
 func TestListCreditTransactionsFundedBalanceProjectsFeatureFilteredImpact(t *testing.T) {
 	t.Run("partial projected impact", func(t *testing.T) {
 		env := newTestEnv(t)

--- a/openmeter/ledger/customerbalance/transactions.go
+++ b/openmeter/ledger/customerbalance/transactions.go
@@ -107,6 +107,7 @@ type CreditTransaction struct {
 	CreatedAt   time.Time
 	BookedAt    time.Time
 	Type        CreditTransactionType
+	GrantVoided bool
 	Currency    currencyx.Code
 	Amount      alpacadecimal.Decimal
 	Balance     CreditTransactionBalance


### PR DESCRIPTION
## Summary

- add `voided: "true"` to the labels of funded credit transactions whose backing grant has been voided
- leave the label absent for active grants and non-funded transaction types
- derive the marker from persisted credit-purchase state, so existing funded history needs no new write-time data

## Verification

- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./api/v3/handlers/customers/credits ./openmeter/ledger/customerbalance`
- `go test -C e2e ./... -run "^$"`
- `go vet -tags=dynamic ./api/v3/handlers/customers/credits ./openmeter/ledger/customerbalance`
- `go vet -C e2e ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credit transaction listings now identify funded credits tied to voided grants with a `voided: "true"` label.
  * Transaction documentation now describes the `voided` transaction type and label behavior.

* **Bug Fixes**
  * Transaction details now accurately reflect when an associated credit grant has been voided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR derives whether a funded credit transaction’s backing grant has been voided and exposes that state as a `voided: "true"` API label.
- Adds `GrantVoided` to the customer-balance transaction read model.
- Hydrates the marker from persisted credit-purchase state.
- Restricts the API label to funded transactions.
- Adds unit and end-to-end coverage and documents the response semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security defects identified.

The void state is read from the same persisted credit-purchase charge updated during grant voiding, retained through funded-row reconstruction, and exposed only for funded API transactions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ledger/customerbalance/funded_loader.go | Derives `GrantVoided` from the persisted credit-purchase charge state and preserves it through balance reconstruction. |
| openmeter/ledger/customerbalance/transactions.go | Adds the internal boolean carrying the backing grant’s current void state. |
| api/v3/handlers/customers/credits/convert.go | Emits the voided label only for funded transactions whose backing grant is marked voided. |
| openmeter/ledger/customerbalance/funded_loader_test.go | Verifies that voided and active funded grants receive distinct internal markers. |
| e2e/customer_credits_v3_test.go | Extends the grant-void flow to verify the public transaction labels. |
| openmeter/ledger/customerbalance/README.md | Documents voided transactions and the current-state label on historical funded rows. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Grant[Credit grant] --> Purchase[Persisted credit-purchase charge]
    Void[Grant void operation] -->|sets VoidedAt| Purchase
    Purchase --> Loader[Funded transaction loader]
    Loader -->|GrantVoided| ReadModel[Credit transaction read model]
    ReadModel --> Converter[API converter]
    Converter -->|funded and voided| Label[voided: true label]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ledger): label voided funded transa..."](https://github.com/openmeterio/openmeter/commit/9d62957f87d5dc9117aeb002c3d784e4b5eb5c13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59935148)</sub>

<!-- /greptile_comment -->