### PR TITLE
feat(billing): gate gathering line invoice assignment

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -74,6 +74,13 @@ owns the line-specific calculations and lifecycle side effects for the lines
 routed to it. The built-in invoicing engine handles billing-native lines;
 charge engines handle charge-backed lines.
 
+Before splitting or materializing otherwise billable gathering lines, billing
+asks each line engine to gate their invoice assignment. Blocked lines remain on
+the gathering invoice and do not consume the invoice line limit. A gate may
+persist engine-owned state explaining its decision; when every candidate is
+blocked, collection succeeds without creating an invoice so those writes can
+commit. Gate errors abort collection and roll back its writes.
+
 Engine callbacks operate on groups of lines. When a callback replaces lines,
 billing requires it to preserve the input line IDs before accepting the
 result. API-originated line edits and system-originated reconciliation are

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -34,6 +34,10 @@ func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineB
 	return true, nil
 }
 
+func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	return nil, nil
+}
+
 func (e *LineEngine) SplitGatheringLine(_ context.Context, _ billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
 	return billing.SplitGatheringLineResult{}, fmt.Errorf("credit purchase line is not progressively billed")
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -36,6 +36,10 @@ func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineB
 	return true, nil
 }
 
+func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	return nil, nil
+}
+
 func (e *LineEngine) SplitGatheringLine(context.Context, billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
 	return billing.SplitGatheringLineResult{}, fmt.Errorf("flat fee line is not progressively billed")
 }

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -38,6 +38,10 @@ func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineB
 	return !input.AsOf.Before(input.ResolvedBillablePeriod.To), nil
 }
 
