### PR TITLE
refactor(billing): move billability into line engines

### DIFF
--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -211,17 +211,19 @@ func NewChargesFlatFeeService(
 	lineageService lineage.Service,
 	metaAdapter meta.Adapter,
 	locker *lockr.Locker,
+	featureMeterResolver *billingfeaturemeterservice.Resolver,
 	ratingService rating.Service,
 	currenciesService currencies.Service,
 ) (flatfee.Service, error) {
 	flatFeeSvc, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       flatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: ratingService,
-		Currencies:    currenciesService,
+		Adapter:              flatFeeAdapter,
+		Handler:              flatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: featureMeterResolver,
+		RatingService:        ratingService,
+		Currencies:           currenciesService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create charges flat fee service: %w", err)
@@ -488,7 +490,7 @@ func newChargesRegistry(
 		return nil, err
 	}
 
-	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker, ratingService, currenciesService)
+	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker, featureMeterResolver, ratingService, currenciesService)
 	if err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -81,6 +81,11 @@ persist engine-owned state explaining its decision; when every candidate is
 blocked, collection succeeds without creating an invoice so those writes can
 commit. Gate errors abort collection and roll back its writes.
 
+Billability is also engine-owned. Billing submits each engine's subset of one
+gathering invoice as an ordered batch. The engine resolves any feature or charge
+dependencies it needs before returning one eligibility decision and billable
+period per input in the same order.
+
 Engine callbacks operate on groups of lines. When a callback replaces lines,
 billing requires it to preserve the input line IDs before accepting the
 result. API-originated line edits and system-originated reconciliation are

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -84,7 +84,9 @@ commit. Gate errors abort collection and roll back its writes.
 Billability is also engine-owned. Billing submits each engine's subset of one
 gathering invoice as an ordered batch. The engine resolves any feature or charge
 dependencies it needs before returning one eligibility decision and billable
-period per input in the same order.
+period per input in the same order. Missing feature or meter dependencies are
+reported as validation issues while billability falls back to non-progressive
+eligibility; operational dependency failures still abort collection.
 
 Engine callbacks operate on groups of lines. When a callback replaces lines,
 billing requires it to preserve the input line IDs before accepting the

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -13,6 +13,7 @@ import (
 	creditpurchasemodels "github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 var _ billing.LineEngine = (*LineEngine)(nil)
@@ -30,7 +31,7 @@ func (e *LineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLi
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
 		if line.SplitLineGroupID != nil {
 			return billing.IsLineBillableAsOfResult{}, billing.ValidationError{Err: billing.ErrInvoiceProgressiveBillingNotSupported}
 		}

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	creditpurchasemodels "github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -24,14 +25,25 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeCreditPurchase
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	// Billing enforces that credit purchases are never progressively billed, so there is no
-	// engine-side partial-period filtering to do here.
-	return true, nil
+	return lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+		if line.SplitLineGroupID != nil {
+			return billing.IsLineBillableAsOfResult{}, billing.ValidationError{Err: billing.ErrInvoiceProgressiveBillingNotSupported}
+		}
+
+		if line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration).After(input.AsOf.Truncate(streaming.MinimumWindowSizeDuration)) {
+			return billing.IsLineBillableAsOfResult{}, nil
+		}
+
+		return billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}, nil
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestLineEngineDoesNotImplementLineCalculator(t *testing.T) {
@@ -17,6 +22,71 @@ func TestLineEngineDoesNotImplementLineCalculator(t *testing.T) {
 	require.Equal(t, billing.LineEngineTypeChargeCreditPurchase, lineEngine.GetLineEngineType())
 	_, implementsLineCalculator := lineEngine.(billing.LineCalculator)
 	require.False(t, implementsLineCalculator)
+}
+
+func TestAreLinesBillableAsOfPreservesResultsWithValidationIssues(t *testing.T) {
+	// Given a batch with valid credit-purchase lines around an unsupported split line.
+	firstPeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+	}
+	lastPeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC),
+	}
+	firstChargeID := "charge-1"
+	firstLine := billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+			ID:              "line-1",
+			Name:            "credit purchase",
+		},
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeChargeCreditPurchase,
+		InvoiceID:     "invoice-id",
+		Currency:      currencyx.FiatCode("USD"),
+		ServicePeriod: firstPeriod,
+		InvoiceAt:     firstPeriod.From,
+		Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount: alpacadecimal.NewFromInt(10),
+		}),
+		ChargeID: &firstChargeID,
+	}}
+	splitLine := firstLine
+	splitLine.ID = "line-2"
+	splitChargeID := "charge-2"
+	splitLine.ChargeID = &splitChargeID
+	splitLineGroupID := "split-group"
+	splitLine.SplitLineGroupID = &splitLineGroupID
+	lastLine := firstLine
+	lastLine.ID = "line-3"
+	lastChargeID := "charge-3"
+	lastLine.ChargeID = &lastChargeID
+	lastLine.ServicePeriod = lastPeriod
+	lastLine.InvoiceAt = lastPeriod.From
+	engine := &LineEngine{}
+
+	// When a valid line, an invalid split line, and another valid line are checked together.
+	results, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: firstLine.Namespace},
+				ID:              firstLine.InvoiceID,
+			},
+		}},
+		AsOf:  lastPeriod.To,
+		Lines: billing.GatheringLines{firstLine, splitLine, lastLine},
+	})
+
+	// Then the validation issue is returned without losing the ordered per-line results.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{billing.ErrInvoiceProgressiveBillingNotSupported}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{
+		{Billable: true, BillablePeriod: firstPeriod},
+		{},
+		{Billable: true, BillablePeriod: lastPeriod},
+	}, results)
 }
 
 func TestPopulateInvoiceCreditPurchaseStandardLineRejectsUnresolvedCostBasis(t *testing.T) {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
@@ -12,6 +13,7 @@ import (
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
@@ -28,12 +30,56 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeFlatFee
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return true, nil
+	chargeIDs, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (string, error) {
+		if line.ChargeID == nil || *line.ChargeID == "" {
+			return "", fmt.Errorf("flat fee gathering line[%s]: charge id is required", line.ID)
+		}
+
+		return *line.ChargeID, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	charges, err := e.service.GetByIDs(ctx, flatfee.GetByIDsInput{
+		Namespace: input.Invoice.Namespace,
+		IDs:       chargeIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting flat fee charges for billability: %w", err)
+	}
+
+	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, charges...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters for flat fee charges: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, index int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		charge := charges[index]
+		if charge.GetFeatureMeterRef() != nil {
+			_, err := featureMeters.Get(charge)
+			// This becomes a validation issue on the resulting standard invoice, but we still need to provide
+			// the result too.
+			errs = append(errs, err)
+		}
+
+		result, err := e.service.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/flatfee/service/lineengine_test.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine_test.go
@@ -1,15 +1,228 @@
 package service
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestAreLinesBillableAsOfUsesBillingRating(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	ratingService := &billabilityRatingService{
+		result: billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: period,
+		},
+	}
+	featureMeterResolver := newFlatFeeBillabilityFeatureMeterResolver(t)
+	const chargeID = "charge-id"
+	engine := &LineEngine{service: &service{
+		adapter:              &flatFeeBillabilityAdapter{charges: []flatfee.Charge{newFlatFeeBillabilityCharge("namespace", chargeID, nil)}},
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        ratingService,
+	}}
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "line-id",
+				Name:            "flat fee",
+			},
+			ManagedBy:     billing.SystemManagedLine,
+			Engine:        billing.LineEngineTypeChargeFlatFee,
+			InvoiceID:     "invoice-id",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.From,
+			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(10),
+			}),
+			ChargeID: lo.ToPtr(chargeID),
+		},
+	}
+
+	ctx, err := transaction.SetDriverOnContext(t.Context(), flatFeeBillabilityTransaction{})
+	require.NoError(t, err)
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:               period.From,
+		ProgressiveBilling: true,
+		Lines:              billing.GatheringLines{line},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{ratingService.result}, results)
+	require.Len(t, ratingService.inputs, 1)
+	require.Equal(t, line.ID, ratingService.inputs[0].Line.GetID())
+	require.True(t, ratingService.inputs[0].ProgressiveBilling)
+	require.Nil(t, ratingService.inputs[0].Feature)
+	require.Nil(t, ratingService.inputs[0].Meter)
+}
+
+func TestAreLinesBillableAsOfValidatesChargeFeature(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	const chargeID = "charge-id"
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "line-id",
+				Name:            "flat fee",
+			},
+			ManagedBy:     billing.SystemManagedLine,
+			Engine:        billing.LineEngineTypeChargeFlatFee,
+			InvoiceID:     "invoice-id",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.From,
+			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(10),
+			}),
+			ChargeID: lo.ToPtr(chargeID),
+		},
+	}
+	ratingService := &billabilityRatingService{result: billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: period,
+	}}
+	engine := &LineEngine{service: &service{
+		adapter: &flatFeeBillabilityAdapter{charges: []flatfee.Charge{
+			newFlatFeeBillabilityCharge("namespace", chargeID, lo.ToPtr("missing-feature")),
+		}},
+		featureMeterResolver: newFlatFeeBillabilityFeatureMeterResolver(t),
+		ratingService:        ratingService,
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), flatFeeBillabilityTransaction{})
+	require.NoError(t, err)
+
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:  period.From,
+		Lines: billing.GatheringLines{line},
+	})
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  "feature[missing-feature]: invoice line: feature not found",
+		Path:     "/charges/charge-id",
+	}}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{{
+		Billable:       true,
+		BillablePeriod: period,
+	}}, results)
+	require.Len(t, ratingService.inputs, 1)
+}
+
+type flatFeeBillabilityAdapter struct {
+	flatfee.Adapter
+	charges []flatfee.Charge
+}
+
+func (a *flatFeeBillabilityAdapter) GetByIDs(_ context.Context, input flatfee.GetByIDsInput) ([]flatfee.Charge, error) {
+	return lo.MapErr(input.IDs, func(chargeID string, _ int) (flatfee.Charge, error) {
+		charge, ok := lo.Find(a.charges, func(charge flatfee.Charge) bool {
+			return charge.Namespace == input.Namespace && charge.ID == chargeID
+		})
+		if !ok {
+			return flatfee.Charge{}, fmt.Errorf("charge[%s] not found", chargeID)
+		}
+
+		return charge, nil
+	})
+}
+
+type flatFeeBillabilityFeatureService struct{}
+
+func (flatFeeBillabilityFeatureService) ListFeatures(context.Context, feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+	return pagination.Result[feature.Feature]{}, nil
+}
+
+type flatFeeBillabilityMeterService struct{}
+
+func (flatFeeBillabilityMeterService) ListMeters(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	return pagination.Result[meter.Meter]{}, nil
+}
+
+func newFlatFeeBillabilityFeatureMeterResolver(t *testing.T) *featuremeterservice.Resolver {
+	t.Helper()
+
+	resolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: flatFeeBillabilityFeatureService{},
+		MeterService:   flatFeeBillabilityMeterService{},
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+
+	return resolver
+}
+
+func newFlatFeeBillabilityCharge(namespace, chargeID string, featureID *string) flatfee.Charge {
+	return flatfee.Charge{ChargeBase: flatfee.ChargeBase{
+		ManagedResource: meta.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              chargeID,
+		},
+		State: flatfee.State{FeatureID: featureID},
+	}}
+}
+
+type flatFeeBillabilityTransaction struct{}
+
+func (flatFeeBillabilityTransaction) Commit() error    { return nil }
+func (flatFeeBillabilityTransaction) Rollback() error  { return nil }
+func (flatFeeBillabilityTransaction) SavePoint() error { return nil }
+
+type billabilityRatingService struct {
+	result billing.IsLineBillableAsOfResult
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *billabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return s.result, nil
+}
+
+func (*billabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
 
 func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T) {
 	servicePeriod := timeutil.ClosedPeriod{

--- a/openmeter/billing/charges/flatfee/service/service.go
+++ b/openmeter/billing/charges/flatfee/service/service.go
@@ -12,19 +12,21 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	billingfeaturemeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
 type Config struct {
-	Adapter       flatfee.Adapter
-	Handler       flatfee.Handler
-	Lineage       lineage.Service
-	MetaAdapter   meta.Adapter
-	Locker        *lockr.Locker
-	RatingService rating.Service
-	Currencies    currencies.Service
+	Adapter              flatfee.Adapter
+	Handler              flatfee.Handler
+	Lineage              lineage.Service
+	MetaAdapter          meta.Adapter
+	Locker               *lockr.Locker
+	RatingService        rating.Service
+	FeatureMeterResolver *billingfeaturemeterservice.Resolver
+	Currencies           currencies.Service
 }
 
 func (c Config) Validate() error {
@@ -52,6 +54,10 @@ func (c Config) Validate() error {
 
 	if c.RatingService == nil {
 		errs = append(errs, errors.New("rating service cannot be null"))
+	}
+
+	if c.FeatureMeterResolver == nil {
+		errs = append(errs, errors.New("feature meter resolver cannot be null"))
 	}
 
 	if c.Currencies == nil {
@@ -84,12 +90,14 @@ func New(config Config) (flatfee.Service, error) {
 	}
 
 	svc := &service{
-		adapter:           config.Adapter,
-		handler:           config.Handler,
-		metaAdapter:       config.MetaAdapter,
-		locker:            config.Locker,
-		realizations:      realizations,
-		costbasisResolver: costbasisResolver,
+		adapter:              config.Adapter,
+		handler:              config.Handler,
+		metaAdapter:          config.MetaAdapter,
+		locker:               config.Locker,
+		ratingService:        config.RatingService,
+		featureMeterResolver: config.FeatureMeterResolver,
+		realizations:         realizations,
+		costbasisResolver:    costbasisResolver,
 	}
 	svc.creditNotesSupported.Store(charges.CreditNotesSupportedByLineUpdater)
 
@@ -101,6 +109,8 @@ type service struct {
 	handler              flatfee.Handler
 	metaAdapter          meta.Adapter
 	locker               *lockr.Locker
+	ratingService        rating.Service
+	featureMeterResolver *billingfeaturemeterservice.Resolver
 	realizations         *flatfeerealizations.Service
 	creditNotesSupported atomic.Bool
 	costbasisResolver    costbasis.Resolver

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -504,10 +504,7 @@ func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace stri
 
 	featureMeters, err := s.featureMeterResolver.Resolve(ctx, namespace, featureReferences...)
 	if err != nil {
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return nil, fmt.Errorf("resolving features: %w", systemErr)
-		}
+		return nil, fmt.Errorf("resolving features: %w", err)
 	}
 
 	for _, featureReference := range featureReferences {
@@ -517,18 +514,15 @@ func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace stri
 		}
 
 		featureMeter, err := featureMeters.Get(featureReference)
-		if err != nil {
-			_, systemErr := billing.ToValidationIssues(err)
-			if systemErr != nil {
-				return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, systemErr)
-			}
+		if err != nil && !billing.IsValidationIssueOnly(err) {
+			return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, err)
+		}
 
-			// Feature expansion is best-effort. A missing feature is omitted so
-			// the API retains its ID/key fallback, while other validation issues
-			// can still return a usable feature below.
-			if featureMeter.Feature.ID == "" {
-				continue
-			}
+		// Feature expansion is best-effort. A missing feature is omitted so
+		// the API retains its ID/key fallback, while other validation issues
+		// can still return a usable feature below.
+		if featureMeter.Feature.ID == "" {
+			continue
 		}
 
 		out[featureRef.IDOrKey] = featureMeter.Feature

--- a/openmeter/billing/charges/service/api_list_customcurrency_test.go
+++ b/openmeter/billing/charges/service/api_list_customcurrency_test.go
@@ -64,13 +64,14 @@ func (s *CustomerChargeCustomCurrencyListTestSuite) enableFlatFeeCustomCurrencyS
 	lineageMock.On("BackfillAdvanceLineageSegments", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	customCurrencyFlatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       s.FlatFeeAdapter,
-		Handler:       s.FlatFeeTestHandler,
-		Lineage:       lineageMock,
-		MetaAdapter:   s.MetaAdapter,
-		Locker:        s.Locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-		Currencies:    s.CurrencyService,
+		Adapter:              s.FlatFeeAdapter,
+		Handler:              s.FlatFeeTestHandler,
+		Lineage:              lineageMock,
+		MetaAdapter:          s.MetaAdapter,
+		Locker:               s.Locker,
+		FeatureMeterResolver: s.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+		Currencies:           s.CurrencyService,
 	})
 	s.Require().NoError(err)
 

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -193,13 +193,14 @@ func (s *BaseSuite) SetupSuite() {
 	}
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       flatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-		Currencies:    currencyService,
+		Adapter:              flatFeeAdapter,
+		Handler:              flatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: s.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+		Currencies:           currencyService,
 	})
 	s.NoError(err)
 

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -464,7 +464,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyRe
 	})
 
 	s.Require().Error(err)
