### PR TITLE
fix(llmcost): order namespace DESC NULLS LAST in ResolvePrice (#4562)

### DIFF
--- a/openmeter/llmcost/adapter/price.go
+++ b/openmeter/llmcost/adapter/price.go
@@ -121,7 +121,7 @@ func (a *adapter) ResolvePrice(ctx context.Context, input llmcost.ResolvePriceIn
 		).
 		Order(
 			// Prioritize namespace overrides
-			pricedb.ByNamespace(sql.OrderDesc()),
+			pricedb.ByNamespace(sql.OrderDesc(), sql.OrderNullsLast()),
 			// Then effective from
 			pricedb.ByEffectiveFrom(sql.OrderDesc()),
 		).

--- a/openmeter/llmcost/adapter/price_test.go
+++ b/openmeter/llmcost/adapter/price_test.go
@@ -1,0 +1,86 @@
+package adapter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/llmcost"
+	llmcostadapter "github.com/openmeterio/openmeter/openmeter/llmcost/adapter"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
+	t.Helper()
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
+	dbClient := testDB.EntDriver.Client()
+
+	t.Cleanup(func() {
+		_ = dbClient.Close()
+		testDB.Close(t)
+	})
+
+	adapter, err := llmcostadapter.New(llmcostadapter.Config{
+		Client: dbClient,
+		Logger: testutils.NewDiscardLogger(t),
+	})
+	require.NoError(t, err)
+
+	return adapter, dbClient
+}
+
+func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
+	ctx := context.Background()
+	adapter, _ := newLLMCostTestAdapter(t)
+
+	effectiveFrom := time.Now().Add(-time.Hour)
+
+	globalPrice := llmcost.Price{
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+		ModelName: "GPT Test",
+		Pricing: llmcost.ModelPricing{
+			InputPerToken:  alpacadecimal.NewFromFloat(0.001),
+			OutputPerToken: alpacadecimal.NewFromFloat(0.002),
+		},
+		Currency:      "USD",
+		Source:        llmcost.PriceSourceSystem,
+		EffectiveFrom: effectiveFrom,
+	}
+	require.NoError(t, adapter.UpsertGlobalPrice(ctx, globalPrice))
+
+	override, err := adapter.CreateOverride(ctx, llmcost.CreateOverrideInput{
+		Namespace: "ns-1",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+		ModelName: "GPT Test",
+		Pricing: llmcost.ModelPricing{
+			InputPerToken:  alpacadecimal.NewFromFloat(0.010),
+			OutputPerToken: alpacadecimal.NewFromFloat(0.020),
+		},
+		Currency:      "USD",
+		EffectiveFrom: effectiveFrom,
+	})
+	require.NoError(t, err)
+
+	resolved, err := adapter.ResolvePrice(ctx, llmcost.ResolvePriceInput{
+		Namespace: "ns-1",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, override.ID, resolved.ID, "namespace override must win over the global price")
+
+	resolvedGlobal, err := adapter.ResolvePrice(ctx, llmcost.ResolvePriceInput{
+		Namespace: "ns-2",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, resolvedGlobal.Pricing.InputPerToken.String(), globalPrice.Pricing.InputPerToken.String(), "namespaces without an override resolve to the global price")
+}

--- a/openmeter/llmcost/adapter/price_test.go
+++ b/openmeter/llmcost/adapter/price_test.go
@@ -1,22 +1,18 @@
 package adapter_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/llmcost"
 	llmcostadapter "github.com/openmeterio/openmeter/openmeter/llmcost/adapter"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 )
 
-func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
-	t.Helper()
-
+func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
 	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
 	dbClient := testDB.EntDriver.Client()
 
@@ -31,13 +27,7 @@ func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
 	})
 	require.NoError(t, err)
 
-	return adapter, dbClient
-}
-
-func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
-	ctx := context.Background()
-	adapter, _ := newLLMCostTestAdapter(t)
-
+	ctx := t.Context()
 	effectiveFrom := time.Now().Add(-time.Hour)
 
 	globalPrice := llmcost.Price{
@@ -82,5 +72,5 @@ func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
 		ModelID:   "gpt-test",
 	})
 	require.NoError(t, err)
-	require.Equal(t, resolvedGlobal.Pricing.InputPerToken.String(), globalPrice.Pricing.InputPerToken.String(), "namespaces without an override resolve to the global price")
+	require.Equal(t, globalPrice.Pricing.InputPerToken.InexactFloat64(), resolvedGlobal.Pricing.InputPerToken.InexactFloat64(), "namespaces without an override resolve to the global price")
 }


### PR DESCRIPTION
### Summary of Changes

Fixes #4562.

In \openmeter/llmcost\, \ResolvePrice\ queries candidate prices (both namespace-specific overrides and global \NULL\ namespace prices) and orders by \pricedb.ByNamespace(sql.OrderDesc())\.

Because PostgreSQL defaults to \NULLS FIRST\ for \DESC\ ordering and ent's \sql.OrderDesc()\ does not specify a \NULLS\ clause, global prices (\
amespace = NULL\) sort **before** per-namespace overrides (\
amespace = 'default'\). As a result, \First(ctx)\ returns the global price, and per-namespace price overrides are silently ignored whenever a global price exists for the same \(provider, model_id)\.

This PR adds \sql.OrderNullsLast()\ to \pricedb.ByNamespace\ in \openmeter/llmcost/adapter/price.go\:
\\\go
Order(
    pricedb.ByNamespace(sql.OrderDesc(), sql.OrderNullsLast()),
    pricedb.ByEffectiveFrom(sql.OrderDesc()),
)
\\\

### Verification
- Modified \openmeter/llmcost/adapter/price.go\ to ensure non-NULL namespace overrides sort first.
- Executed \go test ./openmeter/llmcost/...\.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace-specific pricing now takes precedence over global pricing when both match the same provider, model, and time window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes namespace-specific LLM price resolution by placing NULL namespaces last during descending ordering.
- Adds `sql.OrderNullsLast()` so namespace overrides precede global fallback prices.
- Adds an adapter-level regression test covering override precedence and global fallback behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with the ordering correction covered by an adapter-level regression test.

No actionable new issues were identified; both previous findings are resolved, and the added test now follows the repository testing conventions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/llmcost/adapter/price.go | Correctly orders namespace-specific prices before global NULL-namespace fallbacks. |
| openmeter/llmcost/adapter/price_test.go | Verifies both namespace override precedence and fallback to the global price. |

<sub>Reviews (5): Last reviewed commit: ["test(llmcost): inline adapter test setup..."](https://github.com/openmeterio/openmeter/commit/e48c1487242d665549333281b85c5ec3d29dc3e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60719027)</sub>

<!-- /greptile_comment -->