+func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	return nil, nil
+}
+
 func (e *LineEngine) SplitGatheringLine(_ context.Context, input billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
 	res := billing.SplitGatheringLineResult{}
 

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -208,6 +208,53 @@ func (i IsLineBillableAsOfInput) Validate() error {
 	return nil
 }
 
+type GateInvoiceAssignmentInput struct {
+	Lines GatheringLines
+}
+
+func (i GateInvoiceAssignmentInput) Validate() error {
+	var errs []error
+
+	if len(i.Lines) == 0 {
+		errs = append(errs, errors.New("lines are required"))
+	}
+
+	if err := i.Lines.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("lines: %w", err))
+	}
+
+	lineIDs := lo.Map(i.Lines, func(line GatheringLine, _ int) LineID {
+		return line.GetLineID()
+	})
+	if len(lo.Uniq(lineIDs)) != len(lineIDs) {
+		errs = append(errs, errors.New("line IDs must be unique"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type InvoiceAssignmentGateResponse struct {
+	ExcludeFromInvoice bool
+}
+
+type GateInvoiceAssignmentResult map[LineID]InvoiceAssignmentGateResponse
+
+func (r GateInvoiceAssignmentResult) Validate(input GateInvoiceAssignmentInput) error {
+	var errs []error
+
+	expectedLineIDs := lo.SliceToMap(input.Lines, func(line GatheringLine) (LineID, struct{}) {
+		return line.GetLineID(), struct{}{}
+	})
+
+	for lineID := range r {
+		if _, ok := expectedLineIDs[lineID]; !ok {
+			errs = append(errs, fmt.Errorf("unknown line ID: %s/%s", lineID.Namespace, lineID.ID))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 type SplitGatheringLineInput struct {
 	Line          GatheringLine
 	FeatureMeters billingfeaturemeter.FeatureMeters
@@ -259,6 +306,10 @@ type LineEngine interface {
 
 	// IsLineBillableAsOf returns true if the line is billable as of the given time.
 	IsLineBillableAsOf(ctx context.Context, input IsLineBillableAsOfInput) (bool, error)
+	// GateInvoiceAssignment decides which otherwise billable gathering lines may be assigned to an invoice.
+	// Implementations may persist engine-owned state explaining blocked decisions. Returning an error aborts
+	// invoice creation and rolls back those writes.
+	GateInvoiceAssignment(ctx context.Context, input GateInvoiceAssignmentInput) (GateInvoiceAssignmentResult, error)
 
 	// SplitGatheringLine splits a gathering line on an engine-specific boundary if required.
 	SplitGatheringLine(ctx context.Context, input SplitGatheringLineInput) (SplitGatheringLineResult, error)

--- a/openmeter/billing/lineengine/stdinvoice.go
+++ b/openmeter/billing/lineengine/stdinvoice.go
@@ -99,3 +99,7 @@ func (e *Engine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBilla
 
 	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
 }
+
+func (e *Engine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	return nil, nil
+}

--- a/openmeter/billing/lineengine_test.go
+++ b/openmeter/billing/lineengine_test.go
@@ -143,7 +143,7 @@ func TestGateInvoiceAssignmentResultValidate(t *testing.T) {
 	})
 
 	t.Run("accepts an empty response", func(t *testing.T) {
-		require.NoError(t, (GateInvoiceAssignmentResult(nil)).Validate(input))
+		require.NoError(t, GateInvoiceAssignmentResult(nil).Validate(input))
 	})
 
 	t.Run("rejects unknown decisions", func(t *testing.T) {

--- a/openmeter/billing/lineengine_test.go
+++ b/openmeter/billing/lineengine_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -98,4 +101,80 @@ func TestIsLineBillableAsOfResultValidate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestGateInvoiceAssignmentInputValidate(t *testing.T) {
+	line := newGateInvoiceAssignmentLine("line-1")
+
+	t.Run("accepts unique lines", func(t *testing.T) {
+		require.NoError(t, (GateInvoiceAssignmentInput{Lines: GatheringLines{line}}).Validate())
+	})
+
+	t.Run("requires lines", func(t *testing.T) {
+		err := (GateInvoiceAssignmentInput{}).Validate()
+
+		require.Error(t, err)
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "lines are required")
+	})
+
+	t.Run("rejects duplicate line IDs", func(t *testing.T) {
+		err := (GateInvoiceAssignmentInput{Lines: GatheringLines{line, line}}).Validate()
+
+		require.Error(t, err)
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "line IDs must be unique")
+	})
+}
+
+func TestGateInvoiceAssignmentResultValidate(t *testing.T) {
+	line1 := newGateInvoiceAssignmentLine("line-1")
+	line2 := newGateInvoiceAssignmentLine("line-2")
+	input := GateInvoiceAssignmentInput{Lines: GatheringLines{line1, line2}}
+
+	t.Run("accepts sparse exclusion responses", func(t *testing.T) {
+		result := GateInvoiceAssignmentResult{
+			line2.GetLineID(): {ExcludeFromInvoice: true},
+		}
+
+		require.NoError(t, result.Validate(input))
+		require.False(t, result[line1.GetLineID()].ExcludeFromInvoice)
+		require.True(t, result[line2.GetLineID()].ExcludeFromInvoice)
+	})
+
+	t.Run("accepts an empty response", func(t *testing.T) {
+		require.NoError(t, (GateInvoiceAssignmentResult(nil)).Validate(input))
+	})
+
+	t.Run("rejects unknown decisions", func(t *testing.T) {
+		unknownLine := newGateInvoiceAssignmentLine("unknown")
+		result := GateInvoiceAssignmentResult{
+			unknownLine.GetLineID(): {},
+		}
+
+		err := result.Validate(input)
+
+		require.Error(t, err)
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "unknown line ID: default/unknown")
+	})
+}
+
+func newGateInvoiceAssignmentLine(id string) GatheringLine {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return NewFlatFeeGatheringLine(NewFlatFeeLineInput{
+		ID:            id,
+		Namespace:     "default",
+		Period:        period,
+		InvoiceAt:     period.To,
+		Name:          id,
+		Currency:      currencyx.FiatCode("USD"),
+		ManagedBy:     ManuallyManagedLine,
+		PerUnitAmount: alpacadecimal.NewFromInt(1),
+		PaymentTerm:   productcatalog.InArrearsPaymentTerm,
+	})
 }

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -205,15 +205,28 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			linesToBeBilledByCurrency := make(map[currencyx.FiatCode]billing.GatheringLines)
+			assignmentCandidateLineCount := 0
+			assignmentExcludedLineCount := 0
 
 			for currency, inScopeLines := range inScopeLinesByCurrency {
-				// Let's first make sure we have properly split the progressively billed
-				// lines into multiple lines on the gathering invoice if needed.
 				gatheringInvoice, ok := invoicesByCurrency[currency]
 				if !ok {
 					return nil, fmt.Errorf("gathering invoice for currency [%s] not found", currency)
 				}
 
+				if len(inScopeLines) == 0 {
+					continue
+				}
+
+				assignmentCandidateLineCount += len(inScopeLines)
+
+				gateResult, err := s.gateInvoiceAssignment(ctx, inScopeLines)
+				if err != nil {
+					return nil, fmt.Errorf("gating invoice assignment for currency [%s]: %w", currency, err)
+				}
+
+				inScopeLines = gateResult.Lines
+				assignmentExcludedLineCount += gateResult.ExcludedLineCount
 				if len(inScopeLines) == 0 {
 					continue
 				}
@@ -252,6 +265,12 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			if totalLinesToBeBilled == 0 {
+				if assignmentCandidateLineCount > 0 && assignmentCandidateLineCount == assignmentExcludedLineCount {
+					return &billing.PrepareBillableLinesResult{
+						LinesByCurrency: linesToBeBilledByCurrency,
+					}, nil
+				}
+
 				return nil, billing.ValidationError{
 					Err: billing.ErrInvoiceCreateNoLines,
 				}
@@ -454,6 +473,69 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 	}
 
 	return res, nil
+}
+
+type gateInvoiceAssignmentResult struct {
+	Lines             []gatheringLineWithBillablePeriod
+	ExcludedLineCount int
+}
+
+func (s *Service) gateInvoiceAssignment(ctx context.Context, lines []gatheringLineWithBillablePeriod) (gateInvoiceAssignmentResult, error) {
+	result := gateInvoiceAssignmentResult{
+		Lines: make([]gatheringLineWithBillablePeriod, 0, len(lines)),
+	}
+
+	if len(lines) == 0 {
+		return result, nil
+	}
+
+	gatheringLines := lo.Map(lines, func(line gatheringLineWithBillablePeriod, _ int) billing.GatheringLine {
+		return line.Line
+	})
+
+	groupedLines, err := s.lineEngines.groupGatheringLinesByEngine(gatheringLines)
+	if err != nil {
+		return gateInvoiceAssignmentResult{}, fmt.Errorf("grouping gathering lines by engine: %w", err)
+	}
+
+	responsesByLineID := make(map[billing.LineID]billing.InvoiceAssignmentGateResponse)
+	for _, grouped := range groupedLines {
+		input := billing.GateInvoiceAssignmentInput{
+			Lines: grouped.Lines,
+		}
+		if err := input.Validate(); err != nil {
+			return gateInvoiceAssignmentResult{}, fmt.Errorf("validating input for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		gateResult, err := grouped.Engine.GateInvoiceAssignment(ctx, input)
+		if err != nil {
+			return gateInvoiceAssignmentResult{}, fmt.Errorf("gating invoice assignment with engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		if err := gateResult.Validate(input); err != nil {
+			return gateInvoiceAssignmentResult{}, fmt.Errorf("validating result from engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		for lineID, response := range gateResult {
+			if _, ok := responsesByLineID[lineID]; ok {
+				return gateInvoiceAssignmentResult{}, fmt.Errorf("line ID returned by multiple engines: %s/%s", lineID.Namespace, lineID.ID)
+			}
+
+			responsesByLineID[lineID] = response
+		}
+	}
+
+	for _, line := range lines {
+		lineID := line.Line.GetLineID()
+		if responsesByLineID[lineID].ExcludeFromInvoice {
+			result.ExcludedLineCount++
+			continue
+		}
+
+		result.Lines = append(result.Lines, line)
+	}
+
+	return result, nil
 }
 
 func limitGatheringLinesForInvoice(lines []gatheringLineWithBillablePeriod, maxLines int) []gatheringLineWithBillablePeriod {

--- a/openmeter/billing/service/gatheringinvoicependinglines_test.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines_test.go
@@ -1,12 +1,18 @@
 package billingservice
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -43,6 +49,104 @@ func TestLimitGatheringLinesForInvoice(t *testing.T) {
 		got := limitGatheringLinesForInvoice(lines, 3)
 
 		require.Equal(t, []string{"earliest", "tie-a", "tie-b"}, gatheringLineIDsForLimitTest(got))
+	})
+}
+
+func TestGateInvoiceAssignment(t *testing.T) {
+	t.Run("filters blocked lines and preserves input order", func(t *testing.T) {
+		invoiceEngine := &syntheticGateLineEngine{
+			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+		}
+		chargeEngine := &syntheticGateLineEngine{
+			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeFlatFee},
+		}
+		invoiceEngine.gate = func(_ context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+			return billing.GateInvoiceAssignmentResult{
+				input.Lines[1].GetLineID(): {ExcludeFromInvoice: true},
+			}, nil
+		}
+
+		service := newGateTestService(t, invoiceEngine, chargeEngine)
+		lines := []gatheringLineWithBillablePeriod{
+			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
+			newGateTestGatheringLine("line-2", billing.LineEngineTypeInvoice),
+			newGateTestGatheringLine("line-3", billing.LineEngineTypeChargeFlatFee),
+		}
+
+		result, err := service.gateInvoiceAssignment(t.Context(), lines)
+
+		require.NoError(t, err)
+		require.Equal(t, 1, result.ExcludedLineCount)
+		require.Equal(t, []string{"line-1", "line-3"}, gatheringLineIDsForLimitTest(result.Lines))
+		require.Len(t, invoiceEngine.inputs, 1)
+		require.Len(t, invoiceEngine.inputs[0].Lines, 2)
+		require.Len(t, chargeEngine.inputs, 1)
+		require.Len(t, chargeEngine.inputs[0].Lines, 1)
+	})
+
+	t.Run("allows an empty candidate set without invoking an engine", func(t *testing.T) {
+		service := &Service{lineEngines: newEngineRegistry()}
+
+		result, err := service.gateInvoiceAssignment(t.Context(), nil)
+
+		require.NoError(t, err)
+		require.Empty(t, result.Lines)
+		require.Zero(t, result.ExcludedLineCount)
+	})
+
+	t.Run("returns gate errors", func(t *testing.T) {
+		gateErr := errors.New("gate failed")
+		engine := &syntheticGateLineEngine{
+			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+			gate: func(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+				return billing.GateInvoiceAssignmentResult{}, gateErr
+			},
+		}
+		service := newGateTestService(t, engine)
+
+		_, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
+			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
+		})
+
+		require.ErrorIs(t, err, gateErr)
+		require.ErrorContains(t, err, "gating invoice assignment with engine invoicing")
+	})
+
+	t.Run("allows omitted responses", func(t *testing.T) {
+		engine := &syntheticGateLineEngine{
+			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+			gate: func(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+				return nil, nil
+			},
+		}
+		service := newGateTestService(t, engine)
+
+		result, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
+			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"line-1"}, gatheringLineIDsForLimitTest(result.Lines))
+		require.Zero(t, result.ExcludedLineCount)
+	})
+
+	t.Run("rejects unknown decisions", func(t *testing.T) {
+		engine := &syntheticGateLineEngine{
+			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+			gate: func(_ context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+				return billing.GateInvoiceAssignmentResult{
+					{Namespace: "default", ID: "unknown"}: {},
+				}, nil
+			},
+		}
+		service := newGateTestService(t, engine)
+
+		_, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
+			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
+		})
+
+		require.ErrorContains(t, err, "validating result from engine invoicing")
+		require.ErrorContains(t, err, "unknown line ID: default/unknown")
 	})
 }
 
@@ -201,4 +305,55 @@ func gatheringLineIDsForLimitTest(lines []gatheringLineWithBillablePeriod) []str
 	}
 
 	return ids
+}
+
+type syntheticGateLineEngine struct {
+	billingtestutils.NoopLineEngine
+
+	gate   func(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error)
+	inputs []billing.GateInvoiceAssignmentInput
+}
+
+func (e *syntheticGateLineEngine) GateInvoiceAssignment(ctx context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	e.inputs = append(e.inputs, input)
+	if e.gate == nil {
+		return nil, nil
+	}
+
+	return e.gate(ctx, input)
+}
+
+func newGateTestService(t *testing.T, engines ...billing.LineEngine) *Service {
+	t.Helper()
+
+	service := &Service{lineEngines: newEngineRegistry()}
+	for _, engine := range engines {
+		require.NoError(t, service.lineEngines.Register(engine))
+	}
+
+	return service
+}
+
+func newGateTestGatheringLine(id string, engineType billing.LineEngineType) gatheringLineWithBillablePeriod {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+		ID:            id,
+		Namespace:     "default",
+		Period:        period,
+		InvoiceAt:     period.To,
+		Name:          id,
+		Currency:      currencyx.FiatCode("USD"),
+		ManagedBy:     billing.ManuallyManagedLine,
+		PerUnitAmount: alpacadecimal.NewFromInt(1),
+		PaymentTerm:   productcatalog.InArrearsPaymentTerm,
+	})
+	line.Engine = engineType
+
+	return gatheringLineWithBillablePeriod{
+		Line:           line,
+		BillablePeriod: period,
+	}
 }