-	s.ErrorContains(err, "resolve create feature meter")
+	s.ErrorContains(err, "resolve flat fee feature")
 	issue := requireFeatureMeterValidationIssue(s.T(), err, billing.ErrInvoiceLineFeatureNotFound.Code)
 	s.Empty(issue.Path)
 

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -5568,13 +5568,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 			Once()
 
 		customCurrencyFlatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-			Adapter:       s.FlatFeeAdapter,
-			Handler:       s.FlatFeeTestHandler,
-			Lineage:       lineageMock,
-			MetaAdapter:   s.MetaAdapter,
-			Locker:        s.Locker,
-			RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-			Currencies:    s.CurrencyService,
+			Adapter:              s.FlatFeeAdapter,
+			Handler:              s.FlatFeeTestHandler,
+			Lineage:              lineageMock,
+			MetaAdapter:          s.MetaAdapter,
+			Locker:               s.Locker,
+			FeatureMeterResolver: s.FeatureMeterResolver,
+			RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+			Currencies:           s.CurrencyService,
 		})
 		s.Require().NoError(err)
 

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -181,13 +181,14 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 	}
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       config.FlatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
-		Currencies:    currencyService,
+		Adapter:              flatFeeAdapter,
+		Handler:              config.FlatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: config.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
+		Currencies:           currencyService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating flat fee service: %w", err)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -31,12 +33,67 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeUsageBased
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return !input.AsOf.Before(input.ResolvedBillablePeriod.To), nil
+	chargeIDs, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (string, error) {
+		if line.ChargeID == nil || *line.ChargeID == "" {
+			return "", fmt.Errorf("usage based gathering line[%s]: charge id is required", line.ID)
+		}
+
+		return *line.ChargeID, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	charges, err := e.service.GetByIDs(ctx, usagebased.GetByIDsInput{
+		Namespace: input.Invoice.Namespace,
+		IDs:       chargeIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting usage based charges for billability: %w", err)
+	}
+
+	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, charges...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters for usage based charges: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, index int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		charge := charges[index]
+		featureMeter, err := featureMeters.Get(charge)
+
+		ratingInput := rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		}
+		if err != nil {
+			// This becomes a validation issue on the resulting standard invoice, but we still need to provide
+			// the result too.
+			//
+			// Rating engine will resolve these usagebased items as if progressive billing was disabled as we don't
+			// know the underlying meter.
+			errs = append(errs, err)
+		} else {
+			ratingInput.Feature = &featureMeter.Feature
+			ratingInput.Meter = featureMeter.Meter
+		}
+
+		result, err := e.service.ratingService.ResolveBillablePeriod(ratingInput)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		// TODO: We should disallow billing in case the charge has a current realization run, so
+		// that we enforce that there are no multiple drafts for the same charge.
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(ctx context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -89,9 +89,6 @@ func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.Are
 			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
 		}
 
-		// TODO: We should disallow billing in case the charge has a current realization run, so
-		// that we enforce that there are no multiple drafts for the same charge.
-
 		return result, errors.Join(errs...)
 	})
 }

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -374,14 +374,14 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	stdLines, err := slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(stdLine *billing.StandardLine, _ int) (*billing.StandardLine, error) {
 		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, err
+			return stdLine, err
 		}
 
 		if stateMachine.GetCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-			return nil, fmt.Errorf(
+			return stdLine, fmt.Errorf(
 				"usage based standard line[%s]: unsupported settlement mode for standard invoice creation: %s",
 				stdLine.ID,
 				stateMachine.GetCharge().Intent.GetSettlementMode(),
@@ -392,11 +392,11 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		// still rely on the generic TriggerNext/AdvanceUntilStable flow before invoice-created
 		// lifecycle transitions take over.
 		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing usage based charge[%s]: %w", stateMachine.GetCharge().ID, err)
+			return stdLine, fmt.Errorf("advancing usage based charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
 		if stateMachine.GetCharge().State.CurrentRealizationRunID != nil {
-			return nil, billing.ValidationError{
+			return stdLine, billing.ValidationError{
 				Err: fmt.Errorf("line[%s]: %w", stdLine.ID, usagebased.ErrActiveRealizationRunAlreadyExists),
 			}
 		}
@@ -406,13 +406,13 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			InvoiceID:     input.Invoice.ID,
 			ServicePeriod: stdLine.Period,
 		}); err != nil {
-			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
+			return stdLine, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
 		}
 
 		charge := stateMachine.GetCharge()
 		currentRun, err := charge.GetCurrentRealizationRun()
 		if err != nil {
-			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
+			return stdLine, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
 		}
 
 		if err := populateStandardLineFromRun(stdLine, populateStandardLineFromRunInput{
@@ -420,20 +420,15 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			Run:    currentRun,
 			Stage:  standardLinePopulationStageInvoiceCreated,
 		}); err != nil {
-			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
+			return stdLine, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
 		}
 
 		if err := stdLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
+			return stdLine, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
 		}
 
 		return stdLine, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return stdLines, nil
 }
 
 func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine_test.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -128,6 +129,54 @@ func TestAreLinesBillableAsOfRequiresChargeID(t *testing.T) {
 
 	// Then the engine rejects the line before resolving charge dependencies.
 	require.ErrorContains(t, err, "charge id is required")
+}
+
+func TestAreLinesBillableAsOfFallsBackWhenChargeFeatureIsMissing(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newUsageBasedBillabilityLine("namespace", "line", "charge", period)
+	charge := newUsageBasedBillabilityCharge("namespace", "charge", "missing-feature")
+	featureMeterResolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: usageBasedBillabilityFeatureService{},
+		MeterService:   usageBasedBillabilityMeterService{},
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+	engine := &LineEngine{service: &service{
+		adapter:              &usageBasedBillabilityAdapter{charges: []usagebased.Charge{charge}},
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        billingratingservice.New(billingratingservice.Config{}),
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), usageBasedBillabilityTransaction{})
+	require.NoError(t, err)
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+			ID:              line.InvoiceID,
+		},
+	}}
+
+	// Given a usage-based charge whose persisted feature no longer exists.
+	// When billability is checked with progressive billing enabled.
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice:            invoice,
+		AsOf:               period.From.Add(24 * time.Hour),
+		ProgressiveBilling: true,
+		Lines:              billing.GatheringLines{line},
+	})
+
+	// Then the engine returns a usable non-progressive result and the missing-feature validation issue.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  "feature[missing-feature]: invoice line: feature not found",
+		Path:     "/charges/charge",
+	}}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{{}}, results)
 }
 
 type usageBasedBillabilityAdapter struct {

--- a/openmeter/billing/charges/usagebased/service/lineengine_test.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -9,34 +11,223 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestLineEngineIsLineBillableAsOfSupportsPartialBillablePeriod(t *testing.T) {
-	engine := &LineEngine{}
+const usageBasedBillabilityInvoiceID = "invoice-id"
 
-	servicePeriod := timeutil.ClosedPeriod{
-		From: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-		To:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+func TestAreLinesBillableAsOfResolvesChargeFeatureMeters(t *testing.T) {
+	periods := []timeutil.ClosedPeriod{
+		{From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)},
 	}
-	billablePeriod := timeutil.ClosedPeriod{
-		From: servicePeriod.From,
-		To:   time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+	lines := []billing.GatheringLine{
+		newUsageBasedBillabilityLine("namespace", "line-1", "charge-1", periods[0]),
+		newUsageBasedBillabilityLine("namespace", "line-2", "charge-2", periods[1]),
+	}
+	charges := []usagebased.Charge{
+		newUsageBasedBillabilityCharge("namespace", "charge-1", "feature-1"),
+		newUsageBasedBillabilityCharge("namespace", "charge-2", "feature-2"),
+	}
+	featureEntities := []feature.Feature{
+		{Namespace: "namespace", ID: "feature-1", Key: "charge-feature-1", MeterID: lo.ToPtr("meter-1")},
+		{Namespace: "namespace", ID: "feature-2", Key: "charge-feature-2", MeterID: lo.ToPtr("meter-2")},
+	}
+	meterEntities := []meter.Meter{
+		newUsageBasedBillabilityMeter("namespace", "meter-1"),
+		newUsageBasedBillabilityMeter("namespace", "meter-2"),
 	}
 
-	billable, err := engine.IsLineBillableAsOf(t.Context(), billing.IsLineBillableAsOfInput{
-		AsOf:                   billablePeriod.To,
-		ProgressiveBilling:     true,
-		ResolvedBillablePeriod: billablePeriod,
+	// Given usage-based gathering lines whose copied feature keys differ from
+	// the persisted feature snapshots owned by their charges.
+	adapter := &usageBasedBillabilityAdapter{charges: charges}
+	ratingService := &usageBasedBillabilityRatingService{}
+	featureMeterResolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: usageBasedBillabilityFeatureService{features: featureEntities},
+		MeterService:   usageBasedBillabilityMeterService{meters: meterEntities},
+		Logger:         slog.Default(),
 	})
 	require.NoError(t, err)
-	require.True(t, billable)
+	engine := &LineEngine{service: &service{
+		adapter:              adapter,
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        ratingService,
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), usageBasedBillabilityTransaction{})
+	require.NoError(t, err)
+
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+			ID:              usageBasedBillabilityInvoiceID,
+		},
+	}}
+
+	// When billability is resolved as an ordered batch.
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice:            invoice,
+		AsOf:               lines[len(lines)-1].InvoiceAt,
+		ProgressiveBilling: true,
+		Lines:              lines,
+	})
+
+	// Then rating receives the charge-owned feature and meter for each line,
+	// while results retain the original input order.
+	require.NoError(t, err)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{
+		{Billable: true, BillablePeriod: periods[0]},
+		{Billable: true, BillablePeriod: periods[1]},
+	}, results)
+	require.Equal(t, []usagebased.GetByIDsInput{{
+		Namespace: "namespace",
+		IDs:       []string{"charge-1", "charge-2"},
+	}}, adapter.inputs)
+
+	ratingInputsByLineID := lo.SliceToMap(ratingService.inputs, func(input rating.ResolveBillablePeriodInput) (string, rating.ResolveBillablePeriodInput) {
+		return input.Line.GetID(), input
+	})
+	require.Equal(t, "feature-1", ratingInputsByLineID["line-1"].Feature.ID)
+	require.Equal(t, "meter-1", ratingInputsByLineID["line-1"].Meter.ID)
+	require.Equal(t, "feature-2", ratingInputsByLineID["line-2"].Feature.ID)
+	require.Equal(t, "meter-2", ratingInputsByLineID["line-2"].Meter.ID)
+}
+
+func TestAreLinesBillableAsOfRequiresChargeID(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newUsageBasedBillabilityLine("namespace", "line", "charge", period)
+	line.ChargeID = nil
+
+	// Given a usage-based gathering line without its owning charge identity.
+	engine := &LineEngine{}
+
+	// When billability is requested.
+	_, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:  line.InvoiceAt,
+		Lines: billing.GatheringLines{line},
+	})
+
+	// Then the engine rejects the line before resolving charge dependencies.
+	require.ErrorContains(t, err, "charge id is required")
+}
+
+type usageBasedBillabilityAdapter struct {
+	usagebased.Adapter
+
+	charges []usagebased.Charge
+	inputs  []usagebased.GetByIDsInput
+}
+
+func (a *usageBasedBillabilityAdapter) GetByIDs(_ context.Context, input usagebased.GetByIDsInput) ([]usagebased.Charge, error) {
+	a.inputs = append(a.inputs, input)
+
+	return lo.Filter(a.charges, func(charge usagebased.Charge, _ int) bool {
+		return charge.Namespace == input.Namespace && lo.Contains(input.IDs, charge.ID)
+	}), nil
+}
+
+type usageBasedBillabilityFeatureService struct {
+	features []feature.Feature
+}
+
+func (s usageBasedBillabilityFeatureService) ListFeatures(_ context.Context, params feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+	return pagination.Result[feature.Feature]{Items: lo.Filter(s.features, func(featureEntity feature.Feature, _ int) bool {
+		return featureEntity.Namespace == params.Namespace && (lo.Contains(params.IDsOrKeys, featureEntity.ID) || lo.Contains(params.IDsOrKeys, featureEntity.Key))
+	})}, nil
+}
+
+type usageBasedBillabilityMeterService struct {
+	meters []meter.Meter
+}
+
+func (s usageBasedBillabilityMeterService) ListMeters(_ context.Context, params meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	return pagination.Result[meter.Meter]{Items: lo.Filter(s.meters, func(meterEntity meter.Meter, _ int) bool {
+		return meterEntity.Namespace == params.Namespace && params.IDFilter != nil && lo.Contains(*params.IDFilter, meterEntity.ID)
+	})}, nil
+}
+
+type usageBasedBillabilityRatingService struct {
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *usageBasedBillabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: input.Line.GetServicePeriod(),
+	}, nil
+}
+
+func (*usageBasedBillabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
+
+type usageBasedBillabilityTransaction struct{}
+
+func (usageBasedBillabilityTransaction) Commit() error    { return nil }
+func (usageBasedBillabilityTransaction) Rollback() error  { return nil }
+func (usageBasedBillabilityTransaction) SavePoint() error { return nil }
+
+func newUsageBasedBillabilityCharge(namespace, chargeID, featureID string) usagebased.Charge {
+	return usagebased.Charge{ChargeBase: usagebased.ChargeBase{
+		ManagedResource: meta.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              chargeID,
+		},
+		Status: usagebased.StatusActive,
+		State:  usagebased.State{FeatureID: featureID},
+	}}
+}
+
+func newUsageBasedBillabilityMeter(namespace, meterID string) meter.Meter {
+	return meter.Meter{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              meterID,
+		},
+		Aggregation: meter.MeterAggregationSum,
+	}
+}
+
+func newUsageBasedBillabilityLine(namespace, lineID, chargeID string, period timeutil.ClosedPeriod) billing.GatheringLine {
+	return billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              lineID,
+			Name:            "usage",
+		},
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeChargeUsageBased,
+		InvoiceID:     usageBasedBillabilityInvoiceID,
+		Currency:      currencyx.FiatCode("USD"),
+		ServicePeriod: period,
+		InvoiceAt:     period.To,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+		FeatureKey: "line-feature-must-not-be-resolved",
+		ChargeID:   lo.ToPtr(chargeID),
+	}}
 }
 
 func TestLineEngineSplitGatheringLineKeepsChargeGroupingWithoutChildReferences(t *testing.T) {
@@ -72,9 +263,8 @@ func TestLineEngineSplitGatheringLineKeepsChargeGroupingWithoutChildReferences(t
 	}
 
 	result, err := engine.SplitGatheringLine(t.Context(), billing.SplitGatheringLineInput{
-		Line:          line,
-		FeatureMeters: billingtestFeatureMeters(),
-		SplitAt:       splitAt,
+		Line:    line,
+		SplitAt: splitAt,
 	})
 	require.NoError(t, err)
 
@@ -113,8 +303,4 @@ func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T)
 	}
 
 	require.NoError(t, validateCustomCurrencyInvoiceLineDelete(invoice, line.AsGenericLine(), run))
