### PR TITLE
feat(billing): persist charge validation issues

### DIFF
--- a/api/v3/handlers/billinginvoices/convert.go
+++ b/api/v3/handlers/billinginvoices/convert.go
@@ -259,10 +259,11 @@ func mapValidationIssues(issues []billing.ValidationIssue) *[]api.BillingInvoice
 
 	out := lo.Map(issues, func(v billing.ValidationIssue, _ int) api.BillingInvoiceValidationIssue {
 		return api.BillingInvoiceValidationIssue{
-			Severity: api.BillingInvoiceValidationIssueSeverity(v.Severity),
-			Message:  v.Message,
-			Code:     v.Code,
-			Field:    lo.EmptyableToPtr(v.Path),
+			Severity:   api.BillingInvoiceValidationIssueSeverity(v.Severity),
+			Message:    v.Message,
+			Code:       v.Code,
+			Field:      lo.EmptyableToPtr(v.Path),
+			Attributes: lo.EmptyableToPtr(map[string]any(v.Attributes)),
 		}
 	})
 

--- a/api/v3/handlers/billinginvoices/convert_test.go
+++ b/api/v3/handlers/billinginvoices/convert_test.go
@@ -15,6 +15,21 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
+func TestMapValidationIssues(t *testing.T) {
+	require.Nil(t, mapValidationIssues(nil))
+
+	issues := mapValidationIssues(billing.ValidationIssues{
+		{
+			Severity:   billing.ValidationIssueSeverityWarning,
+			Message:    "invoice line needs attention",
+			Code:       "line_context",
+			Attributes: models.Annotations{"invoice": "invoice-1", "line": "line-1"},
+		},
+	})
+	require.NotNil(t, issues)
+	require.Equal(t, &map[string]any{"invoice": "invoice-1", "line": "line-1"}, (*issues)[0].Attributes)
+}
+
 func mergeTestPeriod() timeutil.ClosedPeriod {
 	return timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -758,11 +758,12 @@ func (a *adapter) mapStandardInvoiceFromDB(ctx context.Context, invoice *db.Bill
 				UpdatedAt: issue.UpdatedAt.In(time.UTC),
 				DeletedAt: convert.TimePtrIn(issue.DeletedAt, time.UTC),
 
-				Severity:  issue.Severity,
-				Message:   issue.Message,
-				Code:      lo.FromPtr(issue.Code),
-				Component: billing.ComponentName(issue.Component),
-				Path:      lo.FromPtr(issue.Path),
+				Severity:   issue.Severity,
+				Message:    issue.Message,
+				Code:       lo.FromPtr(issue.Code),
+				Component:  billing.ComponentName(issue.Component),
+				Path:       lo.FromPtr(issue.Path),
+				Attributes: issue.Attributes,
 			}
 		})
 	}

