### PR TITLE
ci: benchmark Nix Go with Depot cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,14 +234,6 @@ jobs:
           primary-key: ${{ needs.cache-rebuild.outputs.cache-key }}
           save: "false"
 
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
-
       - name: Validate Nix flake
         run: nix flake check --impure
 
@@ -266,10 +258,11 @@ jobs:
           mkdir -p \
             "$GITHUB_WORKSPACE/.tmp/go-work" \
             "$GITHUB_WORKSPACE/.tmp/system"
-          env \
+          nix develop --impure .#ci -c env \
+            -u GOCACHE \
             GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
             TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            nix develop --impure .#ci -c make -j 4 build
+            make -j 4 build
 
       - name: Validate commit messages
         run: |
@@ -670,32 +663,18 @@ jobs:
       - name: Upsert Nix store
         run: nix develop --impure .#ci
 
-      - name: Restore Go module cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-openmeter-go-modules-${{ hashFiles('go.*', 'collector/go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-modules-
+      - name: Verify Depot Go cache
+        run: |
+          cache_program="$(nix develop --impure .#ci -c env -u GOCACHE go env GOCACHEPROG)"
 
-      # PR merge commits change on every update, so use the target commit to
-      # keep unchanged package analysis reusable across the pull request. Bind
-      # every fallback to the Nix cache selected above because this cache also
-      # holds Go linker results with toolchain-specific Nix store paths.
-      - name: Go lint caches
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            .devenv/golangci-lint-cache
-            .devenv/state/go/build-cache
-          key: ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-${{ github.event.pull_request.base.sha || github.sha }}-${{ hashFiles('.golangci*.yaml', 'go.*', 'api/v3/client/go.*', 'e2e/go.*') }}
-          restore-keys: |
-            ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-${{ github.event.pull_request.base.sha || github.sha }}-
-            ${{ runner.os }}-openmeter-go-lint-${{ needs.cache-rebuild.outputs.cache-key }}-
+          if [[ "${cache_program}" != *"depot gocache"* ]]; then
+            echo "Depot Go cache is unavailable inside the Nix CI shell"
+            exit 1
+          fi
+
+          echo "Using ${cache_program}"
 
       - name: Run linters - go
-        env:
-          GOLANGCI_LINT_CACHE: ${{ github.workspace }}/.devenv/golangci-lint-cache
         run: |
           # On Depot runners, golangci-lint still uses Go/system temp space for
           # transient analysis artifacts. Keep those temp files on the workspace
@@ -703,10 +682,13 @@ jobs:
           mkdir -p \
             "$GITHUB_WORKSPACE/.tmp/go-work" \
             "$GITHUB_WORKSPACE/.tmp/system"
-          env \
+          # Keep the worktree-local Nix cache for development, but use the
+          # ephemeral runner's default local cache alongside Depot in CI.
+          nix develop --impure .#ci -c env \
+            -u GOCACHE \
             GOTMPDIR="$GITHUB_WORKSPACE/.tmp/go-work" \
             TMPDIR="$GITHUB_WORKSPACE/.tmp/system" \
-            nix develop --impure .#ci -c make lint-go
+            make lint-go
 
       - name: Run linters - api spec
         run: |


### PR DESCRIPTION
Disposable benchmark PR; expected to be closed after measurements.\n\n- Keeps the existing Nix build and lint toolchain.\n- Uses the Depot runner-provided Go cache program.\n- Lets the runner select its default local Go cache directory instead of the Nix worktree override.\n- Removes Go module and GolangCI-Lint archive cache restores for build and lint.\n- Leaves flake.nix unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This disposable CI benchmark replaces the build and lint jobs' restored Go caches with Depot's runner-provided Go cache while retaining the Nix toolchain and store cache.
- Removes Go module and GolangCI-Lint archive-cache restores from build and lint.
- Unsets the Nix shell's worktree-local GOCACHE for build and Go lint.
- Adds a lint preflight check for the Depot GOCACHEPROG configuration.

<h3>Confidence Score: 4/5</h3>

The cache benchmark should not be merged without preserving runtime-linker partitioning or validating the actual Depot-backed cache used by build and lint.

Build and lint now bypass the cache namespace specifically designed to prevent Go from reusing link outputs across Nix runtime-loader generations, while the existing loader probe still checks a different cache.

**Files Needing Attention:** .github/workflows/ci.yaml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | The cache benchmark is narrowly scoped, but bypassing the runtime-linker-keyed GOCACHE can reuse stale Nix-linked outputs. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235071%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5071&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yaml%3A262%0A**Runtime%20linker%20cache%20isolation%20lost**%0A%0AIf%20Depot%20retains%20Go%20action-cache%20entries%20across%20Nixpkgs%20generations%2C%20unsetting%20%60GOCACHE%60%20lets%20build%20and%20lint%20reuse%20link%20outputs%20whose%20keys%20omit%20the%20Nix%20runtime-loader%20identity%2C%20causing%20binaries%20to%20reference%20a%20stale%20Nix-store%20interpreter.%20The%20existing%20loader%20probe%20cannot%20catch%20this%20because%20it%20checks%20the%20separate%20Nix-keyed%20cache%20rather%20than%20the%20cache%20used%20by%20these%20steps.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5071&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fci-benchmark-nix-depot-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fci-benchmark-nix-depot-cache%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fci.yaml%3A262%0A**Runtime%20linker%20cache%20isolation%20lost**%0A%0AIf%20Depot%20retains%20Go%20action-cache%20entries%20across%20Nixpkgs%20generations%2C%20unsetting%20%60GOCACHE%60%20lets%20build%20and%20lint%20reuse%20link%20outputs%20whose%20keys%20omit%20the%20Nix%20runtime-loader%20identity%2C%20causing%20binaries%20to%20reference%20a%20stale%20Nix-store%20interpreter.%20The%20existing%20loader%20probe%20cannot%20catch%20this%20because%20it%20checks%20the%20separate%20Nix-keyed%20cache%20rather%20than%20the%20cache%20used%20by%20these%20steps.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5071&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/ci.yaml:262
**Runtime linker cache isolation lost**

If Depot retains Go action-cache entries across Nixpkgs generations, unsetting `GOCACHE` lets build and lint reuse link outputs whose keys omit the Nix runtime-loader identity, causing binaries to reference a stale Nix-store interpreter. The existing loader probe cannot catch this because it checks the separate Nix-keyed cache rather than the cache used by these steps.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: benchmark nix with depot go cache"](https://github.com/openmeterio/openmeter/commit/51ecd2d5f0dae9f0a8be3caa0dbcd507d67d23ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60036372)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->