-}
-
-func billingtestFeatureMeters() billingfeaturemeter.FeatureMeters {
-	return featuremeterservice.FeatureMeterCollection{}
 }

--- a/openmeter/billing/featuremeter/service/resolver.go
+++ b/openmeter/billing/featuremeter/service/resolver.go
@@ -68,12 +68,9 @@ type Resolver struct {
 	logger         *slog.Logger
 }
 
-// Resolve extracts and resolves the feature and meter dependencies of billing entities.
-//
-// When target validation fails, Resolve returns any feature-meter data it could
-// resolve alongside the error. Callers that can continue with partial data must
-// split the error with billing.ToValidationIssues and may continue only when the
-// returned system error is nil.
+// Resolve fetches the feature and meter dependencies of billing entities.
+// Missing features and required meters are reported by FeatureMeters.Get at the
+// operation that consumes each dependency.
 func (r Resolver) Resolve[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) (billingfeaturemeter.FeatureMeters, error) {
 	if namespace == "" {
 		return nil, models.NewGenericValidationError(errors.New("namespace is required"))
@@ -143,11 +140,27 @@ func (r Resolver) Resolve[T billingfeaturemeter.FeatureReferenceGetter](ctx cont
 		}
 	}
 
-	if err := validateReferences(resolved, targets); err != nil {
-		return resolved, err
+	return resolved, nil
+}
+
+// RequireFeatureMeters verifies that every supplied feature dependency can be
+// resolved, preserving each target's identity in the returned validation errors.
+func (r Resolver) RequireFeatureMeters[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) error {
+	featureMeters, err := r.Resolve(ctx, namespace, targets...)
+	if err != nil {
+		return err
 	}
 
-	return resolved, nil
+	errs := lo.Map(targets, func(target T, _ int) error {
+		if target.GetFeatureMeterRef() == nil {
+			return nil
+		}
+
+		_, err := featureMeters.Get(target)
+		return err
+	})
+
+	return errors.Join(errs...)
 }
 
 func collectUniqueFeatureMeterRefs[T billingfeaturemeter.FeatureReferenceGetter](references []T) []billingfeaturemeter.FeatureMeterRef {
@@ -175,19 +188,6 @@ func collectUniqueFeatureMeterRefs[T billingfeaturemeter.FeatureReferenceGetter]
 	)
 
 	return featureRefs
-}
-
-func validateReferences[T billingfeaturemeter.FeatureReferenceGetter](featureMeters billingfeaturemeter.FeatureMeters, targets []T) error {
-	errs := lo.FilterMap(targets, func(target T, _ int) (error, bool) {
-		if target.GetFeatureMeterRef() == nil {
-			return nil, false
-		}
-
-		_, err := featureMeters.Get(target)
-		return err, err != nil
-	})
-
-	return errors.Join(errs...)
 }
 
 func resolveFeatureMeters(features []feature.Feature) FeatureMeterCollection {

--- a/openmeter/billing/featuremeter/service/resolver_test.go
+++ b/openmeter/billing/featuremeter/service/resolver_test.go
@@ -165,7 +165,7 @@ func TestResolver(t *testing.T) {
 		require.Equal(t, meterID, byArchivedID.Meter.ID)
 	})
 