--- a/openmeter/billing/adapter/validationissue.go
+++ b/openmeter/billing/adapter/validationissue.go
@@ -3,6 +3,8 @@ package billingadapter
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
@@ -12,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/convert"
 )
 
 type validationIssueWithDedupe struct {
@@ -19,7 +22,7 @@ type validationIssueWithDedupe struct {
 	hash  []byte
 }
 
-func issueDedupeHash(issue billing.ValidationIssue) []byte {
+func issueDedupeHash(issue billing.ValidationIssue) ([]byte, error) {
 	algo := sha256.New()
 
 	algo.Write([]byte(issue.Severity))
@@ -27,27 +30,47 @@ func issueDedupeHash(issue billing.ValidationIssue) []byte {
 	algo.Write([]byte(issue.Message))
 	algo.Write([]byte(issue.Component))
 	algo.Write([]byte(issue.Path))
-	return algo.Sum(nil)
+
+	if len(issue.Attributes) > 0 {
+		attributes, err := json.Marshal(issue.Attributes)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling attributes: %w", err)
+		}
+
+		algo.Write([]byte{0})
+		algo.Write(attributes)
+	}
+
+	return algo.Sum(nil), nil
 }
 
 // persistValidationIssues persists the validation issues for the given invoice, it will remove any
 // existing issues that are not present in the new list. It relies on consistent hashing to deduplicate
 // issues.
 func (a *adapter) persistValidationIssues(ctx context.Context, invoice billing.InvoiceID, issues []billing.ValidationIssue) error {
-	// FIXME (pmarton): Why do we need to deduplicate issues?
-	hashedIssues := lo.FindUniquesBy(
-		lo.Map(issues, func(issue billing.ValidationIssue, _ int) validationIssueWithDedupe {
-			return validationIssueWithDedupe{
-				issue: issue,
-				hash:  issueDedupeHash(issue),
-			}
-		}),
+	hashedIssues, err := lo.MapErr(issues, func(issue billing.ValidationIssue, _ int) (validationIssueWithDedupe, error) {
+		hash, err := issueDedupeHash(issue)
+		if err != nil {
+			return validationIssueWithDedupe{}, fmt.Errorf("hashing validation issue: %w", err)
+		}
+
+		return validationIssueWithDedupe{
+			issue: issue,
+			hash:  hash,
+		}, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	hashedIssues = lo.FindUniquesBy(
+		hashedIssues,
 		func(issue validationIssueWithDedupe) string {
 			return string(issue.hash)
 		},
 	)
 
-	err := a.db.BillingInvoiceValidationIssue.Update().
+	err = a.db.BillingInvoiceValidationIssue.Update().
 		Where(billinginvoicevalidationissue.InvoiceID(invoice.ID)).
 		Where(billinginvoicevalidationissue.Namespace(invoice.Namespace)).
 		Where(billinginvoicevalidationissue.DedupeHashNotIn(
@@ -78,6 +101,10 @@ func (a *adapter) persistValidationIssues(ctx context.Context, invoice billing.I
 		if issue.Path != "" {
 			c.SetPath(issue.Path)
 		}
+
+		if len(issue.Attributes) > 0 {
+			c.SetAttributes(issue.Attributes)
+		}
 	}).OnConflict(
 		sql.ConflictColumns(
 			billinginvoicevalidationissue.FieldNamespace,
@@ -92,17 +119,10 @@ func (a *adapter) persistValidationIssues(ctx context.Context, invoice billing.I
 		}).Exec(ctx)
 }
 
-type ValidationIssueWithDBMeta struct {
-	billing.ValidationIssue
-
-	ID        string     `json:"id"`
-	DeletedAt *time.Time `json:"deletedAt,omitempty"`
-}
-
 // IntropectValidationIssues returns the validation issues for the given invoice, this is not
 // exposed via the adpter interface, as it's only used by tests to validate the state of the
 // database.
-func (a *adapter) IntrospectValidationIssues(ctx context.Context, invoice billing.InvoiceID) ([]ValidationIssueWithDBMeta, error) {
+func (a *adapter) IntrospectValidationIssues(ctx context.Context, invoice billing.InvoiceID) (billing.ValidationIssues, error) {
 	issues, err := a.db.BillingInvoiceValidationIssue.Query().
 		Where(billinginvoicevalidationissue.InvoiceID(invoice.ID)).
 		Where(billinginvoicevalidationissue.Namespace(invoice.Namespace)).
@@ -112,17 +132,19 @@ func (a *adapter) IntrospectValidationIssues(ctx context.Context, invoice billin
 		return nil, err
 	}
 
-	return lo.Map(issues, func(issue *db.BillingInvoiceValidationIssue, _ int) ValidationIssueWithDBMeta {
-		return ValidationIssueWithDBMeta{
-			ValidationIssue: billing.ValidationIssue{
-				Severity:  issue.Severity,
-				Message:   issue.Message,
-				Code:      lo.FromPtr(issue.Code),
-				Component: billing.ComponentName(issue.Component),
-				Path:      lo.FromPtr(issue.Path),
-			},
+	return lo.Map(issues, func(issue *db.BillingInvoiceValidationIssue, _ int) billing.ValidationIssue {
+		return billing.ValidationIssue{
 			ID:        issue.ID,
-			DeletedAt: issue.DeletedAt,
+			CreatedAt: issue.CreatedAt.In(time.UTC),
+			UpdatedAt: issue.UpdatedAt.In(time.UTC),
+			DeletedAt: convert.TimePtrIn(issue.DeletedAt, time.UTC),
+
+			Severity:   issue.Severity,
+			Message:    issue.Message,
+			Code:       lo.FromPtr(issue.Code),
+			Component:  billing.ComponentName(issue.Component),
+			Path:       lo.FromPtr(issue.Path),
+			Attributes: issue.Attributes,
 		}
 	}), nil
 }

--- a/openmeter/billing/adapter/validationissue_test.go
+++ b/openmeter/billing/adapter/validationissue_test.go
@@ -1,0 +1,41 @@
+package billingadapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestIssueDedupeHashIncludesAttributes(t *testing.T) {
+	base := billing.ValidationIssue{
+		Severity: billing.ValidationIssueSeverityWarning,
+		Message:  "invoice line needs attention",
+		Attributes: models.Annotations{
+			"invoice": "invoice-1",
+			"line":    "line-1",
+		},
+	}
+
+	baseHash, err := issueDedupeHash(base)
+	require.NoError(t, err)
+
+	sameHash, err := issueDedupeHash(billing.ValidationIssue{
+		Severity: base.Severity,
+		Message:  base.Message,
+		Attributes: models.Annotations{
+			"line":    "line-1",
+			"invoice": "invoice-1",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, baseHash, sameHash)
+
+	changed := base
+	changed.Attributes = models.Annotations{"invoice": "invoice-1", "line": "line-2"}
+	changedHash, err := issueDedupeHash(changed)
+	require.NoError(t, err)
+	require.NotEqual(t, baseHash, changedHash)
+}

--- a/openmeter/billing/charges/charge.go
+++ b/openmeter/billing/charges/charge.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -165,6 +166,31 @@ func (c Charge) GetUniqueReferenceID() (*string, error) {
 		}
 
 		return c.usageBased.Intent.GetUniqueReferenceID(), nil
+	}
+
+	return nil, fmt.Errorf("invalid charge type: %s", c.t)
+}
+
+func (c Charge) GetValidationIssues() (billing.ValidationIssues, error) {
+	switch c.t {
+	case meta.ChargeTypeFlatFee:
+		if c.flatFee == nil {
+			return nil, fmt.Errorf("flat fee charge is nil")
+		}
+
+		return c.flatFee.ValidationIssues.Clone()
+	case meta.ChargeTypeCreditPurchase:
+		if c.creditPurchase == nil {
+			return nil, fmt.Errorf("credit purchase charge is nil")
+		}
+
+		return c.creditPurchase.ValidationIssues.Clone()
+	case meta.ChargeTypeUsageBased:
+		if c.usageBased == nil {
+			return nil, fmt.Errorf("usage based charge is nil")
+		}
+
+		return c.usageBased.ValidationIssues.Clone()
 	}
 
 	return nil, fmt.Errorf("invalid charge type: %s", c.t)

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -45,6 +45,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge creditpurchase.Charge
 			Intent:              charge.Intent.Intent,
 			IntentMutableFields: charge.Intent.IntentMutableFields.IntentMutableFields,
 			Status:              metaStatus,
+			ValidationIssues:    charge.ValidationIssues,
 		})
 		if err != nil {
 			return creditpurchase.ChargeBase{}, err

--- a/openmeter/billing/charges/creditpurchase/adapter/mapper.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/mapper.go
@@ -43,8 +43,9 @@ func fromDBBase(dbEntity *entdb.ChargeCreditPurchase, mappedMeta meta.Charge) (c
 	}
 
 	charge := creditpurchase.ChargeBase{
-		ManagedResource: mappedMeta.ManagedResource,
-		Status:          dbEntity.StatusDetailed,
+		ManagedResource:  mappedMeta.ManagedResource,
+		Status:           dbEntity.StatusDetailed,
+		ValidationIssues: mappedMeta.ValidationIssues,
 		Intent: creditpurchase.Intent{
 			Intent: mappedMeta.Intent,
 			IntentMutableFields: creditpurchase.IntentMutableFields{

--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargecostbasis "github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
@@ -23,8 +24,9 @@ import (
 type ChargeBase struct {
 	meta.ManagedResource
 
-	Intent Intent `json:"intent"`
-	Status Status `json:"status"`
+	Intent           Intent                   `json:"intent"`
+	Status           Status                   `json:"status"`
+	ValidationIssues billing.ValidationIssues `json:"validationIssues,omitempty"`
 
 	State State `json:"state"`
 }

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -79,6 +79,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 			IntentMutableFields: intent.IntentMutableFields.IntentMutableFields,
 			Status:              metaStatus,
 			AdvanceAfter:        meta.NormalizeOptionalTimestamp(charge.State.AdvanceAfter),
+			ValidationIssues:    charge.ValidationIssues,
 		})
 		if err != nil {
 			return flatfee.ChargeBase{}, err
@@ -192,6 +193,7 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 			Intent:              baseIntent.Intent,
 			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
 			Status:              metaStatus,
+			ValidationIssues:    charge.ValidationIssues,
 		})
 		if err != nil {
 			return err

--- a/openmeter/billing/charges/flatfee/adapter/mapping.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapping.go
@@ -197,8 +197,9 @@ func fromDBBase(entity *entdb.ChargeFlatFee, mappedMeta meta.Charge) (flatfee.Ch
 	}
 
 	return flatfee.ChargeBase{
-		ManagedResource: mappedMeta.ManagedResource,
-		Status:          entity.StatusDetailed,
+		ManagedResource:  mappedMeta.ManagedResource,
+		Status:           entity.StatusDetailed,
+		ValidationIssues: mappedMeta.ValidationIssues,
 		State: flatfee.State{
 			AdvanceAfter:         mappedMeta.AdvanceAfter,
 			FeatureID:            entity.FeatureID,

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -32,8 +32,9 @@ var (
 type ChargeBase struct {
 	meta.ManagedResource
 
-	Intent OverridableIntent `json:"intent"`
-	Status Status            `json:"status"`
+	Intent           OverridableIntent        `json:"intent"`
+	Status           Status                   `json:"status"`
+	ValidationIssues billing.ValidationIssues `json:"validationIssues,omitempty"`
 
 	State State `json:"state"`
 }

--- a/openmeter/billing/charges/meta/charge.go
+++ b/openmeter/billing/charges/meta/charge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/expand"
@@ -159,6 +160,7 @@ type Charge struct {
 	IntentMutableFields IntentMutableFields
 	Status              ChargeStatus
 	AdvanceAfter        *time.Time
+	ValidationIssues    billing.ValidationIssues
 }
 
 func (c Charge) Validate() error {

--- a/openmeter/billing/charges/models/chargemeta/model.go
+++ b/openmeter/billing/charges/models/chargemeta/model.go
@@ -97,6 +97,7 @@ type Updater[T any] interface {
 	SetFullServicePeriodTo(fullServicePeriodTo time.Time) T
 	SetStatus(status meta.ChargeStatus) T
 	SetOrClearAdvanceAfter(advanceAfter *time.Time) T
+	SetOrClearValidationIssues(validationIssues *billing.ValidationIssues) T
 }
 
 func Create[T Creator[T]](creator Creator[T], in CreateInput) (T, error) {
@@ -169,8 +170,9 @@ type UpdateInput struct {
 	Intent              meta.Intent
 	IntentMutableFields meta.IntentMutableFields
 
-	Status       meta.ChargeStatus
-	AdvanceAfter *time.Time
+	Status           meta.ChargeStatus
+	AdvanceAfter     *time.Time
+	ValidationIssues billing.ValidationIssues
 }
 
 func Update[T Updater[T]](updater Updater[T], in UpdateInput) (T, error) {
@@ -187,6 +189,11 @@ func Update[T Updater[T]](updater Updater[T], in UpdateInput) (T, error) {
 		return empty, err
 	}
 
+	var validationIssues *billing.ValidationIssues
+	if len(in.ValidationIssues) > 0 {
+		validationIssues = &in.ValidationIssues
+	}
+
 	return updater.
 		SetName(in.IntentMutableFields.Name).
 		SetOrClearDescription(in.IntentMutableFields.Description).
@@ -199,7 +206,8 @@ func Update[T Updater[T]](updater Updater[T], in UpdateInput) (T, error) {
 		SetFullServicePeriodFrom(in.IntentMutableFields.FullServicePeriod.From.UTC()).
 		SetFullServicePeriodTo(in.IntentMutableFields.FullServicePeriod.To.UTC()).
 		SetStatus(in.Status).
-		SetOrClearAdvanceAfter(in.AdvanceAfter), nil
+		SetOrClearAdvanceAfter(in.AdvanceAfter).
+		SetOrClearValidationIssues(validationIssues), nil
 }
 
 type Getter[T any] interface {
@@ -230,6 +238,7 @@ type Getter[T any] interface {
 	GetTaxBehavior() *productcatalog.TaxBehavior
 	GetFiatCurrencyCode() *currencyx.Code
 	GetCustomCurrencyID() *string
+	GetValidationIssues() billing.ValidationIssues
 }
 
 type EdgeGetter interface {
@@ -260,6 +269,11 @@ func FromDB[T Getter[T]](entity T, edges EdgeGetter) (meta.Charge, error) {
 func FromDBWithCurrency[T Getter[T]](entity T, currency currencies.Currency) (meta.Charge, error) {
 	if err := currency.Validate(); err != nil {
 		return meta.Charge{}, fmt.Errorf("currency: %w", err)
+	}
+
+	validationIssues := entity.GetValidationIssues()
+	if len(validationIssues) == 0 {
+		validationIssues = nil
 	}
 
 	var subscriptionReference *meta.SubscriptionReference
@@ -308,7 +322,8 @@ func FromDBWithCurrency[T Getter[T]](entity T, currency currencies.Currency) (me
 				To:   entity.GetBillingPeriodTo().UTC(),
 			},
 		},
-		Status:       entity.GetStatus(),
-		AdvanceAfter: entity.GetAdvanceAfter(),
+		Status:           entity.GetStatus(),
+		AdvanceAfter:     entity.GetAdvanceAfter(),
+		ValidationIssues: validationIssues,
 	}, nil
 }

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -65,6 +65,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
 			Status:              metaStatus,
 			AdvanceAfter:        meta.NormalizeOptionalTimestamp(charge.State.AdvanceAfter),
+			ValidationIssues:    charge.ValidationIssues,
 		})
 		if err != nil {
 			return usagebased.ChargeBase{}, err
@@ -174,6 +175,7 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
 			Status:              metaStatus,
 			AdvanceAfter:        charge.State.AdvanceAfter,
+			ValidationIssues:    charge.ValidationIssues,
 		})
 		if err != nil {
 			return err

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -112,9 +112,10 @@ func fromDBBase(entity *entdb.ChargeUsageBased, chargeMeta meta.Charge) (usageba
 	}
 
 	return usagebased.ChargeBase{
-		ManagedResource: chargeMeta.ManagedResource,
-		Status:          entity.StatusDetailed,
-		Intent:          usagebased.NewOverridableIntent(intent, fromDBOverride(entity.Edges.IntentOverride)),
+		ManagedResource:  chargeMeta.ManagedResource,
+		Status:           entity.StatusDetailed,
+		ValidationIssues: chargeMeta.ValidationIssues,
+		Intent:           usagebased.NewOverridableIntent(intent, fromDBOverride(entity.Edges.IntentOverride)),
 		State: usagebased.State{
 			CurrentRealizationRunID: entity.CurrentRealizationRunID,
 			AdvanceAfter:            entity.AdvanceAfter,

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -33,8 +33,9 @@ var (
 type ChargeBase struct {
 	meta.ManagedResource
 
-	Intent OverridableIntent `json:"intent"`
-	Status Status            `json:"status"`
+	Intent           OverridableIntent        `json:"intent"`
+	Status           Status                   `json:"status"`
+	ValidationIssues billing.ValidationIssues `json:"validationIssues,omitempty"`
 
 	State State `json:"state"`
 }

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -610,7 +610,10 @@ func (m *InvoiceStateMachine) FireAndActivate(ctx context.Context, trigger billi
 
 	activationError := m.StateMachine.ActivateCtx(ctx)
 	if activationError != nil || m.Invoice.HasCriticalValidationIssues() {
-		validationIssues := m.Invoice.ValidationIssues.Clone()
+		validationIssues, err := m.Invoice.ValidationIssues.Clone()
+		if err != nil {
+			return fmt.Errorf("cloning validation issues: %w", err)
+		}
 
 		// There was an error activating the state, we should trigger a transition to the failed state
 		canFire, err := m.StateMachine.CanFireCtx(ctx, billing.TriggerFailed)

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -550,7 +550,10 @@ func (i StandardInvoice) Clone() (StandardInvoice, error) {
 	}
 
 	clone.Lines = clonedLines
-	clone.ValidationIssues = i.ValidationIssues.Clone()
+	clone.ValidationIssues, err = i.ValidationIssues.Clone()
+	if err != nil {
+		return StandardInvoice{}, fmt.Errorf("cloning validation issues: %w", err)
+	}
 	clone.Totals = i.Totals
 
 	return clone, nil

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type ValidationIssueSeverity string
@@ -39,7 +40,10 @@ type ValidationIssue struct {
 	Message   string                  `json:"message"`
 	Code      string                  `json:"code,omitempty"`
 	Component ComponentName           `json:"component,omitempty"`
-	Path      string                  `json:"path,omitempty"`
+	// TODO: migrate billing validation issues to models.ValidationIssue's FieldDescriptor-based path.
+	// Deprecated: this field should be moved to models.ValidationIssue's FieldDescriptor-based path implementation.
+	Path       string             `json:"path,omitempty"`
+	Attributes models.Annotations `json:"attributes,omitempty"`
 }
 
 func (i ValidationIssue) EncodeAsErrorExtension() map[string]interface{} {
@@ -60,11 +64,35 @@ func (i ValidationIssue) EncodeAsErrorExtension() map[string]interface{} {
 		out["code"] = i.Code
 	}
 
+	if len(i.Attributes) > 0 {
+		out["attributes"] = i.Attributes
+	}
+
 	return out
+}
+
+func (i ValidationIssue) Clone() (ValidationIssue, error) {
+	clone := i
+
+	attributes, err := i.Attributes.Clone()
+	if err != nil {
+		return ValidationIssue{}, fmt.Errorf("cloning attributes: %w", err)
+	}
+
+	clone.Attributes = attributes
+
+	return clone, nil
 }
 
 func (i ValidationIssue) Error() string {
 	return i.Message
+}
+
+// Is identifies coded validation issues independently of their contextual details.
+func (i ValidationIssue) Is(target error) bool {
+	other, ok := target.(ValidationIssue)
+
+	return ok && i.Code != "" && i.Code == other.Code
 }
 
 func NewValidationWarning(code, message string) ValidationIssue {
@@ -171,19 +199,45 @@ func ValidationWithFieldPrefix(prefix string, err error) error {
 	}
 }
 
+type attributesWrapper struct {
+	attributes models.Annotations
+	err        error
+}
+
+func (a attributesWrapper) Error() string {
+	return a.err.Error()
+}
+
+func (a attributesWrapper) Unwrap() error {
+	return a.err
+}
+
+// ValidationWithAttributes adds contextual attributes to validation issues extracted from err.
+// When wrappers are nested, attributes from the outermost wrapper take precedence.
+func ValidationWithAttributes(attributes models.Annotations, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return attributesWrapper{
+		attributes: attributes,
+		err:        err,
+	}
+}
+
 type ValidationIssues []ValidationIssue
 
 // ToValidationIssues converts an error into a list of validation issues
 // If the error is nil, it returns nil
-// If any error in the error tree is not wrapped in ValidationWithComponent or ValidationWithFieldPrefix
-// and not an instance of ValidationIssue, it will return an error. This behavior allows us to have
-// critical errors that are not validation issues.
+// If any error in the error tree is not wrapped in ValidationWithComponent,
+// ValidationWithFieldPrefix, or ValidationWithAttributes and not an instance of ValidationIssue,
+// it will return an error. This behavior allows us to have critical errors that are not validation issues.
 func ToValidationIssues(errIn error) (ValidationIssues, error) {
 	if errIn == nil {
 		return nil, nil
 	}
 
-	issues, err := toValidationIssue(errIn, "", "", "", false)
+	issues, err := toValidationIssue(errIn, "", "", "", nil, false)
 	if err != nil {
 		return nil, errIn
 	}
@@ -202,8 +256,14 @@ func (v ValidationIssues) RemoveMetaForCompare() ValidationIssues {
 	})
 }
 
-func (v ValidationIssues) Clone() ValidationIssues {
-	return append(make(ValidationIssues, 0, len(v)), v...)
+func (v ValidationIssues) Clone() (ValidationIssues, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	return lo.MapErr(v, func(issue ValidationIssue, _ int) (ValidationIssue, error) {
+		return issue.Clone()
+	})
 }
 
 func (v ValidationIssues) AsError() error {
@@ -260,7 +320,7 @@ func appendMessagePrefix(prefix string, message string) string {
 	return prefix + ": " + message
 }
 
-func toValidationIssue(err error, fieldPrefix string, component ComponentName, messagePrefix string, unknownAsValidationIssue bool) ([]ValidationIssue, error) {
+func toValidationIssue(err error, fieldPrefix string, component ComponentName, messagePrefix string, attributes models.Annotations, unknownAsValidationIssue bool) ([]ValidationIssue, error) {
 	if err == nil {
 		return nil, nil
 	}
@@ -274,24 +334,42 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, m
 			issueComponent = errT.component
 		}
 
-		return toValidationIssue(errT.err, fieldPrefix, issueComponent, messagePrefix, true)
+		return toValidationIssue(errT.err, fieldPrefix, issueComponent, messagePrefix, attributes, true)
 	case fieldPrefixWrapper:
-		return toValidationIssue(errT.err, appendToPrefix(fieldPrefix, errT.prefix), component, messagePrefix, true)
+		return toValidationIssue(errT.err, appendToPrefix(fieldPrefix, errT.prefix), component, messagePrefix, attributes, true)
 	case messageWrapper:
-		return toValidationIssue(errT.err, fieldPrefix, component, appendMessagePrefix(messagePrefix, errT.prefix), unknownAsValidationIssue)
+		return toValidationIssue(errT.err, fieldPrefix, component, appendMessagePrefix(messagePrefix, errT.prefix), attributes, unknownAsValidationIssue)
+	case attributesWrapper:
+		mergedAttributes, err := errT.attributes.Merge(attributes)
+		if err != nil {
+			return nil, fmt.Errorf("merging validation issue attributes: %w", err)
+		}
+
+		return toValidationIssue(errT.err, fieldPrefix, component, messagePrefix, mergedAttributes, true)
 	case ValidationIssue:
 		issueComponent := component
 		if issueComponent == "" {
 			issueComponent = errT.Component
 		}
 
+		mergedAttributes, err := errT.Attributes.Merge(attributes)
+		if err != nil {
+			return nil, fmt.Errorf("merging validation issue attributes: %w", err)
+		}
+
+		mergedAttributes, err = mergedAttributes.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("cloning validation issue attributes: %w", err)
+		}
+
 		return []ValidationIssue{
 			{
-				Severity:  errT.Severity,
-				Message:   appendMessagePrefix(messagePrefix, errT.Message),
-				Code:      errT.Code,
-				Path:      appendToPrefix(fieldPrefix, errT.Path),
-				Component: issueComponent,
+				Severity:   errT.Severity,
+				Message:    appendMessagePrefix(messagePrefix, errT.Message),
+				Code:       errT.Code,
+				Path:       appendToPrefix(fieldPrefix, errT.Path),
+				Component:  issueComponent,
+				Attributes: mergedAttributes,
 			},
 		}, nil
 	}
@@ -300,7 +378,7 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, m
 	case errorsUnwrap:
 		var issues []ValidationIssue
 		for _, e := range errT.Unwrap() {
-			out, err := toValidationIssue(e, fieldPrefix, component, messagePrefix, unknownAsValidationIssue)
+			out, err := toValidationIssue(e, fieldPrefix, component, messagePrefix, attributes, unknownAsValidationIssue)
 			if err != nil {
 				return nil, err
 			}
@@ -311,16 +389,22 @@ func toValidationIssue(err error, fieldPrefix string, component ComponentName, m
 
 		return issues, nil
 	case errorUnwrap:
-		return toValidationIssue(errT.Unwrap(), fieldPrefix, component, messagePrefix, unknownAsValidationIssue)
+		return toValidationIssue(errT.Unwrap(), fieldPrefix, component, messagePrefix, attributes, unknownAsValidationIssue)
 	default:
 		// Non-validation errors get coded as critical
 		if unknownAsValidationIssue {
+			issueAttributes, cloneErr := attributes.Clone()
+			if cloneErr != nil {
+				return nil, fmt.Errorf("cloning validation issue attributes: %w", cloneErr)
+			}
+
 			return []ValidationIssue{
 				{
-					Severity:  ValidationIssueSeverityCritical,
-					Message:   appendMessagePrefix(messagePrefix, err.Error()),
-					Path:      fieldPrefix,
-					Component: component,
+					Severity:   ValidationIssueSeverityCritical,
+					Message:    appendMessagePrefix(messagePrefix, err.Error()),
+					Path:       fieldPrefix,
+					Component:  component,
+					Attributes: issueAttributes,
 				},
 			}, nil
 		} else {

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -6,7 +6,144 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
+
+func TestValidationIssueAttributes(t *testing.T) {
+	issue := ValidationIssue{
+		Severity: ValidationIssueSeverityWarning,
+		Message:  "invoice line needs attention",
+		Code:     "line_context",
+		Attributes: models.Annotations{
+			"invoice": map[string]any{"id": "invoice-1"},
+			"line":    map[string]any{"id": "line-1"},
+		},
+	}
+
+	t.Run("preserved through error extraction", func(t *testing.T) {
+		wrapped := ValidationWithComponent("test", issue)
+		require.ErrorIs(t, wrapped, issue)
+
+		issues, err := ToValidationIssues(wrapped)
+		require.NoError(t, err)
+		require.Equal(t, issue.Attributes, issues[0].Attributes)
+	})
+
+	t.Run("code determines error identity", func(t *testing.T) {
+		require.ErrorIs(t, issue, ValidationIssue{
+			Severity: ValidationIssueSeverityCritical,
+			Message:  "different context",
+			Code:     issue.Code,
+		})
+		require.NotErrorIs(t, issue, ValidationIssue{Message: issue.Message})
+	})
+
+	t.Run("encoded as API attributes", func(t *testing.T) {
+		extension := issue.EncodeAsErrorExtension()
+		require.Equal(t, issue.Attributes, extension["attributes"])
+		require.NotContains(t, extension, "annotations")
+	})
+
+	t.Run("deep cloned", func(t *testing.T) {
+		clone, err := issue.Clone()
+		require.NoError(t, err)
+
+		clone.Attributes["invoice"].(map[string]any)["id"] = "invoice-2"
+		require.Equal(t, "invoice-1", issue.Attributes["invoice"].(map[string]any)["id"])
+	})
+}
+
+func TestValidationWithAttributes(t *testing.T) {
+	baseIssue := ValidationIssue{
+		Severity: ValidationIssueSeverityWarning,
+		Message:  "invoice line needs attention",
+		Code:     "line_context",
+		Attributes: models.Annotations{
+			"base":       "base",
+			"precedence": "base",
+		},
+	}
+
+	t.Run("merges nested attributes with outermost precedence", func(t *testing.T) {
+		err := ValidationWithAttributes(
+			models.Annotations{
+				"outer":      "outer",
+				"precedence": "outer",
+			},
+			ValidationWithAttributes(
+				models.Annotations{
+					"inner":      "inner",
+					"precedence": "inner",
+				},
+				baseIssue,
+			),
+		)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, models.Annotations{
+			"base":       "base",
+			"inner":      "inner",
+			"outer":      "outer",
+			"precedence": "outer",
+		}, issues[0].Attributes)
+	})
+
+	t.Run("applies attributes to every joined issue", func(t *testing.T) {
+		attributes := models.Annotations{
+			"invoice": map[string]any{"id": "invoice-1"},
+		}
+		err := ValidationWithAttributes(
+			attributes,
+			errors.Join(baseIssue, NewValidationError("second", "second issue")),
+		)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Len(t, issues, 2)
+		require.Equal(t, "invoice-1", issues[0].Attributes["invoice"].(map[string]any)["id"])
+		require.Equal(t, "invoice-1", issues[1].Attributes["invoice"].(map[string]any)["id"])
+
+		issues[0].Attributes["invoice"].(map[string]any)["id"] = "invoice-2"
+		require.Equal(t, "invoice-1", issues[1].Attributes["invoice"].(map[string]any)["id"])
+		require.Equal(t, "invoice-1", attributes["invoice"].(map[string]any)["id"])
+	})
+
+	t.Run("classifies an ordinary error as a validation issue", func(t *testing.T) {
+		err := ValidationWithAttributes(
+			models.Annotations{"invoice_id": "invoice-1"},
+			errors.New("invoice context unavailable"),
+		)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, ValidationIssues{
+			{
+				Severity:   ValidationIssueSeverityCritical,
+				Message:    "invoice context unavailable",
+				Attributes: models.Annotations{"invoice_id": "invoice-1"},
+			},
+		}, issues)
+	})
+
+	t.Run("does not alias input attributes", func(t *testing.T) {
+		attributes := models.Annotations{
+			"invoice": map[string]any{"id": "invoice-1"},
+		}
+		err := ValidationWithAttributes(attributes, baseIssue)
+
+		issues, systemErr := ToValidationIssues(err)
+		require.NoError(t, systemErr)
+
+		issues[0].Attributes["invoice"].(map[string]any)["id"] = "invoice-2"
+		require.Equal(t, "invoice-1", attributes["invoice"].(map[string]any)["id"])
+	})
+
+	t.Run("returns nil for a nil error", func(t *testing.T) {
+		require.NoError(t, ValidationWithAttributes(models.Annotations{"unused": true}, nil))
+	})
+}
 
 func TestValidationIssueParsing(t *testing.T) {
 	quantityNegativeErr := NewValidationError("quantity_negative", "Quantity is negative")

--- a/openmeter/ent/db/billinginvoicevalidationissue.go
+++ b/openmeter/ent/db/billinginvoicevalidationissue.go
@@ -3,6 +3,7 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceValidationIssue is the model entity for the BillingInvoiceValidationIssue schema.
@@ -39,6 +41,8 @@ type BillingInvoiceValidationIssue struct {
 	Path *string `json:"path,omitempty"`
 	// Component holds the value of the "component" field.
 	Component string `json:"component,omitempty"`
+	// Attributes holds the value of the "attributes" field.
+	Attributes models.Annotations `json:"attributes,omitempty"`
 	// DedupeHash holds the value of the "dedupe_hash" field.
 	DedupeHash []byte `json:"dedupe_hash,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -72,7 +76,7 @@ func (*BillingInvoiceValidationIssue) scanValues(columns []string) ([]any, error
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case billinginvoicevalidationissue.FieldDedupeHash:
+		case billinginvoicevalidationissue.FieldAttributes, billinginvoicevalidationissue.FieldDedupeHash:
 			values[i] = new([]byte)
 		case billinginvoicevalidationissue.FieldID, billinginvoicevalidationissue.FieldNamespace, billinginvoicevalidationissue.FieldInvoiceID, billinginvoicevalidationissue.FieldSeverity, billinginvoicevalidationissue.FieldCode, billinginvoicevalidationissue.FieldMessage, billinginvoicevalidationissue.FieldPath, billinginvoicevalidationissue.FieldComponent:
 			values[i] = new(sql.NullString)
@@ -162,6 +166,14 @@ func (_m *BillingInvoiceValidationIssue) assignValues(columns []string, values [
 			} else if value.Valid {
 				_m.Component = value.String
 			}
+		case billinginvoicevalidationissue.FieldAttributes:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field attributes", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.Attributes); err != nil {
+					return fmt.Errorf("unmarshal field attributes: %w", err)
+				}
+			}
 		case billinginvoicevalidationissue.FieldDedupeHash:
 			if value, ok := values[i].(*[]byte); !ok {
 				return fmt.Errorf("unexpected type %T for field dedupe_hash", values[i])
@@ -244,6 +256,9 @@ func (_m *BillingInvoiceValidationIssue) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("component=")
 	builder.WriteString(_m.Component)
+	builder.WriteString(", ")
+	builder.WriteString("attributes=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Attributes))
 	builder.WriteString(", ")
 	builder.WriteString("dedupe_hash=")
 	builder.WriteString(fmt.Sprintf("%v", _m.DedupeHash))

--- a/openmeter/ent/db/billinginvoicevalidationissue/billinginvoicevalidationissue.go
+++ b/openmeter/ent/db/billinginvoicevalidationissue/billinginvoicevalidationissue.go
@@ -36,6 +36,8 @@ const (
 	FieldPath = "path"
 	// FieldComponent holds the string denoting the component field in the database.
 	FieldComponent = "component"
+	// FieldAttributes holds the string denoting the attributes field in the database.
+	FieldAttributes = "attributes"
 	// FieldDedupeHash holds the string denoting the dedupe_hash field in the database.
 	FieldDedupeHash = "dedupe_hash"
 	// EdgeBillingInvoice holds the string denoting the billing_invoice edge name in mutations.
@@ -64,6 +66,7 @@ var Columns = []string{
 	FieldMessage,
 	FieldPath,
 	FieldComponent,
+	FieldAttributes,
 	FieldDedupeHash,
 }
 

--- a/openmeter/ent/db/billinginvoicevalidationissue/where.go
+++ b/openmeter/ent/db/billinginvoicevalidationissue/where.go
@@ -686,6 +686,16 @@ func ComponentContainsFold(v string) predicate.BillingInvoiceValidationIssue {
 	return predicate.BillingInvoiceValidationIssue(sql.FieldContainsFold(FieldComponent, v))
 }
 
+// AttributesIsNil applies the IsNil predicate on the "attributes" field.
+func AttributesIsNil() predicate.BillingInvoiceValidationIssue {
+	return predicate.BillingInvoiceValidationIssue(sql.FieldIsNull(FieldAttributes))
+}
+
+// AttributesNotNil applies the NotNil predicate on the "attributes" field.
+func AttributesNotNil() predicate.BillingInvoiceValidationIssue {
+	return predicate.BillingInvoiceValidationIssue(sql.FieldNotNull(FieldAttributes))
+}
+
 // DedupeHashEQ applies the EQ predicate on the "dedupe_hash" field.
 func DedupeHashEQ(v []byte) predicate.BillingInvoiceValidationIssue {
 	return predicate.BillingInvoiceValidationIssue(sql.FieldEQ(FieldDedupeHash, v))

--- a/openmeter/ent/db/billinginvoicevalidationissue_create.go
+++ b/openmeter/ent/db/billinginvoicevalidationissue_create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceValidationIssueCreate is the builder for creating a BillingInvoiceValidationIssue entity.
@@ -122,6 +123,12 @@ func (_c *BillingInvoiceValidationIssueCreate) SetNillablePath(v *string) *Billi
 // SetComponent sets the "component" field.
 func (_c *BillingInvoiceValidationIssueCreate) SetComponent(v string) *BillingInvoiceValidationIssueCreate {
 	_c.mutation.SetComponent(v)
+	return _c
+}
+
+// SetAttributes sets the "attributes" field.
+func (_c *BillingInvoiceValidationIssueCreate) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueCreate {
+	_c.mutation.SetAttributes(v)
 	return _c
 }
 
@@ -331,6 +338,10 @@ func (_c *BillingInvoiceValidationIssueCreate) createSpec() (*BillingInvoiceVali
 		_spec.SetField(billinginvoicevalidationissue.FieldComponent, field.TypeString, value)
 		_node.Component = value
 	}
+	if value, ok := _c.mutation.Attributes(); ok {
+		_spec.SetField(billinginvoicevalidationissue.FieldAttributes, field.TypeJSON, value)
+		_node.Attributes = value
+	}
 	if value, ok := _c.mutation.DedupeHash(); ok {
 		_spec.SetField(billinginvoicevalidationissue.FieldDedupeHash, field.TypeBytes, value)
 		_node.DedupeHash = value
@@ -515,6 +526,24 @@ func (u *BillingInvoiceValidationIssueUpsert) SetComponent(v string) *BillingInv
 // UpdateComponent sets the "component" field to the value that was provided on create.
 func (u *BillingInvoiceValidationIssueUpsert) UpdateComponent() *BillingInvoiceValidationIssueUpsert {
 	u.SetExcluded(billinginvoicevalidationissue.FieldComponent)
+	return u
+}
+
+// SetAttributes sets the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsert) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueUpsert {
+	u.Set(billinginvoicevalidationissue.FieldAttributes, v)
+	return u
+}
+
+// UpdateAttributes sets the "attributes" field to the value that was provided on create.
+func (u *BillingInvoiceValidationIssueUpsert) UpdateAttributes() *BillingInvoiceValidationIssueUpsert {
+	u.SetExcluded(billinginvoicevalidationissue.FieldAttributes)
+	return u
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsert) ClearAttributes() *BillingInvoiceValidationIssueUpsert {
+	u.SetNull(billinginvoicevalidationissue.FieldAttributes)
 	return u
 }
 
@@ -714,6 +743,27 @@ func (u *BillingInvoiceValidationIssueUpsertOne) SetComponent(v string) *Billing
 func (u *BillingInvoiceValidationIssueUpsertOne) UpdateComponent() *BillingInvoiceValidationIssueUpsertOne {
 	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
 		s.UpdateComponent()
+	})
+}
+
+// SetAttributes sets the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsertOne) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueUpsertOne {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.SetAttributes(v)
+	})
+}
+
+// UpdateAttributes sets the "attributes" field to the value that was provided on create.
+func (u *BillingInvoiceValidationIssueUpsertOne) UpdateAttributes() *BillingInvoiceValidationIssueUpsertOne {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.UpdateAttributes()
+	})
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsertOne) ClearAttributes() *BillingInvoiceValidationIssueUpsertOne {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.ClearAttributes()
 	})
 }
 
@@ -1082,6 +1132,27 @@ func (u *BillingInvoiceValidationIssueUpsertBulk) SetComponent(v string) *Billin
 func (u *BillingInvoiceValidationIssueUpsertBulk) UpdateComponent() *BillingInvoiceValidationIssueUpsertBulk {
 	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
 		s.UpdateComponent()
+	})
+}
+
+// SetAttributes sets the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsertBulk) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueUpsertBulk {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.SetAttributes(v)
+	})
+}
+
+// UpdateAttributes sets the "attributes" field to the value that was provided on create.
+func (u *BillingInvoiceValidationIssueUpsertBulk) UpdateAttributes() *BillingInvoiceValidationIssueUpsertBulk {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.UpdateAttributes()
+	})
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (u *BillingInvoiceValidationIssueUpsertBulk) ClearAttributes() *BillingInvoiceValidationIssueUpsertBulk {
+	return u.Update(func(s *BillingInvoiceValidationIssueUpsert) {
+		s.ClearAttributes()
 	})
 }
 

--- a/openmeter/ent/db/billinginvoicevalidationissue_update.go
+++ b/openmeter/ent/db/billinginvoicevalidationissue_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceValidationIssueUpdate is the builder for updating BillingInvoiceValidationIssue entities.
@@ -152,6 +153,18 @@ func (_u *BillingInvoiceValidationIssueUpdate) SetNillableComponent(v *string) *
 	return _u
 }
 
+// SetAttributes sets the "attributes" field.
+func (_u *BillingInvoiceValidationIssueUpdate) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueUpdate {
+	_u.mutation.SetAttributes(v)
+	return _u
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (_u *BillingInvoiceValidationIssueUpdate) ClearAttributes() *BillingInvoiceValidationIssueUpdate {
+	_u.mutation.ClearAttributes()
+	return _u
+}
+
 // SetDedupeHash sets the "dedupe_hash" field.
 func (_u *BillingInvoiceValidationIssueUpdate) SetDedupeHash(v []byte) *BillingInvoiceValidationIssueUpdate {
 	_u.mutation.SetDedupeHash(v)
@@ -285,6 +298,12 @@ func (_u *BillingInvoiceValidationIssueUpdate) sqlSave(ctx context.Context) (_no
 	}
 	if value, ok := _u.mutation.Component(); ok {
 		_spec.SetField(billinginvoicevalidationissue.FieldComponent, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Attributes(); ok {
+		_spec.SetField(billinginvoicevalidationissue.FieldAttributes, field.TypeJSON, value)
+	}
+	if _u.mutation.AttributesCleared() {
+		_spec.ClearField(billinginvoicevalidationissue.FieldAttributes, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.DedupeHash(); ok {
 		_spec.SetField(billinginvoicevalidationissue.FieldDedupeHash, field.TypeBytes, value)
@@ -460,6 +479,18 @@ func (_u *BillingInvoiceValidationIssueUpdateOne) SetNillableComponent(v *string
 	return _u
 }
 
+// SetAttributes sets the "attributes" field.
+func (_u *BillingInvoiceValidationIssueUpdateOne) SetAttributes(v models.Annotations) *BillingInvoiceValidationIssueUpdateOne {
+	_u.mutation.SetAttributes(v)
+	return _u
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (_u *BillingInvoiceValidationIssueUpdateOne) ClearAttributes() *BillingInvoiceValidationIssueUpdateOne {
+	_u.mutation.ClearAttributes()
+	return _u
+}
+
 // SetDedupeHash sets the "dedupe_hash" field.
 func (_u *BillingInvoiceValidationIssueUpdateOne) SetDedupeHash(v []byte) *BillingInvoiceValidationIssueUpdateOne {
 	_u.mutation.SetDedupeHash(v)
@@ -623,6 +654,12 @@ func (_u *BillingInvoiceValidationIssueUpdateOne) sqlSave(ctx context.Context) (
 	}
 	if value, ok := _u.mutation.Component(); ok {
 		_spec.SetField(billinginvoicevalidationissue.FieldComponent, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.Attributes(); ok {
+		_spec.SetField(billinginvoicevalidationissue.FieldAttributes, field.TypeJSON, value)
+	}
+	if _u.mutation.AttributesCleared() {
+		_spec.ClearField(billinginvoicevalidationissue.FieldAttributes, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.DedupeHash(); ok {
 		_spec.SetField(billinginvoicevalidationissue.FieldDedupeHash, field.TypeBytes, value)

--- a/openmeter/ent/db/chargecreditpurchase.go
+++ b/openmeter/ent/db/chargecreditpurchase.go
@@ -89,6 +89,8 @@ type ChargeCreditPurchase struct {
 	Name string `json:"name,omitempty"`
 	// Description holds the value of the "description" field.
 	Description *string `json:"description,omitempty"`
+	// ValidationIssues holds the value of the "validation_issues" field.
+	ValidationIssues billing.ValidationIssues `json:"validation_issues,omitempty"`
 	// SchemaLevel holds the value of the "schema_level" field.
 	SchemaLevel int `json:"schema_level,omitempty"`
 	// FiatCostBasis holds the value of the "fiat_cost_basis" field.
@@ -282,7 +284,7 @@ func (*ChargeCreditPurchase) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargecreditpurchase.FieldFiatCostBasis:
 			values[i] = &sql.NullScanner{S: new(alpacadecimal.Decimal)}
-		case chargecreditpurchase.FieldAnnotations, chargecreditpurchase.FieldMetadata:
+		case chargecreditpurchase.FieldAnnotations, chargecreditpurchase.FieldMetadata, chargecreditpurchase.FieldValidationIssues:
 			values[i] = new([]byte)
 		case chargecreditpurchase.FieldCreditAmount:
 			values[i] = new(alpacadecimal.Decimal)
@@ -484,6 +486,14 @@ func (_m *ChargeCreditPurchase) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				_m.Description = new(string)
 				*_m.Description = value.String
+			}
+		case chargecreditpurchase.FieldValidationIssues:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field validation_issues", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.ValidationIssues); err != nil {
+					return fmt.Errorf("unmarshal field validation_issues: %w", err)
+				}
 			}
 		case chargecreditpurchase.FieldSchemaLevel:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -767,6 +777,9 @@ func (_m *ChargeCreditPurchase) String() string {
 		builder.WriteString("description=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("validation_issues=")
+	builder.WriteString(fmt.Sprintf("%v", _m.ValidationIssues))
 	builder.WriteString(", ")
 	builder.WriteString("schema_level=")
 	builder.WriteString(fmt.Sprintf("%v", _m.SchemaLevel))

--- a/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
+++ b/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
@@ -71,6 +71,8 @@ const (
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
+	// FieldValidationIssues holds the string denoting the validation_issues field in the database.
+	FieldValidationIssues = "validation_issues"
 	// FieldSchemaLevel holds the string denoting the schema_level field in the database.
 	FieldSchemaLevel = "schema_level"
 	// FieldFiatCostBasis holds the string denoting the fiat_cost_basis field in the database.
@@ -231,6 +233,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldName,
 	FieldDescription,
+	FieldValidationIssues,
 	FieldSchemaLevel,
 	FieldFiatCostBasis,
 	FieldSettlementType,

--- a/openmeter/ent/db/chargecreditpurchase/where.go
+++ b/openmeter/ent/db/chargecreditpurchase/where.go
@@ -1577,6 +1577,16 @@ func DescriptionContainsFold(v string) predicate.ChargeCreditPurchase {
 	return predicate.ChargeCreditPurchase(sql.FieldContainsFold(FieldDescription, v))
 }
 
+// ValidationIssuesIsNil applies the IsNil predicate on the "validation_issues" field.
+func ValidationIssuesIsNil() predicate.ChargeCreditPurchase {
+	return predicate.ChargeCreditPurchase(sql.FieldIsNull(FieldValidationIssues))
+}
+
+// ValidationIssuesNotNil applies the NotNil predicate on the "validation_issues" field.
+func ValidationIssuesNotNil() predicate.ChargeCreditPurchase {
+	return predicate.ChargeCreditPurchase(sql.FieldNotNull(FieldValidationIssues))
+}
+
 // SchemaLevelEQ applies the EQ predicate on the "schema_level" field.
 func SchemaLevelEQ(v int) predicate.ChargeCreditPurchase {
 	return predicate.ChargeCreditPurchase(sql.FieldEQ(FieldSchemaLevel, v))

--- a/openmeter/ent/db/chargecreditpurchase_create.go
+++ b/openmeter/ent/db/chargecreditpurchase_create.go
@@ -294,6 +294,12 @@ func (_c *ChargeCreditPurchaseCreate) SetNillableDescription(v *string) *ChargeC
 	return _c
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (_c *ChargeCreditPurchaseCreate) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseCreate {
+	_c.mutation.SetValidationIssues(v)
+	return _c
+}
+
 // SetSchemaLevel sets the "schema_level" field.
 func (_c *ChargeCreditPurchaseCreate) SetSchemaLevel(v int) *ChargeCreditPurchaseCreate {
 	_c.mutation.SetSchemaLevel(v)
@@ -874,6 +880,10 @@ func (_c *ChargeCreditPurchaseCreate) createSpec() (*ChargeCreditPurchase, *sqlg
 		_spec.SetField(chargecreditpurchase.FieldDescription, field.TypeString, value)
 		_node.Description = &value
 	}
+	if value, ok := _c.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargecreditpurchase.FieldValidationIssues, field.TypeJSON, value)
+		_node.ValidationIssues = value
+	}
 	if value, ok := _c.mutation.SchemaLevel(); ok {
 		_spec.SetField(chargecreditpurchase.FieldSchemaLevel, field.TypeInt, value)
 		_node.SchemaLevel = value
@@ -1377,6 +1387,24 @@ func (u *ChargeCreditPurchaseUpsert) ClearDescription() *ChargeCreditPurchaseUps
 	return u
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsert) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpsert {
+	u.Set(chargecreditpurchase.FieldValidationIssues, v)
+	return u
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsert) UpdateValidationIssues() *ChargeCreditPurchaseUpsert {
+	u.SetExcluded(chargecreditpurchase.FieldValidationIssues)
+	return u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsert) ClearValidationIssues() *ChargeCreditPurchaseUpsert {
+	u.SetNull(chargecreditpurchase.FieldValidationIssues)
+	return u
+}
+
 // SetSchemaLevel sets the "schema_level" field.
 func (u *ChargeCreditPurchaseUpsert) SetSchemaLevel(v int) *ChargeCreditPurchaseUpsert {
 	u.Set(chargecreditpurchase.FieldSchemaLevel, v)
@@ -1857,6 +1885,27 @@ func (u *ChargeCreditPurchaseUpsertOne) UpdateDescription() *ChargeCreditPurchas
 func (u *ChargeCreditPurchaseUpsertOne) ClearDescription() *ChargeCreditPurchaseUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsertOne) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsertOne) UpdateValidationIssues() *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsertOne) ClearValidationIssues() *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 
@@ -2529,6 +2578,27 @@ func (u *ChargeCreditPurchaseUpsertBulk) UpdateDescription() *ChargeCreditPurcha
 func (u *ChargeCreditPurchaseUpsertBulk) ClearDescription() *ChargeCreditPurchaseUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsertBulk) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsertBulk) UpdateValidationIssues() *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeCreditPurchaseUpsertBulk) ClearValidationIssues() *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 

--- a/openmeter/ent/db/chargecreditpurchase_update.go
+++ b/openmeter/ent/db/chargecreditpurchase_update.go
@@ -10,8 +10,10 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchase"
@@ -256,6 +258,24 @@ func (_u *ChargeCreditPurchaseUpdate) SetNillableDescription(v *string) *ChargeC
 // ClearDescription clears the value of the "description" field.
 func (_u *ChargeCreditPurchaseUpdate) ClearDescription() *ChargeCreditPurchaseUpdate {
 	_u.mutation.ClearDescription()
+	return _u
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdate) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpdate {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdate) AppendValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpdate {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdate) ClearValidationIssues() *ChargeCreditPurchaseUpdate {
+	_u.mutation.ClearValidationIssues()
 	return _u
 }
 
@@ -654,6 +674,17 @@ func (_u *ChargeCreditPurchaseUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargecreditpurchase.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargecreditpurchase.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargecreditpurchase.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargecreditpurchase.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.SchemaLevel(); ok {
 		_spec.SetField(chargecreditpurchase.FieldSchemaLevel, field.TypeInt, value)
@@ -1096,6 +1127,24 @@ func (_u *ChargeCreditPurchaseUpdateOne) ClearDescription() *ChargeCreditPurchas
 	return _u
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdateOne) SetValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdateOne) AppendValidationIssues(v billing.ValidationIssues) *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeCreditPurchaseUpdateOne) ClearValidationIssues() *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.ClearValidationIssues()
+	return _u
+}
+
 // SetSchemaLevel sets the "schema_level" field.
 func (_u *ChargeCreditPurchaseUpdateOne) SetSchemaLevel(v int) *ChargeCreditPurchaseUpdateOne {
 	_u.mutation.ResetSchemaLevel()
@@ -1521,6 +1570,17 @@ func (_u *ChargeCreditPurchaseUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargecreditpurchase.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargecreditpurchase.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargecreditpurchase.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargecreditpurchase.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.SchemaLevel(); ok {
 		_spec.SetField(chargecreditpurchase.FieldSchemaLevel, field.TypeInt, value)

--- a/openmeter/ent/db/chargeflatfee.go
+++ b/openmeter/ent/db/chargeflatfee.go
@@ -88,6 +88,8 @@ type ChargeFlatFee struct {
 	Name string `json:"name,omitempty"`
 	// Description holds the value of the "description" field.
 	Description *string `json:"description,omitempty"`
+	// ValidationIssues holds the value of the "validation_issues" field.
+	ValidationIssues billing.ValidationIssues `json:"validation_issues,omitempty"`
 	// PaymentTerm holds the value of the "payment_term" field.
 	PaymentTerm productcatalog.PaymentTermType `json:"payment_term,omitempty"`
 	// InvoiceAt holds the value of the "invoice_at" field.
@@ -286,7 +288,7 @@ func (*ChargeFlatFee) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case chargeflatfee.FieldAnnotations, chargeflatfee.FieldMetadata:
+		case chargeflatfee.FieldAnnotations, chargeflatfee.FieldMetadata, chargeflatfee.FieldValidationIssues:
 			values[i] = new([]byte)
 		case chargeflatfee.FieldAmountBeforeProration, chargeflatfee.FieldAmountAfterProration:
 			values[i] = new(alpacadecimal.Decimal)
@@ -486,6 +488,14 @@ func (_m *ChargeFlatFee) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.Description = new(string)
 				*_m.Description = value.String
+			}
+		case chargeflatfee.FieldValidationIssues:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field validation_issues", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.ValidationIssues); err != nil {
+					return fmt.Errorf("unmarshal field validation_issues: %w", err)
+				}
 			}
 		case chargeflatfee.FieldPaymentTerm:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -763,6 +773,9 @@ func (_m *ChargeFlatFee) String() string {
 		builder.WriteString("description=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("validation_issues=")
+	builder.WriteString(fmt.Sprintf("%v", _m.ValidationIssues))
 	builder.WriteString(", ")
 	builder.WriteString("payment_term=")
 	builder.WriteString(fmt.Sprintf("%v", _m.PaymentTerm))

--- a/openmeter/ent/db/chargeflatfee/chargeflatfee.go
+++ b/openmeter/ent/db/chargeflatfee/chargeflatfee.go
@@ -72,6 +72,8 @@ const (
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
+	// FieldValidationIssues holds the string denoting the validation_issues field in the database.
+	FieldValidationIssues = "validation_issues"
 	// FieldPaymentTerm holds the string denoting the payment_term field in the database.
 	FieldPaymentTerm = "payment_term"
 	// FieldInvoiceAt holds the string denoting the invoice_at field in the database.
@@ -239,6 +241,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldName,
 	FieldDescription,
+	FieldValidationIssues,
 	FieldPaymentTerm,
 	FieldInvoiceAt,
 	FieldSettlementMode,

--- a/openmeter/ent/db/chargeflatfee/where.go
+++ b/openmeter/ent/db/chargeflatfee/where.go
@@ -1567,6 +1567,16 @@ func DescriptionContainsFold(v string) predicate.ChargeFlatFee {
 	return predicate.ChargeFlatFee(sql.FieldContainsFold(FieldDescription, v))
 }
 
+// ValidationIssuesIsNil applies the IsNil predicate on the "validation_issues" field.
+func ValidationIssuesIsNil() predicate.ChargeFlatFee {
+	return predicate.ChargeFlatFee(sql.FieldIsNull(FieldValidationIssues))
+}
+
+// ValidationIssuesNotNil applies the NotNil predicate on the "validation_issues" field.
+func ValidationIssuesNotNil() predicate.ChargeFlatFee {
+	return predicate.ChargeFlatFee(sql.FieldNotNull(FieldValidationIssues))
+}
+
 // PaymentTermEQ applies the EQ predicate on the "payment_term" field.
 func PaymentTermEQ(v productcatalog.PaymentTermType) predicate.ChargeFlatFee {
 	vc := string(v)

--- a/openmeter/ent/db/chargeflatfee_create.go
+++ b/openmeter/ent/db/chargeflatfee_create.go
@@ -293,6 +293,12 @@ func (_c *ChargeFlatFeeCreate) SetNillableDescription(v *string) *ChargeFlatFeeC
 	return _c
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (_c *ChargeFlatFeeCreate) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeCreate {
+	_c.mutation.SetValidationIssues(v)
+	return _c
+}
+
 // SetPaymentTerm sets the "payment_term" field.
 func (_c *ChargeFlatFeeCreate) SetPaymentTerm(v productcatalog.PaymentTermType) *ChargeFlatFeeCreate {
 	_c.mutation.SetPaymentTerm(v)
@@ -846,6 +852,10 @@ func (_c *ChargeFlatFeeCreate) createSpec() (*ChargeFlatFee, *sqlgraph.CreateSpe
 		_spec.SetField(chargeflatfee.FieldDescription, field.TypeString, value)
 		_node.Description = &value
 	}
+	if value, ok := _c.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeflatfee.FieldValidationIssues, field.TypeJSON, value)
+		_node.ValidationIssues = value
+	}
 	if value, ok := _c.mutation.PaymentTerm(); ok {
 		_spec.SetField(chargeflatfee.FieldPaymentTerm, field.TypeString, value)
 		_node.PaymentTerm = value
@@ -1359,6 +1369,24 @@ func (u *ChargeFlatFeeUpsert) ClearDescription() *ChargeFlatFeeUpsert {
 	return u
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeFlatFeeUpsert) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpsert {
+	u.Set(chargeflatfee.FieldValidationIssues, v)
+	return u
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsert) UpdateValidationIssues() *ChargeFlatFeeUpsert {
+	u.SetExcluded(chargeflatfee.FieldValidationIssues)
+	return u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeFlatFeeUpsert) ClearValidationIssues() *ChargeFlatFeeUpsert {
+	u.SetNull(chargeflatfee.FieldValidationIssues)
+	return u
+}
+
 // SetPaymentTerm sets the "payment_term" field.
 func (u *ChargeFlatFeeUpsert) SetPaymentTerm(v productcatalog.PaymentTermType) *ChargeFlatFeeUpsert {
 	u.Set(chargeflatfee.FieldPaymentTerm, v)
@@ -1842,6 +1870,27 @@ func (u *ChargeFlatFeeUpsertOne) UpdateDescription() *ChargeFlatFeeUpsertOne {
 func (u *ChargeFlatFeeUpsertOne) ClearDescription() *ChargeFlatFeeUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeFlatFeeUpsertOne) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertOne) UpdateValidationIssues() *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeFlatFeeUpsertOne) ClearValidationIssues() *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 
@@ -2522,6 +2571,27 @@ func (u *ChargeFlatFeeUpsertBulk) UpdateDescription() *ChargeFlatFeeUpsertBulk {
 func (u *ChargeFlatFeeUpsertBulk) ClearDescription() *ChargeFlatFeeUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeFlatFeeUpsertBulk) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertBulk) UpdateValidationIssues() *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeFlatFeeUpsertBulk) ClearValidationIssues() *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfee_update.go
+++ b/openmeter/ent/db/chargeflatfee_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -257,6 +258,24 @@ func (_u *ChargeFlatFeeUpdate) SetNillableDescription(v *string) *ChargeFlatFeeU
 // ClearDescription clears the value of the "description" field.
 func (_u *ChargeFlatFeeUpdate) ClearDescription() *ChargeFlatFeeUpdate {
 	_u.mutation.ClearDescription()
+	return _u
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdate) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpdate {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdate) AppendValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpdate {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdate) ClearValidationIssues() *ChargeFlatFeeUpdate {
+	_u.mutation.ClearValidationIssues()
 	return _u
 }
 
@@ -678,6 +697,17 @@ func (_u *ChargeFlatFeeUpdate) sqlSave(ctx context.Context) (_node int, err erro
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargeflatfee.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeflatfee.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargeflatfee.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargeflatfee.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.PaymentTerm(); ok {
 		_spec.SetField(chargeflatfee.FieldPaymentTerm, field.TypeString, value)
@@ -1116,6 +1146,24 @@ func (_u *ChargeFlatFeeUpdateOne) SetNillableDescription(v *string) *ChargeFlatF
 // ClearDescription clears the value of the "description" field.
 func (_u *ChargeFlatFeeUpdateOne) ClearDescription() *ChargeFlatFeeUpdateOne {
 	_u.mutation.ClearDescription()
+	return _u
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdateOne) SetValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpdateOne {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdateOne) AppendValidationIssues(v billing.ValidationIssues) *ChargeFlatFeeUpdateOne {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeFlatFeeUpdateOne) ClearValidationIssues() *ChargeFlatFeeUpdateOne {
+	_u.mutation.ClearValidationIssues()
 	return _u
 }
 
@@ -1567,6 +1615,17 @@ func (_u *ChargeFlatFeeUpdateOne) sqlSave(ctx context.Context) (_node *ChargeFla
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargeflatfee.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeflatfee.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargeflatfee.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargeflatfee.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.PaymentTerm(); ok {
 		_spec.SetField(chargeflatfee.FieldPaymentTerm, field.TypeString, value)

--- a/openmeter/ent/db/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased.go
@@ -88,6 +88,8 @@ type ChargeUsageBased struct {
 	Name string `json:"name,omitempty"`
 	// Description holds the value of the "description" field.
 	Description *string `json:"description,omitempty"`
+	// ValidationIssues holds the value of the "validation_issues" field.
+	ValidationIssues billing.ValidationIssues `json:"validation_issues,omitempty"`
 	// InvoiceAt holds the value of the "invoice_at" field.
 	InvoiceAt time.Time `json:"invoice_at,omitempty"`
 	// SettlementMode holds the value of the "settlement_mode" field.
@@ -295,7 +297,7 @@ func (*ChargeUsageBased) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case chargeusagebased.FieldAnnotations, chargeusagebased.FieldMetadata:
+		case chargeusagebased.FieldAnnotations, chargeusagebased.FieldMetadata, chargeusagebased.FieldValidationIssues:
 			values[i] = new([]byte)
 		case chargeusagebased.FieldID, chargeusagebased.FieldCustomerID, chargeusagebased.FieldStatus, chargeusagebased.FieldUniqueReferenceID, chargeusagebased.FieldFiatCurrencyCode, chargeusagebased.FieldCustomCurrencyID, chargeusagebased.FieldManagedBy, chargeusagebased.FieldSubscriptionID, chargeusagebased.FieldSubscriptionPhaseID, chargeusagebased.FieldSubscriptionItemID, chargeusagebased.FieldTaxCodeID, chargeusagebased.FieldTaxBehavior, chargeusagebased.FieldNamespace, chargeusagebased.FieldName, chargeusagebased.FieldDescription, chargeusagebased.FieldSettlementMode, chargeusagebased.FieldFeatureKey, chargeusagebased.FieldFeatureID, chargeusagebased.FieldRatingEngine, chargeusagebased.FieldCurrentRealizationRunID, chargeusagebased.FieldCostBasisID, chargeusagebased.FieldStatusDetailed:
 			values[i] = new(sql.NullString)
@@ -497,6 +499,14 @@ func (_m *ChargeUsageBased) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.Description = new(string)
 				*_m.Description = value.String
+			}
+		case chargeusagebased.FieldValidationIssues:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field validation_issues", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.ValidationIssues); err != nil {
+					return fmt.Errorf("unmarshal field validation_issues: %w", err)
+				}
 			}
 		case chargeusagebased.FieldInvoiceAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -771,6 +781,9 @@ func (_m *ChargeUsageBased) String() string {
 		builder.WriteString("description=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("validation_issues=")
+	builder.WriteString(fmt.Sprintf("%v", _m.ValidationIssues))
 	builder.WriteString(", ")
 	builder.WriteString("invoice_at=")
 	builder.WriteString(_m.InvoiceAt.Format(time.ANSIC))

--- a/openmeter/ent/db/chargeusagebased/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased/chargeusagebased.go
@@ -73,6 +73,8 @@ const (
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
+	// FieldValidationIssues holds the string denoting the validation_issues field in the database.
+	FieldValidationIssues = "validation_issues"
 	// FieldInvoiceAt holds the string denoting the invoice_at field in the database.
 	FieldInvoiceAt = "invoice_at"
 	// FieldSettlementMode holds the string denoting the settlement_mode field in the database.
@@ -247,6 +249,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldName,
 	FieldDescription,
+	FieldValidationIssues,
 	FieldInvoiceAt,
 	FieldSettlementMode,
 	FieldIntentDeletedAt,

--- a/openmeter/ent/db/chargeusagebased/where.go
+++ b/openmeter/ent/db/chargeusagebased/where.go
@@ -1550,6 +1550,16 @@ func DescriptionContainsFold(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldContainsFold(FieldDescription, v))
 }
 
+// ValidationIssuesIsNil applies the IsNil predicate on the "validation_issues" field.
+func ValidationIssuesIsNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldIsNull(FieldValidationIssues))
+}
+
+// ValidationIssuesNotNil applies the NotNil predicate on the "validation_issues" field.
+func ValidationIssuesNotNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldNotNull(FieldValidationIssues))
+}
+
 // InvoiceAtEQ applies the EQ predicate on the "invoice_at" field.
 func InvoiceAtEQ(v time.Time) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldEQ(FieldInvoiceAt, v))

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -294,6 +294,12 @@ func (_c *ChargeUsageBasedCreate) SetNillableDescription(v *string) *ChargeUsage
 	return _c
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (_c *ChargeUsageBasedCreate) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedCreate {
+	_c.mutation.SetValidationIssues(v)
+	return _c
+}
+
 // SetInvoiceAt sets the "invoice_at" field.
 func (_c *ChargeUsageBasedCreate) SetInvoiceAt(v time.Time) *ChargeUsageBasedCreate {
 	_c.mutation.SetInvoiceAt(v)
@@ -853,6 +859,10 @@ func (_c *ChargeUsageBasedCreate) createSpec() (*ChargeUsageBased, *sqlgraph.Cre
 		_spec.SetField(chargeusagebased.FieldDescription, field.TypeString, value)
 		_node.Description = &value
 	}
+	if value, ok := _c.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeusagebased.FieldValidationIssues, field.TypeJSON, value)
+		_node.ValidationIssues = value
+	}
 	if value, ok := _c.mutation.InvoiceAt(); ok {
 		_spec.SetField(chargeusagebased.FieldInvoiceAt, field.TypeTime, value)
 		_node.InvoiceAt = value
@@ -1386,6 +1396,24 @@ func (u *ChargeUsageBasedUpsert) ClearDescription() *ChargeUsageBasedUpsert {
 	return u
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeUsageBasedUpsert) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpsert {
+	u.Set(chargeusagebased.FieldValidationIssues, v)
+	return u
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsert) UpdateValidationIssues() *ChargeUsageBasedUpsert {
+	u.SetExcluded(chargeusagebased.FieldValidationIssues)
+	return u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeUsageBasedUpsert) ClearValidationIssues() *ChargeUsageBasedUpsert {
+	u.SetNull(chargeusagebased.FieldValidationIssues)
+	return u
+}
+
 // SetInvoiceAt sets the "invoice_at" field.
 func (u *ChargeUsageBasedUpsert) SetInvoiceAt(v time.Time) *ChargeUsageBasedUpsert {
 	u.Set(chargeusagebased.FieldInvoiceAt, v)
@@ -1857,6 +1885,27 @@ func (u *ChargeUsageBasedUpsertOne) UpdateDescription() *ChargeUsageBasedUpsertO
 func (u *ChargeUsageBasedUpsertOne) ClearDescription() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeUsageBasedUpsertOne) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertOne) UpdateValidationIssues() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeUsageBasedUpsertOne) ClearValidationIssues() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 
@@ -2523,6 +2572,27 @@ func (u *ChargeUsageBasedUpsertBulk) UpdateDescription() *ChargeUsageBasedUpsert
 func (u *ChargeUsageBasedUpsertBulk) ClearDescription() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.ClearDescription()
+	})
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (u *ChargeUsageBasedUpsertBulk) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetValidationIssues(v)
+	})
+}
+
+// UpdateValidationIssues sets the "validation_issues" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertBulk) UpdateValidationIssues() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateValidationIssues()
+	})
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (u *ChargeUsageBasedUpsertBulk) ClearValidationIssues() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearValidationIssues()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -258,6 +259,24 @@ func (_u *ChargeUsageBasedUpdate) SetNillableDescription(v *string) *ChargeUsage
 // ClearDescription clears the value of the "description" field.
 func (_u *ChargeUsageBasedUpdate) ClearDescription() *ChargeUsageBasedUpdate {
 	_u.mutation.ClearDescription()
+	return _u
+}
+
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdate) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpdate {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdate) AppendValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpdate {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdate) ClearValidationIssues() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearValidationIssues()
 	return _u
 }
 
@@ -698,6 +717,17 @@ func (_u *ChargeUsageBasedUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargeusagebased.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeusagebased.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargeusagebased.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargeusagebased.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.InvoiceAt(); ok {
 		_spec.SetField(chargeusagebased.FieldInvoiceAt, field.TypeTime, value)
@@ -1189,6 +1219,24 @@ func (_u *ChargeUsageBasedUpdateOne) ClearDescription() *ChargeUsageBasedUpdateO
 	return _u
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdateOne) SetValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpdateOne {
+	_u.mutation.SetValidationIssues(v)
+	return _u
+}
+
+// AppendValidationIssues appends value to the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdateOne) AppendValidationIssues(v billing.ValidationIssues) *ChargeUsageBasedUpdateOne {
+	_u.mutation.AppendValidationIssues(v)
+	return _u
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (_u *ChargeUsageBasedUpdateOne) ClearValidationIssues() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearValidationIssues()
+	return _u
+}
+
 // SetInvoiceAt sets the "invoice_at" field.
 func (_u *ChargeUsageBasedUpdateOne) SetInvoiceAt(v time.Time) *ChargeUsageBasedUpdateOne {
 	_u.mutation.SetInvoiceAt(v)
@@ -1656,6 +1704,17 @@ func (_u *ChargeUsageBasedUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 	}
 	if _u.mutation.DescriptionCleared() {
 		_spec.ClearField(chargeusagebased.FieldDescription, field.TypeString)
+	}
+	if value, ok := _u.mutation.ValidationIssues(); ok {
+		_spec.SetField(chargeusagebased.FieldValidationIssues, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedValidationIssues(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, chargeusagebased.FieldValidationIssues, value)
+		})
+	}
+	if _u.mutation.ValidationIssuesCleared() {
+		_spec.ClearField(chargeusagebased.FieldValidationIssues, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.InvoiceAt(); ok {
 		_spec.SetField(chargeusagebased.FieldInvoiceAt, field.TypeTime, value)

--- a/openmeter/ent/db/entmixinaccessor.go
+++ b/openmeter/ent/db/entmixinaccessor.go
@@ -1100,6 +1100,10 @@ func (e *ChargeCreditPurchase) GetDescription() *string {
 	return e.Description
 }
 
+func (e *ChargeCreditPurchase) GetValidationIssues() billing.ValidationIssues {
+	return e.ValidationIssues
+}
+
 func (e *ChargeCreditPurchaseCostBasis) GetID() string {
 	return e.ID
 }
@@ -1398,6 +1402,10 @@ func (e *ChargeFlatFee) GetName() string {
 
 func (e *ChargeFlatFee) GetDescription() *string {
 	return e.Description
+}
+
+func (e *ChargeFlatFee) GetValidationIssues() billing.ValidationIssues {
+	return e.ValidationIssues
 }
 
 func (e *ChargeFlatFeeCostBasis) GetID() string {
@@ -1978,6 +1986,10 @@ func (e *ChargeUsageBased) GetName() string {
 
 func (e *ChargeUsageBased) GetDescription() *string {
 	return e.Description
+}
+
+func (e *ChargeUsageBased) GetValidationIssues() billing.ValidationIssues {
+	return e.ValidationIssues
 }
 
 func (e *ChargeUsageBasedCostBasis) GetID() string {

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1391,6 +1391,7 @@ var (
 		{Name: "message", Type: field.TypeString},
 		{Name: "path", Type: field.TypeString, Nullable: true},
 		{Name: "component", Type: field.TypeString},
+		{Name: "attributes", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "dedupe_hash", Type: field.TypeBytes, Size: 32},
 		{Name: "invoice_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
@@ -1402,7 +1403,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "billing_invoice_validation_issues_billing_invoices_billing_invoice_validation_issues",
-				Columns:    []*schema.Column{BillingInvoiceValidationIssuesColumns[11]},
+				Columns:    []*schema.Column{BillingInvoiceValidationIssuesColumns[12]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -1421,7 +1422,7 @@ var (
 			{
 				Name:    "billinginvoicevalidationissue_namespace_invoice_id_dedupe_hash",
 				Unique:  true,
-				Columns: []*schema.Column{BillingInvoiceValidationIssuesColumns[1], BillingInvoiceValidationIssuesColumns[11], BillingInvoiceValidationIssuesColumns[10]},
+				Columns: []*schema.Column{BillingInvoiceValidationIssuesColumns[1], BillingInvoiceValidationIssuesColumns[12], BillingInvoiceValidationIssuesColumns[11]},
 			},
 		},
 	}
@@ -1852,6 +1853,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
+		{Name: "validation_issues", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "schema_level", Type: field.TypeInt, Default: 2, SchemaType: map[string]string{"postgres": "smallint"}},
 		{Name: "fiat_cost_basis", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "settlement_type", Type: field.TypeEnum, Nullable: true, Enums: []string{"invoice", "external", "promotional"}},
@@ -1881,43 +1883,43 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_credit_purchase_cost_basis_charge_fk",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[34]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[35]},
 				RefColumns: []*schema.Column{ChargeCreditPurchaseCostBasesColumns[0]},
 				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_credit_purchases_custom_currencies_charges_credit_purchase",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[35]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[36]},
 				RefColumns: []*schema.Column{CustomCurrenciesColumns[0]},
 				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_credit_purchases_customers_charges_credit_purchase",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[36]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[37]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_credit_purchases_subscriptions_charges_credit_purchase",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[37]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[38]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_credit_purchases_subscription_items_charges_credit_purchase",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[38]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[39]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_credit_purchases_subscription_phases_charges_credit_purchase",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[39]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[40]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_credit_purchases_tax_codes_charge_credit_purchases",
-				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[40]},
+				Columns:    []*schema.Column{ChargeCreditPurchasesColumns[41]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -1926,7 +1928,7 @@ var (
 			{
 				Name:    "chargecreditpurchase_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeCreditPurchasesColumns[14], ChargeCreditPurchasesColumns[36], ChargeCreditPurchasesColumns[8]},
+				Columns: []*schema.Column{ChargeCreditPurchasesColumns[14], ChargeCreditPurchasesColumns[37], ChargeCreditPurchasesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -1959,17 +1961,17 @@ var (
 			{
 				Name:    "chargecreditpurchases_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeCreditPurchasesColumns[40]},
+				Columns: []*schema.Column{ChargeCreditPurchasesColumns[41]},
 			},
 			{
 				Name:    "chargecreditpurchases_cost_basis_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeCreditPurchasesColumns[34]},
+				Columns: []*schema.Column{ChargeCreditPurchasesColumns[35]},
 			},
 			{
 				Name:    "chargecreditpurchase_namespace_customer_id_key",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeCreditPurchasesColumns[14], ChargeCreditPurchasesColumns[36], ChargeCreditPurchasesColumns[32]},
+				Columns: []*schema.Column{ChargeCreditPurchasesColumns[14], ChargeCreditPurchasesColumns[37], ChargeCreditPurchasesColumns[33]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "key IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -2231,6 +2233,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
+		{Name: "validation_issues", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "payment_term", Type: field.TypeString},
 		{Name: "invoice_at", Type: field.TypeTime},
 		{Name: "settlement_mode", Type: field.TypeEnum, Enums: []string{"credit_then_invoice", "credit_only"}},
@@ -2259,55 +2262,55 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_flat_fees_charge_flat_fee_runs_current_run",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[31]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[32]},
 				RefColumns: []*schema.Column{ChargeFlatFeeRunsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fee_cost_basis_charge_fk",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[32]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[33]},
 				RefColumns: []*schema.Column{ChargeFlatFeeCostBasesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_flat_fees_custom_currencies_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[33]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[34]},
 				RefColumns: []*schema.Column{CustomCurrenciesColumns[0]},
 				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_flat_fees_customers_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[34]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[35]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_flat_fees_features_flat_fee_charges",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[35]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[36]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscriptions_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[36]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[37]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscription_items_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[37]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[38]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscription_phases_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[38]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[39]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_tax_codes_charge_flat_fees",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[39]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[40]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -2316,7 +2319,7 @@ var (
 			{
 				Name:    "chargeflatfee_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeFlatFeesColumns[14], ChargeFlatFeesColumns[34], ChargeFlatFeesColumns[8]},
+				Columns: []*schema.Column{ChargeFlatFeesColumns[14], ChargeFlatFeesColumns[35], ChargeFlatFeesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -2349,12 +2352,12 @@ var (
 			{
 				Name:    "chargeflatfees_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeesColumns[39]},
+				Columns: []*schema.Column{ChargeFlatFeesColumns[40]},
 			},
 			{
 				Name:    "chargeflatfees_cost_basis_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeFlatFeesColumns[32]},
+				Columns: []*schema.Column{ChargeFlatFeesColumns[33]},
 			},
 		},
 	}
@@ -2931,6 +2934,7 @@ var (
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
+		{Name: "validation_issues", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "invoice_at", Type: field.TypeTime},
 		{Name: "settlement_mode", Type: field.TypeEnum, Enums: []string{"credit_then_invoice", "credit_only"}},
 		{Name: "intent_deleted_at", Type: field.TypeTime, Nullable: true},
@@ -2958,55 +2962,55 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_charge_usage_based_runs_current_run",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[30]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_cost_basis_charge_fk",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
 				RefColumns: []*schema.Column{ChargeUsageBasedCostBasesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_custom_currencies_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
 				RefColumns: []*schema.Column{CustomCurrenciesColumns[0]},
 				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_usage_based_customers_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[34]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_features_usage_based_charges",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[34]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_subscriptions_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[36]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_items_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[36]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[37]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_phases_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[37]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[38]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_tax_codes_charge_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[38]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[39]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3015,7 +3019,7 @@ var (
 			{
 				Name:    "chargeusagebased_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[33], ChargeUsageBasedColumns[8]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[34], ChargeUsageBasedColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -3048,12 +3052,12 @@ var (
 			{
 				Name:    "chargeusagebased_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[38]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[39]},
 			},
 			{
 				Name:    "chargeusagebased_cost_basis_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[31]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[32]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -29950,6 +29950,7 @@ type BillingInvoiceValidationIssueMutation struct {
 	message                *string
 	_path                  *string
 	component              *string
+	attributes             *models.Annotations
 	dedupe_hash            *[]byte
 	clearedFields          map[string]struct{}
 	billing_invoice        *string
@@ -30462,6 +30463,55 @@ func (m *BillingInvoiceValidationIssueMutation) ResetComponent() {
 	m.component = nil
 }
 
+// SetAttributes sets the "attributes" field.
+func (m *BillingInvoiceValidationIssueMutation) SetAttributes(value models.Annotations) {
+	m.attributes = &value
+}
+
+// Attributes returns the value of the "attributes" field in the mutation.
+func (m *BillingInvoiceValidationIssueMutation) Attributes() (r models.Annotations, exists bool) {
+	v := m.attributes
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAttributes returns the old "attributes" field's value of the BillingInvoiceValidationIssue entity.
+// If the BillingInvoiceValidationIssue object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceValidationIssueMutation) OldAttributes(ctx context.Context) (v models.Annotations, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAttributes is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAttributes requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAttributes: %w", err)
+	}
+	return oldValue.Attributes, nil
+}
+
+// ClearAttributes clears the value of the "attributes" field.
+func (m *BillingInvoiceValidationIssueMutation) ClearAttributes() {
+	m.attributes = nil
+	m.clearedFields[billinginvoicevalidationissue.FieldAttributes] = struct{}{}
+}
+
+// AttributesCleared returns if the "attributes" field was cleared in this mutation.
+func (m *BillingInvoiceValidationIssueMutation) AttributesCleared() bool {
+	_, ok := m.clearedFields[billinginvoicevalidationissue.FieldAttributes]
+	return ok
+}
+
+// ResetAttributes resets all changes to the "attributes" field.
+func (m *BillingInvoiceValidationIssueMutation) ResetAttributes() {
+	m.attributes = nil
+	delete(m.clearedFields, billinginvoicevalidationissue.FieldAttributes)
+}
+
 // SetDedupeHash sets the "dedupe_hash" field.
 func (m *BillingInvoiceValidationIssueMutation) SetDedupeHash(b []byte) {
 	m.dedupe_hash = &b
@@ -30572,7 +30622,7 @@ func (m *BillingInvoiceValidationIssueMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BillingInvoiceValidationIssueMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.namespace != nil {
 		fields = append(fields, billinginvoicevalidationissue.FieldNamespace)
 	}
@@ -30602,6 +30652,9 @@ func (m *BillingInvoiceValidationIssueMutation) Fields() []string {
 	}
 	if m.component != nil {
 		fields = append(fields, billinginvoicevalidationissue.FieldComponent)
+	}
+	if m.attributes != nil {
+		fields = append(fields, billinginvoicevalidationissue.FieldAttributes)
 	}
 	if m.dedupe_hash != nil {
 		fields = append(fields, billinginvoicevalidationissue.FieldDedupeHash)
@@ -30634,6 +30687,8 @@ func (m *BillingInvoiceValidationIssueMutation) Field(name string) (ent.Value, b
 		return m.Path()
 	case billinginvoicevalidationissue.FieldComponent:
 		return m.Component()
+	case billinginvoicevalidationissue.FieldAttributes:
+		return m.Attributes()
 	case billinginvoicevalidationissue.FieldDedupeHash:
 		return m.DedupeHash()
 	}
@@ -30665,6 +30720,8 @@ func (m *BillingInvoiceValidationIssueMutation) OldField(ctx context.Context, na
 		return m.OldPath(ctx)
 	case billinginvoicevalidationissue.FieldComponent:
 		return m.OldComponent(ctx)
+	case billinginvoicevalidationissue.FieldAttributes:
+		return m.OldAttributes(ctx)
 	case billinginvoicevalidationissue.FieldDedupeHash:
 		return m.OldDedupeHash(ctx)
 	}
@@ -30746,6 +30803,13 @@ func (m *BillingInvoiceValidationIssueMutation) SetField(name string, value ent.
 		}
 		m.SetComponent(v)
 		return nil
+	case billinginvoicevalidationissue.FieldAttributes:
+		v, ok := value.(models.Annotations)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAttributes(v)
+		return nil
 	case billinginvoicevalidationissue.FieldDedupeHash:
 		v, ok := value.([]byte)
 		if !ok {
@@ -30792,6 +30856,9 @@ func (m *BillingInvoiceValidationIssueMutation) ClearedFields() []string {
 	if m.FieldCleared(billinginvoicevalidationissue.FieldPath) {
 		fields = append(fields, billinginvoicevalidationissue.FieldPath)
 	}
+	if m.FieldCleared(billinginvoicevalidationissue.FieldAttributes) {
+		fields = append(fields, billinginvoicevalidationissue.FieldAttributes)
+	}
 	return fields
 }
 
@@ -30814,6 +30881,9 @@ func (m *BillingInvoiceValidationIssueMutation) ClearField(name string) error {
 		return nil
 	case billinginvoicevalidationissue.FieldPath:
 		m.ClearPath()
+		return nil
+	case billinginvoicevalidationissue.FieldAttributes:
+		m.ClearAttributes()
 		return nil
 	}
 	return fmt.Errorf("unknown BillingInvoiceValidationIssue nullable field %s", name)
@@ -30852,6 +30922,9 @@ func (m *BillingInvoiceValidationIssueMutation) ResetField(name string) error {
 		return nil
 	case billinginvoicevalidationissue.FieldComponent:
 		m.ResetComponent()
+		return nil
+	case billinginvoicevalidationissue.FieldAttributes:
+		m.ResetAttributes()
 		return nil
 	case billinginvoicevalidationissue.FieldDedupeHash:
 		m.ResetDedupeHash()
@@ -39950,6 +40023,8 @@ type ChargeCreditPurchaseMutation struct {
 	deleted_at                        *time.Time
 	name                              *string
 	description                       *string
+	validation_issues                 *billing.ValidationIssues
+	appendvalidation_issues           billing.ValidationIssues
 	schema_level                      *int
 	addschema_level                   *int
 	fiat_cost_basis                   *alpacadecimal.Decimal
@@ -41189,6 +41264,71 @@ func (m *ChargeCreditPurchaseMutation) ResetDescription() {
 	delete(m.clearedFields, chargecreditpurchase.FieldDescription)
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (m *ChargeCreditPurchaseMutation) SetValidationIssues(bi billing.ValidationIssues) {
+	m.validation_issues = &bi
+	m.appendvalidation_issues = nil
+}
+
+// ValidationIssues returns the value of the "validation_issues" field in the mutation.
+func (m *ChargeCreditPurchaseMutation) ValidationIssues() (r billing.ValidationIssues, exists bool) {
+	v := m.validation_issues
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldValidationIssues returns the old "validation_issues" field's value of the ChargeCreditPurchase entity.
+// If the ChargeCreditPurchase object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeCreditPurchaseMutation) OldValidationIssues(ctx context.Context) (v billing.ValidationIssues, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldValidationIssues is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldValidationIssues requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldValidationIssues: %w", err)
+	}
+	return oldValue.ValidationIssues, nil
+}
+
+// AppendValidationIssues adds bi to the "validation_issues" field.
+func (m *ChargeCreditPurchaseMutation) AppendValidationIssues(bi billing.ValidationIssues) {
+	m.appendvalidation_issues = append(m.appendvalidation_issues, bi...)
+}
+
+// AppendedValidationIssues returns the list of values that were appended to the "validation_issues" field in this mutation.
+func (m *ChargeCreditPurchaseMutation) AppendedValidationIssues() (billing.ValidationIssues, bool) {
+	if len(m.appendvalidation_issues) == 0 {
+		return nil, false
+	}
+	return m.appendvalidation_issues, true
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (m *ChargeCreditPurchaseMutation) ClearValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	m.clearedFields[chargecreditpurchase.FieldValidationIssues] = struct{}{}
+}
+
+// ValidationIssuesCleared returns if the "validation_issues" field was cleared in this mutation.
+func (m *ChargeCreditPurchaseMutation) ValidationIssuesCleared() bool {
+	_, ok := m.clearedFields[chargecreditpurchase.FieldValidationIssues]
+	return ok
+}
+
+// ResetValidationIssues resets all changes to the "validation_issues" field.
+func (m *ChargeCreditPurchaseMutation) ResetValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	delete(m.clearedFields, chargecreditpurchase.FieldValidationIssues)
+}
+
 // SetSchemaLevel sets the "schema_level" field.
 func (m *ChargeCreditPurchaseMutation) SetSchemaLevel(i int) {
 	m.schema_level = &i
@@ -42256,7 +42396,7 @@ func (m *ChargeCreditPurchaseMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeCreditPurchaseMutation) Fields() []string {
-	fields := make([]string, 0, 40)
+	fields := make([]string, 0, 41)
 	if m.customer != nil {
 		fields = append(fields, chargecreditpurchase.FieldCustomerID)
 	}
@@ -42334,6 +42474,9 @@ func (m *ChargeCreditPurchaseMutation) Fields() []string {
 	}
 	if m.description != nil {
 		fields = append(fields, chargecreditpurchase.FieldDescription)
+	}
+	if m.validation_issues != nil {
+		fields = append(fields, chargecreditpurchase.FieldValidationIssues)
 	}
 	if m.schema_level != nil {
 		fields = append(fields, chargecreditpurchase.FieldSchemaLevel)
@@ -42437,6 +42580,8 @@ func (m *ChargeCreditPurchaseMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case chargecreditpurchase.FieldDescription:
 		return m.Description()
+	case chargecreditpurchase.FieldValidationIssues:
+		return m.ValidationIssues()
 	case chargecreditpurchase.FieldSchemaLevel:
 		return m.SchemaLevel()
 	case chargecreditpurchase.FieldFiatCostBasis:
@@ -42526,6 +42671,8 @@ func (m *ChargeCreditPurchaseMutation) OldField(ctx context.Context, name string
 		return m.OldName(ctx)
 	case chargecreditpurchase.FieldDescription:
 		return m.OldDescription(ctx)
+	case chargecreditpurchase.FieldValidationIssues:
+		return m.OldValidationIssues(ctx)
 	case chargecreditpurchase.FieldSchemaLevel:
 		return m.OldSchemaLevel(ctx)
 	case chargecreditpurchase.FieldFiatCostBasis:
@@ -42745,6 +42892,13 @@ func (m *ChargeCreditPurchaseMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetDescription(v)
 		return nil
+	case chargecreditpurchase.FieldValidationIssues:
+		v, ok := value.(billing.ValidationIssues)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetValidationIssues(v)
+		return nil
 	case chargecreditpurchase.FieldSchemaLevel:
 		v, ok := value.(int)
 		if !ok {
@@ -42936,6 +43090,9 @@ func (m *ChargeCreditPurchaseMutation) ClearedFields() []string {
 	if m.FieldCleared(chargecreditpurchase.FieldDescription) {
 		fields = append(fields, chargecreditpurchase.FieldDescription)
 	}
+	if m.FieldCleared(chargecreditpurchase.FieldValidationIssues) {
+		fields = append(fields, chargecreditpurchase.FieldValidationIssues)
+	}
 	if m.FieldCleared(chargecreditpurchase.FieldFiatCostBasis) {
 		fields = append(fields, chargecreditpurchase.FieldFiatCostBasis)
 	}
@@ -43018,6 +43175,9 @@ func (m *ChargeCreditPurchaseMutation) ClearField(name string) error {
 		return nil
 	case chargecreditpurchase.FieldDescription:
 		m.ClearDescription()
+		return nil
+	case chargecreditpurchase.FieldValidationIssues:
+		m.ClearValidationIssues()
 		return nil
 	case chargecreditpurchase.FieldFiatCostBasis:
 		m.ClearFiatCostBasis()
@@ -43137,6 +43297,9 @@ func (m *ChargeCreditPurchaseMutation) ResetField(name string) error {
 		return nil
 	case chargecreditpurchase.FieldDescription:
 		m.ResetDescription()
+		return nil
+	case chargecreditpurchase.FieldValidationIssues:
+		m.ResetValidationIssues()
 		return nil
 	case chargecreditpurchase.FieldSchemaLevel:
 		m.ResetSchemaLevel()
@@ -48027,6 +48190,8 @@ type ChargeFlatFeeMutation struct {
 	deleted_at                *time.Time
 	name                      *string
 	description               *string
+	validation_issues         *billing.ValidationIssues
+	appendvalidation_issues   billing.ValidationIssues
 	payment_term              *productcatalog.PaymentTermType
 	invoice_at                *time.Time
 	settlement_mode           *productcatalog.SettlementMode
@@ -49264,6 +49429,71 @@ func (m *ChargeFlatFeeMutation) ResetDescription() {
 	delete(m.clearedFields, chargeflatfee.FieldDescription)
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (m *ChargeFlatFeeMutation) SetValidationIssues(bi billing.ValidationIssues) {
+	m.validation_issues = &bi
+	m.appendvalidation_issues = nil
+}
+
+// ValidationIssues returns the value of the "validation_issues" field in the mutation.
+func (m *ChargeFlatFeeMutation) ValidationIssues() (r billing.ValidationIssues, exists bool) {
+	v := m.validation_issues
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldValidationIssues returns the old "validation_issues" field's value of the ChargeFlatFee entity.
+// If the ChargeFlatFee object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeMutation) OldValidationIssues(ctx context.Context) (v billing.ValidationIssues, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldValidationIssues is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldValidationIssues requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldValidationIssues: %w", err)
+	}
+	return oldValue.ValidationIssues, nil
+}
+
+// AppendValidationIssues adds bi to the "validation_issues" field.
+func (m *ChargeFlatFeeMutation) AppendValidationIssues(bi billing.ValidationIssues) {
+	m.appendvalidation_issues = append(m.appendvalidation_issues, bi...)
+}
+
+// AppendedValidationIssues returns the list of values that were appended to the "validation_issues" field in this mutation.
+func (m *ChargeFlatFeeMutation) AppendedValidationIssues() (billing.ValidationIssues, bool) {
+	if len(m.appendvalidation_issues) == 0 {
+		return nil, false
+	}
+	return m.appendvalidation_issues, true
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (m *ChargeFlatFeeMutation) ClearValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	m.clearedFields[chargeflatfee.FieldValidationIssues] = struct{}{}
+}
+
+// ValidationIssuesCleared returns if the "validation_issues" field was cleared in this mutation.
+func (m *ChargeFlatFeeMutation) ValidationIssuesCleared() bool {
+	_, ok := m.clearedFields[chargeflatfee.FieldValidationIssues]
+	return ok
+}
+
+// ResetValidationIssues resets all changes to the "validation_issues" field.
+func (m *ChargeFlatFeeMutation) ResetValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	delete(m.clearedFields, chargeflatfee.FieldValidationIssues)
+}
+
 // SetPaymentTerm sets the "payment_term" field.
 func (m *ChargeFlatFeeMutation) SetPaymentTerm(ptt productcatalog.PaymentTermType) {
 	m.payment_term = &ptt
@@ -50232,7 +50462,7 @@ func (m *ChargeFlatFeeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeMutation) Fields() []string {
-	fields := make([]string, 0, 39)
+	fields := make([]string, 0, 40)
 	if m.customer != nil {
 		fields = append(fields, chargeflatfee.FieldCustomerID)
 	}
@@ -50310,6 +50540,9 @@ func (m *ChargeFlatFeeMutation) Fields() []string {
 	}
 	if m.description != nil {
 		fields = append(fields, chargeflatfee.FieldDescription)
+	}
+	if m.validation_issues != nil {
+		fields = append(fields, chargeflatfee.FieldValidationIssues)
 	}
 	if m.payment_term != nil {
 		fields = append(fields, chargeflatfee.FieldPaymentTerm)
@@ -50410,6 +50643,8 @@ func (m *ChargeFlatFeeMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case chargeflatfee.FieldDescription:
 		return m.Description()
+	case chargeflatfee.FieldValidationIssues:
+		return m.ValidationIssues()
 	case chargeflatfee.FieldPaymentTerm:
 		return m.PaymentTerm()
 	case chargeflatfee.FieldInvoiceAt:
@@ -50497,6 +50732,8 @@ func (m *ChargeFlatFeeMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldName(ctx)
 	case chargeflatfee.FieldDescription:
 		return m.OldDescription(ctx)
+	case chargeflatfee.FieldValidationIssues:
+		return m.OldValidationIssues(ctx)
 	case chargeflatfee.FieldPaymentTerm:
 		return m.OldPaymentTerm(ctx)
 	case chargeflatfee.FieldInvoiceAt:
@@ -50714,6 +50951,13 @@ func (m *ChargeFlatFeeMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetDescription(v)
 		return nil
+	case chargeflatfee.FieldValidationIssues:
+		v, ok := value.(billing.ValidationIssues)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetValidationIssues(v)
+		return nil
 	case chargeflatfee.FieldPaymentTerm:
 		v, ok := value.(productcatalog.PaymentTermType)
 		if !ok {
@@ -50871,6 +51115,9 @@ func (m *ChargeFlatFeeMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeflatfee.FieldDescription) {
 		fields = append(fields, chargeflatfee.FieldDescription)
 	}
+	if m.FieldCleared(chargeflatfee.FieldValidationIssues) {
+		fields = append(fields, chargeflatfee.FieldValidationIssues)
+	}
 	if m.FieldCleared(chargeflatfee.FieldIntentDeletedAt) {
 		fields = append(fields, chargeflatfee.FieldIntentDeletedAt)
 	}
@@ -50938,6 +51185,9 @@ func (m *ChargeFlatFeeMutation) ClearField(name string) error {
 		return nil
 	case chargeflatfee.FieldDescription:
 		m.ClearDescription()
+		return nil
+	case chargeflatfee.FieldValidationIssues:
+		m.ClearValidationIssues()
 		return nil
 	case chargeflatfee.FieldIntentDeletedAt:
 		m.ClearIntentDeletedAt()
@@ -51042,6 +51292,9 @@ func (m *ChargeFlatFeeMutation) ResetField(name string) error {
 		return nil
 	case chargeflatfee.FieldDescription:
 		m.ResetDescription()
+		return nil
+	case chargeflatfee.FieldValidationIssues:
+		m.ResetValidationIssues()
 		return nil
 	case chargeflatfee.FieldPaymentTerm:
 		m.ResetPaymentTerm()
@@ -64097,6 +64350,8 @@ type ChargeUsageBasedMutation struct {
 	deleted_at                *time.Time
 	name                      *string
 	description               *string
+	validation_issues         *billing.ValidationIssues
+	appendvalidation_issues   billing.ValidationIssues
 	invoice_at                *time.Time
 	settlement_mode           *productcatalog.SettlementMode
 	intent_deleted_at         *time.Time
@@ -65336,6 +65591,71 @@ func (m *ChargeUsageBasedMutation) ResetDescription() {
 	delete(m.clearedFields, chargeusagebased.FieldDescription)
 }
 
+// SetValidationIssues sets the "validation_issues" field.
+func (m *ChargeUsageBasedMutation) SetValidationIssues(bi billing.ValidationIssues) {
+	m.validation_issues = &bi
+	m.appendvalidation_issues = nil
+}
+
+// ValidationIssues returns the value of the "validation_issues" field in the mutation.
+func (m *ChargeUsageBasedMutation) ValidationIssues() (r billing.ValidationIssues, exists bool) {
+	v := m.validation_issues
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldValidationIssues returns the old "validation_issues" field's value of the ChargeUsageBased entity.
+// If the ChargeUsageBased object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedMutation) OldValidationIssues(ctx context.Context) (v billing.ValidationIssues, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldValidationIssues is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldValidationIssues requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldValidationIssues: %w", err)
+	}
+	return oldValue.ValidationIssues, nil
+}
+
+// AppendValidationIssues adds bi to the "validation_issues" field.
+func (m *ChargeUsageBasedMutation) AppendValidationIssues(bi billing.ValidationIssues) {
+	m.appendvalidation_issues = append(m.appendvalidation_issues, bi...)
+}
+
+// AppendedValidationIssues returns the list of values that were appended to the "validation_issues" field in this mutation.
+func (m *ChargeUsageBasedMutation) AppendedValidationIssues() (billing.ValidationIssues, bool) {
+	if len(m.appendvalidation_issues) == 0 {
+		return nil, false
+	}
+	return m.appendvalidation_issues, true
+}
+
+// ClearValidationIssues clears the value of the "validation_issues" field.
+func (m *ChargeUsageBasedMutation) ClearValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	m.clearedFields[chargeusagebased.FieldValidationIssues] = struct{}{}
+}
+
+// ValidationIssuesCleared returns if the "validation_issues" field was cleared in this mutation.
+func (m *ChargeUsageBasedMutation) ValidationIssuesCleared() bool {
+	_, ok := m.clearedFields[chargeusagebased.FieldValidationIssues]
+	return ok
+}
+
+// ResetValidationIssues resets all changes to the "validation_issues" field.
+func (m *ChargeUsageBasedMutation) ResetValidationIssues() {
+	m.validation_issues = nil
+	m.appendvalidation_issues = nil
+	delete(m.clearedFields, chargeusagebased.FieldValidationIssues)
+}
+
 // SetInvoiceAt sets the "invoice_at" field.
 func (m *ChargeUsageBasedMutation) SetInvoiceAt(t time.Time) {
 	m.invoice_at = &t
@@ -66309,7 +66629,7 @@ func (m *ChargeUsageBasedMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedMutation) Fields() []string {
-	fields := make([]string, 0, 38)
+	fields := make([]string, 0, 39)
 	if m.customer != nil {
 		fields = append(fields, chargeusagebased.FieldCustomerID)
 	}
@@ -66387,6 +66707,9 @@ func (m *ChargeUsageBasedMutation) Fields() []string {
 	}
 	if m.description != nil {
 		fields = append(fields, chargeusagebased.FieldDescription)
+	}
+	if m.validation_issues != nil {
+		fields = append(fields, chargeusagebased.FieldValidationIssues)
 	}
 	if m.invoice_at != nil {
 		fields = append(fields, chargeusagebased.FieldInvoiceAt)
@@ -66484,6 +66807,8 @@ func (m *ChargeUsageBasedMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case chargeusagebased.FieldDescription:
 		return m.Description()
+	case chargeusagebased.FieldValidationIssues:
+		return m.ValidationIssues()
 	case chargeusagebased.FieldInvoiceAt:
 		return m.InvoiceAt()
 	case chargeusagebased.FieldSettlementMode:
@@ -66569,6 +66894,8 @@ func (m *ChargeUsageBasedMutation) OldField(ctx context.Context, name string) (e
 		return m.OldName(ctx)
 	case chargeusagebased.FieldDescription:
 		return m.OldDescription(ctx)
+	case chargeusagebased.FieldValidationIssues:
+		return m.OldValidationIssues(ctx)
 	case chargeusagebased.FieldInvoiceAt:
 		return m.OldInvoiceAt(ctx)
 	case chargeusagebased.FieldSettlementMode:
@@ -66784,6 +67111,13 @@ func (m *ChargeUsageBasedMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetDescription(v)
 		return nil
+	case chargeusagebased.FieldValidationIssues:
+		v, ok := value.(billing.ValidationIssues)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetValidationIssues(v)
+		return nil
 	case chargeusagebased.FieldInvoiceAt:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -66934,6 +67268,9 @@ func (m *ChargeUsageBasedMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebased.FieldDescription) {
 		fields = append(fields, chargeusagebased.FieldDescription)
 	}
+	if m.FieldCleared(chargeusagebased.FieldValidationIssues) {
+		fields = append(fields, chargeusagebased.FieldValidationIssues)
+	}
 	if m.FieldCleared(chargeusagebased.FieldIntentDeletedAt) {
 		fields = append(fields, chargeusagebased.FieldIntentDeletedAt)
 	}
@@ -66998,6 +67335,9 @@ func (m *ChargeUsageBasedMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebased.FieldDescription:
 		m.ClearDescription()
+		return nil
+	case chargeusagebased.FieldValidationIssues:
+		m.ClearValidationIssues()
 		return nil
 	case chargeusagebased.FieldIntentDeletedAt:
 		m.ClearIntentDeletedAt()
@@ -67099,6 +67439,9 @@ func (m *ChargeUsageBasedMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebased.FieldDescription:
 		m.ResetDescription()
+		return nil
+	case chargeusagebased.FieldValidationIssues:
+		m.ResetValidationIssues()
 		return nil
 	case chargeusagebased.FieldInvoiceAt:
 		m.ResetInvoiceAt()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -830,7 +830,7 @@ func init() {
 	// billinginvoicevalidationissue.MessageValidator is a validator for the "message" field. It is called by the builders before save.
 	billinginvoicevalidationissue.MessageValidator = billinginvoicevalidationissueDescMessage.Validators[0].(func(string) error)
 	// billinginvoicevalidationissueDescDedupeHash is the schema descriptor for dedupe_hash field.
-	billinginvoicevalidationissueDescDedupeHash := billinginvoicevalidationissueFields[6].Descriptor()
+	billinginvoicevalidationissueDescDedupeHash := billinginvoicevalidationissueFields[7].Descriptor()
 	// billinginvoicevalidationissue.DedupeHashValidator is a validator for the "dedupe_hash" field. It is called by the builders before save.
 	billinginvoicevalidationissue.DedupeHashValidator = func() func([]byte) error {
 		validators := billinginvoicevalidationissueDescDedupeHash.Validators

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -2108,6 +2108,20 @@ func (u *BillingInvoiceValidationIssueUpdateOne) SetOrClearPath(value *string) *
 	return u.SetPath(*value)
 }
 
+func (u *BillingInvoiceValidationIssueUpdate) SetOrClearAttributes(value *models.Annotations) *BillingInvoiceValidationIssueUpdate {
+	if value == nil {
+		return u.ClearAttributes()
+	}
+	return u.SetAttributes(*value)
+}
+
+func (u *BillingInvoiceValidationIssueUpdateOne) SetOrClearAttributes(value *models.Annotations) *BillingInvoiceValidationIssueUpdateOne {
+	if value == nil {
+		return u.ClearAttributes()
+	}
+	return u.SetAttributes(*value)
+}
+
 func (u *BillingProfileUpdate) SetOrClearMetadata(value *map[string]string) *BillingProfileUpdate {
 	if value == nil {
 		return u.ClearMetadata()
@@ -2612,6 +2626,20 @@ func (u *ChargeCreditPurchaseUpdateOne) SetOrClearDescription(value *string) *Ch
 	return u.SetDescription(*value)
 }
 
+func (u *ChargeCreditPurchaseUpdate) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeCreditPurchaseUpdate {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
+}
+
+func (u *ChargeCreditPurchaseUpdateOne) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeCreditPurchaseUpdateOne {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
+}
+
 func (u *ChargeCreditPurchaseUpdate) SetOrClearFiatCostBasis(value *alpacadecimal.Decimal) *ChargeCreditPurchaseUpdate {
 	if value == nil {
 		return u.ClearFiatCostBasis()
@@ -3016,6 +3044,20 @@ func (u *ChargeFlatFeeUpdateOne) SetOrClearDescription(value *string) *ChargeFla
 		return u.ClearDescription()
 	}
 	return u.SetDescription(*value)
+}
+
+func (u *ChargeFlatFeeUpdate) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeFlatFeeUpdate {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
+}
+
+func (u *ChargeFlatFeeUpdateOne) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeFlatFeeUpdateOne {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
 }
 
 func (u *ChargeFlatFeeUpdate) SetOrClearIntentDeletedAt(value *time.Time) *ChargeFlatFeeUpdate {
@@ -3730,6 +3772,20 @@ func (u *ChargeUsageBasedUpdateOne) SetOrClearDescription(value *string) *Charge
 		return u.ClearDescription()
 	}
 	return u.SetDescription(*value)
+}
+
+func (u *ChargeUsageBasedUpdate) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeUsageBasedUpdate {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
+}
+
+func (u *ChargeUsageBasedUpdateOne) SetOrClearValidationIssues(value *billing.ValidationIssues) *ChargeUsageBasedUpdateOne {
+	if value == nil {
+		return u.ClearValidationIssues()
+	}
+	return u.SetValidationIssues(*value)
 }
 
 func (u *ChargeUsageBasedUpdate) SetOrClearIntentDeletedAt(value *time.Time) *ChargeUsageBasedUpdate {

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var (
@@ -1455,6 +1456,12 @@ func (BillingInvoiceValidationIssue) Fields() []ent.Field {
 			Nillable(),
 
 		field.String("component"),
+
+		field.JSON("attributes", models.Annotations{}).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional(),
 
 		field.Bytes("dedupe_hash").
 			MinLen(32).

--- a/openmeter/ent/schema/charges.go
+++ b/openmeter/ent/schema/charges.go
@@ -21,6 +21,20 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
+type ChargeValidationIssuesMixin struct {
+	mixin.Schema
+}
+
+func (ChargeValidationIssuesMixin) Fields() []ent.Field {
+	return []ent.Field{
+		field.JSON("validation_issues", billing.ValidationIssues(nil)).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional(),
+	}
+}
+
 var chargesSearchV1Columns = []string{
 	"id",
 	"namespace",

--- a/openmeter/ent/schema/chargescreditpurchase.go
+++ b/openmeter/ent/schema/chargescreditpurchase.go
@@ -23,6 +23,7 @@ type ChargeCreditPurchase struct {
 func (ChargeCreditPurchase) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		ChargesMetaMixin{},
+		ChargeValidationIssuesMixin{},
 	}
 }
 

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -29,6 +29,7 @@ type ChargeFlatFee struct {
 func (ChargeFlatFee) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		ChargesMetaMixin{},
+		ChargeValidationIssuesMixin{},
 	}
 }
 

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -29,6 +29,7 @@ type ChargeUsageBased struct {
 func (ChargeUsageBased) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		ChargesMetaMixin{},
+		ChargeValidationIssuesMixin{},
 	}
 }
 

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1189,7 +1189,7 @@ func (s *InvoicingTestSuite) TestStatusDetailsSimulationDoesNotMutatePaymentProc
 }
 
 type ValidationIssueIntrospector interface {
-	IntrospectValidationIssues(ctx context.Context, invoice billing.InvoiceID) ([]billingadapter.ValidationIssueWithDBMeta, error)
+	IntrospectValidationIssues(ctx context.Context, invoice billing.InvoiceID) (billing.ValidationIssues, error)
 }
 
 func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
@@ -1218,12 +1218,21 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 			advance: func(t *testing.T, ctx context.Context, ns string, customer *customer.Customer, mockApp *appsandbox.MockApp) *billing.StandardInvoice {
 				calcMock := s.InvoiceCalculator.EnableMock()
 				defer s.InvoiceCalculator.DisableMock(t)
+				validationAttributes := models.Annotations{
+					"invoice": "invoice-context",
+					"line":    "line-context",
+				}
 
 				validationIssueGetter, ok := s.BillingAdapter.(ValidationIssueIntrospector)
 				require.True(t, ok)
 
 				// Given that the app will return a validation error
-				mockApp.OnValidateStandardInvoice(billing.NewValidationError("test1", "validation error"))
+				mockApp.OnValidateStandardInvoice(billing.ValidationIssue{
+					Severity:   billing.ValidationIssueSeverityCritical,
+					Code:       "test1",
+					Message:    "validation error",
+					Attributes: validationAttributes,
+				})
 				calcMock.OnCalculate(nil)
 				calcMock.OnCalculateGatheringInvoice(nil)
 
@@ -1249,10 +1258,11 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				}, invoice.StatusDetails)
 				require.Equal(s.T(), billing.ValidationIssues{
 					{
-						Severity:  billing.ValidationIssueSeverityCritical,
-						Code:      "test1",
-						Message:   "validation error",
-						Component: "app.sandbox.invoiceCustomers.validate",
+						Severity:   billing.ValidationIssueSeverityCritical,
+						Code:       "test1",
+						Message:    "validation error",
+						Component:  "app.sandbox.invoiceCustomers.validate",
+						Attributes: validationAttributes,
 					},
 				}, invoice.ValidationIssues.RemoveMetaForCompare())
 
@@ -1265,12 +1275,13 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				require.Len(t, issues, 1)
 				require.Equal(t,
 					billing.ValidationIssue{
-						Severity:  billing.ValidationIssueSeverityCritical,
-						Code:      "test1",
-						Message:   "validation error",
-						Component: "app.sandbox.invoiceCustomers.validate",
+						Severity:   billing.ValidationIssueSeverityCritical,
+						Code:       "test1",
+						Message:    "validation error",
+						Component:  "app.sandbox.invoiceCustomers.validate",
+						Attributes: validationAttributes,
 					},
-					issues[0].ValidationIssue,
+					billing.ValidationIssues{issues[0]}.RemoveMetaForCompare()[0],
 				)
 				require.Nil(t, issues[0].DeletedAt)
 				customerValidationIssueID := issues[0].ID
@@ -1323,39 +1334,41 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				require.Len(t, issues, 3)
 
 				// The old issue should be deleted
-				invoiceIssue, ok := lo.Find(issues, func(i billingadapter.ValidationIssueWithDBMeta) bool {
+				invoiceIssue, ok := lo.Find(issues, func(i billing.ValidationIssue) bool {
 					return i.ID == customerValidationIssueID
 				})
 				require.True(t, ok, "old issue should be present")
 				require.NotNil(t, invoiceIssue.DeletedAt)
 				require.Equal(t,
 					billing.ValidationIssue{
-						Severity:  billing.ValidationIssueSeverityCritical,
-						Code:      "test1",
-						Message:   "validation error",
-						Component: "app.sandbox.invoiceCustomers.validate",
+						Severity:   billing.ValidationIssueSeverityCritical,
+						Code:       "test1",
+						Message:    "validation error",
+						Component:  "app.sandbox.invoiceCustomers.validate",
+						Attributes: validationAttributes,
 					},
-					invoiceIssue.ValidationIssue,
+					billing.ValidationIssues{invoiceIssue}.RemoveMetaForCompare()[0],
 				)
 
 				// A new version of the issue is present with downgraded severity, to facilitate the retry
-				downgradedIssue, ok := lo.Find(issues, func(i billingadapter.ValidationIssueWithDBMeta) bool {
+				downgradedIssue, ok := lo.Find(issues, func(i billing.ValidationIssue) bool {
 					return i.Code == "test1" && i.Severity == billing.ValidationIssueSeverityWarning
 				})
 				require.True(t, ok, "the issue should be present")
 				require.NotNil(t, downgradedIssue.DeletedAt)
 				require.Equal(t,
 					billing.ValidationIssue{
-						Severity:  billing.ValidationIssueSeverityWarning,
-						Code:      "test1",
-						Message:   "validation error",
-						Component: "app.sandbox.invoiceCustomers.validate",
+						Severity:   billing.ValidationIssueSeverityWarning,
+						Code:       "test1",
+						Message:    "validation error",
+						Component:  "app.sandbox.invoiceCustomers.validate",
+						Attributes: validationAttributes,
 					},
-					downgradedIssue.ValidationIssue,
+					billing.ValidationIssues{downgradedIssue}.RemoveMetaForCompare()[0],
 				)
 
 				// The new issue should not be deleted
-				calculationErrorIssue, ok := lo.Find(issues, func(i billingadapter.ValidationIssueWithDBMeta) bool {
+				calculationErrorIssue, ok := lo.Find(issues, func(i billing.ValidationIssue) bool {
 					return i.Code == "test2"
 				})
 				require.True(t, ok, "new issue should be present")
@@ -1366,14 +1379,19 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 						Message:   "validation error",
 						Component: "openmeter",
 					},
-					calculationErrorIssue.ValidationIssue,
+					billing.ValidationIssues{calculationErrorIssue}.RemoveMetaForCompare()[0],
 				)
 
 				mockApp.Reset(t)
 				calcMock.Reset(t)
 
 				// Given that both issues are present, both will be reported
-				mockApp.OnValidateStandardInvoice(billing.NewValidationError("test1", "validation error"))
+				mockApp.OnValidateStandardInvoice(billing.ValidationIssue{
+					Severity:   billing.ValidationIssueSeverityCritical,
+					Code:       "test1",
+					Message:    "validation error",
+					Attributes: validationAttributes,
+				})
 				calcMock.OnCalculate(billing.NewValidationError("test2", "validation error"))
 
 				// regardless the state transition will be the same for now.
@@ -1399,10 +1417,11 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				}, invoice.StatusDetails)
 				require.ElementsMatch(s.T(), billing.ValidationIssues{
 					{
-						Severity:  billing.ValidationIssueSeverityCritical,
-						Code:      "test1",
-						Message:   "validation error",
-						Component: "app.sandbox.invoiceCustomers.validate",
+						Severity:   billing.ValidationIssueSeverityCritical,
+						Code:       "test1",
+						Message:    "validation error",
+						Component:  "app.sandbox.invoiceCustomers.validate",
+						Attributes: validationAttributes,
 					},
 					{
 						Severity:  billing.ValidationIssueSeverityCritical,
@@ -1418,12 +1437,12 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 					ID:        invoice.ID,
 				})
 				require.NoError(t, err)
-				criticalIssues := lo.Filter(issues, func(i billingadapter.ValidationIssueWithDBMeta, _ int) bool {
+				criticalIssues := lo.Filter(issues, func(i billing.ValidationIssue, _ int) bool {
 					return i.Severity == billing.ValidationIssueSeverityCritical
 				})
 				require.Len(t, criticalIssues, 2)
 
-				_, deletedIssueFound := lo.Find(criticalIssues, func(i billingadapter.ValidationIssueWithDBMeta) bool {
+				_, deletedIssueFound := lo.Find(criticalIssues, func(i billing.ValidationIssue) bool {
 					return i.DeletedAt != nil
 				})
 				require.False(t, deletedIssueFound, "no issues should be deleted")

--- a/tools/migrate/migrations/20260906100323_add_charge_and_billing_validation_issues.down.sql
+++ b/tools/migrate/migrations/20260906100323_add_charge_and_billing_validation_issues.down.sql
@@ -1,0 +1,8 @@
+-- reverse: modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" DROP COLUMN "validation_issues";
+-- reverse: modify "charge_flat_fees" table
+ALTER TABLE "charge_flat_fees" DROP COLUMN "validation_issues";
+-- reverse: modify "charge_credit_purchases" table
+ALTER TABLE "charge_credit_purchases" DROP COLUMN "validation_issues";
+-- reverse: modify "billing_invoice_validation_issues" table
+ALTER TABLE "billing_invoice_validation_issues" DROP COLUMN "attributes";

--- a/tools/migrate/migrations/20260906100323_add_charge_and_billing_validation_issues.up.sql
+++ b/tools/migrate/migrations/20260906100323_add_charge_and_billing_validation_issues.up.sql
@@ -1,0 +1,8 @@
+-- modify "billing_invoice_validation_issues" table
+ALTER TABLE "billing_invoice_validation_issues" ADD COLUMN "attributes" jsonb NULL;
+-- modify "charge_credit_purchases" table
+ALTER TABLE "charge_credit_purchases" ADD COLUMN "validation_issues" jsonb NULL;
+-- modify "charge_flat_fees" table
+ALTER TABLE "charge_flat_fees" ADD COLUMN "validation_issues" jsonb NULL;
+-- modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ADD COLUMN "validation_issues" jsonb NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QgL30XoPBU6sbsAb/iH5uJ4anqWp3vaz71vKOh1aBZg=
+h1:vP1Tw1GzBUtg4eaBa5aTImcQqtUn6z59OzODJ2pEt5w=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -277,3 +277,4 @@ h1:QgL30XoPBU6sbsAb/iH5uJ4anqWp3vaz71vKOh1aBZg=
 20260827103408_add_charge_overage_preparation_state.up.sql h1:BmCUpvxwwWOPo4OhPJoB32kELVamexLpaOlGQqbvRPc=
 20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=
 20260903102842_add_lineage_custom_currency_identity.up.sql h1:KHYAUoTB7vwPQ/wsLAoRCm5gQGml5L1t3QExsZdwKWE=
+20260906100323_add_charge_and_billing_validation_issues.up.sql h1:nHSiTwJq6s7c3SU1CV103bpnPf2Nsi3zLm6UIIyF8sA=


### PR DESCRIPTION
## Overview

- add contextual attributes to billing validation issues, including nested wrapper merging with outermost precedence
- persist validation issue attributes on invoices and validation issues on all charge types
- normalize empty charge validation issue collections to SQL NULL and omit them from domain JSON
- add the Ent schema, generated code, consolidated migration, and focused coverage

## Notes for reviewer

This is a self-contained change based directly on `main`. There is no Jira ticket.

Validation performed:

- `go test ./openmeter/billing/... ./api/v3/handlers/billinginvoices/...`
- `make lint-go-fast GO_LINT_PATH=./openmeter/billing/...`
- `make migrate-check-lint migrate-check-validate`
- `git diff --check`

The charge validation issue column remains nullable; empty issue collections are persisted as SQL NULL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation issues now include contextual attributes and preserve them through invoices, charges, persistence, cloning, and error responses.
  * Added support for viewing and retrieving validation issues across flat-fee, credit-purchase, and usage-based charges.
  * Validation issue matching and deduplication now account for issue codes and attributes.
* **Bug Fixes**
  * Improved validation issue persistence and propagation during charge updates, deletion, and invoice activation.
  * Added safeguards and error handling for cloning and attribute processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds contextual attributes to billing validation issues and persists validation issues for invoices and all charge types.
- Implements outermost-precedence attribute merging and deep cloning.
- Includes attributes in invoice issue deduplication and API conversion.
- Adds nullable JSONB storage and generated Ent mappings for charge validation issues.
- Normalizes empty charge issue collections to SQL NULL and omits them from domain JSON.
- Adds focused domain, adapter, API conversion, and invoice lifecycle coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, migration, or repository-rule violations identified.

Attribute precedence, cloning, deduplication, nullable persistence, database rehydration, and JSON omission behavior are internally consistent across the changed domain, adapter, schema, and API layers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/validationissue.go | Adds validation issue attributes, wrapper merging with outermost precedence, deep cloning, and code-based error identity. |
| openmeter/billing/adapter/validationissue.go | Persists invoice issue attributes and incorporates them into deterministic deduplication hashes. |
| openmeter/billing/charges/models/chargemeta/model.go | Maps charge validation issues between domain and Ent representations while normalizing empty collections to SQL NULL. |
| openmeter/ent/schema/charges.go | Defines the reusable nullable JSONB validation issue field for all charge schemas. |
| openmeter/ent/schema/billing.go | Adds nullable contextual attributes to persisted invoice validation issues. |
| tools/migrate/migrations/20260906100323_add_charge_and_billing_validation_issues.up.sql | Adds the nullable JSONB columns required by the updated invoice and charge persistence mappings. |
| api/v3/handlers/billinginvoices/convert.go | Exposes non-empty validation issue attributes through the billing invoice API representation. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  E[Validation error] --> W[Context wrappers]
  W --> X[Extract validation issues]
  X --> D[Domain invoice or charge]
  D --> P{Persistence target}
  P -->|Invoice| I[Invoice validation issue rows]
  P -->|Charge| C[Nullable validation_issues JSONB]
  I --> A[Invoice API validation issues]
  C --> R[Reloaded charge domain model]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(billing): persist charge validation..."](https://github.com/openmeterio/openmeter/commit/18518aef5f27b91cdd6aee2fc33c48c5a914a492) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60965485)</sub>

<!-- /greptile_comment -->