### PR TITLE
fix(credits): preserve purchase and correction accounting

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -220,11 +220,21 @@ authorization and settlement; its cost basis carries the amount paid per unit.
 Custom-currency credit instead materializes a fiat-to-custom receivable exchange
 before the fiat payment is authorized.
 
+Paid purchases must round to a positive amount in the settlement currency.
+Dynamic purchases enforce this after resolving their price, before granting
+credits; promotional grants do not enter the payment lifecycle.
+
 Persisted credit purchases read settlement and cost basis only from their
 dedicated fields. Fiat purchases persist their scalar rate on the charge row;
 custom-currency purchases reference durable shared cost-basis state. Resolution
 time and charge creation time are not a validation invariant. The legacy
 settlement JSON column is deprecated and ignored.
+
+Credit purchases carry the ledger's booked accrued-backfill amounts per spend
+back to lineage persistence. Each spend consumes its own oldest uncovered
+segments; a purchase-wide amount cannot redistribute backing across spends.
+Source-less legacy attribution and receivable-only attribution do not make
+tracked usage lineage credit-backed.
 
 A credit grant, payment authorization, and payment settlement are separate
 durable facts. A later state cannot be inferred from the presence of an earlier

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -143,6 +143,20 @@ func (c Charge) GetFiatSettlementAmount() (alpacadecimal.Decimal, error) {
 	return fiatAmount, nil
 }
 
+// ValidateSettlementAmount prevents issuing paid credits whose rounded purchase
+// value cannot enter the payment lifecycle. Dynamic purchases call this after
+// resolving their cost basis; promotional credits have no settlement amount.
+func (c Charge) ValidateSettlementAmount() error {
+	amount, err := c.GetFiatSettlementAmount()
+	if err != nil {
+		return err
+	}
+	if !amount.IsPositive() {
+		return models.NewGenericValidationError(errors.New("purchase amount must be positive after rounding to settlement currency precision"))
+	}
+	return nil
+}
+
 type Intent struct {
 	meta.Intent
 	IntentMutableFields

--- a/openmeter/billing/charges/creditpurchase/handler.go
+++ b/openmeter/billing/charges/creditpurchase/handler.go
@@ -31,7 +31,7 @@ type Handler interface {
 
 	// OnPromotionalCreditPurchase is called when a promotional credit purchase is created (e.g. costbasis is 0)
 	// For promotional credit purchases we don't call any of the payment handler methods.
-	OnPromotionalCreditPurchase(ctx context.Context, charge Charge) (ledgertransaction.GroupReference, error)
+	OnPromotionalCreditPurchase(ctx context.Context, charge Charge) (CreditGrantResult, error)
 
 	// Credit purchase handler methods (cost basis > 0)
 	// ------------------------------------------------
@@ -39,7 +39,7 @@ type Handler interface {
 	// OnCreditPurchaseInitiated is called when a credit purchase is initiated that is going to be settled by
 	// a payment (either external or a standard invoice)
 	// Initial call
-	OnCreditPurchaseInitiated(ctx context.Context, charge Charge) (ledgertransaction.GroupReference, error)
+	OnCreditPurchaseInitiated(ctx context.Context, charge Charge) (CreditGrantResult, error)
 
 	// OnCreditPurchasePaymentAuthorized is called when a credit purchase payment is authorized for a credit
 	// purchase.
@@ -48,6 +48,14 @@ type Handler interface {
 	// OnCreditPurchasePaymentSettled is called when a credit purchase payment is settled for a credit
 	// purchase.
 	OnCreditPurchasePaymentSettled(ctx context.Context, input PaymentEventInput) (ledgertransaction.GroupReference, error)
+}
+
+// CreditGrantResult carries booked facts back to the charge lifecycle. Backfill
+// amounts include only accrued value attributed to an identified spend; issuance
+// and receivable-only attribution do not make usage lineage credit-backed.
+type CreditGrantResult struct {
+	ledgertransaction.GroupReference
+	AdvanceBackfillAmountsByChargeID map[string]alpacadecimal.Decimal
 }
 
 type PaymentEventInput struct {

--- a/openmeter/billing/charges/creditpurchase/service/create.go
+++ b/openmeter/billing/charges/creditpurchase/service/create.go
@@ -43,6 +43,12 @@ func (s *service) Create(ctx context.Context, input creditpurchase.CreateInput) 
 			return creditpurchase.ChargeWithGatheringLine{}, err
 		}
 
+		if charge.State.ResolvedCostBasis != nil {
+			if err := charge.ValidateSettlementAmount(); err != nil {
+				return creditpurchase.ChargeWithGatheringLine{}, err
+			}
+		}
+
 		// Let's activate the state machine for the credit purchase charge
 		switch charge.Intent.Settlement.Type() {
 		case creditpurchase.SettlementTypePromotional:

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -40,7 +40,7 @@ func TestExternalCreditPurchaseServiceRoutesAuthorizedInitialStatus(t *testing.T
 	lineageService := &externalStateMachineLineage{}
 	handler := &externalStateMachineHandler{}
 	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
-		Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+		Return(creditpurchase.CreditGrantResult{GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}}, nil).
 		Once()
 	lineageService.On("BackfillAdvanceLineageSegments", mock.Anything, mock.Anything).
 		Return(nil).
@@ -304,9 +304,9 @@ type externalStateMachineHandler struct {
 	mock.Mock
 }
 
-func (h *externalStateMachineHandler) OnCreditPurchaseInitiated(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *externalStateMachineHandler) OnCreditPurchaseInitiated(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
 	args := h.Called(ctx, charge)
-	return args.Get(0).(ledgertransaction.GroupReference), args.Error(1)
+	return args.Get(0).(creditpurchase.CreditGrantResult), args.Error(1)
 }
 
 func (h *externalStateMachineHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/creditpurchase/service/promotional_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/promotional_test.go
@@ -236,10 +236,8 @@ func newPromotionalStateMachineTestMachine(
 	adapter := &promotionalStateMachineAdapter{}
 	lineageService := &promotionalStateMachineLineage{}
 	handler := &promotionalStateMachineHandler{
-		onPromotionalCreditPurchase: func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-			return ledgertransaction.GroupReference{
-				TransactionGroupID: "ledger-tx-1",
-			}, nil
+		onPromotionalCreditPurchase: func(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
+			return creditpurchase.CreditGrantResult{GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "ledger-tx-1"}}, nil
 		},
 	}
 	realizationsService := newPromotionalStateMachineRealizations(t, adapter, handler, lineageService)
@@ -356,12 +354,12 @@ func (a *promotionalStateMachineAdapter) CreateCreditGrant(ctx context.Context, 
 type promotionalStateMachineHandler struct {
 	creditpurchase.Handler
 
-	onPromotionalCreditPurchase func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error)
+	onPromotionalCreditPurchase func(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error)
 }
 
-func (h *promotionalStateMachineHandler) OnPromotionalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *promotionalStateMachineHandler) OnPromotionalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
 	if h.onPromotionalCreditPurchase == nil {
-		return ledgertransaction.GroupReference{}, nil
+		return creditpurchase.CreditGrantResult{}, nil
 	}
 
 	return h.onPromotionalCreditPurchase(ctx, charge)

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -84,6 +84,7 @@ func (s *Service) GrantPromotionalCredits(ctx context.Context, charge creditpurc
 			CustomerID:                charge.Intent.CustomerID,
 			Currency:                  charge.Intent.Currency,
 			Amount:                    charge.Intent.CreditAmount,
+			AmountsByChargeID:         ledgerTransactionGroupReference.AdvanceBackfillAmountsByChargeID,
 			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
 			FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
 		}); err != nil {
@@ -101,6 +102,10 @@ func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge
 
 	if charge.Intent.Settlement.Type() == creditpurchase.SettlementTypePromotional {
 		return creditpurchase.Charge{}, fmt.Errorf("promotional credit purchases do not use payment-backed credit grants")
+	}
+
+	if err := charge.ValidateSettlementAmount(); err != nil {
+		return creditpurchase.Charge{}, err
 	}
 
 	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {
@@ -128,6 +133,7 @@ func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge
 			CustomerID:                charge.Intent.CustomerID,
 			Currency:                  charge.Intent.Currency,
 			Amount:                    charge.Intent.CreditAmount,
+			AmountsByChargeID:         ledgerTransactionGroupReference.AdvanceBackfillAmountsByChargeID,
 			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
 			FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
 		}); err != nil {

--- a/openmeter/billing/charges/lineage/service.go
+++ b/openmeter/billing/charges/lineage/service.go
@@ -94,6 +94,9 @@ func (i PersistCorrectionLineageSegmentsInput) Validate() error {
 }
 
 type BackfillAdvanceLineageSegmentsInput struct {
+	// AmountsByChargeID is the actual accrued attribution booked for each spend.
+	// Empty facts make no lineage transitions, including source-less legacy postings.
+	AmountsByChargeID         map[string]alpacadecimal.Decimal
 	Namespace                 string
 	CustomerID                string
 	Currency                  currencies.Currency
@@ -121,6 +124,19 @@ func (i BackfillAdvanceLineageSegmentsInput) Validate() error {
 		errs = append(errs, errors.New("backing transaction group id is required"))
 	}
 
+	total := alpacadecimal.Zero
+	for chargeID, amount := range i.AmountsByChargeID {
+		if chargeID == "" {
+			errs = append(errs, errors.New("backfill charge id is required"))
+		}
+		if !amount.IsPositive() {
+			errs = append(errs, fmt.Errorf("backfill amount for charge %s must be positive", chargeID))
+		}
+		total = total.Add(amount)
+	}
+	if total.GreaterThan(i.Amount) {
+		errs = append(errs, errors.New("backfill amounts exceed purchase amount"))
+	}
 	return errors.Join(errs...)
 }
 

--- a/openmeter/billing/charges/lineage/service/service.go
+++ b/openmeter/billing/charges/lineage/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -180,6 +181,9 @@ func (s *service) BackfillAdvanceLineageSegments(ctx context.Context, input line
 		return err
 	}
 
+	if len(input.AmountsByChargeID) == 0 {
+		return nil
+	}
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
 		lineages, err := s.adapter.LockAdvanceLineagesForBackfill(ctx, input.Namespace, input.CustomerID, input.Currency.Reference())
 		if err != nil {
@@ -194,10 +198,18 @@ func (s *service) BackfillAdvanceLineageSegments(ctx context.Context, input line
 		}
 
 		lineageIDs := make([]string, 0, len(lineages))
+		chargeByLineageID := make(map[string]string, len(lineages))
 		for _, entry := range lineages {
+			if !input.AmountsByChargeID[entry.ChargeID].IsPositive() {
+				continue
+			}
+			chargeByLineageID[entry.ID] = entry.ChargeID
 			lineageIDs = append(lineageIDs, entry.ID)
 		}
 
+		if len(lineageIDs) == 0 {
+			return nil
+		}
 		state := creditrealization.LineageSegmentStateAdvanceUncovered
 		segments, err := s.adapter.ListActiveSegments(ctx, lineage.ListActiveSegmentsInput{
 			LineageIDs: lineageIDs,
@@ -208,11 +220,13 @@ func (s *service) BackfillAdvanceLineageSegments(ctx context.Context, input line
 		}
 
 		now := clock.Now().Truncate(time.Microsecond)
-		remaining := input.Amount
+		remainingByChargeID := maps.Clone(input.AmountsByChargeID)
 
 		for _, segment := range segments {
+			chargeID := chargeByLineageID[segment.LineageID]
+			remaining := remainingByChargeID[chargeID]
 			if !remaining.IsPositive() {
-				break
+				continue
 			}
 
 			coveredAmount := lineage.MinDecimal(segment.Amount, remaining)
@@ -240,7 +254,7 @@ func (s *service) BackfillAdvanceLineageSegments(ctx context.Context, input line
 				return fmt.Errorf("create backfilled advance lineage segment for segment %s: %w", segment.ID, err)
 			}
 
-			remaining = remaining.Sub(coveredAmount)
+			remainingByChargeID[chargeID] = remaining.Sub(coveredAmount)
 		}
 
 		return nil

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -150,20 +150,22 @@ func newCreditPurchaseTestHandler() *creditPurchaseTestHandler {
 	return &creditPurchaseTestHandler{}
 }
 
-func (h *creditPurchaseTestHandler) OnPromotionalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseTestHandler) OnPromotionalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
 	if h.onPromotionalCreditPurchase == nil {
-		return ledgertransaction.GroupReference{}, errors.New("onPromotionalCreditPurchase is not set")
+		return creditpurchase.CreditGrantResult{}, errors.New("onPromotionalCreditPurchase is not set")
 	}
 
-	return h.onPromotionalCreditPurchase(ctx, charge)
+	reference, err := h.onPromotionalCreditPurchase(ctx, charge)
+	return creditpurchase.CreditGrantResult{GroupReference: reference}, err
 }
 
-func (h *creditPurchaseTestHandler) OnCreditPurchaseInitiated(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseTestHandler) OnCreditPurchaseInitiated(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
 	if h.onCreditPurchaseInitiated == nil {
-		return ledgertransaction.GroupReference{}, errors.New("onCreditPurchaseInitiated is not set")
+		return creditpurchase.CreditGrantResult{}, errors.New("onCreditPurchaseInitiated is not set")
 	}
 
-	return h.onCreditPurchaseInitiated(ctx, charge)
+	reference, err := h.onCreditPurchaseInitiated(ctx, charge)
+	return creditpurchase.CreditGrantResult{GroupReference: reference}, err
 }
 
 func (h *creditPurchaseTestHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -320,12 +320,15 @@ func (s *CreditRealizationLineageTestSuite) TestBackfillAdvanceLineageSegmentsFi
 	apiLineageID := s.createAdvanceLineageForBackfill(ctx, ns, customerID, []string{"api-calls"}, alpacadecimal.NewFromInt(40))
 	storageLineageID := s.createAdvanceLineageForBackfill(ctx, ns, customerID, []string{"storage"}, alpacadecimal.NewFromInt(30))
 	backingTransactionGroupID := ulid.Make().String()
+	apiLineage, err := s.DBClient.CreditRealizationLineage.Get(ctx, apiLineageID)
+	s.Require().NoError(err)
 
 	err = service.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
 		Namespace:                 ns,
 		CustomerID:                customerID,
 		Currency:                  currenciestestutils.NewFiatCurrency(s.T(), currency.USD),
 		Amount:                    alpacadecimal.NewFromInt(50),
+		AmountsByChargeID:         map[string]alpacadecimal.Decimal{apiLineage.ChargeID: alpacadecimal.NewFromInt(40)},
 		BackingTransactionGroupID: backingTransactionGroupID,
 		FeatureFilters:            []string{"api-calls"},
 	})

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -116,12 +116,12 @@ type mockCreditPurchaseHandler struct{}
 
 var _ creditpurchase.Handler = (*mockCreditPurchaseHandler)(nil)
 
-func (mockCreditPurchaseHandler) OnPromotionalCreditPurchase(context.Context, creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-	return newMockLedgerTransactionGroupReference(), nil
+func (mockCreditPurchaseHandler) OnPromotionalCreditPurchase(context.Context, creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
+	return creditpurchase.CreditGrantResult{GroupReference: newMockLedgerTransactionGroupReference()}, nil
 }
 
-func (mockCreditPurchaseHandler) OnCreditPurchaseInitiated(context.Context, creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-	return newMockLedgerTransactionGroupReference(), nil
+func (mockCreditPurchaseHandler) OnCreditPurchaseInitiated(context.Context, creditpurchase.Charge) (creditpurchase.CreditGrantResult, error) {
+	return creditpurchase.CreditGrantResult{GroupReference: newMockLedgerTransactionGroupReference()}, nil
 }
 
 func (mockCreditPurchaseHandler) OnCreditPurchasePaymentAuthorized(context.Context, creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -92,11 +92,11 @@ func resolveCreditPurchasePaymentPosting(input chargecreditpurchase.PaymentEvent
 	}, nil
 }
 
-func (h *creditPurchaseHandler) OnPromotionalCreditPurchase(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseHandler) OnPromotionalCreditPurchase(ctx context.Context, charge chargecreditpurchase.Charge) (chargecreditpurchase.CreditGrantResult, error) {
 	return h.issueCreditPurchase(ctx, charge)
 }
 
-func (h *creditPurchaseHandler) OnCreditPurchaseInitiated(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseHandler) OnCreditPurchaseInitiated(ctx context.Context, charge chargecreditpurchase.Charge) (chargecreditpurchase.CreditGrantResult, error) {
 	return h.issueCreditPurchase(ctx, charge)
 }
 
@@ -252,19 +252,19 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 // issueCreditPurchase is the shared logic for issuing credits (both promotional and externally settled).
 // It attributes outstanding advance receivables and unattributed accrued balances to the given cost basis,
 // then issues new receivables for any remaining amount.
-func (h *creditPurchaseHandler) issueCreditPurchase(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-	return transaction.Run(ctx, h.transactionManager, func(ctx context.Context) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseHandler) issueCreditPurchase(ctx context.Context, charge chargecreditpurchase.Charge) (chargecreditpurchase.CreditGrantResult, error) {
+	return transaction.Run(ctx, h.transactionManager, func(ctx context.Context) (chargecreditpurchase.CreditGrantResult, error) {
 		return h.issueCreditPurchaseGroup(ctx, charge)
 	})
 }
 
-func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, charge chargecreditpurchase.Charge) (chargecreditpurchase.CreditGrantResult, error) {
 	if err := charge.Validate(); err != nil {
-		return ledgertransaction.GroupReference{}, err
+		return chargecreditpurchase.CreditGrantResult{}, err
 	}
 
 	if charge.Intent.CreditAmount.IsZero() {
-		return ledgertransaction.GroupReference{}, nil
+		return chargecreditpurchase.CreditGrantResult{}, nil
 	}
 
 	var costBasisPtr *alpacadecimal.Decimal
@@ -275,7 +275,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		}
 	} else {
 		if charge.State.ResolvedCostBasis == nil {
-			return ledgertransaction.GroupReference{}, models.NewGenericPreConditionFailedError(
+			return chargecreditpurchase.CreditGrantResult{}, models.NewGenericPreConditionFailedError(
 				fmt.Errorf("credit purchase charge[%s] cost basis is unresolved", charge.ID),
 			)
 		}
@@ -284,7 +284,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		if charge.Intent.Currency.IsCustom() {
 			fiatCurrency, err := charge.Intent.GetSettlementFiatCurrency()
 			if err != nil {
-				return ledgertransaction.GroupReference{}, fmt.Errorf("get settlement fiat currency: %w", err)
+				return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("get settlement fiat currency: %w", err)
 			}
 
 			costBasisCurrency = lo.ToPtr(currencyx.Code(fiatCurrency.GetFiatCode()))
@@ -318,7 +318,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	if costBasisPtr != nil {
 		advanceAttributions, err = h.advanceAttributions(ctx, customerID, charge.Intent.Currency, charge.Intent.CreditAmount, featureFilters)
 		if err != nil {
-			return ledgertransaction.GroupReference{}, fmt.Errorf("get advance attributions: %w", err)
+			return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("get advance attributions: %w", err)
 		}
 	}
 
@@ -401,7 +401,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	case chargecreditpurchase.SettlementTypeExternal, chargecreditpurchase.SettlementTypeInvoice:
 		// Deferred settlement modes are handled by later lifecycle events.
 	default:
-		return ledgertransaction.GroupReference{}, fmt.Errorf("unsupported settlement type: %s", charge.Intent.Settlement.Type())
+		return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("unsupported settlement type: %s", charge.Intent.Settlement.Type())
 	}
 
 	inputs, err := transactions.ResolveTransactions(
@@ -414,7 +414,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		templates...,
 	)
 	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("resolve transactions: %w", err)
+		return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("resolve transactions: %w", err)
 	}
 
 	var pendingBreakage []breakage.PendingRecord
@@ -444,7 +444,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			SourceChargeID:    &charge.ID,
 		})
 		if err != nil {
-			return ledgertransaction.GroupReference{}, fmt.Errorf("resolve breakage plan: %w", err)
+			return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("resolve breakage plan: %w", err)
 		}
 
 		inputs = append(inputs, breakageInputs...)
@@ -452,7 +452,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	}
 
 	if len(inputs) == 0 {
-		return ledgertransaction.GroupReference{}, nil
+		return chargecreditpurchase.CreditGrantResult{}, nil
 	}
 
 	for i, input := range inputs {
@@ -467,15 +467,24 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		inputs...,
 	))
 	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("commit ledger transaction group: %w", err)
+		return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("commit ledger transaction group: %w", err)
 	}
 
 	if err := h.breakage.PersistCommittedRecords(ctx, pendingBreakage, transactionGroup); err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("persist breakage records: %w", err)
+		return chargecreditpurchase.CreditGrantResult{}, fmt.Errorf("persist breakage records: %w", err)
 	}
 