-	t.Run("returns partial results alongside validation errors", func(t *testing.T) {
+	t.Run("returns partial results without validating references", func(t *testing.T) {
 		// given:
 		// - one resolvable feature and one missing feature
 		targets := []featureMeterReference{
@@ -179,13 +179,15 @@ func TestResolver(t *testing.T) {
 		resolved, err := resolver.Resolve(t.Context(), namespace, targets...)
 
 		// then:
-		// - the resolved feature remains usable and the error contains validation issues only
+		// - resolution succeeds, the resolved feature remains usable, and validation is deferred to Get
 		require.NotNil(t, resolved)
+		require.NoError(t, err)
 		resolvedFeature, getErr := resolved.Get(targets[0])
 		require.NoError(t, getErr)
 		require.Equal(t, "feature-new", resolvedFeature.Feature.ID)
 
-		issues, systemErr := billing.ToValidationIssues(err)
+		_, getErr = resolved.Get(targets[1])
+		issues, systemErr := billing.ToValidationIssues(getErr)
 		require.NoError(t, systemErr)
 		require.Equal(t, billing.ValidationIssues{{
 			Severity: billing.ValidationIssueSeverityCritical,
@@ -194,7 +196,7 @@ func TestResolver(t *testing.T) {
 		}}, issues)
 	})
 
-	t.Run("returns meterless feature alongside validation error", func(t *testing.T) {
+	t.Run("returns meterless feature without validating meter requirements", func(t *testing.T) {
 		// given:
 		// - a feature exists but has no meter
 		resolver := newResolver(t, []string{"requests"}, nil)
@@ -208,13 +210,15 @@ func TestResolver(t *testing.T) {
 		resolved, err := resolver.Resolve(t.Context(), namespace, target)
 
 		// then:
-		// - the feature remains addressable and the missing meter is a validation-only error
+		// - resolution succeeds, the feature remains addressable, and Get enforces the meter requirement
 		require.NotNil(t, resolved)
+		require.NoError(t, err)
 		resolvedFeature, getErr := resolved.Get(featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: target.IDOrKey}))
 		require.NoError(t, getErr)
 		require.Equal(t, "feature-other", resolvedFeature.Feature.ID)
 
-		issues, systemErr := billing.ToValidationIssues(err)
+		_, getErr = resolved.Get(target)
+		issues, systemErr := billing.ToValidationIssues(getErr)
 		require.NoError(t, systemErr)
 		require.Equal(t, billing.ValidationIssues{{
 			Severity: billing.ValidationIssueSeverityCritical,
@@ -223,7 +227,7 @@ func TestResolver(t *testing.T) {
 		}}, issues)
 	})
 
-	t.Run("deduplicated lookup validates every original identified reference", func(t *testing.T) {
+	t.Run("require validates every original identified reference", func(t *testing.T) {
 		// given:
 		// - two gathering lines reference the same missing feature
 		resolver := newResolver(t, []string{"missing-feature"}, nil)
@@ -245,12 +249,11 @@ func TestResolver(t *testing.T) {
 		}
 
 		// when:
-		// - feature meters are resolved
-		resolved, err := resolver.Resolve(t.Context(), namespace, references...)
+		// - every feature meter is required
+		err := resolver.RequireFeatureMeters(t.Context(), namespace, references...)
 
 		// then:
 		// - the catalog lookup is deduplicated while each original line receives an issue
-		require.NotNil(t, resolved)
 		issues, systemErr := billing.ToValidationIssues(err)
 		require.NoError(t, systemErr)
 		require.ElementsMatch(t, []string{"/lines/line-1", "/lines/line-2"}, lo.Map(issues, func(issue billing.ValidationIssue, _ int) string {

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -1124,5 +1124,6 @@ func (i UpdateGatheringInvoiceInput) Validate() error {
 type PrepareBillableLinesInput = InvoicePendingLinesInput
 
 type PrepareBillableLinesResult struct {
-	LinesByCurrency map[currencyx.FiatCode]GatheringLines
+	LinesByCurrency            map[currencyx.FiatCode]GatheringLines
+	ValidationIssuesByCurrency map[currencyx.FiatCode]ValidationIssues
 }

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/samber/lo"
 
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -169,12 +168,39 @@ type (
 	OnPaymentSettledInput              = StandardLineEventInput
 )
 
-type IsLineBillableAsOfInput struct {
-	Line                   GatheringLine
-	AsOf                   time.Time
-	ProgressiveBilling     bool
-	FeatureMeters          billingfeaturemeter.FeatureMeters
-	ResolvedBillablePeriod timeutil.ClosedPeriod
+type AreLinesBillableAsOfInput struct {
+	Invoice            GatheringInvoice
+	AsOf               time.Time
+	ProgressiveBilling bool
+	Lines              GatheringLines
+}
+
+func (i AreLinesBillableAsOfInput) Validate() error {
+	var errs []error
+
+	if err := i.Invoice.GetInvoiceID().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invoice: %w", err))
+	}
+
+	if i.AsOf.IsZero() {
+		errs = append(errs, errors.New("as of is required"))
+	}
+
+	if err := i.Lines.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("lines: %w", err))
+	}
+
+	for index, line := range i.Lines {
+		if line.Namespace != i.Invoice.Namespace {
+			errs = append(errs, fmt.Errorf("line[%d]: namespace %s does not match invoice namespace %s", index, line.Namespace, i.Invoice.Namespace))
+		}
+
+		if line.InvoiceID != i.Invoice.ID {
+			errs = append(errs, fmt.Errorf("line[%d]: invoice ID %s does not match invoice ID %s", index, line.InvoiceID, i.Invoice.ID))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type IsLineBillableAsOfResult struct {
@@ -194,18 +220,6 @@ func (r IsLineBillableAsOfResult) Validate() error {
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
-func (i IsLineBillableAsOfInput) Validate() error {
-	if err := i.ResolvedBillablePeriod.Validate(); err != nil {
-		return fmt.Errorf("validating resolved billable period: %w", err)
-	}
-
-	if i.AsOf.IsZero() {
-		return fmt.Errorf("as of is required")
-	}
-
-	return nil
 }
 
 type GateInvoiceAssignmentInput struct {
@@ -256,9 +270,8 @@ func (r GateInvoiceAssignmentResult) Validate(input GateInvoiceAssignmentInput) 
 }
 
 type SplitGatheringLineInput struct {
-	Line          GatheringLine
-	FeatureMeters billingfeaturemeter.FeatureMeters
-	SplitAt       time.Time
+	Line    GatheringLine
+	SplitAt time.Time
 }
 
 func (i SplitGatheringLineInput) Validate() error {
@@ -270,10 +283,6 @@ func (i SplitGatheringLineInput) Validate() error {
 
 	if i.SplitAt.IsZero() {
 		errs = append(errs, fmt.Errorf("split at is required"))
-	}
-
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
 	}
 
 	return errors.Join(errs...)
@@ -304,8 +313,9 @@ type LineEngine interface {
 	// GetLineEngineType returns the discriminator owned by this engine implementation.
 	GetLineEngineType() LineEngineType
 
-	// IsLineBillableAsOf returns true if the line is billable as of the given time.
-	IsLineBillableAsOf(ctx context.Context, input IsLineBillableAsOfInput) (bool, error)
+	// AreLinesBillableAsOf returns one result for each line in the same order. Implementations may return usable
+	// results together with validation issues. Operational errors make the returned results unusable.
+	AreLinesBillableAsOf(ctx context.Context, input AreLinesBillableAsOfInput) ([]IsLineBillableAsOfResult, error)
 	// GateInvoiceAssignment decides which otherwise billable gathering lines may be assigned to an invoice.
 	// Implementations may persist engine-owned state explaining blocked decisions. Returning an error aborts
 	// invoice creation and rolls back those writes.

--- a/openmeter/billing/lineengine/engine_test.go
+++ b/openmeter/billing/lineengine/engine_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -134,6 +135,100 @@ func TestSnapshotLineQuantitiesRejectsResolverSystemErrors(t *testing.T) {
 	require.Nil(t, issues)
 	require.ErrorIs(t, systemErr, resolverErr)
 	require.Nil(t, line.UsageBased.Quantity)
+}
+
+func TestAreLinesBillableAsOfLocalizesFeatureMeterValidationIssues(t *testing.T) {
+	period := lineEngineOverrideTestPeriod()
+	engine, _ := newQuantitySnapshotTestEngine(t, nil, nil, nil)
+	ratingService := &lineEngineBillabilityRatingService{}
+	engine.ratingService = ratingService
+
+	lines := billing.GatheringLines{
+		billabilityGatheringLine("line-1", "missing-feature-1", period),
+		billabilityGatheringLine("line-2", "missing-feature-2", period),
+	}
+
+	// Given multiple legacy lines whose feature references cannot be resolved.
+	// When their billability is evaluated from the resolver's partial result.
+	results, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "namespace",
+				ID:        "invoice-id",
+				Name:      "invoice",
+				CreatedAt: period.From,
+				UpdatedAt: period.From,
+			}),
+		}},
+		AsOf:               period.From,
+		ProgressiveBilling: true,
+		Lines:              lines,
+	})
+
+	// Then every line receives a fallback result and its own localized validation issue.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.ElementsMatch(t, billing.ValidationIssues{
+		{
+			Severity: billing.ValidationIssueSeverityCritical,
+			Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+			Message:  "feature[missing-feature-1]: invoice line: feature not found",
+			Path:     "/lines/line-1",
+		},
+		{
+			Severity: billing.ValidationIssueSeverityCritical,
+			Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+			Message:  "feature[missing-feature-2]: invoice line: feature not found",
+			Path:     "/lines/line-2",
+		},
+	}, issues)
+	require.Len(t, results, len(lines))
+	require.Len(t, ratingService.inputs, len(lines))
+	for index := range lines {
+		require.True(t, results[index].Billable)
+		require.Equal(t, period, results[index].BillablePeriod)
+		require.Nil(t, ratingService.inputs[index].Feature)
+		require.Nil(t, ratingService.inputs[index].Meter)
+	}
+}
+
+type lineEngineBillabilityRatingService struct {
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *lineEngineBillabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: input.Line.GetServicePeriod(),
+	}, nil
+}
+
+func (*lineEngineBillabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
+
+func billabilityGatheringLine(id, featureKey string, period timeutil.ClosedPeriod) billing.GatheringLine {
+	return billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			Namespace: "namespace",
+			ID:        id,
+			Name:      id,
+			CreatedAt: period.From,
+			UpdatedAt: period.From,
+		}),
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeInvoice,
+		InvoiceID:     "invoice-id",
+		Currency:      "USD",
+		ServicePeriod: period,
+		InvoiceAt:     period.From,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+		FeatureKey: featureKey,
+	}}
 }
 
 func TestLineEngineValidationErrorOwnsValidationIssues(t *testing.T) {

--- a/openmeter/billing/lineengine/quantitysnapshot.go
+++ b/openmeter/billing/lineengine/quantitysnapshot.go
@@ -53,12 +53,7 @@ func (e *Engine) SnapshotLineQuantity(ctx context.Context, input SnapshotLineQua
 func (e *Engine) SnapshotLineQuantities(ctx context.Context, invoice billing.StandardInvoice, lines billing.StandardLines) error {
 	featureMeters, err := e.featureMeterResolver.Resolve(ctx, invoice.Namespace, lines...)
 	if err != nil {
-		// Per-line snapshotting below surfaces validation issues with line identity,
-		// so only system errors abort the batch here.
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return fmt.Errorf("resolving feature meters: %w", systemErr)
-		}
+		return fmt.Errorf("resolving feature meters: %w", err)
 	}
 
 	if err := e.snapshotLineQuantitiesInParallel(ctx, invoice.Customer, lines, featureMeters); err != nil {

--- a/openmeter/billing/lineengine/stdinvoice.go
+++ b/openmeter/billing/lineengine/stdinvoice.go
@@ -2,12 +2,13 @@ package lineengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
@@ -92,12 +93,41 @@ func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.Stan
 	return input.Lines, nil
 }
 
-func (e *Engine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *Engine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
+	featureMeters, err := e.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, input.Lines...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		ratingInput := rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		}
+
+		if line.GetFeatureMeterRef() != nil {
+			featureMeter, err := featureMeters.Get(line)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				ratingInput.Feature = &featureMeter.Feature
+				ratingInput.Meter = featureMeter.Meter
+			}
+		}
+
+		result, err := e.ratingService.ResolveBillablePeriod(ratingInput)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *Engine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/rating/line.go
+++ b/openmeter/billing/rating/line.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -15,12 +14,10 @@ import (
 type PriceAccessor interface {
 	GetPrice() *productcatalog.Price
 	GetServicePeriod() timeutil.ClosedPeriod
-	GetFeatureKey() string
 }
 
 type GatheringLineAccessor interface {
 	PriceAccessor
-	billingfeaturemeter.FeatureReferenceGetter
 	GetSplitLineGroupID() *string
 	GetInvoiceAt() time.Time
 	GetID() string

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -1,14 +1,16 @@
 package rating
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
 type Service interface {
@@ -65,21 +67,33 @@ type ResolveBillablePeriodInput struct {
 	AsOf               time.Time
 	ProgressiveBilling bool
 	Line               GatheringLineAccessor
-	FeatureMeters      billingfeaturemeter.FeatureMeters
+	Feature            *feature.Feature
+	Meter              *meter.Meter
 }
 
 func (i ResolveBillablePeriodInput) Validate() error {
-	if i.Line == nil {
-		return fmt.Errorf("line is required")
-	}
+	var errs []error
 
-	if i.FeatureMeters == nil {
-		return fmt.Errorf("feature meters are required")
+	if i.Line == nil {
+		errs = append(errs, errors.New("line is required"))
+	} else {
+		price := i.Line.GetPrice()
+		if price == nil {
+			errs = append(errs, errors.New("line price is required"))
+		} else if price.Type() != productcatalog.FlatPriceType {
+			if i.Feature == nil {
+				errs = append(errs, errors.New("feature is required for metered lines"))
+			}
+
+			if i.Meter == nil {
+				errs = append(errs, errors.New("meter is required for metered lines"))
+			}
+		}
 	}
 
 	if i.AsOf.IsZero() {
-		return fmt.Errorf("as of is required")
+		errs = append(errs, errors.New("as of is required"))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/meter"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
@@ -80,14 +79,6 @@ func (i ResolveBillablePeriodInput) Validate() error {
 		price := i.Line.GetPrice()
 		if price == nil {
 			errs = append(errs, errors.New("line price is required"))
-		} else if price.Type() != productcatalog.FlatPriceType {
-			if i.Feature == nil {
-				errs = append(errs, errors.New("feature is required for metered lines"))
-			}
-
-			if i.Meter == nil {
-				errs = append(errs, errors.New("meter is required for metered lines"))
-			}
 		}
 	}
 

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type Service interface {
@@ -86,5 +87,5 @@ func (i ResolveBillablePeriodInput) Validate() error {
 		errs = append(errs, errors.New("as of is required"))
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
 func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
@@ -24,14 +25,22 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("price is nil")
 	}
 
-	meterTypeAllowsProgressiveBilling := false
-	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling {
-		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters(in)
+	progressiveBillingAllowed := false
+	// We can allow progressive billing only if:
+	// - the line is not flat price (=> usage based)
+	// - the usage based line's features can be resolved
+	//
+	// As any usage-based line is billable in arrears, thus we are safe to continue with non-progressive billing.
+	//
+	// By allowing empty feature/meter for usage-based lines we can create a standard invoice which immediately
+	// enters into failed state, thus we are communicating the issue to the user.
+	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling && in.Feature != nil && in.Meter != nil {
+		progressiveBillingAllowed = isDependingOnIncreaseOnlyMeters(in)
 	}
 
-	// Force disable progressive billing if the meter type does not allow it
-	if !meterTypeAllowsProgressiveBilling {
-		in.ProgressiveBilling = false
+	in.ProgressiveBilling = progressiveBillingAllowed
+	if !in.ProgressiveBilling && in.AsOf.Truncate(streaming.MinimumWindowSizeDuration).Before(in.Line.GetInvoiceAt().Truncate(streaming.MinimumWindowSizeDuration)) {
+		return billing.IsLineBillableAsOfResult{}, nil
 	}
 
 	result, err := linePricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -26,12 +26,7 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 
 	meterTypeAllowsProgressiveBilling := false
 	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling {
-		isDependingOnIncreaseOnlyMeters, err := isDependingOnIncreaseOnlyMeters(in)
-		if err != nil {
-			return billing.IsLineBillableAsOfResult{}, err
-		}
-
-		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters
+		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters(in)
 	}
 
 	// Force disable progressive billing if the meter type does not allow it
@@ -43,7 +38,8 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 		AsOf:               in.AsOf,
 		ProgressiveBilling: in.ProgressiveBilling,
 		Line:               in.Line,
-		FeatureMeters:      in.FeatureMeters,
+		Feature:            in.Feature,
+		Meter:              in.Meter,
 	})
 	if err != nil {
 		return billing.IsLineBillableAsOfResult{}, err
@@ -58,30 +54,13 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 
 // isDependingOnIncreaseOnlyMeters checks if the line is depending on meters that can decrease the totals over time
 // (note: this is somewhat of a lie, as we can input negative values in events, which will have the same effect)
-func isDependingOnIncreaseOnlyMeters(in rating.ResolveBillablePeriodInput) (bool, error) {
-	featureKey := in.Line.GetFeatureKey()
-	if featureKey == "" {
-		return false, fmt.Errorf("feature key is required")
-	}
-
-	// Let's check if the underlying meter can be billed in a progressive manner
-	featureMeter, err := in.FeatureMeters.Get(in.Line)
-	if err != nil {
-		return false, err
-	}
-
-	if featureMeter.Meter == nil {
-		return false, fmt.Errorf("meter is nil for feature[%s]", featureKey)
-	}
-
-	meterEntity := *featureMeter.Meter
-
-	switch meterEntity.Aggregation {
+func isDependingOnIncreaseOnlyMeters(in rating.ResolveBillablePeriodInput) bool {
+	switch in.Meter.Aggregation {
 	case meter.MeterAggregationSum, meter.MeterAggregationCount,
 		meter.MeterAggregationMax, meter.MeterAggregationUniqueCount:
-		return true, nil
+		return true
 	default:
 		// Other types need to be billed in arrears truncated by window size
-		return false, nil
+		return false
 	}
 }

--- a/openmeter/billing/rating/service/billableperiod_test.go
+++ b/openmeter/billing/rating/service/billableperiod_test.go
@@ -1,0 +1,88 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	ratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestResolveBillablePeriodFallsBackToNonProgressiveBillingWithoutDependencies(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	invoiceAt := period.To.Add(24 * time.Hour)
+	line := billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ServicePeriod: period,
+		InvoiceAt:     invoiceAt,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}}
+	service := ratingservice.New(ratingservice.Config{})
+
+	t.Run("valid dependencies allow progressive billing", func(t *testing.T) {
+		// Given a progressively billable metered line with its rating dependencies.
+		asOf := period.From.Add(12 * time.Hour)
+
+		// When billability is resolved before the normal invoice time.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               asOf,
+			ProgressiveBilling: true,
+			Line:               line,
+			Feature:            &feature.Feature{},
+			Meter:              &meter.Meter{Aggregation: meter.MeterAggregationSum},
+		})
+
+		// Then the elapsed portion is billable progressively.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{
+			Billable: true,
+			BillablePeriod: timeutil.ClosedPeriod{
+				From: period.From,
+				To:   asOf,
+			},
+		}, result)
+	})
+
+	t.Run("missing dependencies defer billing until invoice at", func(t *testing.T) {
+		// Given the same line without a resolvable feature or meter.
+		// When billability is resolved after service completion but before InvoiceAt.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               period.To,
+			ProgressiveBilling: true,
+			Line:               line,
+		})
+
+		// Then progressive billing is disabled and the line is not yet billable.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{}, result)
+	})
+
+	t.Run("missing dependencies yield the full period at invoice at", func(t *testing.T) {
+		// Given the same line without a resolvable feature or meter.
+		// When its normal invoice time is reached.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               invoiceAt,
+			ProgressiveBilling: true,
+			Line:               line,
+		})
+
+		// Then the complete service period is billable non-progressively.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: period,
+		}, result)
+	})
+}

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -60,14 +60,13 @@ func TestResolveBillablePeriodInputValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("metered lines require a feature and meter", func(t *testing.T) {
+	t.Run("metered lines allow unresolved rating dependencies", func(t *testing.T) {
 		err := (rating.ResolveBillablePeriodInput{
 			AsOf: asOf,
 			Line: meteredLine,
 		}).Validate()
 
-		require.ErrorContains(t, err, "feature is required for metered lines")
-		require.ErrorContains(t, err, "meter is required for metered lines")
+		require.NoError(t, err)
 	})
 
 	t.Run("rating does not validate the feature meter association", func(t *testing.T) {

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -1,0 +1,86 @@
+package rating_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type gatheringLine struct {
+	price *productcatalog.Price
+}
+
+func (l gatheringLine) GetPrice() *productcatalog.Price {
+	return l.price
+}
+
+func (gatheringLine) GetServicePeriod() timeutil.ClosedPeriod {
+	return timeutil.ClosedPeriod{}
+}
+
+func (gatheringLine) GetSplitLineGroupID() *string {
+	return nil
+}
+
+func (gatheringLine) GetInvoiceAt() time.Time {
+	return time.Time{}
+}
+
+func (gatheringLine) GetID() string {
+	return "line"
+}
+
+func TestResolveBillablePeriodInputValidate(t *testing.T) {
+	flatLine := gatheringLine{
+		price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}
+	meteredLine := gatheringLine{
+		price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}
+	asOf := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
+
+	t.Run("flat lines do not require feature dependencies", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: flatLine,
+		}).Validate()
+
+		require.NoError(t, err)
+	})
+
+	t.Run("metered lines require a feature and meter", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: meteredLine,
+		}).Validate()
+
+		require.ErrorContains(t, err, "feature is required for metered lines")
+		require.ErrorContains(t, err, "meter is required for metered lines")
+	})
+
+	t.Run("rating does not validate the feature meter association", func(t *testing.T) {
+		differentMeterID := "different-meter"
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: meteredLine,
+			Feature: &feature.Feature{
+				MeterID: &differentMeterID,
+			},
+			Meter: &meter.Meter{},
+		}).Validate()
+
+		require.NoError(t, err)
+	})
+}

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -81,5 +82,23 @@ func TestResolveBillablePeriodInputValidate(t *testing.T) {
 		}).Validate()
 
 		require.NoError(t, err)
+	})
+
+	t.Run("missing line and as of return a generic validation error", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{}).Validate()
+
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "line is required")
+		require.ErrorContains(t, err, "as of is required")
+	})
+
+	t.Run("missing line price returns a generic validation error", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: gatheringLine{},
+		}).Validate()
+
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "line price is required")
 	})
 }

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -8,13 +8,8 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
-	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/meter"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -182,18 +177,8 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 			}
 		}
 
