### PR TITLE
refactor(billing): make billability result explicit

### DIFF
--- a/openmeter/billing/charges/usagebased/service/rating/delta/engine_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/delta/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	chargedetailedline "github.com/openmeterio/openmeter/openmeter/billing/charges/models/detailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	ratingtestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating/testutils"
@@ -340,8 +341,8 @@ type stubRatingService struct {
 	lastOpts billingrating.GenerateDetailedLinesOptions
 }
 
-func (s *stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
-	return nil, nil
+func (s *stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	return billing.IsLineBillableAsOfResult{}, nil
 }
 
 func (s *stubRatingService) GenerateDetailedLines(in billingrating.StandardLineAccessor, opts ...billingrating.GenerateDetailedLinesOption) (billingrating.GenerateDetailedLinesResult, error) {

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -611,8 +611,8 @@ var passthroughDetailedLinesFetcher = detailedLinesFetcherFunc(func(_ context.Co
 	return charge, nil
 })
 
-func (s *stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
-	return nil, nil
+func (s *stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	return billing.IsLineBillableAsOfResult{}, nil
 }
 
 func (s *stubRatingService) GenerateDetailedLines(in billingrating.StandardLineAccessor, opts ...billingrating.GenerateDetailedLinesOption) (billingrating.GenerateDetailedLinesResult, error) {

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -182,19 +183,17 @@ type IsLineBillableAsOfResult struct {
 }
 
 func (r IsLineBillableAsOfResult) Validate() error {
+	var errs []error
+
 	if r.Billable {
 		if err := r.BillablePeriod.ValidateAsRequired(); err != nil {
-			return fmt.Errorf("billable period: %w", err)
+			errs = append(errs, fmt.Errorf("billable period: %w", err))
 		}
-
-		return nil
+	} else if !lo.IsEmpty(r.BillablePeriod) {
+		errs = append(errs, errors.New("billable period must be empty when line is not billable"))
 	}
 
-	if !lo.IsEmpty(r.BillablePeriod) {
-		return errors.New("billable period must be empty when line is not billable")
-	}
-
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func (i IsLineBillableAsOfInput) Validate() error {

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/samber/lo"
+
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -79,13 +81,6 @@ func (b LineEngineType) IsCharge() bool {
 		return false
 	}
 }
-
-type LineBillability struct {
-	IsBillable      bool
-	ValidationError error
-}
-
-type LineBillabilities []LineBillability
 
 type BuildStandardInvoiceLinesInput struct {
 	// Invoice is the target standard invoice that will own the built lines.
@@ -179,6 +174,27 @@ type IsLineBillableAsOfInput struct {
 	ProgressiveBilling     bool
 	FeatureMeters          billingfeaturemeter.FeatureMeters
 	ResolvedBillablePeriod timeutil.ClosedPeriod
+}
+
+type IsLineBillableAsOfResult struct {
+	Billable       bool
+	BillablePeriod timeutil.ClosedPeriod
+}
+
+func (r IsLineBillableAsOfResult) Validate() error {
+	if r.Billable {
+		if err := r.BillablePeriod.ValidateAsRequired(); err != nil {
+			return fmt.Errorf("billable period: %w", err)
+		}
+
+		return nil
+	}
+
+	if !lo.IsEmpty(r.BillablePeriod) {
+		return errors.New("billable period must be empty when line is not billable")
+	}
+
+	return nil
 }
 
 func (i IsLineBillableAsOfInput) Validate() error {

--- a/openmeter/billing/lineengine_test.go
+++ b/openmeter/billing/lineengine_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -39,9 +40,47 @@ func TestIsLineBillableAsOfResultValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "billable with period start only",
+			result: IsLineBillableAsOfResult{
+				Billable: true,
+				BillablePeriod: timeutil.ClosedPeriod{
+					From: period.From,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "billable with period end only",
+			result: IsLineBillableAsOfResult{
+				Billable: true,
+				BillablePeriod: timeutil.ClosedPeriod{
+					To: period.To,
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "not billable with period",
 			result: IsLineBillableAsOfResult{
 				BillablePeriod: period,
+			},
+			wantErr: true,
+		},
+		{
+			name: "not billable with period start only",
+			result: IsLineBillableAsOfResult{
+				BillablePeriod: timeutil.ClosedPeriod{
+					From: period.From,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not billable with period end only",
+			result: IsLineBillableAsOfResult{
+				BillablePeriod: timeutil.ClosedPeriod{
+					To: period.To,
+				},
 			},
 			wantErr: true,
 		},
@@ -52,6 +91,7 @@ func TestIsLineBillableAsOfResultValidate(t *testing.T) {
 			err := tt.result.Validate()
 			if tt.wantErr {
 				require.Error(t, err)
+				require.True(t, models.IsGenericValidationError(err))
 				return
 			}
 

--- a/openmeter/billing/lineengine_test.go
+++ b/openmeter/billing/lineengine_test.go
@@ -1,0 +1,61 @@
+package billing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestIsLineBillableAsOfResultValidate(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name    string
+		result  IsLineBillableAsOfResult
+		wantErr bool
+	}{
+		{
+			name:   "not billable without period",
+			result: IsLineBillableAsOfResult{},
+		},
+		{
+			name: "billable with period",
+			result: IsLineBillableAsOfResult{
+				Billable:       true,
+				BillablePeriod: period,
+			},
+		},
+		{
+			name: "billable without period",
+			result: IsLineBillableAsOfResult{
+				Billable: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "not billable with period",
+			result: IsLineBillableAsOfResult{
+				BillablePeriod: period,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -9,11 +9,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type Service interface {
-	ResolveBillablePeriod(in ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error)
+	ResolveBillablePeriod(in ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error)
 	GenerateDetailedLines(in StandardLineAccessor, opts ...GenerateDetailedLinesOption) (GenerateDetailedLinesResult, error)
 }
 

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -3,32 +3,32 @@ package service
 import (
 	"fmt"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	if err := in.Validate(); err != nil {
-		return nil, err
+		return billing.IsLineBillableAsOfResult{}, err
 	}
 
 	linePricer, err := getPricerFor(in.Line, rating.NewGenerateDetailedLinesOptions(), s.unitConfigEnabled)
 	if err != nil {
-		return nil, err
+		return billing.IsLineBillableAsOfResult{}, err
 	}
 
 	linePrice := in.Line.GetPrice()
 	if linePrice == nil {
-		return nil, fmt.Errorf("price is nil")
+		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("price is nil")
 	}
 
 	meterTypeAllowsProgressiveBilling := false
 	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling {
 		isDependingOnIncreaseOnlyMeters, err := isDependingOnIncreaseOnlyMeters(in)
 		if err != nil {
-			return nil, err
+			return billing.IsLineBillableAsOfResult{}, err
 		}
 
 		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters
@@ -39,17 +39,21 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*
 		in.ProgressiveBilling = false
 	}
 
-	billablePeriod, err := linePricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+	result, err := linePricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 		AsOf:               in.AsOf,
 		ProgressiveBilling: in.ProgressiveBilling,
 		Line:               in.Line,
 		FeatureMeters:      in.FeatureMeters,
 	})
 	if err != nil {
-		return nil, err
+		return billing.IsLineBillableAsOfResult{}, err
 	}
 
-	return billablePeriod, nil
+	if err := result.Validate(); err != nil {
+		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("validating billable period result: %w", err)
+	}
+
+	return result, nil
 }
 
 // isDependingOnIncreaseOnlyMeters checks if the line is depending on meters that can decrease the totals over time

--- a/openmeter/billing/rating/service/pricer.go
+++ b/openmeter/billing/rating/service/pricer.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/mutator"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/rate"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func getPricerFor(line rating.PriceAccessor, opts rating.GenerateDetailedLinesOptions, unitConfigEnabled bool) (*priceMutator, error) {
@@ -129,6 +129,6 @@ func (p *priceMutator) GenerateDetailedLines(l rate.PricerCalculateInput) (ratin
 	}, nil
 }
 
-func (p *priceMutator) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (p *priceMutator) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	return p.Pricer.ResolveBillablePeriod(in)
 }

--- a/openmeter/billing/rating/service/rate/base.go
+++ b/openmeter/billing/rating/service/rate/base.go
@@ -2,7 +2,6 @@ package rate
 
 import (
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
@@ -14,17 +13,17 @@ var DecimalOne = alpacadecimal.NewFromInt(1)
 
 type ProgressiveBillingMeteredPricer struct{}
 
-func (ProgressiveBillingMeteredPricer) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (ProgressiveBillingMeteredPricer) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	asOf := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
 	period := in.Line.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)
 
 	// If progressive billing is not enabled we only bill the line if asof >= line.period.end
 	if !in.ProgressiveBilling {
 		if asOf.Before(period.To) {
-			return nil, nil
+			return billing.IsLineBillableAsOfResult{}, nil
 		}
 
-		return &period, nil
+		return billing.IsLineBillableAsOfResult{Billable: true, BillablePeriod: period}, nil
 	}
 
 	// If progressive billing is enabled we only need to make sure that asOf > period.from
@@ -32,7 +31,7 @@ func (ProgressiveBillingMeteredPricer) ResolveBillablePeriod(in rating.ResolveBi
 	// check also makes sure that we have at least 1s of difference, thus usage data in that
 	// period.
 	if !asOf.After(period.From) {
-		return nil, nil
+		return billing.IsLineBillableAsOfResult{}, nil
 	}
 
 	// If the asOf is before the period end, we need to truncate the period to the asOf
@@ -41,28 +40,34 @@ func (ProgressiveBillingMeteredPricer) ResolveBillablePeriod(in rating.ResolveBi
 		periodEnd = asOf
 	}
 
-	return &timeutil.ClosedPeriod{
-		From: period.From,
-		To:   periodEnd,
+	return billing.IsLineBillableAsOfResult{
+		Billable: true,
+		BillablePeriod: timeutil.ClosedPeriod{
+			From: period.From,
+			To:   periodEnd,
+		},
 	}, nil
 }
 
 type NonProgressiveBillingPricer struct{}
 
-func (NonProgressiveBillingPricer) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (NonProgressiveBillingPricer) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	// Invoicing a line that has a parent line is not supported, as that's a progressive billing use-case
 	//
 	// This check is crucial, as when changing a price on a line from progressive billable to non-progressive
 	// billable, the CanBeInvoicedAsOf is called to ensure that the line is still valid.
 	if in.Line.GetSplitLineGroupID() != nil {
-		return nil, billing.ValidationError{
+		return billing.IsLineBillableAsOfResult{}, billing.ValidationError{
 			Err: billing.ErrInvoiceProgressiveBillingNotSupported,
 		}
 	}
 
 	if in.AsOf.Truncate(streaming.MinimumWindowSizeDuration).Before(in.Line.GetServicePeriod().To.Truncate(streaming.MinimumWindowSizeDuration)) {
-		return nil, nil
+		return billing.IsLineBillableAsOfResult{}, nil
 	}
 
-	return lo.ToPtr(in.Line.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)), nil
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: in.Line.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration),
+	}, nil
 }

--- a/openmeter/billing/rating/service/rate/billableperiod_test.go
+++ b/openmeter/billing/rating/service/rate/billableperiod_test.go
@@ -1,0 +1,55 @@
+package rate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/rate"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestProgressiveBillingMeteredPricerResolveBillablePeriod(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC),
+	}
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ServicePeriod: period,
+		},
+	}
+	pricer := rate.ProgressiveBillingMeteredPricer{}
+
+	t.Run("not billable at service period start", func(t *testing.T) {
+		result, err := pricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			Line:               line,
+			AsOf:               period.From,
+			ProgressiveBilling: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{}, result)
+		require.NoError(t, result.Validate())
+	})
+
+	t.Run("billable for elapsed partial period", func(t *testing.T) {
+		asOf := period.From.Add(time.Hour)
+		result, err := pricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			Line:               line,
+			AsOf:               asOf,
+			ProgressiveBilling: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{
+			Billable: true,
+			BillablePeriod: timeutil.ClosedPeriod{
+				From: period.From,
+				To:   asOf,
+			},
+		}, result)
+		require.NoError(t, result.Validate())
+	})
+}

--- a/openmeter/billing/rating/service/rate/flat.go
+++ b/openmeter/billing/rating/service/rate/flat.go
@@ -5,13 +5,11 @@ import (
 	"slices"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type Flat struct{}
@@ -62,9 +60,9 @@ func (p Flat) GenerateDetailedLines(l PricerCalculateInput) (rating.DetailedLine
 	return nil, nil
 }
 
-func (p Flat) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (p Flat) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	if in.Line.GetSplitLineGroupID() != nil {
-		return nil, billing.ValidationError{
+		return billing.IsLineBillableAsOfResult{}, billing.ValidationError{
 			Err: billing.ErrInvoiceProgressiveBillingNotSupported,
 		}
 	}
@@ -75,8 +73,11 @@ func (p Flat) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*time
 	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
 
 	if invoiceAtTruncated.After(asOfTruncated) {
-		return nil, nil
+		return billing.IsLineBillableAsOfResult{}, nil
 	}
 
-	return lo.ToPtr(in.Line.GetServicePeriod()), nil
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: in.Line.GetServicePeriod(),
+	}, nil
 }

--- a/openmeter/billing/rating/service/rate/tiered.go
+++ b/openmeter/billing/rating/service/rate/tiered.go
@@ -3,9 +3,9 @@ package rate
 import (
 	"fmt"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 // Tiered is a pricer that can handle both volume and graduated tiered pricing acts as
@@ -33,10 +33,10 @@ func (p Tiered) GenerateDetailedLines(l PricerCalculateInput) (rating.DetailedLi
 	}
 }
 
-func (p Tiered) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (p Tiered) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
 	price, err := in.Line.GetPrice().AsTiered()
 	if err != nil {
-		return nil, fmt.Errorf("converting price to tiered price: %w", err)
+		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("converting price to tiered price: %w", err)
 	}
 
 	switch price.Mode {
@@ -45,6 +45,6 @@ func (p Tiered) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*ti
 	case productcatalog.GraduatedTieredPrice:
 		return p.graduated.ResolveBillablePeriod(in)
 	default:
-		return nil, fmt.Errorf("unsupported tiered price mode: %s", price.Mode)
+		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("unsupported tiered price mode: %s", price.Mode)
 	}
 }

--- a/openmeter/billing/rating/service/rate/types.go
+++ b/openmeter/billing/rating/service/rate/types.go
@@ -15,9 +15,9 @@ type Pricer interface {
 	// GenerateDetailedLines generates the detailed lines for a line.
 	GenerateDetailedLines(line PricerCalculateInput) (rating.DetailedLines, error)
 
-	// ResolveBillablePeriod checks if the line can be invoiced as of the given time and returns the service
-	// period that can be invoiced.
-	ResolveBillablePeriod(rating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error)
+	// ResolveBillablePeriod determines whether the line can be invoiced as of the given time and, when billable,
+	// returns the service period that can be invoiced.
+	ResolveBillablePeriod(rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error)
 }
 
 type PricerCalculateInput struct {

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -228,7 +228,7 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 			if err := line.Validate(); err != nil {
 				return fmt.Errorf("validating line[%s]: %w", line.ID, err)
 			}
-			period, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
 				FeatureMeters:      featureMeters,
 				ProgressiveBilling: progressiveBilling,
@@ -238,7 +238,7 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 				return fmt.Errorf("checking if line[%s] can be invoiced: %w", line.ID, err)
 			}
 
-			if period == nil {
+			if !result.Billable {
 				return billing.ValidationError{
 					Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.InvoiceAt),
 				}

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -330,7 +330,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
 		linesWithResolvedPeriods, err := slicesx.MapWithErr(invoice.Invoice.Lines.OrEmpty(), func(line billing.GatheringLine) (gatheringLineWithBillablePeriod, error) {
-			period, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
 				FeatureMeters:      invoice.FeatureMeters,
 				ProgressiveBilling: in.ProgressiveBilling,
@@ -350,10 +350,17 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 				AsOf:                   in.AsOf,
 				ProgressiveBilling:     in.ProgressiveBilling,
 				FeatureMeters:          invoice.FeatureMeters,
-				ResolvedBillablePeriod: lo.FromPtr(period),
+				ResolvedBillablePeriod: result.BillablePeriod,
 			}
 			if err := engineInput.Validate(); err != nil {
 				return gatheringLineWithBillablePeriod{}, fmt.Errorf("validating billable status input[%s]: %w", line.ID, err)
+			}
+
+			if !result.Billable {
+				return gatheringLineWithBillablePeriod{
+					Line:   line,
+					Engine: eng,
+				}, nil
 			}
 
 			isBillable, err := eng.IsLineBillableAsOf(ctx, engineInput)
@@ -370,7 +377,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 			return gatheringLineWithBillablePeriod{
 				Line:           line,
-				BillablePeriod: lo.FromPtr(period),
+				BillablePeriod: result.BillablePeriod,
 				Engine:         eng,
 			}, nil
 		})


### PR DESCRIPTION
## Summary

- add a validated IsLineBillableAsOfResult with explicit billability and billable period
- migrate billing rating and pricer implementations away from nil period signaling
- update gathering-line consumers and focused test stubs
- add invariant and progressive-billing coverage

## Verification

- go test -tags=dynamic ./openmeter/billing ./openmeter/billing/rating/service/... ./openmeter/billing/charges/usagebased/service/rating/...
- POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/service ./openmeter/billing/lineengine ./openmeter/billing/charges/creditpurchase/service ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/usagebased/service ./test/billing
- make lint-go-fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Billing evaluation now clearly indicates whether a line is billable and, when applicable, provides the invoicable service period.
  - Invoice processing consistently uses billability status and resolved periods across flat, tiered, progressive, and non-progressive pricing.
  - Invalid billability and service-period combinations are rejected for more reliable invoice generation.
  - Future invoice dates remain non-billable until their service period is eligible.

- **Tests**
  - Added coverage for billability validation and progressive billing period resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces nil-period signaling with an explicit, validated billability result and propagates that contract through rating, pricing, and gathering-line collection.
- Introduces `IsLineBillableAsOfResult` with explicit billability and billable-period invariants.
- Migrates pricers and rating-service consumers to the new result type.
- Ensures non-billable gathering lines remain pending without invoking line-engine billability checks.
- Adds validation and progressive-billing period coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no outstanding correctness, security, or repository-rule violations were identified.

The previously reported validation-error inconsistency is fully fixed by collecting invariant errors into the standard generic validation-error wrapper, and the added tests cover malformed partial periods and non-billable results carrying periods. The migrated consumers consistently branch on explicit billability and use the validated period only for billable lines.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/lineengine.go | Defines and validates the explicit billability result using the repository-standard generic validation-error representation. |
| openmeter/billing/rating/service/billableperiod.go | Resolves price-specific billability and validates the returned result at the rating-service boundary. |
| openmeter/billing/rating/service/rate/base.go | Migrates progressive and non-progressive period resolution from nullable periods to explicit results. |
| openmeter/billing/service/gatheringinvoicependinglines.go | Consumes explicit billability before consulting the line engine and preserves non-billable lines as pending. |
| openmeter/billing/service/gatheringinvoice.go | Uses the explicit result when validating whether requested gathering lines can be invoiced. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    G[Gathering line] --> R[Rating service]
    R --> P[Price-specific period resolver]
    P --> V{Validated result}
    V -->|Billable + period| E[Line-engine eligibility check]
    V -->|Not billable + empty period| K[Keep line pending]
    E -->|Eligible| I[Build standard invoice line]
    E -->|Ineligible| K
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): validate billability resul..."](https://github.com/openmeterio/openmeter/commit/43b96a0ee982e6921d3cd0f3f438335c3101b8df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60334291)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->