-	return ledgertransaction.GroupReference{
-		TransactionGroupID: transactionGroup.ID().ID,
+	backfillAmounts := make(map[string]alpacadecimal.Decimal)
+	for _, attribution := range advanceAttributions {
+		if attribution.spendChargeID == nil || *attribution.spendChargeID == "" || !attribution.accruedAmount.IsPositive() {
+			continue
+		}
+		spendID := *attribution.spendChargeID
+		backfillAmounts[spendID] = backfillAmounts[spendID].Add(attribution.accruedAmount)
+	}
+	return chargecreditpurchase.CreditGrantResult{
+		GroupReference:                   ledgertransaction.GroupReference{TransactionGroupID: transactionGroup.ID().ID},
+		AdvanceBackfillAmountsByChargeID: backfillAmounts,
 	}, nil
 }
 

--- a/openmeter/ledger/chargeadapter/recognition_provenance_test.go
+++ b/openmeter/ledger/chargeadapter/recognition_provenance_test.go
@@ -1,0 +1,133 @@
+package chargeadapter_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	chargeflatfee "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestCustomCurrencyRecognizedCorrectionPreservesSpend(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		differentBasis bool
+		sources        int
+	}{
+		{name: "same cost basis", sources: 1},
+		{name: "different cost bases", differentBasis: true, sources: 1},
+		{name: "multiple sources per allocation", sources: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newFlatFeeHandlerTestEnv(t)
+			custom := currenciestestutils.NewCustomCurrency(t, "ACME", 2)
+			env.currency = custom
+			env.CustomCurrency = &custom
+			env.Currency = custom.GetCode()
+			amount := alpacadecimal.NewFromInt(30)
+			basis := alpacadecimal.NewFromFloat(0.5)
+			fiat := currencyx.Code("USD")
+			deps := transactions.ResolverDependencies{AccountService: env.Deps.ResolversService, AccountCatalog: env.Deps.AccountService, BalanceQuerier: env.Deps.HistoricalLedger}
+			charges := map[string]chargeflatfee.Charge{}
+			// given: two real credit-backed spends recognized together for one managed currency.
+			for i := range 2 {
+				if i == 1 && tc.differentBasis {
+					basis = alpacadecimal.NewFromFloat(0.8)
+				}
+				for range tc.sources {
+					sourceID := ulid.Make().String()
+					inputs, err := transactions.ResolveTransactions(t.Context(), deps, transactions.ResolutionScope{CustomerID: env.CustomerID, Namespace: env.Namespace}, transactions.IssueCustomerReceivableTemplate{
+						At: env.Now(), Amount: amount.Div(alpacadecimal.NewFromInt(int64(tc.sources))), Currency: custom.Reference(), CostBasis: &basis, CostBasisCurrency: &fiat, SourceChargeID: &sourceID,
+					})
+					require.NoError(t, err)
+					_, err = env.Deps.HistoricalLedger.CommitGroup(t.Context(), transactions.GroupInputs(env.Namespace, nil, inputs...))
+					require.NoError(t, err)
+				}
+				input := env.newAssignmentInputWithMode(amount, productcatalog.CreditOnlySettlementMode)
+				input.Charge.ID = ulid.Make().String()
+				allocations, err := env.handler.OnAllocateCredits(t.Context(), input)
+				require.NoError(t, err)
+				require.Len(t, allocations, 1)
+				charge := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
+				charge.ID = input.Charge.ID
+				intent := charge.Intent.GetBaseIntent()
+				intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+				charge.Intent = intent.AsOverridableIntent()
+				env.createInitialLineages(t, charge.ID, charge.Realizations.CurrentRun.CreditRealizations)
+				charges[charge.ID] = charge
+			}
+			groupID := env.recognizeCreditAccrued(t, amount.Mul(alpacadecimal.NewFromInt(2)))
+			recognitionGroup, err := env.Deps.HistoricalLedger.GetTransactionGroup(t.Context(), models.NamespacedID{Namespace: env.Namespace, ID: groupID})
+			require.NoError(t, err)
+			var entries []ledger.Entry
+			for _, tx := range recognitionGroup.Transactions() {
+				entries = append(entries, tx.Entries()...)
+			}
+			var spends []string
+			for _, entry := range entries {
+				if entry.PostingAddress().AccountType() == ledger.AccountTypeCustomerAccrued && entry.Amount().IsNegative() {
+					require.NotNil(t, entry.SpendChargeID())
+					if !slices.Contains(spends, *entry.SpendChargeID()) {
+						spends = append(spends, *entry.SpendChargeID())
+					}
+				}
+			}
+			require.Len(t, spends, 2)
+			// Correct the first spend in the shared recognition transaction.
+			charge := charges[spends[0]]
+			segments := env.assertRecognizedSegments(t, charge.Realizations.CurrentRun.CreditRealizations, groupID)
+			// when: repeated partial corrections consume only this spend's recognized slices.
+			for _, corrected := range []int64{10, 20} {
+				corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
+					Charge: charge, BookedAt: env.Now(),
+					Corrections:                  creditrealization.CorrectionRequest{{Allocation: charge.Realizations.CurrentRun.CreditRealizations[0], Amount: alpacadecimal.NewFromInt(-corrected)}},
+					LineageSegmentsByRealization: segments,
+				})
+				require.NoError(t, err)
+				require.Len(t, corrections, 1)
+				correctionGroup, err := env.Deps.HistoricalLedger.GetTransactionGroup(t.Context(), models.NamespacedID{Namespace: env.Namespace, ID: corrections[0].LedgerTransaction.TransactionGroupID})
+				require.NoError(t, err)
+				var correctionEntries []ledger.Entry
+				for _, tx := range correctionGroup.Transactions() {
+					correctionEntries = append(correctionEntries, tx.Entries()...)
+				}
+				for _, entry := range correctionEntries {
+					if entry.PostingAddress().AccountType() == ledger.AccountTypeEarnings && entry.Amount().IsNegative() {
+						require.NotNil(t, entry.SpendChargeID())
+						require.Equal(t, charge.ID, *entry.SpendChargeID(), "correction reversed another spend's recognized earnings")
+					}
+				}
+			}
+			// then: the corrected spend has no accrued/earned value and the other retains all 30.
+			for _, accountType := range []ledger.AccountType{ledger.AccountTypeCustomerAccrued, ledger.AccountTypeEarnings} {
+				balances := map[string]alpacadecimal.Decimal{}
+				page, err := env.Deps.HistoricalLedger.ListTransactions(t.Context(), ledger.ListTransactionsInput{Namespace: env.Namespace, Limit: 100})
+				require.NoError(t, err)
+				require.Nil(t, page.NextCursor)
+				for _, tx := range page.Items {
+					for _, entry := range tx.Entries() {
+						if entry.PostingAddress().AccountType() == accountType && entry.SpendChargeID() != nil {
+							balances[*entry.SpendChargeID()] = balances[*entry.SpendChargeID()].Add(entry.Amount())
+						}
+					}
+				}
+				require.Equal(t, float64(0), balances[charge.ID].InexactFloat64())
+				expected := float64(0)
+				if accountType == ledger.AccountTypeEarnings {
+					expected = 30
+				}
+				require.Equal(t, expected, balances[spends[1]].InexactFloat64())
+			}
+		})
+	}
+}