-		featureMeters, err := s.featureMeterResolver.Resolve(ctx, invoice.Namespace, invoice.Lines.OrEmpty()...)
-		if err != nil {
-			// Quantity snapshotting surfaces validation issues with line identity when
-			// these gathering lines are collected, so only system errors abort here.
-			_, systemErr := billing.ToValidationIssues(err)
-			if systemErr != nil {
-				return billing.GatheringInvoice{}, fmt.Errorf("resolving feature meters: %w", systemErr)
-			}
-		}
-
 		// Check if the new lines are still invoicable
-		if err := s.checkIfGatheringLinesAreInvoicable(ctx, invoice, customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling, featureMeters); err != nil {
+		if err := s.checkIfGatheringLinesAreInvoicable(ctx, invoice, customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling); err != nil {
 			return billing.GatheringInvoice{}, err
 		}
 
@@ -226,60 +211,33 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 	})
 }
 
-func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice billing.GatheringInvoice, progressiveBilling bool, featureMeters billingfeaturemeter.FeatureMeters) error {
+func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice billing.GatheringInvoice, progressiveBilling bool) error {
 	linesToCheck := lo.Filter(invoice.Lines.OrEmpty(), func(line billing.GatheringLine, _ int) bool {
 		return line.DeletedAt == nil
 	})
 
-	return errors.Join(
-		lo.Map(linesToCheck, func(line billing.GatheringLine, _ int) error {
-			if err := line.Validate(); err != nil {
-				return fmt.Errorf("validating line[%s]: %w", line.ID, err)
-			}
+	var errs []error
+	for _, line := range linesToCheck {
+		// Note: this is considered a low frequency operation, so we are not using the batch API here.
+		// Current implementation focuses on main use-cases and readability over the performance of this operation.
+		results, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            invoice,
+			AsOf:               line.InvoiceAt,
+			ProgressiveBilling: progressiveBilling,
+			Lines:              billing.GatheringLines{line},
+		})
+		if err != nil {
+			return err
+		}
 
-			featureEntity, meterEntity, err := resolveRatingDependencies(line, featureMeters)
-			if err != nil {
-				return fmt.Errorf("resolving rating dependencies for line[%s]: %w", line.ID, err)
-			}
-
-			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
-				Line:               line,
-				Feature:            featureEntity,
-				Meter:              meterEntity,
-				ProgressiveBilling: progressiveBilling,
-				AsOf:               line.InvoiceAt,
+		if len(results) != 1 || !results[0].Billable {
+			errs = append(errs, billing.ValidationError{
+				Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.InvoiceAt),
 			})
-			if err != nil {
-				return fmt.Errorf("checking if line[%s] can be invoiced: %w", line.ID, err)
-			}
-
-			if !result.Billable {
-				return billing.ValidationError{
-					Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.InvoiceAt),
-				}
-			}
-
-			return nil
-		})...,
-	)
-}
-
-func resolveRatingDependencies(line billing.GatheringLine, featureMeters billingfeaturemeter.FeatureMeters) (*feature.Feature, *meter.Meter, error) {
-	price := line.GetPrice()
-	if price == nil {
-		return nil, nil, errors.New("line price is required")
+		}
 	}
 
-	if price.Type() == productcatalog.FlatPriceType {
-		return nil, nil, nil
-	}
-
-	featureMeter, err := featureMeters.Get(line)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &featureMeter.Feature, featureMeter.Meter, nil
+	return errors.Join(errs...)
 }
 
 func (s *Service) GetGatheringInvoiceById(ctx context.Context, input billing.GetGatheringInvoiceByIdInput) (billing.GatheringInvoice, error) {

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -12,6 +12,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -233,9 +236,16 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 			if err := line.Validate(); err != nil {
 				return fmt.Errorf("validating line[%s]: %w", line.ID, err)
 			}
+
+			featureEntity, meterEntity, err := resolveRatingDependencies(line, featureMeters)
+			if err != nil {
+				return fmt.Errorf("resolving rating dependencies for line[%s]: %w", line.ID, err)
+			}
+
 			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
-				FeatureMeters:      featureMeters,
+				Feature:            featureEntity,
+				Meter:              meterEntity,
 				ProgressiveBilling: progressiveBilling,
 				AsOf:               line.InvoiceAt,
 			})
@@ -252,6 +262,24 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 			return nil
 		})...,
 	)
+}
+
+func resolveRatingDependencies(line billing.GatheringLine, featureMeters billingfeaturemeter.FeatureMeters) (*feature.Feature, *meter.Meter, error) {
+	price := line.GetPrice()
+	if price == nil {
+		return nil, nil, errors.New("line price is required")
+	}
+
+	if price.Type() == productcatalog.FlatPriceType {
+		return nil, nil, nil
+	}
+
+	featureMeter, err := featureMeters.Get(line)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &featureMeter.Feature, featureMeter.Meter, nil
 }
 
 func (s *Service) GetGatheringInvoiceById(ctx context.Context, input billing.GetGatheringInvoiceByIdInput) (billing.GatheringInvoice, error) {

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -81,6 +81,7 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 					Customer:          input.Customer,
 					Currency:          currency,
 					Lines:             inScopeLines,
+					ValidationIssues:  billableLines.ValidationIssuesByCurrency[currency],
 					ForceAsyncAdvance: input.ForceAsyncAdvance,
 				})
 				if err != nil {
@@ -173,7 +174,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			// let's gather the in-scope lines and validate it
-			inScopeLinesByCurrency, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
+			inScopeLinesResult, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
 				GatheringInvoicesByCurrency: invoicesByCurrency,
 				LinesToInclude:              input.IncludePendingLines,
 				AsOf:                        asOf,
@@ -184,10 +185,13 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			linesToBeBilledByCurrency := make(map[currencyx.FiatCode]billing.GatheringLines)
+			validationIssuesByCurrency := make(map[currencyx.FiatCode]billing.ValidationIssues)
 			assignmentCandidateLineCount := 0
 			assignmentExcludedLineCount := 0
 
-			for currency, inScopeLines := range inScopeLinesByCurrency {
+			for currency, inScopeLines := range inScopeLinesResult.LinesByCurrency {
+				// Let's first make sure we have properly split the progressively billed
+				// lines into multiple lines on the gathering invoice if needed.
 				gatheringInvoice, ok := invoicesByCurrency[currency]
 				if !ok {
 					return nil, fmt.Errorf("gathering invoice for currency [%s] not found", currency)
@@ -220,6 +224,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 					inScopeLines = limitGatheringLinesForInvoice(inScopeLines, options.MaxLinesPerInvoice)
 				}
 
+				billabilityValidationIssues := inScopeLinesResult.ValidationIssuesByCurrency[currency]
 				// Step 1: Let's make sure we have lines properly split on the gathering invoice.
 				// Invariant: the gathering invoice is updated to contain the new lines if any were split.
 				prepareResults, err := s.prepareLinesToBill(ctx, prepareLinesToBillInput{
@@ -234,7 +239,24 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 					continue
 				}
 
+				if len(billabilityValidationIssues) > 0 {
+					_, billabilityErr := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+						Invoice:            prepareResults.GatheringInvoice,
+						AsOf:               asOf,
+						ProgressiveBilling: progressiveBilling,
+						Lines:              prepareResults.LinesToBill,
+					})
+					selectedValidationIssues, systemErr := billing.ToValidationIssues(billabilityErr)
+					if systemErr != nil {
+						return nil, fmt.Errorf("checking selected gathering line billability: %w", systemErr)
+					}
+					billabilityValidationIssues = selectedValidationIssues
+				}
+
 				linesToBeBilledByCurrency[currency] = prepareResults.LinesToBill
+				if len(billabilityValidationIssues) > 0 {
+					validationIssuesByCurrency[currency] = billabilityValidationIssues
+				}
 			}
 
 			totalLinesToBeBilled := 0
@@ -255,7 +277,8 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			return &billing.PrepareBillableLinesResult{
-				LinesByCurrency: linesToBeBilledByCurrency,
+				LinesByCurrency:            linesToBeBilledByCurrency,
+				ValidationIssuesByCurrency: validationIssuesByCurrency,
 			}, nil
 		},
 	)
@@ -317,10 +340,16 @@ type gatherInScopeLineInput struct {
 	ProgressiveBilling bool
 }
 
-type gatherInScopeLinesResult map[currencyx.FiatCode][]gatheringLineWithBillablePeriod
+type gatherInScopeLinesResult struct {
+	LinesByCurrency            map[currencyx.FiatCode][]gatheringLineWithBillablePeriod
+	ValidationIssuesByCurrency map[currencyx.FiatCode]billing.ValidationIssues
+}
 
 func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineInput) (gatherInScopeLinesResult, error) {
-	res := make(gatherInScopeLinesResult)
+	res := gatherInScopeLinesResult{
+		LinesByCurrency:            make(map[currencyx.FiatCode][]gatheringLineWithBillablePeriod),
+		ValidationIssuesByCurrency: make(map[currencyx.FiatCode]billing.ValidationIssues),
+	}
 
 	billableLineIDs := make(map[string]interface{})
 
@@ -332,10 +361,12 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			ProgressiveBilling: in.ProgressiveBilling,
 			Lines:              lines,
 		})
-		if err != nil && !billing.IsValidationIssueOnly(err) {
-			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		validationIssues, systemErr := billing.ToValidationIssues(err)
+		if systemErr != nil {
+			return gatherInScopeLinesResult{}, fmt.Errorf("checking gathering line billability: %w", systemErr)
 		}
-		if err != nil {
+		if len(validationIssues) > 0 {
+			res.ValidationIssuesByCurrency[currency] = validationIssues
 			s.logger.WarnContext(
 				ctx, "gathering line billability has validation issues; continuing with fallback results",
 				"namespace", invoice.Namespace,
@@ -366,7 +397,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			billableLineIDs[line.Line.ID] = struct{}{}
 		}
 
-		res[currency] = linesWithResolvedPeriods
+		res.LinesByCurrency[currency] = linesWithResolvedPeriods
 	}
 
 	// If the user has requested specific lines to be included, we need to filter the output to only include those lines
@@ -382,7 +413,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 		}
 
 		if len(nonBillableLineIDs) > 0 {
-			return nil, billing.ValidationError{
+			return gatherInScopeLinesResult{}, billing.ValidationError{
 				Err: fmt.Errorf("%w: %s", billing.ErrInvoiceLinesNotBillable, strings.Join(nonBillableLineIDs, ",")),
 			}
 		}
@@ -393,14 +424,15 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			return lineID, struct{}{}
 		})
 
-		for currency, lines := range res {
-			res[currency] = lo.Filter(lines, func(line gatheringLineWithBillablePeriod, _ int) bool {
+		for currency, lines := range res.LinesByCurrency {
+			res.LinesByCurrency[currency] = lo.Filter(lines, func(line gatheringLineWithBillablePeriod, _ int) bool {
 				_, ok := linesShouldBeIncluded[line.Line.ID]
 				return ok
 			})
 
-			if len(res[currency]) == 0 {
-				delete(res, currency)
+			if len(res.LinesByCurrency[currency]) == 0 {
+				delete(res.LinesByCurrency, currency)
+				delete(res.ValidationIssuesByCurrency, currency)
 			}
 		}
 	}
@@ -528,7 +560,7 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 		return false, fmt.Errorf("gathering in scope lines: %w", err)
 	}
 
-	res, found := inScopeLines[in.Invoice.Currency]
+	res, found := inScopeLines.LinesByCurrency[in.Invoice.Currency]
 	if !found {
 		return false, nil
 	}
@@ -727,6 +759,11 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 
 	// let's set the workflow apps as some checks such as CanDraftSyncAdvance depends on the apps
 	invoice.Workflow.Apps = profile.MergedProfile.Apps
+	validationIssues, err := in.ValidationIssues.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning validation issues: %w", err)
+	}
+	invoice.ValidationIssues = append(invoice.ValidationIssues, validationIssues...)
 
 	linesWithEngines, err := s.lineEngines.groupGatheringLinesByEngine(in.Lines)
 	if err != nil {
@@ -924,7 +961,11 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 			return billing.StandardInvoice{}, fmt.Errorf("validating standard invoice created input for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
 		}
 
+		var requestValidationError billing.ValidationError
 		lines, err := grouped.Engine.OnStandardInvoiceCreated(ctx, input)
+		if errors.As(err, &requestValidationError) {
+			return billing.StandardInvoice{}, err
+		}
 		validationIssues, systemErr := billing.ToValidationIssues(err)
 		if systemErr != nil {
 			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), systemErr)

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -12,15 +12,12 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
-	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
-	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -167,27 +164,9 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 				}
 			}
 
