### PR TITLE
fix(billing): retry invalid invoice creation hooks

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -106,8 +106,11 @@ After a standard invoice and its lines are persisted, billing always invokes
 each line engine's invoice-created hook. An engine may return usable lines
 together with validation issues; billing accepts those lines, records the
 issues, and continues creation into `draft.invalid_created`. Operational errors
-still abort creation and make returned lines unusable. Missing-feature lines
-are not collected progressively before their normal due time.
+still abort creation and make returned lines unusable. Retry re-enters
+`draft.created` and replays charge hooks that previously reported a missing
+feature, allowing repaired data to complete the charge lifecycle without
+replaying hooks that already succeeded. Missing-feature lines are not collected
+progressively before their normal due time.
 
 If quantity snapshotting discovers that a persisted feature no longer has its
 required meter association, collection still materializes the standard invoice

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -45,7 +45,7 @@ projection. The type-specific detailed status is the lifecycle state.
 - Invoice-created hooks preflight every line's feature reference before charge
   lifecycle effects. A missing feature returns the unchanged usable lines with
   line-scoped validation issues, allowing billing to persist the invoice as
-  `draft.invalid_created`.
+  `draft.invalid_created`; retry replays only the affected charge hook.
 - [Ledger charge adapters](../../ledger/README.md) translate requested economic
   effects into ledger transactions. They do not decide when a charge advances.
 - [Subscription sync](../worker/subscriptionsync/README.md) reconciles

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -923,13 +924,99 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 		}
 	}
 
