### PR TITLE
ci: skip pnpm bootstrap audit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,10 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          # action-setup uses npm to install a temporary pnpm bootstrap package.
+          # Its audit does not inspect api/spec dependencies; Dependency Review covers repository dependency changes.
+          NPM_CONFIG_AUDIT: "false"
         with:
           package_json_file: api/spec/package.json
 


### PR DESCRIPTION
## Summary

- disable npm audit while pnpm/action-setup installs its temporary bootstrap package for the OpenAPI generator
- document why this does not reduce coverage of repository dependencies

## Why

pnpm/action-setup runs npm ci against an action-owned lockfile containing the pnpm bootstrap package. That implicit audit does not inspect api/spec/pnpm-lock.yaml and has taken 5–7 minutes while waiting on the npm audit endpoint. Repository dependency changes remain covered by the Dependency Review job.

## Validation

CI only, so the workflow run measures the setup-time change on a fresh Depot runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenAPI generator workflow to skip npm audit checks during temporary package manager setup, improving CI setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables npm's advisory audit only while `pnpm/action-setup` installs its temporary bootstrap package for the OpenAPI generator.

- Keeps the setting scoped to the pnpm setup step.
- Leaves subsequent repository dependency installation unaffected.
- Documents the distinction between the bootstrap audit and repository dependency review.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the audit setting is narrowly scoped to the action's temporary bootstrap installation.

No actionable failures were found; later repository dependency operations do not inherit the setting, and npm recognizes the configuration as written.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Adds a step-scoped npm configuration that skips auditing pnpm's temporary bootstrap installation without affecting later dependency steps. |

<sub>Reviews (1): Last reviewed commit: ["ci: skip pnpm bootstrap audit"](https://github.com/openmeterio/openmeter/commit/00c20ab5ffa52bb0ebe72bc8ed2274d740d9a07d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60370543)</sub>

<!-- /greptile_comment -->