-			invoicesByCurrency := lo.SliceToMap(existingGatheringInvoices.Items, func(i billing.GatheringInvoice) (currencyx.FiatCode, gatheringInvoiceWithFeatureMeters) {
-				return i.Currency, gatheringInvoiceWithFeatureMeters{
-					Invoice: i,
-				}
+			invoicesByCurrency := lo.SliceToMap(existingGatheringInvoices.Items, func(invoice billing.GatheringInvoice) (currencyx.FiatCode, billing.GatheringInvoice) {
+				return invoice.Currency, invoice
 			})
-
-			// Let's resolve the feature meters for each gathering invoice line for downstream calculations.
-			for currency, gatheringInvoiceWithCurrency := range invoicesByCurrency {
-				featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, invoicesByCurrency[currency].Invoice.Lines.OrEmpty()...)
-				if err != nil {
-					// Quantity snapshotting surfaces validation issues with line identity,
-					// so only system errors abort line preparation here.
-					_, systemErr := billing.ToValidationIssues(err)
-					if systemErr != nil {
-						return nil, fmt.Errorf("resolving feature meters: %w", systemErr)
-					}
-				}
-
-				gatheringInvoiceWithCurrency.FeatureMeters = featureMeters
-				invoicesByCurrency[currency] = gatheringInvoiceWithCurrency
-			}
 
 			if len(invoicesByCurrency) != len(existingGatheringInvoices.Items) {
 				return nil, fmt.Errorf("customer has multiple gathering invoices for the same currency: %d", len(invoicesByCurrency))
@@ -244,8 +223,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 				// Step 1: Let's make sure we have lines properly split on the gathering invoice.
 				// Invariant: the gathering invoice is updated to contain the new lines if any were split.
 				prepareResults, err := s.prepareLinesToBill(ctx, prepareLinesToBillInput{
-					GatheringInvoice: gatheringInvoice.Invoice,
-					FeatureMeters:    gatheringInvoice.FeatureMeters,
+					GatheringInvoice: gatheringInvoice,
 					InScopeLines:     inScopeLines,
 				})
 				if err != nil {
@@ -329,13 +307,8 @@ type gatheringLineWithBillablePeriod struct {
 	Engine         billing.LineEngine
 }
 
-type gatheringInvoiceWithFeatureMeters struct {
-	Invoice       billing.GatheringInvoice
-	FeatureMeters billingfeaturemeter.FeatureMeters
-}
-
 type gatherInScopeLineInput struct {
-	GatheringInvoicesByCurrency map[currencyx.FiatCode]gatheringInvoiceWithFeatureMeters
+	GatheringInvoicesByCurrency map[currencyx.FiatCode]billing.GatheringInvoice
 	// If set restricts the lines to be included to these IDs, otherwise the AsOf is used
 	// to determine the lines to be included.
 	LinesToInclude     mo.Option[[]string]
@@ -353,67 +326,30 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
 
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
-		linesWithResolvedPeriods, err := slicesx.MapWithErr(invoice.Invoice.Lines.OrEmpty(), func(line billing.GatheringLine) (gatheringLineWithBillablePeriod, error) {
-			featureEntity, meterEntity, err := resolveRatingDependencies(line, invoice.FeatureMeters)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving rating dependencies[%s]: %w", line.ID, err)
-			}
-
-			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
-				Line:               line,
-				Feature:            featureEntity,
-				Meter:              meterEntity,
-				ProgressiveBilling: in.ProgressiveBilling,
-				AsOf:               in.AsOf,
-			})
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving billable period[%s]: %w", line.ID, err)
-			}
-
-			eng, err := s.lineEngines.Get(line.Engine)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("getting engine[%s]: %w", line.ID, err)
-			}
-
-			engineInput := billing.IsLineBillableAsOfInput{
-				Line:                   line,
-				AsOf:                   in.AsOf,
-				ProgressiveBilling:     in.ProgressiveBilling,
-				FeatureMeters:          invoice.FeatureMeters,
-				ResolvedBillablePeriod: result.BillablePeriod,
-			}
-			if err := engineInput.Validate(); err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("validating billable status input[%s]: %w", line.ID, err)
-			}
-
+		lines := invoice.Lines.OrEmpty()
+		billabilityResults, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            invoice,
+			AsOf:               in.AsOf,
+			ProgressiveBilling: in.ProgressiveBilling,
+			Lines:              lines,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		}
+		linesWithResolvedPeriods := lo.Map(billabilityResults, func(result gatheringLineBillabilityResult, index int) gatheringLineWithBillablePeriod {
 			if !result.Billable {
 				return gatheringLineWithBillablePeriod{
-					Line:   line,
-					Engine: eng,
-				}, nil
-			}
-
-			isBillable, err := eng.IsLineBillableAsOf(ctx, engineInput)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("checking billable status[%s]: %w", line.ID, err)
-			}
-
-			if !isBillable {
-				return gatheringLineWithBillablePeriod{
-					Line:   line,
-					Engine: eng,
-				}, nil
+					Line:   lines[index],
+					Engine: result.Engine,
+				}
 			}
 
 			return gatheringLineWithBillablePeriod{
-				Line:           line,
+				Line:           lines[index],
 				BillablePeriod: result.BillablePeriod,
-				Engine:         eng,
-			}, nil
+				Engine:         result.Engine,
+			}
 		})
-		if err != nil {
-			return nil, fmt.Errorf("gathering lines with resolved periods: %w", err)
-		}
 
 		linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
 			return !lo.IsEmpty(line.BillablePeriod)
@@ -568,7 +504,6 @@ func limitGatheringLinesForInvoice(lines []gatheringLineWithBillablePeriod, maxL
 type hasInvoicableLinesInput struct {
 	Invoice            billing.GatheringInvoice
 	AsOf               time.Time
-	FeatureMeters      billingfeaturemeter.FeatureMeters
 	ProgressiveBilling bool
 }
 
@@ -583,10 +518,6 @@ func (i hasInvoicableLinesInput) Validate() error {
 		errs = append(errs, fmt.Errorf("asOf time must not be zero"))
 	}
 
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
-	}
-
 	return errors.Join(errs...)
 }
 
@@ -596,11 +527,8 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 	}
 
 	inScopeLines, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
-		GatheringInvoicesByCurrency: map[currencyx.FiatCode]gatheringInvoiceWithFeatureMeters{
-			in.Invoice.Currency: {
-				Invoice:       in.Invoice,
-				FeatureMeters: in.FeatureMeters,
-			},
+		GatheringInvoicesByCurrency: map[currencyx.FiatCode]billing.GatheringInvoice{
+			in.Invoice.Currency: in.Invoice,
 		},
 		AsOf:               in.AsOf,
 		ProgressiveBilling: in.ProgressiveBilling,
@@ -619,7 +547,6 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 
 type prepareLinesToBillInput struct {
 	GatheringInvoice billing.GatheringInvoice
-	FeatureMeters    billingfeaturemeter.FeatureMeters
 	InScopeLines     []gatheringLineWithBillablePeriod
 }
 
@@ -628,10 +555,6 @@ func (i prepareLinesToBillInput) Validate() error {
 
 	if i.GatheringInvoice.Lines.IsAbsent() {
 		errs = append(errs, fmt.Errorf("gathering invoice must have lines expanded"))
-	}
-
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
 	}
 
 	for _, line := range i.InScopeLines {
@@ -677,9 +600,8 @@ func (s *Service) prepareLinesToBill(ctx context.Context, input prepareLinesToBi
 			}
 
 			engineInput := billing.SplitGatheringLineInput{
-				Line:          currentLine,
-				FeatureMeters: input.FeatureMeters,
-				SplitAt:       line.BillablePeriod.To,
+				Line:    currentLine,
+				SplitAt: line.BillablePeriod.To,
 			}
 			if err := engineInput.Validate(); err != nil {
 				return nil, fmt.Errorf("line[%s]: validating split input: %w", currentLine.ID, err)

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -354,9 +354,15 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
 		linesWithResolvedPeriods, err := slicesx.MapWithErr(invoice.Invoice.Lines.OrEmpty(), func(line billing.GatheringLine) (gatheringLineWithBillablePeriod, error) {
+			featureEntity, meterEntity, err := resolveRatingDependencies(line, invoice.FeatureMeters)
+			if err != nil {
+				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving rating dependencies[%s]: %w", line.ID, err)
+			}
+
 			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
-				FeatureMeters:      invoice.FeatureMeters,
+				Feature:            featureEntity,
+				Meter:              meterEntity,
 				ProgressiveBilling: in.ProgressiveBilling,
 				AsOf:               in.AsOf,
 			})

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
-	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -92,7 +91,8 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 			}
 
 			return createdInvoices, nil
-		})
+		},
+	)
 }
 
 func (s *Service) prepareBillableLines(ctx context.Context, input billing.PrepareBillableLinesInput, options billing.InvoicePendingLinesOptions) (*billing.PrepareBillableLinesResult, error) {
@@ -257,7 +257,8 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			return &billing.PrepareBillableLinesResult{
 				LinesByCurrency: linesToBeBilledByCurrency,
 			}, nil
-		})
+		},
+	)
 }
 
 // resolvePendingLineCollectionCutoff returns the effective AsOf cutoff used when selecting
@@ -323,8 +324,6 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 	billableLineIDs := make(map[string]interface{})
 
-	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
-
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
 		lines := invoice.Lines.OrEmpty()
 		billabilityResults, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
@@ -333,8 +332,16 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			ProgressiveBilling: in.ProgressiveBilling,
 			Lines:              lines,
 		})
-		if err != nil {
+		if err != nil && !billing.IsValidationIssueOnly(err) {
 			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		}
+		if err != nil {
+			s.logger.WarnContext(
+				ctx, "gathering line billability has validation issues; continuing with fallback results",
+				"namespace", invoice.Namespace,
+				"invoice_id", invoice.ID,
+				"error", err,
+			)
 		}
 		linesWithResolvedPeriods := lo.Map(billabilityResults, func(result gatheringLineBillabilityResult, index int) gatheringLineWithBillablePeriod {
 			if !result.Billable {
@@ -354,22 +361,6 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 		linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
 			return !lo.IsEmpty(line.BillablePeriod)
 		})
-
-		if !in.ProgressiveBilling {
-			// Somewhat of a hack: Since we are allowing subscriptions with different billing periods for ratecards, invoiceAt not necessarily equals
-			// to the line's period start and end time.
-
-			// So we have two kinds of progressive billing scenarios:
-			// 1. the line needs to be split into multiple lines
-			// 2. the line does not need to be split but it's invoiceAt is after the line's period end, when the line is technically billable, but
-			//    from the user's perspective as they are not requesting progressive billing we should not include it on the invoice.
-
-			linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
-				invoiceAtTruncated := line.Line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
-
-				return invoiceAtTruncated.Before(asOfTruncated) || invoiceAtTruncated.Equal(asOfTruncated)
-			})
-		}
 
 		for _, line := range linesWithResolvedPeriods {
 			billableLineIDs[line.Line.ID] = struct{}{}
@@ -700,7 +691,8 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 		return nil, fmt.Errorf("fetching customer profile: %w", err)
 	}
 