--- a/openmeter/billing/service/gatheringinvoicependinglines_test.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines_test.go
@@ -54,6 +54,7 @@ func TestLimitGatheringLinesForInvoice(t *testing.T) {
 
 func TestGateInvoiceAssignment(t *testing.T) {
 	t.Run("filters blocked lines and preserves input order", func(t *testing.T) {
+		// given
 		invoiceEngine := &syntheticGateLineEngine{
 			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
 		}
@@ -73,8 +74,10 @@ func TestGateInvoiceAssignment(t *testing.T) {
 			newGateTestGatheringLine("line-3", billing.LineEngineTypeChargeFlatFee),
 		}
 
+		// when
 		result, err := service.gateInvoiceAssignment(t.Context(), lines)
 
+		// then
 		require.NoError(t, err)
 		require.Equal(t, 1, result.ExcludedLineCount)
 		require.Equal(t, []string{"line-1", "line-3"}, gatheringLineIDsForLimitTest(result.Lines))
@@ -85,16 +88,20 @@ func TestGateInvoiceAssignment(t *testing.T) {
 	})
 
 	t.Run("allows an empty candidate set without invoking an engine", func(t *testing.T) {
+		// given
 		service := &Service{lineEngines: newEngineRegistry()}
 
+		// when
 		result, err := service.gateInvoiceAssignment(t.Context(), nil)
 
+		// then
 		require.NoError(t, err)
 		require.Empty(t, result.Lines)
 		require.Zero(t, result.ExcludedLineCount)
 	})
 
 	t.Run("returns gate errors", func(t *testing.T) {
+		// given
 		gateErr := errors.New("gate failed")
 		engine := &syntheticGateLineEngine{
 			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
@@ -104,15 +111,18 @@ func TestGateInvoiceAssignment(t *testing.T) {
 		}
 		service := newGateTestService(t, engine)
 
+		// when
 		_, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
 			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
 		})
 
+		// then
 		require.ErrorIs(t, err, gateErr)
 		require.ErrorContains(t, err, "gating invoice assignment with engine invoicing")
 	})
 
 	t.Run("allows omitted responses", func(t *testing.T) {
+		// given
 		engine := &syntheticGateLineEngine{
 			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
 			gate: func(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
@@ -121,16 +131,19 @@ func TestGateInvoiceAssignment(t *testing.T) {
 		}
 		service := newGateTestService(t, engine)
 
+		// when
 		result, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
 			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
 		})
 
+		// then
 		require.NoError(t, err)
 		require.Equal(t, []string{"line-1"}, gatheringLineIDsForLimitTest(result.Lines))
 		require.Zero(t, result.ExcludedLineCount)
 	})
 
 	t.Run("rejects unknown decisions", func(t *testing.T) {
+		// given
 		engine := &syntheticGateLineEngine{
 			NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
 			gate: func(_ context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
@@ -141,10 +154,12 @@ func TestGateInvoiceAssignment(t *testing.T) {
 		}
 		service := newGateTestService(t, engine)
 
+		// when
 		_, err := service.gateInvoiceAssignment(t.Context(), []gatheringLineWithBillablePeriod{
 			newGateTestGatheringLine("line-1", billing.LineEngineTypeInvoice),
 		})
 
+		// then
 		require.ErrorContains(t, err, "validating result from engine invoicing")
 		require.ErrorContains(t, err, "unknown line ID: default/unknown")
 	})

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -26,6 +26,10 @@ func (NoopLineEngine) IsLineBillableAsOf(context.Context, billing.IsLineBillable
 	return true, nil
 }
 
+func (NoopLineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	return nil, nil
+}
+
 func (NoopLineEngine) SplitGatheringLine(_ context.Context, input billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
 	return billing.SplitGatheringLineResult{
 		PreSplitAtLine: input.Line,

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -215,6 +215,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 	defer s.unregisterLineEngine(s.T(), mockEngine)
 
 	s.Run("all otherwise billable lines blocked returns an empty successful result", func() {
+		// given
 		mockEngine.Reset()
 		namespace := s.GetUniqueNamespace("ns-line-engine-gate-all-blocked")
 		customerID, pendingLines := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now, now)
@@ -234,6 +235,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 			return nil, errors.New("blocked lines must not be materialized")
 		}
 
+		// when
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
 			Customer:            customerID,
 			IncludePendingLines: mo.Some(lo.Map(pendingLines, func(line ombilling.GatheringLine, _ int) string { return line.ID })),
@@ -241,6 +243,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 			ForceAsyncAdvance:   true,
 		}, ombilling.WithBypassCollectionAlignment())
 
+		// then
 		s.Require().NoError(err)
 		s.Empty(invoices)
 		s.True(gateCalled)
@@ -248,6 +251,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 	})
 
 	s.Run("no otherwise billable lines preserves ErrInvoiceCreateNoLines", func() {
+		// given
 		mockEngine.Reset()
 		namespace := s.GetUniqueNamespace("ns-line-engine-gate-no-billable-lines")
 		customerID, _ := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now.Add(time.Hour))
@@ -257,12 +261,14 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 			return nil, nil
 		}
 
+		// when
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
 			Customer:          customerID,
 			AsOf:              &now,
 			ForceAsyncAdvance: true,
 		}, ombilling.WithBypassCollectionAlignment())
 