--- a/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_customcurrency_test.go
@@ -688,6 +688,7 @@ func TestCreateInitialLineages_CustomCurrency(t *testing.T) {
 		Currency:                  firstCurrency,
 		Amount:                    alpacadecimal.NewFromInt(30),
 		BackingTransactionGroupID: ulid.Make().String(),
+		AmountsByChargeID:         map[string]alpacadecimal.Decimal{firstChargeID: alpacadecimal.NewFromInt(30)},
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ledger/collector/README.md
+++ b/openmeter/ledger/collector/README.md
@@ -207,7 +207,14 @@ Net breakage is zero unless the original advance-backed usage is later corrected
 
 Usage correction restores previously collected value. It does not increase usage; it unwinds up to the original collected amount.
 
-Correction uses reverse original collection order.
+Correction uses reverse original collection order within the allocation's FBO
+subaccount. Repeated corrections subtract prior immutable correction links before
+selecting the next source slice. Breakage reopening uses that same selection.
+
+If a shared earnings-recognition group contains other spends or cost bases,
+correction reverses only the accrued route and source/spend provenance needed by
+the original collection or backfill unwind. Group membership alone is not
+sufficient to select recognized value.
 
 Example:
 

--- a/openmeter/ledger/collector/correct.go
+++ b/openmeter/ledger/collector/correct.go
@@ -4,10 +4,12 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -32,15 +34,17 @@ type accrualCorrector struct {
 // collectedSource is one logical “collection” in the group: the FBO→accrued
 // forward tx, plus the receivable issue when that slice was advance-backed.
 type collectedSource struct {
+	entries                           []ledger.Entry
 	transaction                       ledger.Transaction
 	group                             ledger.TransactionGroup
 	advanceReceivableIssueTransaction ledger.Transaction
 }
 
 type transactionCorrectionPlan struct {
-	transaction ledger.Transaction
-	group       ledger.TransactionGroup
-	amount      alpacadecimal.Decimal
+	sourceEntryAmounts map[string]alpacadecimal.Decimal
+	transaction        ledger.Transaction
+	group              ledger.TransactionGroup
+	amount             alpacadecimal.Decimal
 }
 
 type plannedAction interface {
@@ -48,9 +52,10 @@ type plannedAction interface {
 }
 
 type plannedTransactionCorrection struct {
-	transaction ledger.Transaction
-	group       ledger.TransactionGroup
-	amount      alpacadecimal.Decimal
+	sourceEntryAmounts map[string]alpacadecimal.Decimal
+	transaction        ledger.Transaction
+	group              ledger.TransactionGroup
+	amount             alpacadecimal.Decimal
 }
 
 func (plannedTransactionCorrection) isPlannedAction() {}
@@ -79,10 +84,14 @@ func (c *accrualCorrector) correct(ctx context.Context, input CorrectCollectedAc
 			return nil, nil
 		}
 
-		// Plan first, execute later, so we can merge overlapping corrections cleanly.
+		used, err := c.correctedSourceAmounts(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		// Reserve source capacity across the batch before committing any postings.
 		actions := make([]plannedAction, 0, len(input.Corrections))
 		for _, correction := range input.Corrections {
-			correctionActions, err := c.planCorrection(ctx, input, correction)
+			correctionActions, err := c.planCorrection(ctx, input, correction, used)
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +154,7 @@ func (c *accrualCorrector) correct(ctx context.Context, input CorrectCollectedAc
 	return transaction.Run(ctx, c.transactionManager, run)
 }
 
-func (c *accrualCorrector) planCorrection(ctx context.Context, input CorrectCollectedAccruedInput, correction creditrealization.CorrectionRequestItem) ([]plannedAction, error) {
+func (c *accrualCorrector) planCorrection(ctx context.Context, input CorrectCollectedAccruedInput, correction creditrealization.CorrectionRequestItem, used map[string]alpacadecimal.Decimal) ([]plannedAction, error) {
 	originalGroup, err := c.originalGroup(ctx, input, correction)
 	if err != nil {
 		return nil, err
@@ -160,7 +169,7 @@ func (c *accrualCorrector) planCorrection(ctx context.Context, input CorrectColl
 	// Older data may not have lineage yet, so fall back to first-order source correction.
 	segments := input.LineageSegmentsByRealization[correction.Allocation.ID]
 	if len(segments) == 0 {
-		return plannedSourceCorrectionActions(source, correction.Amount.Abs(), source.advanceReceivableIssueTransaction != nil), nil
+		return plannedSourceCorrectionActions(source, correction.Amount.Abs(), source.advanceReceivableIssueTransaction != nil, used)
 	}
 
 	// Lineage tells us what this value looks like now, so consume that state first.
@@ -176,7 +185,7 @@ func (c *accrualCorrector) planCorrection(ctx context.Context, input CorrectColl
 			continue
 		}
 
-		segmentActions, err := c.planSegmentCorrection(ctx, input, source, segment, segmentAmount)
+		segmentActions, err := c.planSegmentCorrection(ctx, input, source, segment, segmentAmount, used)
 		if err != nil {
 			return nil, err
 		}
@@ -204,24 +213,24 @@ func (c *accrualCorrector) originalGroup(ctx context.Context, input CorrectColle
 	return group, nil
 }
 
-func (c *accrualCorrector) planSegmentCorrection(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal) ([]plannedAction, error) {
+func (c *accrualCorrector) planSegmentCorrection(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal, used map[string]alpacadecimal.Decimal) ([]plannedAction, error) {
 	// Each current segment state needs a slightly different unwind.
 	switch segment.State {
 	case creditrealization.LineageSegmentStateRealCredit,
 		creditrealization.LineageSegmentStateReceivableCoverage:
-		return plannedSourceCorrectionActions(source, amount, false), nil
+		return plannedSourceCorrectionActions(source, amount, false, used)
 	case creditrealization.LineageSegmentStateAdvanceUncovered:
-		return plannedSourceCorrectionActions(source, amount, true), nil
+		return plannedSourceCorrectionActions(source, amount, true, used)
 	case creditrealization.LineageSegmentStateAdvanceBackfilled:
-		return c.planBackfilledAdvanceSegment(ctx, input, source, segment, amount)
+		return c.planBackfilledAdvanceSegment(ctx, input, source, segment, amount, used)
 	case creditrealization.LineageSegmentStateEarningsRecognized:
-		return c.planRecognizedEarningsSegment(ctx, input, source, segment, amount)
+		return c.planRecognizedEarningsSegment(ctx, input, source, segment, amount, used)
 	default:
 		return nil, fmt.Errorf("unsupported active lineage segment state %s", segment.State)
 	}
 }
 
-func (c *accrualCorrector) planRecognizedEarningsSegment(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal) ([]plannedAction, error) {
+func (c *accrualCorrector) planRecognizedEarningsSegment(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal, used map[string]alpacadecimal.Decimal) ([]plannedAction, error) {
 	if segment.BackingTransactionGroupID == nil || *segment.BackingTransactionGroupID == "" {
 		return nil, fmt.Errorf("earnings_recognized segment missing backing transaction group id")
 	}
@@ -251,16 +260,23 @@ func (c *accrualCorrector) planRecognizedEarningsSegment(ctx context.Context, in
 	sourceSegment.SourceState = nil
 	sourceSegment.SourceBackingTransactionGroupID = nil
 
-	sourceActions, err := c.planSegmentCorrection(ctx, input, source, sourceSegment, amount)
+	sourceActions, err := c.planSegmentCorrection(ctx, input, source, sourceSegment, amount, used)
 	if err != nil {
 		return nil, err
 	}
 
+	entryAmounts, err := c.recognizedSourceAmounts(ctx, recognizedSourceAmountsInput{
+		correction: input, recognition: recognitionTx, actions: sourceActions, amount: amount, used: used,
+	})
+	if err != nil {
+		return nil, err
+	}
 	actions := []plannedAction{
 		plannedTransactionCorrection{
-			transaction: recognitionTx,
-			group:       recognitionGroup,
-			amount:      amount,
+			sourceEntryAmounts: entryAmounts,
+			transaction:        recognitionTx,
+			group:              recognitionGroup,
+			amount:             amount,
 		},
 	}
 	actions = append(actions, sourceActions...)
@@ -268,7 +284,7 @@ func (c *accrualCorrector) planRecognizedEarningsSegment(ctx context.Context, in
 	return actions, nil
 }
 
-func (c *accrualCorrector) planBackfilledAdvanceSegment(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal) ([]plannedAction, error) {
+func (c *accrualCorrector) planBackfilledAdvanceSegment(ctx context.Context, input CorrectCollectedAccruedInput, source collectedSource, segment lineage.Segment, amount alpacadecimal.Decimal, used map[string]alpacadecimal.Decimal) ([]plannedAction, error) {
 	if segment.BackingTransactionGroupID == nil || *segment.BackingTransactionGroupID == "" {
 		return nil, fmt.Errorf("advance_backfilled segment missing backing transaction group id")
 	}
@@ -284,7 +300,15 @@ func (c *accrualCorrector) planBackfilledAdvanceSegment(ctx context.Context, inp
 	}
 
 	actions := make([]plannedAction, 0, 4)
-	if translateTx, err := c.forwardTransactionByTemplate(backingGroup, transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})); err == nil {
+	translateTx, err := backfillTransactionForSource(backfillTransactionForSourceInput{
+		group: backingGroup, original: source.transaction,
+		accountType:  ledger.AccountTypeCustomerAccrued,
+		templateCode: transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{}),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if translateTx != nil {
 		actions = append(actions, plannedTransactionCorrection{
 			transaction: translateTx,
 			group:       backingGroup,
@@ -292,16 +316,27 @@ func (c *accrualCorrector) planBackfilledAdvanceSegment(ctx context.Context, inp
 		})
 	}
 
-	attributeTx, err := c.forwardTransactionByTemplate(backingGroup, transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{}))
+	attributeTx, err := backfillTransactionForSource(backfillTransactionForSourceInput{
+		group: backingGroup, original: source.advanceReceivableIssueTransaction,
+		accountType:  ledger.AccountTypeCustomerReceivable,
+		templateCode: transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{}),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("find backing advance receivable attribution transaction in group %s: %w", backingGroup.ID().ID, err)
+	}
+	if attributeTx == nil {
+		return nil, fmt.Errorf("backing group %s has no receivable attribution matching the collected source", backingGroup.ID().ID)
 	}
 	actions = append(actions, plannedTransactionCorrection{
 		transaction: attributeTx,
 		group:       backingGroup,
 		amount:      amount,
 	})
-	actions = append(actions, plannedSourceCorrectionActions(source, amount, true)...)
+	sourceActions, err := plannedSourceCorrectionActions(source, amount, true, used)
+	if err != nil {
+		return nil, err
+	}
+	actions = append(actions, sourceActions...)
 
 	reopenInputs, reopenPending, err := c.resolveAdvanceBackfillBreakageReopenInputs(ctx, input, backingGroup, amount)
 	if err != nil {
@@ -370,15 +405,24 @@ func (c *accrualCorrector) reissueBackfilledCredit(ctx context.Context, input Co
 	return out, nil
 }
 
-func plannedSourceCorrectionActions(source collectedSource, amount alpacadecimal.Decimal, includeAdvanceReceivable bool) []plannedAction {
+func plannedSourceCorrectionActions(source collectedSource, amount alpacadecimal.Decimal, includeAdvanceReceivable bool, used map[string]alpacadecimal.Decimal) ([]plannedAction, error) {
+	var entryAmounts map[string]alpacadecimal.Decimal
+	if source.advanceReceivableIssueTransaction == nil {
+		var err error
+		entryAmounts, err = reserveCorrectionSources(source.entries, amount, used)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// A source correction always offsets the original collection transaction itself.
 	// Advance-backed collection also needs the companion receivable-issue correction
 	// so the offset reduces the advance-side obligation instead of manufacturing credit.
 	actions := []plannedAction{
 		plannedTransactionCorrection{
-			transaction: source.transaction,
-			group:       source.group,
-			amount:      amount,
+			sourceEntryAmounts: entryAmounts,
+			transaction:        source.transaction,
+			group:              source.group,
+			amount:             amount,
 		},
 	}
 
@@ -390,7 +434,7 @@ func plannedSourceCorrectionActions(source collectedSource, amount alpacadecimal
 		})
 	}
 
-	return actions
+	return actions, nil
 }
 
 func (c *accrualCorrector) resolvePlannedInputs(ctx context.Context, input CorrectCollectedAccruedInput, actions []plannedAction) (resolvedCorrectionInputs, error) {
@@ -406,14 +450,21 @@ func (c *accrualCorrector) resolvePlannedInputs(ctx context.Context, input Corre
 		case plannedTransactionCorrection:
 			key := planned.mergeKey()
 			if existing, ok := mergedCorrections[key]; ok {
+				if (existing.sourceEntryAmounts == nil) != (planned.sourceEntryAmounts == nil) {
+					return resolvedCorrectionInputs{}, fmt.Errorf("cannot merge scoped and unscoped corrections of transaction %s", key)
+				}
 				existing.amount = existing.amount.Add(planned.amount)
+				for id, amount := range planned.sourceEntryAmounts {
+					existing.sourceEntryAmounts[id] = existing.sourceEntryAmounts[id].Add(amount)
+				}
 				continue
 			}
 
 			mergedCorrections[key] = &transactionCorrectionPlan{
-				transaction: planned.transaction,
-				group:       planned.group,
-				amount:      planned.amount,
+				sourceEntryAmounts: maps.Clone(planned.sourceEntryAmounts),
+				transaction:        planned.transaction,
+				group:              planned.group,
+				amount:             planned.amount,
 			}
 			correctionOrder = append(correctionOrder, key)
 		case plannedDirectInputs:
@@ -436,6 +487,7 @@ func (c *accrualCorrector) resolvePlannedInputs(ctx context.Context, input Corre
 		correctionInputs, err := transactions.CorrectTransaction(ctx, c.deps, transactions.CorrectionInput{
 			At:                  input.AllocateAt,
 			Amount:              transactionPlan.amount,
+			SourceEntryAmounts:  transactionPlan.sourceEntryAmounts,
 			OriginalTransaction: transactionPlan.transaction,
 			OriginalGroup:       transactionPlan.group,
 		})
@@ -483,6 +535,9 @@ func (c *accrualCorrector) resolveAdvanceBackfillBreakageReopenInputs(ctx contex
 		}
 
 		releaseFacts := releaseFactsByTransactionID[release.BreakageTransactionID]
+		if releaseFacts.SpendChargeID != nil && *releaseFacts.SpendChargeID != input.ChargeID {
+			continue
+		}
 		reopenInput, reopenRecord, err := c.breakage.ReopenRelease(ctx, breakage.ReopenReleaseInput{
 			Release:        release,
 			Amount:         reopenAmount,
@@ -542,6 +597,14 @@ func (c *accrualCorrector) resolveBreakageReopenInputs(ctx context.Context, inpu
 	}
 
 	correctedEntries := correctedFBOEntriesForAmount(transactionPlan.transaction, transactionPlan.amount)
+	if transactionPlan.sourceEntryAmounts != nil {
+		correctedEntries = nil
+		for _, entry := range transactionPlan.transaction.Entries() {
+			if amount := transactionPlan.sourceEntryAmounts[entry.ID().ID]; amount.IsPositive() {
+				correctedEntries = append(correctedEntries, correctedFBOEntry{entry: entry, amount: amount})
+			}
+		}
+	}
 	if len(correctedEntries) == 0 {
 		return nil, nil, nil
 	}
@@ -690,9 +753,17 @@ func (c *accrualCorrector) collectedSourcesForGroup(group ledger.TransactionGrou
 			}
 		}
 
+		sourceIndexBySubAccount := make(map[string]int)
 		for _, entry := range transaction.Entries() {
 			if entry.PostingAddress().AccountType() == ledger.AccountTypeCustomerFBO && entry.Amount().IsNegative() {
+				subAccountID := entry.PostingAddress().SubAccountID()
+				if idx, ok := sourceIndexBySubAccount[subAccountID]; ok {
+					out[idx].entries = append(out[idx].entries, entry)
+					continue
+				}
+				sourceIndexBySubAccount[subAccountID] = len(out)
 				out = append(out, collectedSource{
+					entries:                           []ledger.Entry{entry},
 					transaction:                       transaction,
 					group:                             group,
 					advanceReceivableIssueTransaction: advanceReceivableIssueTransaction,
@@ -822,4 +893,191 @@ func minDecimal(a, b alpacadecimal.Decimal) alpacadecimal.Decimal {
 	}
 
 	return a
+}
+
+// correctedSourceAmounts reads immutable correction links so a later partial
+// correction resumes the original source suffix instead of restoring it twice.
+func (c *accrualCorrector) correctedSourceAmounts(ctx context.Context, input CorrectCollectedAccruedInput) (map[string]alpacadecimal.Decimal, error) {
+	out := make(map[string]alpacadecimal.Decimal)
+	var cursor *ledger.TransactionCursor
+	for {
+		page, err := c.ledger.ListTransactions(ctx, ledger.ListTransactionsInput{
+			Namespace: input.Namespace, Limit: 100, Cursor: cursor,
+			AnnotationFilters: map[string]string{
+				ledger.AnnotationChargeID:             input.ChargeID,
+				ledger.AnnotationTransactionDirection: string(ledger.TransactionDirectionCorrection),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list prior charge corrections: %w", err)
+		}
+		for _, tx := range page.Items {
+			for _, entry := range tx.Entries() {
+				if !entry.Amount().IsPositive() {
+					continue
+				}
+				_, identity, err := ledger.EntryIdentityKeyText(entry.IdentityKey()).Parse()
+				if err != nil {
+					return nil, fmt.Errorf("parse correction entry identity: %w", err)
+				}
+				if identity.CorrectionSource != nil {
+					out[*identity.CorrectionSource] = out[*identity.CorrectionSource].Add(entry.Amount())
+				}
+			}
+		}
+		if page.NextCursor == nil {
+			return out, nil
+		}
+		cursor = page.NextCursor
+	}
+}
+
+// reserveCorrectionSources resumes the reverse original collection order after
+// subtracting both persisted corrections and reservations earlier in this batch.
+func reserveCorrectionSources(entries []ledger.Entry, amount alpacadecimal.Decimal, used map[string]alpacadecimal.Decimal) (map[string]alpacadecimal.Decimal, error) {
+	entries = slices.Clone(entries)
+	slices.SortStableFunc(entries, compareCollectedFBOCorrectionSourceEntries)
+	out := make(map[string]alpacadecimal.Decimal)
+	remaining := amount
+	for i := len(entries) - 1; i >= 0 && remaining.IsPositive(); i-- {
+		entry := entries[i]
+		available := entry.Amount().Abs().Sub(used[entry.ID().ID])
+		if !available.IsPositive() {
+			continue
+		}
+		selected := minDecimal(available, remaining)
+		out[entry.ID().ID] = selected
+		used[entry.ID().ID] = used[entry.ID().ID].Add(selected)
+		remaining = remaining.Sub(selected)
+	}
+	if remaining.IsPositive() {
+		return nil, fmt.Errorf("correction exceeds remaining source capacity by %s", remaining)
+	}
+	return out, nil
+}
+
+// Recognition groups can include multiple spends and cost bases. Reverse only
+// the accrued buckets that the source unwind will debit, including a backfill's
+// translation from unknown to known cost basis.
+type recognizedSourceAmountsInput struct {
+	correction  CorrectCollectedAccruedInput
+	recognition ledger.Transaction
+	actions     []plannedAction
+	amount      alpacadecimal.Decimal
+	used        map[string]alpacadecimal.Decimal
+}
+
+func (c *accrualCorrector) recognizedSourceAmounts(ctx context.Context, input recognizedSourceAmountsInput) (map[string]alpacadecimal.Decimal, error) {
+	accrued := make(map[correctionPostingKey]alpacadecimal.Decimal)
+	for _, action := range input.actions {
+		var inputs []ledger.TransactionInput
+		switch planned := action.(type) {
+		case plannedTransactionCorrection:
+			var err error
+			inputs, err = transactions.CorrectTransaction(ctx, c.deps, transactions.CorrectionInput{
+				At: input.correction.AllocateAt, Amount: planned.amount, OriginalTransaction: planned.transaction, OriginalGroup: planned.group, SourceEntryAmounts: planned.sourceEntryAmounts,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("resolve recognition source unwind: %w", err)
+			}
+		case plannedDirectInputs:
+			inputs = planned.inputs
+		default:
+			return nil, fmt.Errorf("unsupported recognition source action %T", action)
+		}
+		for _, tx := range inputs {
+			for _, entry := range tx.EntryInputs() {
+				if entry.PostingAddress().AccountType() == ledger.AccountTypeCustomerAccrued {
+					key := correctionEntryKey(entry)
+					accrued[key] = accrued[key].Sub(entry.Amount())
+				}
+			}
+		}
+	}
+	out := make(map[string]alpacadecimal.Decimal)
+	selected := alpacadecimal.Zero
+	for _, entry := range input.recognition.Entries() {
+		if entry.PostingAddress().AccountType() != ledger.AccountTypeCustomerAccrued || !entry.Amount().IsNegative() {
+			continue
+		}
+		key := correctionEntryKey(entry)
+		required := accrued[key]
+		available := entry.Amount().Abs().Sub(input.used[entry.ID().ID])
+		if !required.IsPositive() || !available.IsPositive() {
+			continue
+		}
+		take := minDecimal(required, available)
+		out[entry.ID().ID] = take
+		input.used[entry.ID().ID] = input.used[entry.ID().ID].Add(take)
+		accrued[key] = required.Sub(take)
+		selected = selected.Add(take)
+	}
+	if !selected.Equal(input.amount) {
+		return nil, fmt.Errorf("recognition source coverage %s does not match correction amount %s", selected, input.amount)
+	}
+	for _, remaining := range accrued {
+		if !remaining.IsZero() {
+			return nil, fmt.Errorf("recognition correction leaves unmatched accrued amount %s", remaining)
+		}
+	}
+	return out, nil
+}
+
+type correctionPostingKey struct{ subAccountID, sourceChargeID, spendChargeID string }
+
+func correctionEntryKey(entry ledger.EntryInput) correctionPostingKey {
+	return correctionPostingKey{
+		subAccountID:   entry.PostingAddress().SubAccountID(),
+		sourceChargeID: lo.FromPtrOr(entry.SourceChargeID(), ""),
+		spendChargeID:  lo.FromPtrOr(entry.SpendChargeID(), ""),
+	}
+}
+
+// A purchase can backfill multiple spends in one group. Match the original
+// unknown-cost route and spend rather than taking the group's first template.
+type backfillTransactionForSourceInput struct {
+	group        ledger.TransactionGroup
+	original     ledger.Transaction
+	accountType  ledger.AccountType
+	templateCode string
+}
+
+func backfillTransactionForSource(input backfillTransactionForSourceInput) (ledger.Transaction, error) {
+	if input.original == nil {
+		return nil, fmt.Errorf("backfill correction requires original %s transaction", input.accountType)
+	}
+	keys := make(map[correctionPostingKey]struct{})
+	for _, entry := range input.original.Entries() {
+		if entry.PostingAddress().AccountType() == input.accountType {
+			keys[correctionEntryKey(entry)] = struct{}{}
+		}
+	}
+	var found ledger.Transaction
+	for _, tx := range input.group.Transactions() {
+		code, err := ledger.TransactionTemplateCodeFromAnnotations(tx.Annotations())
+		if err != nil {
+			return nil, err
+		}
+		direction, err := ledger.TransactionDirectionFromAnnotations(tx.Annotations())
+		if err != nil {
+			return nil, err
+		}
+		if code != input.templateCode || direction != ledger.TransactionDirectionForward {
+			continue
+		}
+		for _, entry := range tx.Entries() {
+			if entry.PostingAddress().AccountType() != input.accountType {
+				continue
+			}
+			if _, ok := keys[correctionEntryKey(entry)]; !ok {
+				continue
+			}
+			if found != nil {
+				return nil, fmt.Errorf("multiple backfill transactions match the original %s source", input.accountType)
+			}
+			found = tx
+			break
+		}
+	}
+	return found, nil
 }

--- a/openmeter/ledger/collector/correct_test.go
+++ b/openmeter/ledger/collector/correct_test.go
@@ -1015,3 +1015,114 @@ func realizationsFromAllocations(env *ledgertestutils.IntegrationEnv, allocation
 
 	return out
 }
+
+func TestCorrectCollectedAccruedResumesCollapsedSourceSuffix(t *testing.T) {
+	env := ledgertestutils.NewIntegrationEnv(t, "collector-correct-source-suffix")
+	collector := newTestAccrualCollector(env)
+	corrector := newTestAccrualCorrector(env, nil)
+
+	// given: one allocation collapses two source charges, followed by another route.
+	sourceA, sourceB, sourceC, spend := testChargeID(1), testChargeID(2), testChargeID(3), testChargeID(4)
+	sharedFBO := fundSourceCharge(t, env, sourceA, 1, 10)
+	fundSourceCharge(t, env, sourceB, 1, 20)
+	otherFBO := fundSourceCharge(t, env, sourceC, 2, 15)
+	allocations, err := collector.collect(t.Context(), CollectToAccruedInput{
+		Namespace: env.Namespace, ChargeID: spend, CustomerID: env.CustomerID.ID,
+		BookedAt: env.Now(), SourceBalanceAsOf: env.Now(), Currency: env.CurrencyReference(),
+		SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+		ServicePeriod:  testServicePeriod(env), Amount: alpacadecimal.NewFromInt(45),
+	})
+	require.NoError(t, err)
+	require.Len(t, allocations, 2)
+	realizations := realizationsFromAllocations(env, allocations)
+
+	// when: correct the second allocation, then repeatedly unwind the collapsed first.
+	for _, correction := range []struct {
+		allocation int
+		amount     int64
+	}{{1, 5}, {0, 10}, {0, 15}} {
+		_, err := corrector.correct(t.Context(), CorrectCollectedAccruedInput{
+			Namespace: env.Namespace, ChargeID: spend, CustomerID: env.CustomerID.ID, AllocateAt: env.Now(),
+			Corrections: creditrealization.CorrectionRequest{{Allocation: realizations[correction.allocation], Amount: alpacadecimal.NewFromInt(-correction.amount)}},
+		})
+		require.NoError(t, err)
+	}
+
+	// then: B's entire 20 and A's last 5 are restored; C independently retains 10 spent.
+	require.Equal(t, float64(25), env.SumBalance(t, sharedFBO).InexactFloat64())
+	require.Equal(t, float64(5), env.SumBalance(t, otherFBO).InexactFloat64())
+	requireAccruedBalanceBuckets(t, env, map[string]float64{
+		sourceSpendChargeKey(&sourceA, &spend): 5,
+		sourceSpendChargeKey(&sourceC, &spend): 10,
+	})
+}
+
+func TestCorrectRecognizedBackfillSelectsOriginalSpend(t *testing.T) {
+	env := ledgertestutils.NewIntegrationEnv(t, "collector-correct-shared-backfill")
+	env.Currency = "ACME"
+	collector := newTestAccrualCollector(env)
+	corrector := newTestAccrualCorrector(env, nil)
+	spends := []string{testChargeID(1), testChargeID(2)}
+	purchase := testChargeID(3)
+	var allocations creditrealization.Realizations
+	var templates []transactions.TransactionTemplate
+	amount := alpacadecimal.NewFromInt(30)
+	basis := alpacadecimal.NewFromFloat(0.5)
+	fiat := currencyx.Code("USD")
+
+	// given: two spends share one later purchase/backfill group and recognition group.
+	for _, spend := range spends {
+		collected, err := collector.collect(t.Context(), CollectToAccruedInput{
+			Namespace: env.Namespace, ChargeID: spend, CustomerID: env.CustomerID.ID,
+			BookedAt: env.Now(), SourceBalanceAsOf: env.Now(), Currency: env.CurrencyReference(),
+			SettlementMode: productcatalog.CreditOnlySettlementMode, ServicePeriod: testServicePeriod(env), Amount: amount,
+		})
+		require.NoError(t, err)
+		require.Len(t, collected, 1)
+		allocations = append(allocations, realizationsFromAllocations(env, collected)...)
+		templates = append(templates,
+			transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{At: env.Now(), Amount: amount, Currency: env.CurrencyReference(), CostBasis: &basis, CostBasisCurrency: &fiat, SourceChargeID: &purchase, SpendChargeID: lo.ToPtr(spend)},
+			transactions.TranslateCustomerAccruedCostBasisTemplate{At: env.Now(), Amount: amount, Currency: env.CurrencyReference(), ToCostBasis: &basis, CostBasisCurrency: &fiat, SourceChargeID: &purchase, SpendChargeID: lo.ToPtr(spend)},
+		)
+	}
+	scope := transactions.ResolutionScope{Namespace: env.Namespace, CustomerID: env.CustomerID}
+	inputs, err := transactions.ResolveTransactions(t.Context(), corrector.deps, scope, templates...)
+	require.NoError(t, err)
+	backing, err := env.Deps.HistoricalLedger.CommitGroup(t.Context(), transactions.GroupInputs(env.Namespace, nil, inputs...))
+	require.NoError(t, err)
+	inputs, err = transactions.ResolveTransactions(t.Context(), corrector.deps, scope, transactions.RecognizeEarningsFromAttributableAccruedTemplate{At: env.Now(), Amount: alpacadecimal.NewFromInt(60), Currency: env.CurrencyReference()})
+	require.NoError(t, err)
+	recognition, err := env.Deps.HistoricalLedger.CommitGroup(t.Context(), transactions.GroupInputs(env.Namespace, nil, inputs...))
+	require.NoError(t, err)
+
+	// when: repeatedly correct the second spend, whose backfill transaction is not first.
+	for _, correction := range []int64{10, 20} {
+		_, err = corrector.correct(t.Context(), CorrectCollectedAccruedInput{
+			Namespace: env.Namespace, ChargeID: spends[1], CustomerID: env.CustomerID.ID, AllocateAt: env.Now(),
+			Corrections: creditrealization.CorrectionRequest{{Allocation: allocations[1], Amount: alpacadecimal.NewFromInt(-correction)}},
+			LineageSegmentsByRealization: lineage.ActiveSegmentsByRealizationID{allocations[1].ID: {{
+				Amount: amount, State: creditrealization.LineageSegmentStateEarningsRecognized,
+				BackingTransactionGroupID:       lo.ToPtr(recognition.ID().ID),
+				SourceState:                     lo.ToPtr(creditrealization.LineageSegmentStateAdvanceBackfilled),
+				SourceBackingTransactionGroupID: lo.ToPtr(backing.ID().ID),
+			}}},
+		})
+		require.NoError(t, err)
+	}
+
+	// then: the first spend retains earnings and no accrued bucket goes negative.
+	requireAccruedBalanceBuckets(t, env, map[string]float64{})
+	page, err := env.Deps.HistoricalLedger.ListTransactions(t.Context(), ledger.ListTransactionsInput{Namespace: env.Namespace, Limit: 100})
+	require.NoError(t, err)
+	require.Nil(t, page.NextCursor)
+	earnings := map[string]alpacadecimal.Decimal{}
+	for _, tx := range page.Items {
+		for _, entry := range tx.Entries() {
+			if entry.PostingAddress().AccountType() == ledger.AccountTypeEarnings && entry.SpendChargeID() != nil {
+				earnings[*entry.SpendChargeID()] = earnings[*entry.SpendChargeID()].Add(entry.Amount())
+			}
+		}
+	}
+	require.Equal(t, float64(30), earnings[spends[0]].InexactFloat64())
+	require.Equal(t, float64(0), earnings[spends[1]].InexactFloat64())
+}

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -95,9 +95,7 @@ func (t TransferCustomerFBOToAccruedTemplate) correct(scope CorrectionInput) ([]
 		negativeFBOEntries,
 		positiveAccruedEntries,
 		t.entryRoutePairingKey,
-		func(entry ledger.Entry) alpacadecimal.Decimal {
-			return entry.Amount().Abs()
-		},
+		scope.sourceEntryAmount,
 		scope.Amount,
 	)
 	if err != nil {

--- a/openmeter/ledger/transactions/correction.go
+++ b/openmeter/ledger/transactions/correction.go
@@ -18,6 +18,9 @@ type CorrectionInput struct {
 	At     time.Time
 	Amount alpacadecimal.Decimal
 
+	// SourceEntryAmounts selects exact original source slices. Nil keeps the template default.
+	SourceEntryAmounts map[string]alpacadecimal.Decimal
+
 	// CostBasis is required only by templates whose correction must reapply an
 	// immutable conversion rate (e.g. ConvertCurrencyTemplate). The charge layer
 	// supplies it; the template validates it against the original booking
@@ -45,6 +48,23 @@ func (i CorrectionScope) Validate() error {
 		errs = append(errs, errors.New("original transaction is required"))
 	}
 
+	if i.SourceEntryAmounts != nil && i.OriginalTransaction != nil {
+		original := make(map[string]ledger.Entry)
+		for _, entry := range i.OriginalTransaction.Entries() {
+			original[entry.ID().ID] = entry
+		}
+		total := alpacadecimal.Zero
+		for id, amount := range i.SourceEntryAmounts {
+			entry, ok := original[id]
+			if !ok || !entry.Amount().IsNegative() || !amount.IsPositive() || amount.GreaterThan(entry.Amount().Abs()) {
+				errs = append(errs, fmt.Errorf("invalid correction source amount for entry %s", id))
+			}
+			total = total.Add(amount)
+		}
+		if !total.Equal(i.Amount) {
+			errs = append(errs, errors.New("source entry amounts must sum to correction amount"))
+		}
+	}
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
@@ -69,6 +89,14 @@ func CorrectTransaction(
 	template, err := transactionTemplateFromAnnotations(scope.OriginalTransaction.Annotations())
 	if err != nil {
 		return nil, fmt.Errorf("transaction template: %w", err)
+	}
+
+	if scope.SourceEntryAmounts != nil {
+		switch template.(type) {
+		case TransferCustomerFBOToAccruedTemplate, CoverCustomerReceivableTemplate, RecognizeEarningsFromAttributableAccruedTemplate:
+		default:
+			return nil, fmt.Errorf("transaction template %T does not support source entry selection", template)
+		}
 	}
 
 	outputs, err := correctTemplate(scope, template)
@@ -134,4 +162,11 @@ func correctTemplate(scope CorrectionScope, template TransactionTemplate) ([]led
 
 func templateCorrectionNotImplemented(template string) error {
 	return fmt.Errorf("%s correction is not implemented", template)
+}
+
+func (i CorrectionInput) sourceEntryAmount(entry ledger.Entry) alpacadecimal.Decimal {
+	if i.SourceEntryAmounts != nil {
+		return i.SourceEntryAmounts[entry.ID().ID]
+	}
+	return entry.Amount().Abs()
 }

--- a/openmeter/ledger/transactions/customer.go
+++ b/openmeter/ledger/transactions/customer.go
@@ -666,7 +666,7 @@ func (t CoverCustomerReceivableTemplate) correct(scope CorrectionInput) ([]ledge
 		negativeFBOEntries,
 		positiveReceivableEntries,
 		t.entryRoutePairingKey,
-		func(entry ledger.Entry) alpacadecimal.Decimal { return entry.Amount().Abs() },
+		scope.sourceEntryAmount,
 		scope.Amount,
 	)
 	if err != nil {

--- a/openmeter/ledger/transactions/earnings.go
+++ b/openmeter/ledger/transactions/earnings.go
@@ -72,9 +72,7 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) correct(scope Correcti
 		negativeAccruedEntries,
 		positiveEarningsEntries,
 		t.entryRoutePairingKey,
-		func(entry ledger.Entry) alpacadecimal.Decimal {
-			return entry.Amount().Abs()
-		},
+		scope.sourceEntryAmount,
 		scope.Amount,
 	)
 	if err != nil {

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -320,6 +320,25 @@ func (s *BaseSuite) CreateLedgerBackedCustomer(ns string, subjectKey string) *cu
 	return cust
 }
 
+func (s *BaseSuite) CreateCustomCurrency(namespace string, code currencyx.Code) currencies.Currency {
+	s.T().Helper()
+
+	currency, err := s.CurrencyService.CreateCurrency(s.T().Context(), currencies.CreateCurrencyInput{
+		Namespace: namespace,
+		CurrencyDetails: currencyx.CurrencyDetails{
+			Code:               code,
+			Name:               code.String(),
+			Symbol:             code.String(),
+			Precision:          2,
+			DecimalMark:        ".",
+			ThousandsSeparator: ",",
+		},
+	})
+	s.Require().NoError(err)
+
+	return currency
+}
+
 // MustCustomerFBOBalance returns customer FBO balance in a currency. Pass mo.None()
 // for all cost bases, mo.Some(nil) for the explicit nil-cost-basis route, or
 // mo.Some(&costBasis) for one concrete cost-basis route.
@@ -340,6 +359,16 @@ func (s *BaseSuite) MustCustomerFBOBalanceAsOf(customerID customer.CustomerID, c
 }
 
 func (s *BaseSuite) MustCustomerFBOBalanceWithPriorityAsOf(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], priority int, asOf *time.Time) alpacadecimal.Decimal {
+	return s.MustCustomerFBOBalanceByRouteAsOf(customerID, ledger.RouteFilter{
+		Currency:       currencies.NewCurrencyReference(code),
+		CostBasis:      costBasis,
+		CreditPriority: lo.ToPtr(priority),
+	}, asOf)
+}
+
+// MustCustomerFBOBalanceByRouteAsOf applies the supplied route filter to the
+// customer FBO balance at an optional historical point.
+func (s *BaseSuite) MustCustomerFBOBalanceByRouteAsOf(customerID customer.CustomerID, route ledger.RouteFilter, asOf *time.Time) alpacadecimal.Decimal {
 	s.T().Helper()
 
 	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
@@ -350,11 +379,7 @@ func (s *BaseSuite) MustCustomerFBOBalanceWithPriorityAsOf(customerID customer.C
 		query.AsOf = asOf
 	}
 
-	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, ledger.RouteFilter{
-		Currency:       currencies.NewCurrencyReference(code),
-		CostBasis:      costBasis,
-		CreditPriority: lo.ToPtr(priority),
-	}, query)
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, route, query)
 	s.NoError(err)
 
 	return balance

--- a/test/credits/creditgrant_settlement_test.go
+++ b/test/credits/creditgrant_settlement_test.go
@@ -1,0 +1,98 @@
+package credits
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+func (s *CreditGrantTestSuite) TestRejectPurchaseRoundingToZeroBeforeIssuance() {
+	for _, code := range []currencyx.Code{"TOKENS", USD} {
+		for _, funding := range []creditgrant.FundingMethod{creditgrant.FundingMethodExternal, creditgrant.FundingMethodInvoice} {
+			s.Run(string(code)+"/"+string(funding), func() {
+				// given a positive purchase price below the settlement currency's precision
+				ctx := s.T().Context()
+				ns := s.GetUniqueNamespace("rounded-zero-purchase")
+				s.ProvisionDefaultTaxCodes(ctx, ns)
+				cust := s.CreateLedgerBackedCustomer(ns, "customer")
+				if code.IsCustom() {
+					s.CreateCustomCurrency(ns, code)
+				}
+				if funding == creditgrant.FundingMethodInvoice {
+					invoicing := s.SetupCustomInvoicing(ns)
+					s.ProvisionBillingProfile(ctx, ns, invoicing.App.GetID())
+				}
+				clock.FreezeTime(time.Date(2026, 4, 17, 11, 0, 0, 0, time.UTC))
+				defer clock.UnFreeze()
+
+				rate := alpacadecimal.RequireFromString("0.001")
+				purchase := &creditgrant.PurchaseTerms{Currency: USD, PerUnitCostBasis: &rate, AvailabilityPolicy: lo.ToPtr(creditpurchase.CreatedInitialPaymentSettlementStatus)}
+				if code.IsCustom() {
+					fiat, err := currencyx.NewFiatCurrency(USD)
+					s.Require().NoError(err)
+					purchase.PerUnitCostBasis = nil
+					purchase.CostBasis = lo.ToPtr(creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: rate})))
+				}
+
+				// when creating paid credits that would otherwise be available immediately
+				_, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+					Namespace: ns, CustomerID: cust.ID, Name: "small purchase", Currency: code,
+					Amount: alpacadecimal.NewFromInt(1), FundingMethod: funding,
+					Purchase: purchase,
+				})
+
+				// then rejection is atomic: no grant, ledger posting or invoice remains
+				s.Require().ErrorContains(err, "purchase amount must be positive after rounding")
+				grants, err := s.CreditGrantService.List(ctx, creditgrant.ListInput{Namespace: ns, CustomerID: cust.ID})
+				s.Require().NoError(err)
+				s.Empty(grants.Items)
+				postings, err := s.DBClient.LedgerTransaction.Query().Where(ledgertransaction.NamespaceEQ(ns)).Count(ctx)
+				s.Require().NoError(err)
+				s.Zero(postings)
+				invoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{Namespace: ns})
+				s.Require().NoError(err)
+				s.Empty(invoices.Items)
+			})
+		}
+	}
+}
+
+func (s *CreditGrantTestSuite) TestPurchaseRoundingToMinorUnitCanSettle() {
+	// given a fractional price that rounds up to one fiat minor unit
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("rounded-positive-purchase")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "customer")
+	s.CreateCustomCurrency(ns, "TOKENS")
+	clock.FreezeTime(time.Date(2026, 4, 17, 11, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+
+	fiat, err := currencyx.NewFiatCurrency(USD)
+	s.Require().NoError(err)
+	// when the custom purchase is created and settled
+	grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace: ns, CustomerID: cust.ID, Name: "one cent purchase", Currency: "TOKENS",
+		Amount: alpacadecimal.NewFromInt(1), FundingMethod: creditgrant.FundingMethodExternal,
+		Purchase: &creditgrant.PurchaseTerms{Currency: USD, CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: alpacadecimal.RequireFromString("0.005")})))},
+	})
+	s.Require().NoError(err)
+	settled, err := s.CreditGrantService.UpdateExternalSettlement(ctx, creditgrant.UpdateExternalSettlementInput{
+		Namespace: ns, CustomerID: cust.ID, ChargeID: grant.ID, TargetStatus: payment.StatusSettled,
+	})
+
+	// then valid rounded purchases retain the normal payment lifecycle
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.StatusFinal, settled.Status)
+	s.Require().NotNil(settled.Realizations.ExternalPaymentSettlement)
+	s.Equal(0.01, settled.Realizations.ExternalPaymentSettlement.FiatAmount.InexactFloat64())
+}

--- a/test/credits/creditpurchase_settlement_test.go
+++ b/test/credits/creditpurchase_settlement_test.go
@@ -1,0 +1,61 @@
+package credits
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoicePurchaseRoundingToZeroIsAtomic() {
+	// given an unresolved dynamic purchase that will round below one fiat minor unit
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("dynamic-zero-purchase")
+	clock.FreezeTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+	invoicing := s.SetupCustomInvoicing(ns)
+	s.ProvisionBillingProfile(ctx, ns, invoicing.App.GetID())
+	fixture := s.provisionDynamicCreditPurchaseFixture(ns)
+	fixture.creditAmount = alpacadecimal.RequireFromString("0.001")
+	clock.FreezeTime(fixture.servicePeriod.From)
+
+	created, err := s.creditPurchaseService.Create(ctx, creditpurchase.CreateInput{
+		Namespace: ns, Intent: fixture.newIntent(creditpurchase.NewInvoiceSettlement()),
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(created.GatheringLineToCreate)
+	s.Nil(created.Charge.State.ResolvedCostBasis)
+	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: fixture.customerID, Currency: currencyx.FiatCode(fixture.settlementCurrency),
+		Lines: []billing.GatheringLine{*created.GatheringLineToCreate},
+	})
+	s.Require().NoError(err)
+
+	// when invoicing resolves the actual purchase price
+	asOf := clock.Now()
+	_, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: fixture.customerID, AsOf: &asOf,
+	})
+
+	// then the failed activation leaves the pending intent unpriced and grants no credit
+	s.Require().ErrorContains(err, "purchase amount must be positive after rounding")
+	charge, err := s.MustGetChargeByID(created.Charge.GetChargeID()).AsCreditPurchaseCharge()
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.StatusCreated, charge.Status)
+	s.Nil(charge.State.ResolvedCostBasis)
+	s.Nil(charge.Realizations.CreditGrantRealization)
+	s.Equal(float64(0), s.mustAccountBalance(fixture.customerAccounts.FBOAccount, ledger.RouteFilter{
+		Currency: fixture.customCurrency.Reference(), CostBasisCurrency: mo.Some(&fixture.settlementCurrency),
+		CostBasis: mo.Some(&fixture.resolvedRate), CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+	}).InexactFloat64())
+	invoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{Namespace: ns})
+	s.Require().NoError(err)
+	s.Empty(invoices.Items)
+}

--- a/test/credits/sanity_lifecycle_test.go
+++ b/test/credits/sanity_lifecycle_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -245,7 +248,7 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 	s.Equal(alpacadecimal.NewFromInt(40), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
 
 	// Given the first later credit purchase arrives while both charges still contribute uncovered advance.
-	// When the customer buys 25 credits at cost basis 0.5, it backfills the older uncovered usage first.
+	// When the customer buys 25 credits at cost basis 0.5, proportional attribution backs 12.5 of each spend.
 	res, err = s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
@@ -276,6 +279,27 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 	s.Equal(purchase1Amount, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 	s.Equal(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 
+	// The ledger and lineage must agree on the exact per-spend backing, not only
+	// the customer-wide total; the original global FIFO lineage split was 20/5.
+	s.requireCustomerAccruedSourceSpendBalanceBuckets(cust.GetID(), ledger.RouteFilter{
+		Currency: currencies.NewCurrencyReference(USD), CostBasis: mo.Some(&costBasis1),
+	}, map[string]float64{
+		sourceSpendChargeBucketKey(&purchase1Charge.ID, &chargeA.ID): 12.5,
+		sourceSpendChargeBucketKey(&purchase1Charge.ID, &chargeB.ID): 12.5,
+	})
+	lineages, err := s.LineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{Namespace: ns, CustomerID: cust.ID, Currency: currencies.NewCurrencyReference(USD)})
+	s.Require().NoError(err)
+	backedBySpend := map[string]alpacadecimal.Decimal{}
+	for _, entry := range lineages {
+		for _, segment := range entry.Segments {
+			if segment.State == creditrealization.LineageSegmentStateAdvanceBackfilled {
+				backedBySpend[entry.ChargeID] = backedBySpend[entry.ChargeID].Add(segment.Amount)
+			}
+		}
+	}
+	s.Equal(float64(12.5), backedBySpend[chargeA.ID].InexactFloat64())
+	s.Equal(float64(12.5), backedBySpend[chargeB.ID].InexactFloat64())
+
 	// Given one more unit becomes visible for Charge B before the final cutoff.
 	// This reduces Charge B's priced amount from 20 down to 11, so part of Purchase 1 is released again.
 	s.MockStreamingConnector.AddSimpleEvent(
@@ -285,30 +309,23 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 		streamingtestutils.WithStoredAt(datetime.MustParseTimeInLocation(s.T(), "2026-03-02T00:00:00Z", time.UTC).AsTime()),
 	)
 
-	// When Charge B finalizes, the lifecycle-driven correction should free the 5 cost-basis-backed
-	// part first and only then reduce the still-uncovered remainder.
-	// That 5 is the portion of Purchase 1 that had already been attributed to Charge B after
-	// fully backfilling Charge A's older 20 first.
-	// !!! Released purchased credit goes back to FBO here. It does not immediately snap onto
-	// Charge B's or any other charge's remaining uncovered advance. Only a later purchase/initiation
-	// pass will backfill uncovered advance again.
+	// When Charge B finalizes, all 9 corrected credits come from its 12.5 backed
+	// portion. Released credit returns to FBO without automatically backfilling
+	// either spend's remaining uncovered advance.
 	clock.FreezeTime(chargeBFinalizeAt)
 	advancedChargeB = s.mustAdvanceUsageBasedChargeByID(ctx, cust.GetID(), chargeB.GetChargeID())
 	s.Require().NotNil(advancedChargeB)
 	s.Equal(meta.ChargeStatusFinal, meta.ChargeStatus(advancedChargeB.Status))
-	s.Equal(alpacadecimal.NewFromInt(-36), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
-	// After the correction, Charge A still accounts for the full 20 costBasis1-backed usage,
-	// while Charge B drops back to 11 uncovered usage and releases those 5 purchased credits to FBO.
-	s.Equal(alpacadecimal.NewFromInt(-11), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(11), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
+	s.Equal(alpacadecimal.NewFromInt(-40), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
+	// Charge A retains 12.5 backed + 7.5 uncovered; B retains 3.5 backed + 7.5 uncovered.
+	s.Equal(alpacadecimal.NewFromInt(-15), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromInt(15), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
 	s.Equal(purchase1Amount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis1), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(20), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
-	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromInt(16), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromInt(9), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 
-	// Given a second later credit purchase now sees only Charge B's remaining uncovered amount.
-	// !!! The released 5 from Purchase 1 stayed as available purchased credit in FBO; it did not
-	// auto-cover this remaining uncovered advance on its own.
-	// When the customer buys another 10 credits at a different cost basis, it should backfill only Charge B.
+	// A second purchase proportionally covers 5 more of each spend's 7.5 advance.
+	// The 9 released credits from Purchase 1 remain available in FBO.
 	clock.FreezeTime(chargeBFinalizeAt.Add(time.Minute))
 	res, err = s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
@@ -333,40 +350,40 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 
 	purchase2Charge, err := res[0].AsCreditPurchaseCharge()
 	s.NoError(err)
-	s.Equal(alpacadecimal.NewFromInt(-36), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(-1), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(1), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
+	s.Equal(alpacadecimal.NewFromInt(-40), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromInt(-5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
 	s.Equal(purchase1Amount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis1), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(20), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
-	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromInt(16), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromInt(9), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 	s.Equal(purchase2Amount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis2), ledger.TransactionAuthorizationStatusOpen))
 	s.Equal(purchase2Amount, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
 	s.Equal(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
 
 	// When Charge B is refunded, only its current backing should be released.
 	s.MustRefundCharge(ctx, cust.GetID(), chargeB.GetChargeID())
-	s.Equal(alpacadecimal.NewFromInt(-35), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
+	s.Equal(alpacadecimal.NewFromFloat(-37.5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromFloat(-2.5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromFloat(2.5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
 	s.Equal(purchase1Amount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis1), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(20), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
-	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromFloat(12.5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromFloat(12.5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 	s.Equal(purchase2Amount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis2), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
-	s.Equal(purchase2Amount, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
+	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
+	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
 
 	// When both later purchases complete their payment lifecycle too.
 	s.mustSettleExternalCreditPurchase(ctx, purchase1Charge.GetChargeID())
 	s.mustSettleExternalCreditPurchase(ctx, purchase2Charge.GetChargeID())
-	s.Equal(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
+	s.Equal(alpacadecimal.NewFromFloat(-2.5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromFloat(-2.5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen))
+	s.Equal(alpacadecimal.NewFromFloat(2.5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)))
 	s.Equal(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis1), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.NewFromInt(20), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
-	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromFloat(12.5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
+	s.Equal(alpacadecimal.NewFromFloat(12.5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis1)))
 	s.Equal(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis2), ledger.TransactionAuthorizationStatusOpen))
-	s.Equal(alpacadecimal.Zero, s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
-	s.Equal(purchase2Amount, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
+	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
+	s.Equal(alpacadecimal.NewFromInt(5), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&costBasis2)))
 }
 
 // Use this helper for the shared single-charge lifecycle setup that stops after

--- a/test/credits/voidgrant_funded_custom_test.go
+++ b/test/credits/voidgrant_funded_custom_test.go
@@ -1,0 +1,101 @@
+package credits
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	ledgerbreakage "github.com/openmeterio/openmeter/openmeter/ledger/breakage"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+)
+
+func (s *VoidGrantTestSuite) TestVoidFundedCustomCurrencyGrantAtPaymentStages() {
+	for _, initial := range []creditpurchase.InitialPaymentSettlementStatus{
+		creditpurchase.CreatedInitialPaymentSettlementStatus,
+		creditpurchase.AuthorizedInitialPaymentSettlementStatus,
+		creditpurchase.SettledInitialPaymentSettlementStatus,
+	} {
+		s.Run(string(initial), func() {
+			// given: expiring custom credits funded at each external payment stage
+			ctx := s.T().Context()
+			ns := s.GetUniqueNamespace("funded-custom-void-" + string(initial))
+			cust := s.setupVoidTestCustomer(ctx, ns)
+			tokens := s.CreateCustomCurrency(ns, "TOKENS")
+			at := time.Date(2026, 4, 17, 11, 0, 0, 0, time.UTC)
+			clock.FreezeTime(at)
+			defer clock.UnFreeze()
+			rate := alpacadecimal.RequireFromString("0.5")
+			fiat, err := currencyx.NewFiatCurrency(USD)
+			s.Require().NoError(err)
+			grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+				Namespace: ns, CustomerID: cust.ID, Name: "funded custom grant",
+				Currency: tokens.GetCode(), Amount: alpacadecimal.NewFromInt(100),
+				ExpiresAfter:  lo.ToPtr(datetime.MustParseDuration(s.T(), "P1D")),
+				FundingMethod: creditgrant.FundingMethodExternal,
+				Purchase:      &creditgrant.PurchaseTerms{Currency: USD, CostBasis: lo.ToPtr(creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: rate}))), AvailabilityPolicy: &initial},
+			})
+			s.Require().NoError(err)
+			route := ledger.RouteFilter{Currency: tokens.Reference(), CostBasisCurrency: mo.Some(lo.ToPtr(USD)), CostBasis: mo.Some(&rate)}
+			s.Equal(float64(100), s.MustCustomerFBOBalanceByRouteAsOf(cust.GetID(), route, lo.ToPtr(clock.Now())).InexactFloat64())
+			plansInput := ledgerbreakage.ListPlansInput{CustomerID: cust.GetID(), Currency: tokens.GetCode(), AsOf: at}
+			plans, err := s.BreakageService.ListPlans(ctx, plansInput)
+			s.Require().NoError(err)
+			s.Require().Len(plans, 1)
+			fiatEntries := s.DBClient.LedgerEntry.Query().Where(
+				ledgerentry.NamespaceEQ(ns),
+				ledgerentry.HasSubAccountWith(ledgersubaccount.HasRouteWith(ledgersubaccountroute.CurrencyEQ(string(USD)))),
+			)
+			paymentEntriesBefore, err := fiatEntries.Clone().IDs(ctx)
+			s.Require().NoError(err)
+
+			// when: the grant is voided and retried before its original expiry
+			clock.FreezeTime(at.Add(time.Hour))
+			voidInput := creditgrant.VoidInput{Namespace: ns, CustomerID: cust.ID, ChargeID: grant.ID}
+			voided, err := s.CreditGrantService.Void(ctx, voidInput)
+			s.Require().NoError(err)
+			s.Require().NotNil(voided.State.VoidedAt)
+			postings := s.DBClient.LedgerTransaction.Query().Where(ledgertransaction.NamespaceEQ(ns))
+			postingCount, err := postings.Clone().Count(ctx)
+			s.Require().NoError(err)
+			retried, err := s.CreditGrantService.Void(ctx, voidInput)
+			s.Require().NoError(err)
+
+			// then: credit and expiry are removed once, without refunding payment
+			s.Equal(voided.State.VoidedAt, retried.State.VoidedAt)
+			s.Equal(grant.Realizations.ExternalPaymentSettlement, voided.Realizations.ExternalPaymentSettlement)
+			s.Equal(grant.Realizations.ExternalPaymentSettlement, retried.Realizations.ExternalPaymentSettlement)
+			s.Equal(grant.Status, retried.Status)
+			paymentEntriesAfter, err := fiatEntries.Clone().IDs(ctx)
+			s.Require().NoError(err)
+			s.ElementsMatch(paymentEntriesBefore, paymentEntriesAfter, "void must not change fiat payment ledger state")
+			retriedPostingCount, err := postings.Clone().Count(ctx)
+			s.Require().NoError(err)
+			s.Equal(postingCount, retriedPostingCount, "retry must not post another correction")
+			s.Equal(float64(0), s.MustCustomerFBOBalanceByRouteAsOf(cust.GetID(), route, lo.ToPtr(clock.Now())).InexactFloat64())
+			plansInput.AsOf = clock.Now()
+			plans, err = s.BreakageService.ListPlans(ctx, plansInput)
+			s.Require().NoError(err)
+			s.Empty(plans, "void must release the planned expiry")
+
+			clock.FreezeTime(at.Add(25 * time.Hour))
+			s.Equal(float64(0), s.MustCustomerFBOBalanceByRouteAsOf(cust.GetID(), route, lo.ToPtr(clock.Now())).InexactFloat64(), "expiry must not withdraw credit twice")
+			businessAccounts, err := s.LedgerResolver.GetBusinessAccounts(ctx, ns)
+			s.Require().NoError(err)
+			breakage, err := s.BalanceQuerier.GetAccountBalance(ctx, businessAccounts.BreakageAccount, route, ledger.BalanceQuery{AsOf: lo.ToPtr(clock.Now())})
+			s.Require().NoError(err)
+			s.Equal(float64(0), breakage.InexactFloat64())
+		})
+	}
+}


### PR DESCRIPTION
Paid credit purchases can issue credits whose fiat payment rounds to zero, and corrections of pooled earnings can reverse another spend's entries. Reject zero-rounded purchases before issuance, select correction entries by their original source, spend and route, and persist backfill lineage from the amounts actually booked per spend.

Adds regressions for deferred dynamic-price rollback, shared recognition and repeated partial corrections, proportional backfill attribution, and funded custom-grant voiding across payment stages. Voiding remaining credit preserves the payment and fiat postings.

Stacked on #5081. Preserves the purchase API merged in #5067, including manual/pinned/dynamic cost basis and the distinction between nominal credit quantity and fiat payment amount.

Validation: full `make test` passed on the final stacked head with PostgreSQL, Svix and ClickHouse (7,975 tests; eight existing skips). Go SDK build/vet/tests, merged API-handler tests, focused Go lint and generated-output checks passed. The standalone E2E module compiles and passes vet; live HTTP E2E runs in CI.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Credit purchases now preserve per-spend attribution, improving lineage tracking for funded credits and corrections.
  - Promotional and funded grants support more accurate backfill allocation across uncovered usage.
  - Custom-currency funding follows clearer currency and feature-flag requirements.

- **Bug Fixes**
  - Purchases that round to zero in the settlement currency are rejected before issuance, invoicing, or ledger changes.
  - Corrections now target the original source and spend amounts more accurately.
  - Custom-currency recognition, refunds, and voids preserve balances and provenance more reliably.

- **Documentation**
  - Added guidance for custom-currency funding, settlement validation, lineage behavior, and correction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens paid-credit purchase and correction accounting:
- Rejects paid purchases whose fiat settlement rounds to a non-positive amount before credits are issued.
- Carries actually booked accrued attribution back to lineage persistence per originating spend.
- Scopes correction and breakage reversal to the original posting source, spend, and route while accounting for prior partial corrections.
- Adds regression coverage for dynamic-price rollback, shared recognition, proportional backfill, repeated corrections, and funded custom-grant voiding across payment stages.

The earlier funded-void coverage concern is addressed by testing created, authorized, and settled external-payment stages and asserting that fiat postings and payment realization remain unchanged. The earlier validation-wrapper finding remains outstanding: `BackfillAdvanceLineageSegmentsInput.Validate` still returns `errors.Join(errs...)` directly instead of the repository-standard generic validation wrapper.

<h3>Confidence Score: 4/5</h3>

The accounting changes appear behaviorally safe, but the explicit repository validation-error requirement must be satisfied before merging.

The new settlement, lineage-attribution, correction-provenance, and funded-void paths are coherently implemented and covered without a newly established correctness defect. The previous funded-void coverage finding is fully addressed. The previous validation finding remains outstanding because `BackfillAdvanceLineageSegmentsInput.Validate` still returns `errors.Join(errs...)` directly, so callers do not receive the repository-standard validation-error classification.

**Files Needing Attention:** openmeter/billing/charges/lineage/service.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ledger/collector/correct.go | Adds provenance-scoped correction planning, prior-correction capacity accounting, and source-specific backfill and recognition reversal. |
| openmeter/ledger/transactions/correction.go | Adds validated per-entry correction amounts so callers can reverse selected original posting slices. |
| openmeter/ledger/chargeadapter/creditpurchase.go | Returns actual accrued backfill amounts grouped by originating spend alongside the issued ledger transaction reference. |
| openmeter/billing/charges/lineage/service/service.go | Applies purchase backfill independently per spend charge rather than redistributing one purchase-wide amount. |
| openmeter/billing/charges/creditpurchase/charge.go | Adds settlement-precision validation that rejects paid purchases rounding to a non-positive fiat amount. |
| openmeter/billing/charges/lineage/service.go | Validates per-spend backfill facts, but its Validate method still bypasses the required generic validation-error wrapper. |
| test/credits/voidgrant_funded_custom_test.go | Covers funded custom-currency grant voiding across created, authorized, and settled payment stages while preserving fiat and payment state. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create paid credit purchase] --> B[Resolve cost basis]
  B --> C[Round fiat settlement amount]
  C -->|Non-positive| D[Reject and roll back]
  C -->|Positive| E[Issue credit ledger group]
  E --> F[Collect booked accrued amounts by spend charge]
  F --> G[Backfill only matching uncovered lineage segments]
  G --> H[Later correction request]
  H --> I[Subtract prior immutable correction links]
  I --> J[Select original source, spend, and route entries]
  J --> K[Post scoped correction and update lineage]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(credits): preserve settlement and le..."](https://github.com/openmeterio/openmeter/commit/e28ece06ea8c74115b93bcbbef03c6001570705e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60503594)</sub>

<!-- /greptile_comment -->