-	invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(ctx,
+	invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(
+		ctx,
 		sequence.GenerationInput{
 			Namespace:    in.Customer.Namespace,
 			CustomerName: profile.Customer.Name,
@@ -933,8 +925,9 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 		}
 
 		lines, err := grouped.Engine.OnStandardInvoiceCreated(ctx, input)
-		if err != nil {
-			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		validationIssues, systemErr := billing.ToValidationIssues(err)
+		if systemErr != nil {
+			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), systemErr)
 		}
 
 		if err := invoice.Lines.ReplaceExact(billing.ReplaceExactLinesInput{
@@ -942,6 +935,16 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 			Replacement: lines,
 		}); err != nil {
 			return billing.StandardInvoice{}, fmt.Errorf("replacing standard invoice created lines for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		if len(validationIssues) > 0 {
+			component := billing.LineEngineValidationComponent(grouped.Engine.GetLineEngineType())
+			if err := invoice.MergeValidationIssues(
+				billing.NewLineEngineValidationError(grouped.Engine, validationIssues.AsError()),
+				component,
+			); err != nil {
+				return billing.StandardInvoice{}, fmt.Errorf("merging standard invoice created validation issues for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+			}
 		}
 	}
 

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -906,7 +906,7 @@ func (s Service) SimulateInvoice(ctx context.Context, input billing.SimulateInvo
 		}
 	}
 
-	_, err = s.featureMeterResolver.Resolve(ctx, input.Namespace, invoice.Lines.OrEmpty()...)
+	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Namespace, invoice.Lines.OrEmpty()...)
 	if err != nil {
 		if err := invoice.MergeValidationIssues(
 			billing.ValidationWithComponent(billing.ValidationComponentOpenMeterMetering, err),

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -201,16 +201,6 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 
 	now := clock.Now()
 
-	featureMeters, err := s.featureMeterResolver.Resolve(ctx, invoice.Namespace, invoice.Lines.OrEmpty()...)
-	if err != nil {
-		// The preview's quantity snapshotting surfaces validation issues with line
-		// identity, so only system errors abort live-data preparation here.
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return nil, fmt.Errorf("resolving feature meters: %w", systemErr)
-		}
-	}
-
 	inScopeGatheringLines := make(billing.GatheringLines, 0, len(invoice.Lines.OrEmpty()))
 	for _, line := range invoice.Lines.OrEmpty() {
 		if line.DeletedAt != nil {
@@ -271,7 +261,6 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 		Invoice:            invoice,
 		AsOf:               now,
 		ProgressiveBilling: out.Workflow.Config.Invoicing.ProgressiveBilling,
-		FeatureMeters:      featureMeters,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("checking if has invoicable lines: %w", err)

--- a/openmeter/billing/service/lineengine.go
+++ b/openmeter/billing/service/lineengine.go
@@ -2,6 +2,7 @@ package billingservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -141,6 +142,72 @@ type GatheringLinesWithEngine struct {
 type StandardLinesWithEngine struct {
 	Engine billing.LineEngine
 	Lines  billing.StandardLines
+}
+
+type gatheringLineBillabilityResult struct {
+	billing.IsLineBillableAsOfResult
+	Engine billing.LineEngine
+}
+
+func (s *Service) areGatheringLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]gatheringLineBillabilityResult, error) {
+	if len(input.Lines) == 0 {
+		return []gatheringLineBillabilityResult{}, nil
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating billability input: %w", err)
+	}
+
+	linesWithEngines, err := s.lineEngines.groupGatheringLinesByEngine(input.Lines)
+	if err != nil {
+		return nil, fmt.Errorf("grouping gathering lines by engine: %w", err)
+	}
+
+	resultsByLineID := make(map[string]gatheringLineBillabilityResult, len(input.Lines))
+	var errs []error
+	for _, grouped := range linesWithEngines {
+		engineType := grouped.Engine.GetLineEngineType()
+		results, err := grouped.Engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            input.Invoice,
+			AsOf:               input.AsOf,
+			ProgressiveBilling: input.ProgressiveBilling,
+			Lines:              grouped.Lines,
+		})
+		if err != nil && !billing.IsValidationIssueOnly(err) {
+			return nil, fmt.Errorf("checking line billability with engine %s: %w", engineType, err)
+		}
+		errs = append(errs, err)
+
+		if len(results) != len(grouped.Lines) {
+			return nil, fmt.Errorf("engine %s returned %d billability results for %d inputs", engineType, len(results), len(grouped.Lines))
+		}
+
+		for index, result := range results {
+			lineID := grouped.Lines[index].ID
+			if err := result.Validate(); err != nil {
+				return nil, fmt.Errorf("validating line[%s] billability result from engine %s: %w", lineID, engineType, err)
+			}
+
+			resultsByLineID[lineID] = gatheringLineBillabilityResult{
+				IsLineBillableAsOfResult: result,
+				Engine:                   grouped.Engine,
+			}
+		}
+	}
+
+	results, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (gatheringLineBillabilityResult, error) {
+		result, ok := resultsByLineID[line.ID]
+		if !ok {
+			return gatheringLineBillabilityResult{}, fmt.Errorf("billability result for line[%s] is missing", line.ID)
+		}
+
+		return result, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results, errors.Join(errs...)
 }
 
 func (r *engineRegistry) groupGatheringLinesByEngine(lines billing.GatheringLines) ([]GatheringLinesWithEngine, error) {

--- a/openmeter/billing/service/lineengine.go
+++ b/openmeter/billing/service/lineengine.go
@@ -176,7 +176,7 @@ func (s *Service) areGatheringLinesBillableAsOf(ctx context.Context, input billi
 		if err != nil && !billing.IsValidationIssueOnly(err) {
 			return nil, fmt.Errorf("checking line billability with engine %s: %w", engineType, err)
 		}
-		errs = append(errs, err)
+		errs = append(errs, billing.NewLineEngineValidationError(grouped.Engine, err))
 
 		if len(results) != len(grouped.Lines) {
 			return nil, fmt.Errorf("engine %s returned %d billability results for %d inputs", engineType, len(results), len(grouped.Lines))

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -3,6 +3,7 @@ package billingservice
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -56,6 +58,80 @@ func TestAreGatheringLinesBillableAsOfPreservesInputOrderAcrossEngines(t *testin
 		invoiceEngine.inputs[0].Lines[1].ID,
 	})
 	require.Equal(t, "charge-1", chargeEngine.inputs[0].Lines[0].ID)
+}
+
+func TestAreGatheringLinesBillableAsOfPreservesResultsWithValidationIssues(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+		err:            billing.ValidationWithFieldPrefix("charges/charge-1", billing.ErrInvoiceLineFeatureNotFound),
+	}
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+	line := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeChargeUsageBased, false)
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+			ID:              line.InvoiceID,
+		},
+	}}
+
+	// Given an engine that can resolve billability while reporting a validation issue.
+	// When billing dispatches the ordered line batch.
+	results, err := svc.areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: invoice,
+		AsOf:    line.InvoiceAt,
+		Lines:   billing.GatheringLines{line},
+	})
+
+	// Then the result and the engine's original validation issue are preserved.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Len(t, results, 1)
+	require.True(t, results[0].Billable)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
+		Path:     "/charges/charge-1",
+	}}, issues)
+}
+
+func TestGatherInScopeLinesContinuesWithBillabilityValidationIssues(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+		err:            billing.ValidationWithFieldPrefix("charges/charge-1", billing.ErrInvoiceLineFeatureNotFound),
+	}
+	svc := &Service{
+		lineEngines: newEngineRegistry(),
+		logger:      slog.New(slog.DiscardHandler),
+	}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+	line := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeChargeUsageBased, false)
+	invoice := billing.GatheringInvoice{
+		GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+			Currency: line.Currency,
+		},
+		Lines: billing.NewGatheringInvoiceLines(billing.GatheringLines{line}),
+	}
+
+	// Given a gathering line with a usable billability result and a validation issue.
+	// When pending-line collection selects its in-scope lines.
+	results, err := svc.gatherInScopeLines(t.Context(), gatherInScopeLineInput{
+		GatheringInvoicesByCurrency: map[currencyx.FiatCode]billing.GatheringInvoice{
+			line.Currency: invoice,
+		},
+		AsOf:               line.InvoiceAt,
+		ProgressiveBilling: true,
+	})
+
+	// Then the validation issue does not abort selection.
+	require.NoError(t, err)
+	require.Len(t, results[line.Currency], 1)
+	require.Equal(t, line.ID, results[line.Currency][0].Line.ID)
 }
 
 func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {
@@ -142,6 +218,7 @@ func TestAreGatheringLinesBillableAsOfRequiresLinesFromInvoice(t *testing.T) {
 type billabilityLineEngine struct {
 	billingtestutils.NoopLineEngine
 	inputs []billing.AreLinesBillableAsOfInput
+	err    error
 }
 
 func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
@@ -155,7 +232,7 @@ func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input bi
 				To:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 		}
-	}), nil
+	}), e.err
 }
 
 func TestDispatchSystemStandardLineDeletionsGroupsLinesByEngine(t *testing.T) {

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -5,14 +5,158 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestAreGatheringLinesBillableAsOfPreservesInputOrderAcrossEngines(t *testing.T) {
+	invoiceEngine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+	}
+	chargeEngine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+	}
+
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(invoiceEngine))
+	require.NoError(t, svc.RegisterLineEngine(chargeEngine))
+
+	lines := billing.GatheringLines{
+		newGatheringLineForLineEngineTest("invoice-1", billing.LineEngineTypeInvoice, false),
+		newGatheringLineForLineEngineTest("charge-1", billing.LineEngineTypeChargeUsageBased, false),
+		newGatheringLineForLineEngineTest("invoice-2", billing.LineEngineTypeInvoice, false),
+	}
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+			ID:              "invoice-1",
+		},
+	}}
+
+	results, err := svc.areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: invoice,
+		AsOf:    lines[0].InvoiceAt,
+		Lines:   lines,
+	})
+	require.NoError(t, err)
+	require.Same(t, invoiceEngine, results[0].Engine)
+	require.Same(t, chargeEngine, results[1].Engine)
+	require.Same(t, invoiceEngine, results[2].Engine)
+	require.Equal(t, []string{"invoice-1", "invoice-2"}, []string{
+		invoiceEngine.inputs[0].Lines[0].ID,
+		invoiceEngine.inputs[0].Lines[1].ID,
+	})
+	require.Equal(t, "charge-1", chargeEngine.inputs[0].Lines[0].ID)
+}
+
+func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+	}
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+
+	// Given gathering lines with different scheduled invoice times.
+	firstLine := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, false)
+	secondLine := newGatheringLineForLineEngineTest("line-2", billing.LineEngineTypeInvoice, false)
+	secondLine.InvoiceAt = firstLine.InvoiceAt.Add(time.Hour)
+	invoice := billing.GatheringInvoice{
+		GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ID:              "invoice-1",
+			},
+		},
+		Lines: billing.NewGatheringInvoiceLines(billing.GatheringLines{firstLine, secondLine}),
+	}
+
+	// When the updated gathering invoice is checked for billability.
+	err := svc.checkIfGatheringLinesAreInvoicable(t.Context(), invoice, true)
+
+	// Then each line is evaluated separately at its own InvoiceAt.
+	require.NoError(t, err)
+	require.Len(t, engine.inputs, 2)
+	require.Equal(t, firstLine.InvoiceAt, engine.inputs[0].AsOf)
+	require.Equal(t, billing.GatheringLines{firstLine}, engine.inputs[0].Lines)
+	require.Equal(t, secondLine.InvoiceAt, engine.inputs[1].AsOf)
+	require.Equal(t, billing.GatheringLines{secondLine}, engine.inputs[1].Lines)
+}
+
+func TestAreGatheringLinesBillableAsOfRequiresLinesFromInvoice(t *testing.T) {
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+			ID:              "invoice-1",
+		},
+	}}
+
+	tests := []struct {
+		name       string
+		mutateLine func(*billing.GatheringLine)
+		wantError  string
+	}{
+		{
+			name: "namespace mismatch",
+			mutateLine: func(line *billing.GatheringLine) {
+				line.Namespace = "other"
+			},
+			wantError: "namespace other does not match invoice namespace ns",
+		},
+		{
+			name: "invoice mismatch",
+			mutateLine: func(line *billing.GatheringLine) {
+				line.InvoiceID = "other"
+			},
+			wantError: "invoice ID other does not match invoice ID invoice-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given a valid gathering line whose invoice ownership is changed.
+			line := newGatheringLineForLineEngineTest("line", billing.LineEngineTypeInvoice, false)
+			test.mutateLine(&line)
+
+			// When billing prepares the line-engine billability batch.
+			_, err := (&Service{}).areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+				Invoice: invoice,
+				AsOf:    line.InvoiceAt,
+				Lines:   billing.GatheringLines{line},
+			})
+
+			// Then the line is rejected before engine dispatch.
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+type billabilityLineEngine struct {
+	billingtestutils.NoopLineEngine
+	inputs []billing.AreLinesBillableAsOfInput
+}
+
+func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
+	e.inputs = append(e.inputs, input)
+
+	return lo.Map(input.Lines, func(billing.GatheringLine, int) billing.IsLineBillableAsOfResult {
+		return billing.IsLineBillableAsOfResult{
+			Billable: true,
+			BillablePeriod: timeutil.ClosedPeriod{
+				From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		}
+	}), nil
+}
 
 func TestDispatchSystemStandardLineDeletionsGroupsLinesByEngine(t *testing.T) {
 	invoiceEngine := &recordingLineEngine{

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -92,7 +92,10 @@ func TestAreGatheringLinesBillableAsOfPreservesResultsWithValidationIssues(t *te
 		Severity: billing.ValidationIssueSeverityCritical,
 		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
 		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
-		Path:     "/charges/charge-1",
+		Component: billing.LineEngineValidationComponent(
+			billing.LineEngineTypeChargeUsageBased,
+		),
+		Path: "/charges/charge-1",
 	}}, issues)
 }
 
@@ -128,10 +131,19 @@ func TestGatherInScopeLinesContinuesWithBillabilityValidationIssues(t *testing.T
 		ProgressiveBilling: true,
 	})
 
-	// Then the validation issue does not abort selection.
+	// Then the validation issue does not abort selection and remains available for the standard invoice.
 	require.NoError(t, err)
-	require.Len(t, results[line.Currency], 1)
-	require.Equal(t, line.ID, results[line.Currency][0].Line.ID)
+	require.Len(t, results.LinesByCurrency[line.Currency], 1)
+	require.Equal(t, line.ID, results.LinesByCurrency[line.Currency][0].Line.ID)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
+		Component: billing.LineEngineValidationComponent(
+			billing.LineEngineTypeChargeUsageBased,
+		),
+		Path: "/charges/charge-1",
+	}}, results.ValidationIssuesByCurrency[line.Currency])
 }
 
 func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -53,7 +53,7 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 		}
 	}
 