+		// then
 		s.Require().Error(err)
 		s.ErrorIs(err, ombilling.ErrInvoiceCreateNoLines)
 		s.ErrorAs(err, &ombilling.ValidationError{})
@@ -271,6 +277,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 	})
 
 	s.Run("blocked lines do not consume the invoice line limit", func() {
+		// given
 		mockEngine.Reset()
 		namespace := s.GetUniqueNamespace("ns-line-engine-gate-line-limit")
 		customerID, pendingLines := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now.Add(-time.Hour), now)
@@ -284,12 +291,14 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 			return mustAsNewStandardLines(input), nil
 		}
 
+		// when
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
 			Customer:          customerID,
 			AsOf:              &now,
 			ForceAsyncAdvance: true,
 		}, ombilling.WithBypassCollectionAlignment(), ombilling.WithMaxLinesPerInvoice(1))
 
+		// then
 		s.Require().NoError(err)
 		s.Require().Len(invoices, 1)
 		s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
@@ -297,6 +306,7 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 	})
 
 	s.Run("gate errors abort invoice creation", func() {
+		// given
 		mockEngine.Reset()
 		namespace := s.GetUniqueNamespace("ns-line-engine-gate-error")
 		customerID, _ := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now)
@@ -305,12 +315,14 @@ func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
 			return ombilling.GateInvoiceAssignmentResult{}, gateErr
 		}
 