-	for _, grouped := range groupedStandardLines {
+	return s.invokeOnStandardInvoiceCreatedForGroups(ctx, invokeOnStandardInvoiceCreatedForGroupsInput{
+		Invoice:              invoice,
+		FeatureMeters:        featureMeters,
+		GroupedStandardLines: groupedStandardLines,
+	})
+}
+
+// retryOnStandardInvoiceCreatedForMissingFeatures replays only charge hooks
+// whose missing-feature issue was downgraded by RetryInvoice. Initial creation
+// issues are critical, so entering draft.created for the first time never
+// invokes a charge hook twice.
+func (s *Service) retryOnStandardInvoiceCreatedForMissingFeatures(ctx context.Context, invoice billing.StandardInvoice) (billing.StandardInvoice, error) {
+	groupedStandardLines, err := s.lineEngines.groupStandardLinesByEngine(invoice.Lines.OrEmpty())
+	if err != nil {
+		return billing.StandardInvoice{}, fmt.Errorf("grouping standard lines by engine: %w", err)
+	}
+
+	groupedStandardLines = lo.Filter(groupedStandardLines, func(grouped StandardLinesWithEngine, _ int) bool {
+		return hasRetryableStandardInvoiceCreatedFeatureIssue(invoice, grouped.Engine.GetLineEngineType())
+	})
+	if len(groupedStandardLines) == 0 {
+		return invoice, nil
+	}
+
+	featureMeters, err := s.featureMeterResolver.Resolve(ctx, invoice.Namespace, invoice.Lines.OrEmpty()...)
+	if err != nil {
+		_, systemErr := billing.ToValidationIssues(err)
+		if systemErr != nil {
+			return billing.StandardInvoice{}, fmt.Errorf("resolving feature meters: %w", systemErr)
+		}
+	}
+
+	return s.invokeOnStandardInvoiceCreatedForGroups(ctx, invokeOnStandardInvoiceCreatedForGroupsInput{
+		Invoice:                 invoice,
+		FeatureMeters:           featureMeters,
+		GroupedStandardLines:    groupedStandardLines,
+		ReplaceValidationIssues: true,
+	})
+}
+
+func hasRetryableStandardInvoiceCreatedFeatureIssue(invoice billing.StandardInvoice, engineType billing.LineEngineType) bool {
+	if !engineType.IsCharge() {
+		return false
+	}
+
+	component := billing.LineEngineValidationComponent(engineType)
+	return lo.ContainsBy(invoice.ValidationIssues, func(issue billing.ValidationIssue) bool {
+		return issue.Severity == billing.ValidationIssueSeverityWarning &&
+			issue.Code == billing.ErrInvoiceLineFeatureNotFound.Code &&
+			issue.Component == component
+	})
+}
+
+type invokeOnStandardInvoiceCreatedForGroupsInput struct {
+	Invoice                 billing.StandardInvoice
+	FeatureMeters           billingfeaturemeter.FeatureMeters
+	GroupedStandardLines    []StandardLinesWithEngine
+	ReplaceValidationIssues bool
+}
+
+var _ models.Validator = invokeOnStandardInvoiceCreatedForGroupsInput{}
+
+func (i invokeOnStandardInvoiceCreatedForGroupsInput) Validate() error {
+	var errs []error
+
+	if i.Invoice.ID == "" {
+		errs = append(errs, errors.New("invoice ID is required"))
+	}
+
+	if i.FeatureMeters == nil {
+		errs = append(errs, errors.New("feature meters are required"))
+	}
+
+	if len(i.GroupedStandardLines) == 0 {
+		errs = append(errs, errors.New("grouped standard lines are required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (s *Service) invokeOnStandardInvoiceCreatedForGroups(ctx context.Context, in invokeOnStandardInvoiceCreatedForGroupsInput) (billing.StandardInvoice, error) {
+	if err := in.Validate(); err != nil {
+		return billing.StandardInvoice{}, fmt.Errorf("validating standard invoice created groups input: %w", err)
+	}
+
+	invoice := in.Invoice
+	for _, grouped := range in.GroupedStandardLines {
 		input := billing.OnStandardInvoiceCreatedInput{
 			StandardLineEventInput: billing.StandardLineEventInput{
 				Invoice: invoice,
 				Lines:   grouped.Lines,
 			},
-			FeatureMeters: featureMeters,
+			FeatureMeters: in.FeatureMeters,
 		}
 		if err := input.Validate(); err != nil {
 			return billing.StandardInvoice{}, fmt.Errorf("validating standard invoice created input for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
@@ -952,17 +1039,19 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 			return billing.StandardInvoice{}, fmt.Errorf("replacing standard invoice created lines for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
 		}
 
-		if len(validationIssues) == 0 {
+		if len(validationIssues) == 0 && !in.ReplaceValidationIssues {
 			continue
 		}
 
 		component := billing.LineEngineValidationComponent(grouped.Engine.GetLineEngineType())
-		validationIssues = append(
-			lo.Filter(invoice.ValidationIssues, func(issue billing.ValidationIssue, _ int) bool {
-				return issue.Component == component
-			}),
-			validationIssues...,
-		)
+		if !in.ReplaceValidationIssues {
+			validationIssues = append(
+				lo.Filter(invoice.ValidationIssues, func(issue billing.ValidationIssue, _ int) bool {
+					return issue.Component == component
+				}),
+				validationIssues...,
+			)
+		}
 
 		if err := invoice.MergeValidationIssues(
 			billing.NewLineEngineValidationError(grouped.Engine, validationIssues.AsError()),

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -88,6 +88,7 @@ func allocateStateMachine() *InvoiceStateMachine {
 		Permit(billing.TriggerDelete, billing.StandardInvoiceStatusDeleteInProgress).
 		Permit(billing.TriggerUpdated, billing.StandardInvoiceStatusDraftUpdating).
 		OnActive(statelessx.AllOf(
+			out.retryOnStandardInvoiceCreatedForMissingFeatures,
 			out.calculateInvoice,
 			out.requireDBSave, // so that any new detailed lines have IDs
 		))
@@ -772,6 +773,17 @@ func (m *InvoiceStateMachine) validateDraftInvoice(ctx context.Context) error {
 
 		return nil, app.ValidateStandardInvoice(ctx, clonedInvoice)
 	})
+}
+
+func (m *InvoiceStateMachine) retryOnStandardInvoiceCreatedForMissingFeatures(ctx context.Context) error {
+	invoice, err := m.Service.retryOnStandardInvoiceCreatedForMissingFeatures(ctx, m.Invoice)
+	if err != nil {
+		return err
+	}
+
+	m.Invoice = invoice
+
+	return nil
 }
 
 func (m *InvoiceStateMachine) calculateInvoice(ctx context.Context) error {

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -458,12 +458,13 @@ func (s *LineEngineTestSuite) TestGatheringPreviewUsesPreviewLineEngineCallback(
 	s.Equal("preview callback line", previewInvoice.Lines.OrEmpty()[0].Name)
 }
 
-func (s *LineEngineTestSuite) TestStandardInvoiceCreatedValidationIssuesPreserveLines() {
+func (s *LineEngineTestSuite) TestStandardInvoiceCreatedValidationIssuesPreserveLinesAndRetryHook() {
 	var (
 		ctx        = s.T().Context()
 		namespace  = s.GetUniqueNamespace("ns-line-engine-standard-invoice-created-validation")
 		mockEngine = &mockCollectionCompletedLineEngine{engineType: ombilling.LineEngineTypeChargeCreditPurchase}
 		invoice    ombilling.StandardInvoice
+		repaired   bool
 		hookCalls  int
 	)
 
@@ -481,16 +482,22 @@ func (s *LineEngineTestSuite) TestStandardInvoiceCreatedValidationIssuesPreserve
 		s.Require().NotNil(input.FeatureMeters)
 		s.Require().True(input.FeatureMeters.Has(input.Lines[0]))
 
-		input.Lines[0].Name = "usable line with creation issue"
+		if !repaired {
+			input.Lines[0].Name = "usable line with creation issue"
 
-		return input.Lines, ombilling.ValidationWithFieldPrefix(
-			fmt.Sprintf("lines/%s", input.Lines[0].ID),
-			ombilling.ValidationWithMessagef(
-				ombilling.ErrInvoiceLineFeatureNotFound,
-				"feature[%s]",
-				input.Lines[0].GetFeatureKey(),
-			),
-		)
+			return input.Lines, ombilling.ValidationWithFieldPrefix(
+				fmt.Sprintf("lines/%s", input.Lines[0].ID),
+				ombilling.ValidationWithMessagef(
+					ombilling.ErrInvoiceLineFeatureNotFound,
+					"feature[%s]",
+					input.Lines[0].GetFeatureKey(),
+				),
+			)
+		}
+
+		input.Lines[0].Name = "repaired line"
+
+		return input.Lines, nil
 	}
 
 	s.Run("Given an invoice-created hook returns usable lines with a validation issue", func() {
@@ -513,6 +520,35 @@ func (s *LineEngineTestSuite) TestStandardInvoiceCreatedValidationIssuesPreserve
 		s.Equal(ombilling.ErrInvoiceLineFeatureNotFound.Code, invoice.ValidationIssues[0].Code)
 		s.Equal(ombilling.ValidationIssueSeverityCritical, invoice.ValidationIssues[0].Severity)
 		s.Equal(ombilling.LineEngineValidationComponent(mockEngine.GetLineEngineType()), invoice.ValidationIssues[0].Component)
+	})
+
+	s.Run("When retry runs while the inconsistency remains", func() {
+		var err error
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+	})
+
+	s.Run("Then draft.created replays the hook and returns to draft.invalid_created", func() {
+		s.Equal(2, hookCalls)
+		s.Equal(ombilling.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.Require().Len(invoice.ValidationIssues, 1)
+		s.Equal(ombilling.ValidationIssueSeverityCritical, invoice.ValidationIssues[0].Severity)
+	})
+
+	s.Run("When retry runs after the inconsistency is repaired", func() {
+		repaired = true
+
+		var err error
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+		s.Require().NoError(err)
+	})
+
+	s.Run("Then the hook succeeds and the invoice leaves the failure state", func() {
+		s.Equal(3, hookCalls)
+		s.Equal(ombilling.StandardInvoiceStatusDraftWaitingForCollection, invoice.Status)
+		s.Empty(invoice.ValidationIssues)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		s.Equal("repaired line", invoice.Lines.OrEmpty()[0].Name)
 	})
 }
 


### PR DESCRIPTION
## Summary

- replay affected charge invoice-created hooks when retrying draft.invalid_created invoices
- preserve hooks that already completed successfully
- allow repaired feature references to complete charge lifecycle processing

## Stack

- Base: feature-meter refactor (#5063)
- Parent: gathering invalid creation (#5065)
- This PR: retry handling for the invalid state

No Jira ticket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replays charge invoice-created hooks when retrying invoices in `draft.invalid_created`, replacing stale hook validation issues while preserving successfully completed engine groups.

- Filters retries to charge-engine components carrying downgraded missing-feature issues.
- Integrates replay into activation of `draft.created` before invoice recalculation.
- Adds lifecycle coverage for repeated failure and successful repair.
- Documents the retry behavior in the billing and charge subsystem guides.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking test-structure issue to address.

The retry implementation targets charge-engine groups carrying downgraded missing-feature issues, clears or refreshes their validation results, and leaves completed engine groups untouched; the remaining concern is limited to required test intent comments.

**Files Needing Attention:** test/billing/lineengine_test.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/service/gatheringinvoicependinglines.go | Extracts grouped invoice-created hook invocation and adds targeted replay for charge engines carrying retryable missing-feature issues. |
| openmeter/billing/service/stdinvoicestate.go | Runs the targeted hook replay when entering `draft.created`, before recalculation and persistence. |
| test/billing/lineengine_test.go | Extends lifecycle coverage through failed and repaired retries, but omits required given/when/then intent comments. |
| openmeter/billing/README.md | Documents replay of affected charge hooks while preserving previously successful hooks. |
| openmeter/billing/charges/README.md | Documents targeted retry behavior for charge invoice-created hooks. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[draft.invalid_created] -->|RetryInvoice downgrades issues| B[draft.created]
    B --> C{Charge engine has missing-feature warning?}
    C -->|No| D[Preserve completed hook]
    C -->|Yes| E[Resolve feature meters]
    E --> F[Replay invoice-created hook]
    F --> G[Replace engine validation issues]
    D --> H[Recalculate invoice]
    G --> H
    H --> I{Critical issues remain?}
    I -->|Yes| A
    I -->|No| J[draft.waiting_for_collection]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235066%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5066&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atest%2Fbilling%2Flineengine_test.go%3A524%0A**Retry%20subtests%20omit%20intent%20comments**%0A%0AThe%20added%20stateful%20retry%20subtests%20lack%20the%20required%20given%2Fwhen%2Fthen%20intent%20comments%2C%20making%20their%20lifecycle%20setup%2C%20actions%2C%20and%20expected%20transitions%20harder%20to%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5066&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fbilling-invalid-created-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fbilling-invalid-created-retry%22.%0A%0A%23%23%23%20Issue%201%0Atest%2Fbilling%2Flineengine_test.go%3A524%0A**Retry%20subtests%20omit%20intent%20comments**%0A%0AThe%20added%20stateful%20retry%20subtests%20lack%20the%20required%20given%2Fwhen%2Fthen%20intent%20comments%2C%20making%20their%20lifecycle%20setup%2C%20actions%2C%20and%20expected%20transitions%20harder%20to%20maintain.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5066&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/billing/lineengine_test.go:524
**Retry subtests omit intent comments**

The added stateful retry subtests lack the required given/when/then intent comments, making their lifecycle setup, actions, and expected transitions harder to maintain.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): retry invalid invoice crea..."](https://github.com/openmeterio/openmeter/commit/8903fbd68b6911a5342226bb234ee40a883c4731) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59984084)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/openmeterio/openmeter/blob/main/AGENTS.md))

<!-- /greptile_comment -->