-	_, err = s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, input.Lines...)
+	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, input.Lines...)
 	if err != nil {
 		return nil, billing.ValidationError{
 			Err: fmt.Errorf("resolving pending line feature meters: %w", err),

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -1276,6 +1276,7 @@ type CreateStandardInvoiceFromGatheringLinesInput struct {
 	Description *string
 
 	Lines                       GatheringLines
+	ValidationIssues            ValidationIssues
 	PostCreationCalculationHook PostCreationCalculationHook
 	ForceAsyncAdvance           bool
 }

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -22,8 +22,16 @@ func (e NoopLineEngine) GetLineEngineType() billing.LineEngineType {
 	return e.EngineType
 }
 
-func (NoopLineEngine) IsLineBillableAsOf(context.Context, billing.IsLineBillableAsOfInput) (bool, error) {
-	return true, nil
+func (NoopLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
+	results := make([]billing.IsLineBillableAsOfResult, len(input.Lines))
+	for index, line := range input.Lines {
+		results[index] = billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}
+	}
+
+	return results, nil
 }
 
 func (NoopLineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -260,6 +260,18 @@ func ToValidationIssues(errIn error) (ValidationIssues, error) {
 	return issues, nil
 }
 
+// IsValidationIssueOnly reports whether the error tree contains validation
+// issues only and no system errors.
+func IsValidationIssueOnly(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, systemErr := ToValidationIssues(err)
+
+	return systemErr == nil
+}
+
 func (v ValidationIssues) RemoveMetaForCompare() ValidationIssues {
 	return lo.Map(v, func(issue ValidationIssue, _ int) ValidationIssue {
 		issue.CreatedAt = time.Time{}

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -253,6 +253,45 @@ func TestValidationIssueParsing(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIsValidationIssueOnly(t *testing.T) {
+	validationErr := NewValidationError("invalid", "invalid")
+	systemErr := errors.New("system error")
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:     "validation issue",
+			err:      validationErr,
+			expected: true,
+		},
+		{
+			name:     "joined validation issues",
+			err:      errors.Join(validationErr, NewValidationWarning("warning", "warning")),
+			expected: true,
+		},
+		{
+			name: "system error",
+			err:  systemErr,
+		},
+		{
+			name: "mixed validation and system errors",
+			err:  errors.Join(validationErr, systemErr),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, IsValidationIssueOnly(test.err))
+		})
+	}
+}
+
 func TestValidationWithComponentPrecedence(t *testing.T) {
 	baseIssue := ValidationIssue{
 		Severity:  ValidationIssueSeverityWarning,

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -290,11 +290,12 @@ func newTestEnv(t *testing.T) *testEnv {
 			},
 			collectorService,
 		),
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
-		Currencies:    currencyService,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: featureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
+		Currencies:           currencyService,
 	})
 	require.NoError(t, err)
 

--- a/pkg/slicesx/map.go
+++ b/pkg/slicesx/map.go
@@ -48,6 +48,22 @@ func MapWithErr[T any, S any](s []T, f func(T) (S, error)) ([]S, error) {
 	return n, nil
 }
 
+// MapWithErrPreservingResults maps every element, preserves each returned result
+// at its input index, and joins all mapping errors.
+func MapWithErrPreservingResults[T any, S any](s []T, f func(T, int) (S, error)) ([]S, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	results := make([]S, len(s))
+	errs := make([]error, len(s))
+	for index, value := range s {
+		results[index], errs[index] = f(value, index)
+	}
+
+	return results, errors.Join(errs...)
+}
+
 func WrapMapFn[T, O any](fn func(T) (O, error)) func(T, int) (O, error) {
 	return func(t T, _ int) (O, error) {
 		return fn(t)

--- a/pkg/slicesx/map_test.go
+++ b/pkg/slicesx/map_test.go
@@ -1,6 +1,7 @@
 package slicesx
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -16,5 +17,32 @@ func TestMap(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatal("map failed")
+	}
+}
+
+func TestMapWithErrPreservingResults(t *testing.T) {
+	firstErr := errors.New("first error")
+	lastErr := errors.New("last error")
+
+	// Given a mapper that returns usable results alongside errors.
+	// When every input is mapped with its index.
+	results, err := MapWithErrPreservingResults([]int{10, 20, 30}, func(value, index int) (int, error) {
+		result := value + index
+		switch index {
+		case 0:
+			return result, firstErr
+		case 2:
+			return result, lastErr
+		default:
+			return result, nil
+		}
+	})
+
+	// Then all input-aligned results and both errors are returned.
+	if !reflect.DeepEqual([]int{10, 21, 32}, results) {
+		t.Fatalf("unexpected results: %v", results)
+	}
+	if !errors.Is(err, firstErr) || !errors.Is(err, lastErr) {
+		t.Fatalf("expected joined errors, got %v", err)
 	}
 }

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -131,6 +131,84 @@ func (s *CollectionTestSuite) TestUncollectableCollection() {
 	s.Len(invoices, 0)
 }
 
+func (s *CollectionTestSuite) TestCollectionWaitsForInvoiceAtAfterServicePeriodEnd() {
+	namespace := "ns-collection-waits-for-invoice-at"
+	ctx := s.T().Context()
+
+	appSandbox := s.InstallSandboxApp(s.T(), namespace)
+	customer := s.CreateTestCustomer(namespace, "test-customer")
+	s.Require().NotNil(customer)
+	s.ProvisionBillingProfile(ctx, namespace, appSandbox.GetID())
+
+	testFeature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+	defer testFeature.Cleanup()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: lo.Must(time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")),
+		To:   lo.Must(time.Parse(time.RFC3339, "2025-01-02T00:00:00Z")),
+	}
+	invoiceAt := lo.Must(time.Parse(time.RFC3339, "2025-02-01T00:00:00Z"))
+
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	testFeatureKey := testFeature.Feature.Key
+	s.MockStreamingConnector.AddSimpleEvent(testFeatureKey, 1, servicePeriod.From.Add(time.Hour))
+
+	// Given a non-progressively billed line whose service period ends before its invoice time.
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customer.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: []billing.GatheringLine{
+			{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Name: "UBP - unit",
+				}),
+				ServicePeriod: servicePeriod,
+				InvoiceAt:     invoiceAt,
+				ManagedBy:     billing.ManuallyManagedLine,
+				FeatureKey:    testFeatureKey,
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(1),
+				})),
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pendingLines.Lines, 1)
+
+	// When collection is attempted after service completion but before InvoiceAt.
+	clock.FreezeTime(servicePeriod.To)
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customer.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+
+	// Then the line remains on the gathering invoice and no standard invoice is created.
+	s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)
+	s.Empty(invoices)
+
+	gatheringInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: pendingLines.Invoice.GetInvoiceID(),
+		Expand:  billing.GatheringInvoiceExpands{billing.GatheringInvoiceExpandLines},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+	// When collection reaches InvoiceAt, the complete service period becomes billable.
+	clock.FreezeTime(invoiceAt)
+	invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customer.GetID(),
+		AsOf:     lo.ToPtr(invoiceAt),
+	})
+
+	// Then one standard invoice contains the full line.
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+	s.True(servicePeriod.Equal(invoices[0].Lines.OrEmpty()[0].Period))
+}
+
 func (s *CollectionTestSuite) TestGatheringLineUnitConfigSnapshotRoundTrip() {
 	// given:
 	// - a legacy (non-charges) usage-based gathering line whose rate card carries a unit_config

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -41,6 +41,7 @@ type mockCollectionCompletedLineEngine struct {
 	engineType ombilling.LineEngineType
 
 	gateInvoiceAssignment                 func(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error)
+	areLinesBillableAsOf                  func(ctx context.Context, input ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error)
 	buildStandardInvoiceLines             func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	buildStandardLinesForGatheringPreview func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	onStandardInvoiceCreated              func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
@@ -75,7 +76,11 @@ func (m *mockCollectionCompletedLineEngine) GetLineEngineType() ombilling.LineEn
 	return m.engineType
 }
 
-func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(_ context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(ctx context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+	if m.areLinesBillableAsOf != nil {
+		return m.areLinesBillableAsOf(ctx, batch)
+	}
+
 	return lo.Map(batch.Lines, func(line ombilling.GatheringLine, _ int) ombilling.IsLineBillableAsOfResult {
 		if batch.AsOf.Before(line.InvoiceAt) {
 			return ombilling.IsLineBillableAsOfResult{}
@@ -94,6 +99,70 @@ func (m *mockCollectionCompletedLineEngine) GateInvoiceAssignment(ctx context.Co
 	}
 
 	return m.gateInvoiceAssignment(ctx, input)
+}
+
+func (s *LineEngineTestSuite) TestBillabilityValidationIssuesPreventInvoiceAdvancement() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("ns-line-engine-billability-validation")
+	mockEngine := &mockCollectionCompletedLineEngine{engineType: ombilling.LineEngineTypeChargeFlatFee}
+	s.registerMockLineEngine(s.T(), mockEngine)
+	defer s.unregisterLineEngine(s.T(), mockEngine)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.FreezeTime(servicePeriod.To)
+	defer clock.UnFreeze()
+
+	mockEngine.areLinesBillableAsOf = func(_ context.Context, input ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+		return lo.Map(input.Lines, func(ombilling.GatheringLine, int) ombilling.IsLineBillableAsOfResult {
+			return ombilling.IsLineBillableAsOfResult{
+				Billable:       true,
+				BillablePeriod: servicePeriod,
+			}
+		}), ombilling.ValidationWithFieldPrefix("charges/charge-id", ombilling.ErrInvoiceLineFeatureNotFound)
+	}
+	mockEngine.buildStandardInvoiceLines = func(_ context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+		return mustAsNewStandardLines(input), nil
+	}
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	customerEntity := s.CreateTestCustomer(namespace, "test-subject")
+
+	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: ombilling.GatheringLines{{
+			GatheringLineBase: ombilling.GatheringLineBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: namespace,
+					Name:      "line with missing feature",
+				}),
+				ManagedBy:     ombilling.ManuallyManagedLine,
+				Engine:        mockEngine.GetLineEngineType(),
+				Currency:      currencyx.FiatCode(currency.USD),
+				ServicePeriod: servicePeriod,
+				InvoiceAt:     servicePeriod.To,
+				Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount: alpacadecimal.NewFromInt(10),
+				}),
+			},
+		}},
+	})
+	s.Require().NoError(err)
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+		Customer: customerEntity.GetID(),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Equal(ombilling.StandardInvoiceStatusDraftInvalidCreated, invoices[0].Status)
+	s.Require().Len(invoices[0].ValidationIssues, 1)
+	s.Equal(ombilling.ErrInvoiceLineFeatureNotFound.Code, invoices[0].ValidationIssues[0].Code)
+	s.Equal("/charges/charge-id", invoices[0].ValidationIssues[0].Path)
+	s.Equal(ombilling.LineEngineValidationComponent(mockEngine.GetLineEngineType()), invoices[0].ValidationIssues[0].Component)
 }
 
 func (m *mockCollectionCompletedLineEngine) SplitGatheringLine(_ context.Context, _ ombilling.SplitGatheringLineInput) (ombilling.SplitGatheringLineResult, error) {

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -75,8 +75,17 @@ func (m *mockCollectionCompletedLineEngine) GetLineEngineType() ombilling.LineEn
 	return m.engineType
 }
 
-func (m *mockCollectionCompletedLineEngine) IsLineBillableAsOf(_ context.Context, input ombilling.IsLineBillableAsOfInput) (bool, error) {
-	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
+func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(_ context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+	return lo.Map(batch.Lines, func(line ombilling.GatheringLine, _ int) ombilling.IsLineBillableAsOfResult {
+		if batch.AsOf.Before(line.InvoiceAt) {
+			return ombilling.IsLineBillableAsOfResult{}
+		}
+
+		return ombilling.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}
+	}), nil
 }
 
 func (m *mockCollectionCompletedLineEngine) GateInvoiceAssignment(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {


### PR DESCRIPTION
## Overview

- Move gathering-line billability decisions behind the batched line-engine contract.
- Let each engine resolve its own feature and meter dependencies while preserving usable results alongside validation issues.
- Fall back to non-progressive eligibility when feature data is missing and enforce InvoiceAt as the collection boundary.
- Preserve standard invoices and charge lines when creation produces critical validation issues.
- Add result-preserving slice mapping and regression coverage for delayed InvoiceAt collection.

## Notes for reviewer

- No Jira issue.
- make lint-go-fast passes.
- make test-nocache completed 7,840 tests. The branch-related charges failures found by that run were fixed and the full charges service package passes on rerun. The remaining test/notification failure is the known local Svix connection refusal on 127.0.0.1:8071.









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Billing now evaluates multiple invoice lines together and reports billability results for each line.
  - Validation issues are associated with individual lines, allowing unaffected lines to continue processing.
  - Invoice preparation preserves validation issues by currency and carries them into invoice status.
  - Billing waits until each line’s invoice time before collecting it.

- **Bug Fixes**
  - Improved fallback to non-progressive billing when feature or meter details are unavailable.
  - Collection now preserves successfully processed lines when other lines encounter validation issues.

- **Documentation**
  - Clarified billing engine ownership, dependency handling, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves gathering-line billability into batched line-engine operations and preserves usable per-line results alongside validation issues.
- Resolves charge-owned feature and meter dependencies inside flat-fee and usage-based engines.
- Enforces InvoiceAt boundaries through rating and credit-purchase billability.
- Carries billability and line-creation validation issues into resulting standard invoices.
- Adds a mapping helper that retains ordered results while aggregating callback errors.
- Adds regression coverage for batching, missing dependencies, validation preservation, and delayed collection.

<h3>Confidence Score: 4/5</h3>

The behavioral changes appear sound, but the outstanding explicit repository requirement to extract meaningful domain translation and validation from inline callbacks must be satisfied before merging.

The earlier flat-fee validation-loss finding is fully fixed by propagating billability issues into standard invoices. The unresolved previous thread still applies because the usage-based and flat-fee billability implementations keep dependency resolution, rating-input construction, fallback behavior, and error combination inside substantial local callbacks rather than named domain helpers.

**Files Needing Attention:** openmeter/billing/charges/usagebased/service/lineengine.go, openmeter/billing/charges/flatfee/service/lineengine.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/lineengine.go | Adds batched dependency-aware billability and preserves standard lines when validation issues occur; the previously reported named-helper rule violation remains outstanding. |
| openmeter/billing/charges/flatfee/service/lineengine.go | Adds batched flat-fee billability with feature validation and non-progressive rating; the same previously reported inline domain-logic pattern remains. |
| openmeter/billing/service/gatheringinvoicependinglines.go | Preserves billability validation issues through line preparation and standard-invoice creation, resolving the prior lost-validation finding. |
| openmeter/billing/service/lineengine.go | Dispatches ordered line batches by engine and reassembles validated results in original input order. |
| openmeter/billing/rating/service/billableperiod.go | Centralizes progressive eligibility and InvoiceAt handling in the rating service. |
| pkg/slicesx/map.go | Adds ordered result-preserving mapping with joined errors and regression tests. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Gathering invoice lines] --> B[Group lines by engine]
    B --> C[Engine resolves charge dependencies]
    C --> D[Engine returns ordered billability results]
    C --> E[Validation issues]
    D --> F[Select and prepare billable lines]
    E --> F
    F --> G[Create standard invoice]
    G --> H[Preserve lines and validation issues]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(billing): preserve billability valid..."](https://github.com/openmeterio/openmeter/commit/88234ded4d5f9dabd923ce5882aa96fe67339d43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60439800)</sub>

<!-- /greptile_comment -->