### PR TITLE
feat(billing): add validation message wrapper

### DIFF
--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -175,19 +175,22 @@ func (e ErrSnapshotFeatureHasNoMeter) Error() string {
 	return fmt.Sprintf("snapshotting line quantity: feature[%s] has no meter associated", e.FeatureKey)
 }
 
-// AsValidationIssue returns the critical invoice issue that represents the
-// missing meter association without exposing it as an operational failure.
-func (e ErrSnapshotFeatureHasNoMeter) AsValidationIssue() ValidationIssue {
-	issue := ValidationIssue{
-		Severity:  ValidationIssueSeverityCritical,
-		Code:      ErrInvoiceLineFeatureHasNoMeters.Code,
-		Message:   fmt.Sprintf("feature[%s] has no meter associated", e.FeatureKey),
-		Component: ValidationComponentOpenMeterMetering,
-	}
+// AsValidationIssue returns the critical invoice issue that represents the missing meter
+// association without exposing it as an operational failure. The wrappers preserve the canonical
+// issue for errors.Is while adding the feature and line context used by invoice validation.
+func (e ErrSnapshotFeatureHasNoMeter) AsValidationIssue() error {
+	err := ValidationWithComponent(
+		ValidationComponentOpenMeterMetering,
+		ValidationWithMessagef(
+			ErrInvoiceLineFeatureHasNoMeters,
+			"feature[%s]",
+			e.FeatureKey,
+		),
+	)
 
 	if e.LineID != "" {
-		issue.Path = fmt.Sprintf("lines/%s", e.LineID)
+		err = ValidationWithFieldPrefix(fmt.Sprintf("lines/%s", e.LineID), err)
 	}
 
-	return issue
+	return err
 }

--- a/openmeter/billing/lineengine/engine_test.go
+++ b/openmeter/billing/lineengine/engine_test.go
@@ -41,8 +41,11 @@ func TestSnapshotValidationIssueClassification(t *testing.T) {
 	}
 
 	t.Run("converts a validation-only error tree", func(t *testing.T) {
+		firstValidationErr := firstErr.AsValidationIssue()
+		require.ErrorIs(t, firstValidationErr, billing.ErrInvoiceLineFeatureHasNoMeters)
+
 		issues, systemErr := billing.ToValidationIssues(errors.Join(
-			fmt.Errorf("snapshot first: %w", firstErr.AsValidationIssue()),
+			fmt.Errorf("snapshot first: %w", firstValidationErr),
 			secondErr.AsValidationIssue(),
 		))
 
@@ -51,14 +54,14 @@ func TestSnapshotValidationIssueClassification(t *testing.T) {
 			{
 				Severity:  billing.ValidationIssueSeverityCritical,
 				Code:      billing.ErrInvoiceLineFeatureHasNoMeters.Code,
-				Message:   "feature[first] has no meter associated",
+				Message:   "feature[first]: usage based invoice line: feature has no meters",
 				Component: billing.ValidationComponentOpenMeterMetering,
 				Path:      "/lines/line-1",
 			},
 			{
 				Severity:  billing.ValidationIssueSeverityCritical,
 				Code:      billing.ErrInvoiceLineFeatureHasNoMeters.Code,
-				Message:   "feature[second] has no meter associated",
+				Message:   "feature[second]: usage based invoice line: feature has no meters",
 				Component: billing.ValidationComponentOpenMeterMetering,
 				Path:      "/lines/line-2",
 			},

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -115,6 +115,34 @@ func ValidationWithComponent(component ComponentName, err error) error {
 	}
 }
 
+type messageWrapper struct {
+	prefix string
+	err    error
+}
+
+func (m messageWrapper) Error() string {
+	return m.prefix + ": " + m.err.Error()
+}
+
+func (m messageWrapper) Unwrap() error {
+	return m.err
+}
+
+// ValidationWithMessagef wraps an error with formatted context, if error is nil, it returns nil.
+// Unlike component and field wrappers, message context does not classify an ordinary error as a
+// validation issue. When the wrapped error contains validation issues, the context is added to each
+// extracted issue's message.
+func ValidationWithMessagef(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+
+	return messageWrapper{
+		prefix: fmt.Sprintf(format, args...),
+		err:    err,
+	}
+}
+
 type fieldPrefixWrapper struct {
 	prefix string
 	err    error
@@ -154,7 +182,7 @@ func ToValidationIssues(errIn error) (ValidationIssues, error) {
 		return nil, nil
 	}
 
-	issues, err := toValidationIssue(errIn, "", "", false)
+	issues, err := toValidationIssue(errIn, "", "", "", false)
 	if err != nil {
 		return nil, errIn
 	}
@@ -223,7 +251,15 @@ func appendToPrefix(prefix string, field string) string {
 	return addStartingSlashIfNeeded(prefix + "/" + field)
 }
 
-func toValidationIssue(err error, fieldPrefix string, component ComponentName, unknownAsValidationIssue bool) ([]ValidationIssue, error) {
+func appendMessagePrefix(prefix string, message string) string {
+	if prefix == "" {
+		return message
+	}
+
+	return prefix + ": " + message
+}
+
+func toValidationIssue(err error, fieldPrefix string, component ComponentName, messagePrefix string, unknownAsValidationIssue bool) ([]ValidationIssue, error) {
 	if err == nil {
 		return nil, nil
 	}
@@ -232,9 +268,11 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, u
 	// ordering is non-deterministic, we first have a typeswitch for the special cases)
 	switch errT := err.(type) {
 	case componentWrapper:
-		return toValidationIssue(errT.err, fieldPrefix, errT.component, true)
+		return toValidationIssue(errT.err, fieldPrefix, errT.component, messagePrefix, true)
 	case fieldPrefixWrapper:
-		return toValidationIssue(errT.err, appendToPrefix(fieldPrefix, errT.prefix), component, true)
+		return toValidationIssue(errT.err, appendToPrefix(fieldPrefix, errT.prefix), component, messagePrefix, true)
+	case messageWrapper:
+		return toValidationIssue(errT.err, fieldPrefix, component, appendMessagePrefix(messagePrefix, errT.prefix), unknownAsValidationIssue)
 	case ValidationIssue:
 		issueComponent := component
 		if issueComponent == "" {
@@ -244,7 +282,7 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, u
 		return []ValidationIssue{
 			{
 				Severity:  errT.Severity,
-				Message:   errT.Message,
+				Message:   appendMessagePrefix(messagePrefix, errT.Message),
 				Code:      errT.Code,
 				Path:      appendToPrefix(fieldPrefix, errT.Path),
 				Component: issueComponent,
@@ -256,7 +294,7 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, u
 	case errorsUnwrap:
 		var issues []ValidationIssue
 		for _, e := range errT.Unwrap() {
-			out, err := toValidationIssue(e, fieldPrefix, component, unknownAsValidationIssue)
+			out, err := toValidationIssue(e, fieldPrefix, component, messagePrefix, unknownAsValidationIssue)
 			if err != nil {
 				return nil, err
 			}
@@ -267,14 +305,14 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, u
 
 		return issues, nil
 	case errorUnwrap:
-		return toValidationIssue(errT.Unwrap(), fieldPrefix, component, unknownAsValidationIssue)
+		return toValidationIssue(errT.Unwrap(), fieldPrefix, component, messagePrefix, unknownAsValidationIssue)
 	default:
 		// Non-validation errors get coded as critical
 		if unknownAsValidationIssue {
 			return []ValidationIssue{
 				{
 					Severity:  ValidationIssueSeverityCritical,
-					Message:   err.Error(),
+					Message:   appendMessagePrefix(messagePrefix, err.Error()),
 					Path:      fieldPrefix,
 					Component: component,
 				},

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -102,8 +102,9 @@ func (c componentWrapper) Unwrap() error {
 	return c.err
 }
 
-// ValidationWithComponent wraps an error with a component name, if error is nil, it returns nil
-// This can be used to add context to an error when we are crossing service boundaries.
+// ValidationWithComponent wraps an error with a component name, if error is nil, it returns nil.
+// This can be used to add context to an error when we are crossing service boundaries. When
+// wrappers are nested, the outermost service boundary defines the extracted issue's component.
 func ValidationWithComponent(component ComponentName, err error) error {
 	if err == nil {
 		return nil
@@ -268,7 +269,12 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, m
 	// ordering is non-deterministic, we first have a typeswitch for the special cases)
 	switch errT := err.(type) {
 	case componentWrapper:
-		return toValidationIssue(errT.err, fieldPrefix, errT.component, messagePrefix, true)
+		issueComponent := component
+		if issueComponent == "" {
+			issueComponent = errT.component
+		}
+
+		return toValidationIssue(errT.err, fieldPrefix, issueComponent, messagePrefix, true)
 	case fieldPrefixWrapper:
 		return toValidationIssue(errT.err, appendToPrefix(fieldPrefix, errT.prefix), component, messagePrefix, true)
 	case messageWrapper:

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -68,6 +68,32 @@ func TestValidationIssueParsing(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidationWithComponentPrecedence(t *testing.T) {
+	baseIssue := ValidationIssue{
+		Severity:  ValidationIssueSeverityWarning,
+		Message:   "canonical message",
+		Code:      "canonical_code",
+		Component: "issue-component",
+		Path:      "original/path",
+	}
+	err := ValidationWithComponent(
+		"outer-component",
+		ValidationWithComponent("inner-component", baseIssue),
+	)
+
+	issues, systemErr := ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, ValidationIssues{
+		{
+			Severity:  baseIssue.Severity,
+			Message:   baseIssue.Message,
+			Code:      baseIssue.Code,
+			Component: "outer-component",
+			Path:      "/original/path",
+		},
+	}, issues)
+}
+
 func TestAsError(t *testing.T) {
 	issues := ValidationIssues{
 		{

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -84,3 +84,95 @@ func TestAsError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, issues, validationIssues)
 }
+
+func TestValidationWithMessagef(t *testing.T) {
+	baseIssue := ValidationIssue{
+		Severity:  ValidationIssueSeverityWarning,
+		Message:   "canonical message",
+		Code:      "canonical_code",
+		Component: "original-component",
+		Path:      "original/path",
+	}
+
+	t.Run("adds formatted context and preserves error identity", func(t *testing.T) {
+		err := ValidationWithMessagef(baseIssue, "feature[%s]", "requests")
+
+		require.EqualError(t, err, "feature[requests]: canonical message")
+		require.ErrorIs(t, err, baseIssue)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, ValidationIssues{
+			{
+				Severity:  baseIssue.Severity,
+				Message:   "feature[requests]: canonical message",
+				Code:      baseIssue.Code,
+				Component: baseIssue.Component,
+				Path:      "/original/path",
+			},
+		}, issues)
+	})
+
+	t.Run("composes nested message component and field context", func(t *testing.T) {
+		err := ValidationWithMessagef(
+			ValidationWithComponent(
+				"outer-component",
+				ValidationWithFieldPrefix(
+					"lines/line-1",
+					ValidationWithMessagef(baseIssue, "inner[%d]", 42),
+				),
+			),
+			"outer",
+		)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, ValidationIssues{
+			{
+				Severity:  baseIssue.Severity,
+				Message:   "outer: inner[42]: canonical message",
+				Code:      baseIssue.Code,
+				Component: "outer-component",
+				Path:      "/lines/line-1/original/path",
+			},
+		}, issues)
+	})
+
+	t.Run("prefixes every validation issue in a joined error", func(t *testing.T) {
+		secondIssue := NewValidationError("second_code", "second message")
+		err := ValidationWithMessagef(errors.Join(baseIssue, secondIssue), "shared context")
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, ValidationIssues{
+			{
+				Severity:  baseIssue.Severity,
+				Message:   "shared context: canonical message",
+				Code:      baseIssue.Code,
+				Component: baseIssue.Component,
+				Path:      "/original/path",
+			},
+			{
+				Severity: secondIssue.Severity,
+				Message:  "shared context: second message",
+				Code:     secondIssue.Code,
+			},
+		}, issues)
+	})
+
+	t.Run("does not promote a system error", func(t *testing.T) {
+		systemErr := errors.New("database unavailable")
+		err := ValidationWithMessagef(systemErr, "loading invoice[%s]", "invoice-1")
+
+		require.EqualError(t, err, "loading invoice[invoice-1]: database unavailable")
+		require.ErrorIs(t, err, systemErr)
+
+		issues, extractionErr := ToValidationIssues(err)
+		require.Nil(t, issues)
+		require.Equal(t, err, extractionErr)
+	})
+
+	t.Run("returns nil for a nil error", func(t *testing.T) {
+		require.NoError(t, ValidationWithMessagef(nil, "unused %s", "context"))
+	})
+}

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -4753,7 +4753,7 @@ func (s *InvoicingTestSuite) TestSnapshotQuantityInvalidDatabaseState() {
 		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
 		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeInvoice), issue.Component)
 		s.Equal(fmt.Sprintf("/lines/%s", pendingLineID), issue.Path)
-		s.Contains(issue.Message, "feature[snapshot-feature] has no meter associated")
+		s.Equal("feature[snapshot-feature]: usage based invoice line: feature has no meters", issue.Message)
 
 		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),


### PR DESCRIPTION
## Summary

- add a printf-style validation message wrapper that preserves Go error chains
- recursively prefix extracted validation issue messages, including joined and nested errors
- use the wrapper for missing feature-meter snapshot validation while preserving validation identity and line ownership

## Testing

- go test -tags=dynamic -count=1 ./openmeter/billing ./openmeter/billing/lineengine
- go test -tags=dynamic -count=1 ./test/billing -run TestInvoicing/TestSnapshotQuantityInvalidDatabaseState
- go vet -tags=dynamic ./openmeter/billing ./openmeter/billing/lineengine ./test/billing
- golangci-lint fmt -v -d on changed files
- golangci-lint run -v ./openmeter/billing ./openmeter/billing/lineengine ./test/billing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation error reporting for features without meters.
  - Validation messages now provide clearer context, including the affected feature and usage-based invoice line.
  - Preserved issue classification and location details for more reliable error handling.
  - Improved consistency when reporting nested or combined validation errors.
  - Prevented non-validation system errors from being incorrectly classified as validation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a printf-style validation-message wrapper that preserves Go error chains and propagates context through nested and joined validation errors.
- Converts missing feature-meter snapshot failures into wrapped canonical validation errors with feature, component, and line context.
- Defines outermost-component precedence for nested validation boundaries.
- Adds unit and integration coverage for error identity, recursive message prefixes, metadata extraction, and invoice retry behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/validationissue.go | Adds recursive message-context extraction and makes the outermost validation component authoritative. |
| openmeter/billing/errors.go | Rebuilds missing-meter snapshot validation from composable wrappers while preserving canonical error identity. |
| openmeter/billing/validationissue_test.go | Covers formatting, nested and joined errors, component precedence, identity preservation, and system-error classification. |
| openmeter/billing/lineengine/engine_test.go | Verifies snapshot failures retain canonical identity and extract expected line-scoped validation metadata. |
| test/billing/invoice_test.go | Updates the invoice lifecycle integration expectation for the contextualized missing-meter message. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Snapshot[Missing feature meter during snapshot] --> Canonical[Canonical validation error]
  Canonical --> Message[Add feature message context]
  Message --> Component[Add metering component]
  Component --> Field[Add invoice line path]
  Field --> Extract[Extract validation issue]
  Extract --> Invoice[Persist issue on invalid invoice]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): preserve outer validation ..."](https://github.com/openmeterio/openmeter/commit/94d6649845df4c852268ede1db92e30a22c61603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59935510)</sub>

<!-- /greptile_comment -->