+		// when
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
 			Customer:          customerID,
 			AsOf:              &now,
 			ForceAsyncAdvance: true,
 		}, ombilling.WithBypassCollectionAlignment())
 
+		// then
 		s.Require().ErrorIs(err, gateErr)
 		s.ErrorContains(err, "gating invoice assignment")
 		s.Empty(invoices)

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/invopop/gobl/currency"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
@@ -39,6 +40,7 @@ func TestLineEngine(t *testing.T) {
 type mockCollectionCompletedLineEngine struct {
 	engineType ombilling.LineEngineType
 
+	gateInvoiceAssignment                 func(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error)
 	buildStandardInvoiceLines             func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	buildStandardLinesForGatheringPreview func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	onStandardInvoiceCreated              func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
@@ -75,6 +77,14 @@ func (m *mockCollectionCompletedLineEngine) GetLineEngineType() ombilling.LineEn
 
 func (m *mockCollectionCompletedLineEngine) IsLineBillableAsOf(_ context.Context, input ombilling.IsLineBillableAsOfInput) (bool, error) {
 	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
+}
+
+func (m *mockCollectionCompletedLineEngine) GateInvoiceAssignment(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {
+	if m.gateInvoiceAssignment == nil {
+		return nil, nil
+	}
+
+	return m.gateInvoiceAssignment(ctx, input)
 }
 
 func (m *mockCollectionCompletedLineEngine) SplitGatheringLine(_ context.Context, _ ombilling.SplitGatheringLineInput) (ombilling.SplitGatheringLineResult, error) {
@@ -190,6 +200,159 @@ func (s *LineEngineTestSuite) registerMockLineEngine(t *testing.T, engine ombill
 func (s *LineEngineTestSuite) unregisterLineEngine(t *testing.T, engine ombilling.LineEngine) {
 	t.Helper()
 	s.Require().NoError(s.BillingService.DeregisterLineEngine(engine.GetLineEngineType()))
+}
+
+func (s *LineEngineTestSuite) TestGateInvoiceAssignmentDuringCollection() {
+	ctx := s.T().Context()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	mockEngine := &mockCollectionCompletedLineEngine{
+		engineType: ombilling.LineEngineTypeChargeCreditPurchase,
+	}
+	s.registerMockLineEngine(s.T(), mockEngine)
+	defer s.unregisterLineEngine(s.T(), mockEngine)
+
+	s.Run("all otherwise billable lines blocked returns an empty successful result", func() {
+		mockEngine.Reset()
+		namespace := s.GetUniqueNamespace("ns-line-engine-gate-all-blocked")
+		customerID, pendingLines := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now, now)
+		gateCalled := false
+		buildCalled := false
+		mockEngine.gateInvoiceAssignment = func(_ context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {
+			gateCalled = true
+			result := make(ombilling.GateInvoiceAssignmentResult, len(input.Lines))
+			for _, line := range input.Lines {
+				result[line.GetLineID()] = ombilling.InvoiceAssignmentGateResponse{ExcludeFromInvoice: true}
+			}
+
+			return result, nil
+		}
+		mockEngine.buildStandardInvoiceLines = func(context.Context, ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+			buildCalled = true
+			return nil, errors.New("blocked lines must not be materialized")
+		}
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+			Customer:            customerID,
+			IncludePendingLines: mo.Some(lo.Map(pendingLines, func(line ombilling.GatheringLine, _ int) string { return line.ID })),
+			AsOf:                &now,
+			ForceAsyncAdvance:   true,
+		}, ombilling.WithBypassCollectionAlignment())
+
+		s.Require().NoError(err)
+		s.Empty(invoices)
+		s.True(gateCalled)
+		s.False(buildCalled)
+	})
+
+	s.Run("no otherwise billable lines preserves ErrInvoiceCreateNoLines", func() {
+		mockEngine.Reset()
+		namespace := s.GetUniqueNamespace("ns-line-engine-gate-no-billable-lines")
+		customerID, _ := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now.Add(time.Hour))
+		gateCalled := false
+		mockEngine.gateInvoiceAssignment = func(_ context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {
+			gateCalled = true
+			return nil, nil
+		}
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+			Customer:          customerID,
+			AsOf:              &now,
+			ForceAsyncAdvance: true,
+		}, ombilling.WithBypassCollectionAlignment())
+
+		s.Require().Error(err)
+		s.ErrorIs(err, ombilling.ErrInvoiceCreateNoLines)
+		s.ErrorAs(err, &ombilling.ValidationError{})
+		s.Empty(invoices)
+		s.False(gateCalled)
+	})
+
+	s.Run("blocked lines do not consume the invoice line limit", func() {
+		mockEngine.Reset()
+		namespace := s.GetUniqueNamespace("ns-line-engine-gate-line-limit")
+		customerID, pendingLines := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now.Add(-time.Hour), now)
+		blockedLineID := pendingLines[0].GetLineID()
+		mockEngine.gateInvoiceAssignment = func(_ context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {
+			return ombilling.GateInvoiceAssignmentResult{
+				blockedLineID: {ExcludeFromInvoice: true},
+			}, nil
+		}
+		mockEngine.buildStandardInvoiceLines = func(_ context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+			return mustAsNewStandardLines(input), nil
+		}
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+			Customer:          customerID,
+			AsOf:              &now,
+			ForceAsyncAdvance: true,
+		}, ombilling.WithBypassCollectionAlignment(), ombilling.WithMaxLinesPerInvoice(1))
+
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+		s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+		s.Equal(pendingLines[1].ID, invoices[0].Lines.OrEmpty()[0].ID)
+	})
+
+	s.Run("gate errors abort invoice creation", func() {
+		mockEngine.Reset()
+		namespace := s.GetUniqueNamespace("ns-line-engine-gate-error")
+		customerID, _ := s.createInvoiceAssignmentGateFixture(ctx, namespace, mockEngine.GetLineEngineType(), now)
+		gateErr := errors.New("synthetic gate failure")
+		mockEngine.gateInvoiceAssignment = func(context.Context, ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {
+			return ombilling.GateInvoiceAssignmentResult{}, gateErr
+		}
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+			Customer:          customerID,
+			AsOf:              &now,
+			ForceAsyncAdvance: true,
+		}, ombilling.WithBypassCollectionAlignment())
+
+		s.Require().ErrorIs(err, gateErr)
+		s.ErrorContains(err, "gating invoice assignment")
+		s.Empty(invoices)
+	})
+}
+
+func (s *LineEngineTestSuite) createInvoiceAssignmentGateFixture(
+	ctx context.Context,
+	namespace string,
+	engineType ombilling.LineEngineType,
+	invoiceAt ...time.Time,
+) (customer.CustomerID, ombilling.GatheringLines) {
+	s.T().Helper()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	customerEntity := s.CreateTestCustomer(namespace, "invoice-assignment-gate-customer")
+
+	lines := lo.Map(invoiceAt, func(at time.Time, idx int) ombilling.GatheringLine {
+		line := ombilling.NewFlatFeeGatheringLine(ombilling.NewFlatFeeLineInput{
+			Namespace:     namespace,
+			Period:        timeutil.ClosedPeriod{From: at.Add(-time.Hour), To: at},
+			InvoiceAt:     at,
+			Name:          fmt.Sprintf("invoice assignment gate line %d", idx+1),
+			ManagedBy:     ombilling.ManuallyManagedLine,
+			PerUnitAmount: alpacadecimal.NewFromInt(1),
+			PaymentTerm:   productcatalog.InArrearsPaymentTerm,
+		})
+		line.Engine = engineType
+
+		return line
+	})
+
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines:    lines,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pendingLines.Lines, len(lines))
+
+	return customerEntity.GetID(), pendingLines.Lines
 }
 
 func (s *LineEngineTestSuite) createMeteredDraftInvoiceWaitingForCollection(


### PR DESCRIPTION
## Overview

Add a line-engine gate that can exclude otherwise billable gathering lines from invoice assignment based on external state.

- introduce a sparse `GateInvoiceAssignment` response where omitted line IDs are allowed by default
- invoke gates after regular billability selection and before line limits, splitting, and materialization
- treat an all-excluded candidate set as a successful empty result, preserving gate side effects and avoiding `ErrInvoiceCreateNoLines` worker warnings
- keep existing line engines as no-op gates until their domain-specific implementations are added
- cover validation, engine grouping, sparse responses, exclusion, line limits, fatal errors, and `ErrInvoiceCreateNoLines` behavior
- document the line-engine lifecycle contract

## Notes for reviewer

- Usage-based external-state gating and charge validation-issue persistence are intentionally outside this PR.
- TypeSpec and API changes are intentionally outside this PR.
- `ErrInvoiceCreateNoLines` remains unchanged when there were no otherwise billable candidates.

## Validation

- `go test ./openmeter/billing ./openmeter/billing/service ./openmeter/billing/charges/creditpurchase/service ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/usagebased/service`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/billing -run '^TestLineEngine$'`
- `make lint-go-fast`






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a sparse, engine-specific gate between billability selection and invoice materialization.
- Groups otherwise billable gathering lines by their owning line engine and validates each gate response.
- Leaves omitted lines eligible while excluding explicitly blocked lines before line limits and progressive splitting.
- Treats a fully blocked candidate set as a successful empty collection so gate-owned writes can commit.
- Adds no-op implementations for existing engines, lifecycle documentation, and focused unit and integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule violations identified.

The gate is applied at the intended collection boundary, validates engine responses, preserves sparse allow-by-default behavior, and distinguishes fully excluded candidates from having no billable candidates. The earlier testing-convention thread was manually resolved without explanation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/lineengine.go | Defines and validates the sparse invoice-assignment gate contract on the line-engine interface. |
| openmeter/billing/service/gatheringinvoicependinglines.go | Invokes gates after billability selection, filters excluded lines, and handles fully excluded collections successfully. |
| openmeter/billing/service/gatheringinvoicependinglines_test.go | Covers engine grouping, sparse responses, exclusions, ordering, and gate failures. |
| test/billing/lineengine_test.go | Exercises collection behavior for fully blocked lines, line limits, no-candidate errors, and fatal gate failures. |
| openmeter/billing/README.md | Documents gate ordering, persistence semantics, and rollback behavior. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    G[Gathering lines] --> B[Billability selection]
    B --> E[Group candidates by line engine]
    E --> A[Gate invoice assignment]
    A -->|Excluded| P[Remain pending]
    A -->|Allowed| L[Apply invoice line limit]
    L --> S[Split progressive lines]
    S --> M[Materialize standard invoice]
    A -->|All excluded| N[Successful empty result]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(billing): address gate review feedb..."](https://github.com/openmeterio/openmeter/commit/7f32069273e6baa26b582ee40540555b5d1ceba2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61166063)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added invoice-assignment gating for billable lines before invoice creation.
  - Line engines can exclude selected lines from invoices while preserving them on the gathering invoice.
  - Excluded lines do not count toward invoice line limits.
  - Collections complete without creating an invoice when all candidates are excluded.
  - Gate failures stop collection and roll back related writes.

- **Documentation**
  - Documented invoice-assignment gating behavior and outcomes in the billing guide.

- **Tests**
  - Added coverage for exclusions, validation, line limits, empty results, and gate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->