### PR TITLE
ci: establish Depot benchmark control

### DIFF
--- a/.github/ci-benchmark-control.md
+++ b/.github/ci-benchmark-control.md
@@ -1,0 +1,6 @@
+# CI benchmark control
+
+This branch intentionally preserves the CI configuration from `origin/main`.
+The documentation-only change exists to trigger repeatable pull-request runs
+for comparison with the Depot CI optimization candidate and is not intended to
+be merged.


### PR DESCRIPTION
## Summary

- preserve the CI configuration from origin/main
- add a documentation-only marker to trigger repeatable pull-request runs
- serve as the behaviorally unchanged control for Depot lead-time and cost measurements

This PR is for measurement only and is not intended to be merged.

## Validation

- GitHub Actions only; no local validation
- at least three complete CI runs will be measured

## Jira

No Jira ticket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a documentation-only marker to trigger repeatable CI runs while preserving the existing CI configuration as a Depot benchmark control.
- Adds `.github/ci-benchmark-control.md`.
- Documents the control branch’s measurement purpose and non-merge intent.

<h3>Confidence Score: 5/5</h3>

The PR appears safe for its stated measurement-only purpose, with no actionable defects identified.

The sole change adds documentation and does not modify CI configuration, runtime behavior, security boundaries, or public contracts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/ci-benchmark-control.md | Adds a concise, documentation-only CI benchmark marker without changing runtime or workflow behavior. |

<sub>Reviews (1): Last reviewed commit: ["ci: add depot benchmark control"](https://github.com/openmeterio/openmeter/commit/de1c3de92d004e24f7c61e6cfa2efb4643400305) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60112263)</sub>

<!-- /greptile_comment -->