### PR TITLE
feat(subscription): enable custom currency billing

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -45,8 +45,9 @@ projection. The type-specific detailed status is the lifecycle state.
 - [Ledger charge adapters](../../ledger/README.md) translate requested economic
   effects into ledger transactions. They do not decide when a charge advances.
 - [Subscription sync](../worker/subscriptionsync/README.md) reconciles
-  subscription-derived source intent. It does not treat API overrides as new
-  subscription source state.
+  subscription-derived source intent, including item currency and subscription
+  cost-basis selection. It does not treat API overrides as new subscription
+  source state.
 
 `AdvanceCharges` coordinates concrete services; it is not a second
 implementation of their state machines.

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -17,6 +17,7 @@ import (
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
 	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
@@ -56,6 +57,7 @@ type Config struct {
 	CreditPurchaseHandler creditpurchase.Handler
 	UsageBasedHandler     usagebased.Handler
 	CreditsConfig         config.CreditsConfiguration
+	LineageService        lineage.Service
 }
 
 func (c Config) Validate() error {
@@ -157,18 +159,21 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 		return nil, fmt.Errorf("creating locker: %w", err)
 	}
 
-	lineageAdapter, err := lineageadapter.New(lineageadapter.Config{
-		Client: config.Client,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating lineage adapter: %w", err)
-	}
+	lineageService := config.LineageService
+	if lineageService == nil {
+		lineageAdapter, err := lineageadapter.New(lineageadapter.Config{
+			Client: config.Client,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating lineage adapter: %w", err)
+		}
 
-	lineageService, err := lineageservice.New(lineageservice.Config{
-		Adapter: lineageAdapter,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating lineage service: %w", err)
+		lineageService, err = lineageservice.New(lineageservice.Config{
+			Adapter: lineageAdapter,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating lineage service: %w", err)
+		}
 	}
 
 	flatFeeAdapter, err := flatfeeadapter.New(flatfeeadapter.Config{

--- a/openmeter/billing/worker/subscriptionsync/README.md
+++ b/openmeter/billing/worker/subscriptionsync/README.md
@@ -90,7 +90,9 @@ charge.
 ## Deletion, cancellation, and retries
 
 Cancellation syncs through the subscription end so artifacts are shortened or
-removed according to the final desired periods. A deleted subscription has no
+removed according to the final desired periods. A cancellation event superseded
+by continuation or a different cancellation date is ignored; the newer event
+and periodic reconciler own that schedule. A deleted subscription has no
 view and therefore produces an empty target, asking reconciliation to remove
 its remaining owned artifacts subject to immutable-invoice rules. Cleanup must
 use an ID-based entrypoint because the normal subscription view lookup excludes

--- a/openmeter/billing/worker/subscriptionsync/README.md
+++ b/openmeter/billing/worker/subscriptionsync/README.md
@@ -90,11 +90,13 @@ charge.
 ## Deletion, cancellation, and retries
 
 Cancellation syncs through the subscription end so artifacts are shortened or
-removed according to the final desired periods. A cancellation event superseded
-by continuation or a different cancellation date is ignored; the newer event
-and periodic reconciler own that schedule. A deleted subscription has no
-view and therefore produces an empty target, asking reconciliation to remove
-its remaining owned artifacts subject to immutable-invoice rules. Cleanup must
+removed according to the final desired periods. A cancellation event whose root
+subscription `UpdatedAt` predates the current root is ignored. Cancellation and
+continuation update that timestamp, including when the same cancellation date
+is reused; it is not a version for all child changes. The newer event and
+periodic reconciler own that schedule. A deleted subscription has no view and
+therefore produces an empty target, asking reconciliation to remove its remaining
+owned artifacts subject to immutable-invoice rules. Cleanup must
 use an ID-based entrypoint because the normal subscription view lookup excludes
 deleted records.
 

--- a/openmeter/billing/worker/subscriptionsync/README.md
+++ b/openmeter/billing/worker/subscriptionsync/README.md
@@ -104,8 +104,12 @@ write artifacts or sync state.
 
 ## Intentional limitations
 
-- subscription sync materializes fiat billables only; custom-currency billables
-  are outside this worker's billing contract
+- invoice-backed subscription artifacts remain fiat-only; custom-currency items
+  require the charges backend
+- charge intents preserve each subscription item's fiat or managed custom
+  currency. For `credit_then_invoice`, subscription cost-basis mode maps to a
+  dynamic charge cost basis or the subscription's pinned cost-basis resource;
+  the charge lifecycle performs overage conversion into invoice currency
 - subscription-owned credit-purchase charges are unsupported
 - immutable invoice drift is reported, not automatically corrected
 - an `asOf` at the current instant is not a request to provision the entire

--- a/openmeter/billing/worker/subscriptionsync/README.md
+++ b/openmeter/billing/worker/subscriptionsync/README.md
@@ -90,11 +90,12 @@ charge.
 ## Deletion, cancellation, and retries
 
 Cancellation syncs through the subscription end so artifacts are shortened or
-removed according to the final desired periods. A cancellation event whose root
-subscription `UpdatedAt` predates the current root is ignored. Cancellation and
-continuation update that timestamp, including when the same cancellation date
-is reused; it is not a version for all child changes. The newer event and
-periodic reconciler own that schedule. A deleted subscription has no view and
+removed according to the final desired periods. When a cancellation event's root
+`UpdatedAt` predates the current subscription, sync uses the current view and
+current cancellation end; a continued subscription needs no cancellation sync.
+Annotation writes can also advance the root timestamp, so age alone must not
+discard a still-valid cancellation. This timestamp is not a version for all child
+changes. A deleted subscription has no view and
 therefore produces an empty target, asking reconciliation to remove its remaining
 owned artifacts subject to immutable-invoice rules. Cleanup must
 use an ID-based entrypoint because the normal subscription view lookup excludes

--- a/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
@@ -209,7 +209,7 @@ func (r *Reconciler) mapToSubscriptionWithSyncState(ctx context.Context, subs []
 }
 
 func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.NamespacedID) error {
-	return r.subscriptionSync.SyncByID(ctx, subsID, time.Now(), subscriptionsync.SkipCustomCurrencySubscriptions())
+	return r.subscriptionSync.SyncByID(ctx, subsID, time.Now())
 }
 
 type ReconcilerAllInput struct {

--- a/openmeter/billing/worker/subscriptionsync/reconciler/reconciler_test.go
+++ b/openmeter/billing/worker/subscriptionsync/reconciler/reconciler_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func TestReconcileSubscriptionSkipsUnsupportedCustomCurrencies(t *testing.T) {
+func TestReconcileSubscriptionUsesDefaultSyncOptions(t *testing.T) {
 	// given:
 	// - periodic reconciliation delegates to subscription sync
 	// when:
 	// - a subscription is reconciled
 	// then:
-	// - it opts into the temporary custom-currency skip behavior
+	// - it does not suppress any supported billing behavior
 	spy := &subscriptionSyncSpy{}
 	reconciler := Reconciler{subscriptionSync: spy}
 
@@ -27,7 +27,7 @@ func TestReconcileSubscriptionSkipsUnsupportedCustomCurrencies(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.True(t, spy.options.SkipCustomCurrencySubscriptions)
+	require.Equal(t, subscriptionsync.SynchronizeSubscriptionOptions{}, spy.options)
 }
 
 type subscriptionSyncSpy struct {

--- a/openmeter/billing/worker/subscriptionsync/service.go
+++ b/openmeter/billing/worker/subscriptionsync/service.go
@@ -2,7 +2,6 @@ package subscriptionsync
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -35,8 +34,7 @@ type SyncStateService interface {
 }
 
 type SynchronizeSubscriptionOptions struct {
-	DryRun                          bool
-	SkipCustomCurrencySubscriptions bool
+	DryRun bool
 }
 
 type SynchronizeSubscriptionOption func(*SynchronizeSubscriptionOptions)
@@ -46,16 +44,3 @@ func EnableDryRun() SynchronizeSubscriptionOption {
 		o.DryRun = true
 	}
 }
-
-// SkipCustomCurrencySubscriptions makes automatic reconciliation ignore subscriptions
-// that billing cannot represent yet. Explicit sync callers should omit this option so
-// the unsupported operation remains visible to them.
-func SkipCustomCurrencySubscriptions() SynchronizeSubscriptionOption {
-	return func(o *SynchronizeSubscriptionOptions) {
-		o.SkipCustomCurrencySubscriptions = true
-	}
-}
-
-// ErrCustomCurrencyBillingNotSupported is returned when explicit sync reaches
-// a subscription that billing cannot represent without currency conversion.
-var ErrCustomCurrencyBillingNotSupported = errors.New("billing sync does not support subscriptions with custom-currency priced items")

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"slices"
 	"strings"
@@ -20,6 +21,8 @@ import (
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currencyadapter "github.com/openmeterio/openmeter/openmeter/currencies/adapter"
+	currencyservice "github.com/openmeterio/openmeter/openmeter/currencies/service"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -116,6 +119,96 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) SetupSuite() {
 		CreditPurchaseHandler: handlers.CreditPurchase,
 		UsageBasedHandler:     handlers.UsageBased,
 	})
+}
+
+func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCustomCurrencyFlatFeeProvisioning() {
+	// given:
+	// - a credit-only subscription whose flat fee is denominated in a managed custom currency
+	// - an event-carried view whose runtime-only currency definition was removed by serialization
+	// when:
+	// - subscription sync reconciles that view
+	// then:
+	// - it reloads the authoritative currency snapshot and creates custom-currency charges
+	ctx := s.testContext()
+	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
+	startAt := s.mustParseTime("2024-02-01T00:00:00Z")
+	syncUntil := s.mustParseTime("2024-02-15T00:00:00Z")
+
+	clock.SetTime(setupAt)
+	defer clock.ResetTime()
+
+	currencyAdapter, err := currencyadapter.New(currencyadapter.Config{Client: s.DBClient})
+	s.NoError(err)
+	currencyService, err := currencyservice.New(currencyAdapter)
+	s.NoError(err)
+	customCurrency, err := currencyService.CreateCurrency(ctx, currencies.CreateCurrencyInput{
+		Namespace: s.Namespace,
+		CurrencyDetails: currencyx.CurrencyDetails{
+			Code:               "CREDITS",
+			Name:               "Credits",
+			Symbol:             "CR",
+			Precision:          0,
+			DecimalMark:        ".",
+			ThousandsSeparator: ",",
+		},
+	})
+	s.NoError(err)
+
+	subscriptionView := s.createSubscriptionFromPlanAt(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{Namespace: s.Namespace},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Custom Currency Credits Only",
+				Key:            "custom-currency-credits-only",
+				Version:        1,
+				Currency:       customCurrency.Reference(),
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+			},
+			Phases: []productcatalog.Phase{{
+				PhaseMeta: s.phaseMeta("first-phase", ""),
+				RateCards: productcatalog.RateCards{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Name: "flat-fee",
+							Key:  "flat-fee",
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      alpacadecimal.NewFromInt(25),
+								PaymentTerm: productcatalog.InAdvancePaymentTerm,
+							}),
+						},
+						BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+					},
+				},
+			}},
+		},
+	}, startAt)
+
+	serialized, err := json.Marshal(subscriptionView)
+	s.NoError(err)
+	var eventView subscription.SubscriptionView
+	s.NoError(json.Unmarshal(serialized, &eventView))
+	eventCurrency := eventView.Phases[0].ItemsByKey["flat-fee"][0].Spec.RateCard.AsMeta().Currency
+	s.NotNil(eventCurrency)
+	s.False(eventCurrency.IsResolved())
+
+	s.NoError(s.Service.SyncByView(ctx, eventView, syncUntil))
+
+	result, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:       s.Namespace,
+		SubscriptionIDs: []string{subscriptionView.Subscription.ID},
+		ChargeTypes:     []chargesmeta.ChargeType{chargesmeta.ChargeTypeFlatFee},
+	})
+	s.NoError(err)
+	s.Len(result.Items, 2)
+	for _, item := range result.Items {
+		charge, err := item.AsFlatFeeCharge()
+		s.NoError(err)
+		s.True(charge.Intent.GetCurrency().IsCustom())
+		s.Equal(customCurrency.ID, charge.Intent.GetCurrency().ID)
+		s.Equal(customCurrency.GetCode(), charge.Intent.GetCurrency().GetCode())
+		s.Nil(charge.Intent.GetCostBasisIntent())
+	}
 }
 
 func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeProvisioningAndReconciliation() {

--- a/openmeter/billing/worker/subscriptionsync/service/currency_boundary_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/currency_boundary_test.go
@@ -5,207 +5,53 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	syncreconciler "github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/reconciler"
-	"github.com/openmeterio/openmeter/openmeter/currencies"
-	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func TestCustomCurrencySubscriptionBillingBoundary(t *testing.T) {
-	view := newCustomCurrencySubscriptionView(t)
+func TestDeletedSubscriptionStillReconcilesAfterCustomCurrencySupport(t *testing.T) {
+	// given:
+	// - a deleted subscription whose billing artifacts still need cleanup
+	// when:
+	// - subscription sync runs from the last event-carried view
+	// then:
+	// - it plans an empty target and records that no future billables remain
+	deletedAt := time.Now()
+	view := subscription.SubscriptionView{Subscription: subscription.Subscription{
+		NamespacedID:    models.NamespacedID{Namespace: "namespace", ID: "subscription-id"},
+		ManagedModel:    models.ManagedModel{DeletedAt: &deletedAt},
+		CustomerId:      "customer-id",
+		InvoiceCurrency: currencyx.Code("USD"),
+	}}
+
+	billingService := &billingServiceSpy{}
 	syncAdapter := &subscriptionSyncAdapterSpy{}
+	reconciler := &syncReconcilerSpy{}
 	service := &Service{
+		billingService:          billingService,
+		reconciler:              reconciler,
 		subscriptionService:     &subscriptionServiceSpy{view: view},
 		subscriptionSyncAdapter: syncAdapter,
 		logger:                  testutils.NewDiscardLogger(t),
 		tracer:                  noop.NewTracerProvider().Tracer("test"),
 	}
 
-	t.Run("explicit sync fails before billing mutations", func(t *testing.T) {
-		// given:
-		// - a subscription with a priced custom-currency item
-		// when:
-		// - an explicit caller requests billing sync
-		// then:
-		// - sync fails with a conflict before requiring any billing dependency
-		err := service.SyncByView(t.Context(), view, time.Now())
+	err := service.SyncByView(t.Context(), view, time.Now())
 
-		require.ErrorIs(t, err, subscriptionsync.ErrCustomCurrencyBillingNotSupported)
-		require.True(t, models.IsGenericConflictError(err))
-	})
-
-	t.Run("automatic sync skips the whole subscription", func(t *testing.T) {
-		// given:
-		// - a subscription with a priced custom-currency item
-		// when:
-		// - an automatic caller requests sync and customer invoicing
-		// then:
-		// - the subscription is ignored and customer invoicing is not attempted
-		err := service.SyncByViewAndInvoiceCustomer(
-			t.Context(),
-			view,
-			time.Now(),
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
-		)
-
-		require.NoError(t, err)
-		require.Empty(t, syncAdapter.upserts)
-	})
-
-	t.Run("explicit sync rejects a stale fiat view when current state is custom", func(t *testing.T) {
-		// given:
-		// - an event-carried fiat-only view older than the persisted custom-currency state
-		// when:
-		// - an explicit caller synchronizes the stale view
-		// then:
-		// - persisted state keeps the custom-currency boundary from being bypassed
-		staleView := newFiatCurrencySubscriptionView(t)
-		err := service.SyncByView(t.Context(), staleView, time.Now())
-
-		require.ErrorIs(t, err, subscriptionsync.ErrCustomCurrencyBillingNotSupported)
-		require.True(t, models.IsGenericConflictError(err))
-		require.Empty(t, syncAdapter.upserts)
-	})
-
-	t.Run("automatic sync skips a stale fiat view when current state is custom", func(t *testing.T) {
-		// given:
-		// - an event-carried fiat-only view older than the persisted custom-currency state
-		// when:
-		// - automatic reconciliation synchronizes the stale view
-		// then:
-		// - the whole subscription is skipped without billing mutations
-		staleView := newFiatCurrencySubscriptionView(t)
-		err := service.SyncByViewAndInvoiceCustomer(
-			t.Context(),
-			staleView,
-			time.Now(),
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
-		)
-
-		require.NoError(t, err)
-		require.Empty(t, syncAdapter.upserts)
-	})
-
-	t.Run("scheduled sync event opts into skipping", func(t *testing.T) {
-		// given:
-		// - an automatic subscription-sync event for a custom-currency subscription
-		// when:
-		// - the event handler loads and synchronizes the current view
-		// then:
-		// - it skips without surfacing an error or mutating sync state
-		event := subscription.NewSubscriptionSyncEvent(t.Context(), view.Subscription)
-
-		err := service.HandleSubscriptionSyncEvent(t.Context(), &event)
-
-		require.NoError(t, err)
-		require.Empty(t, syncAdapter.upserts)
-	})
-
-	t.Run("deleted subscriptions still reconcile", func(t *testing.T) {
-		// given:
-		// - a deleted subscription whose last view contained a custom-currency item
-		// when:
-		// - automatic deletion cleanup runs with custom-currency skipping enabled
-		// then:
-		// - the deleted entity bypasses the guard and reaches persisted-state reconciliation
-		deletedAt := time.Now()
-		deletedView := view
-		deletedView.Subscription.DeletedAt = &deletedAt
-		deletedView.Subscription.InvoiceCurrency = currencyx.Code("USD")
-
-		billingService := &billingServiceSpy{}
-		syncAdapter := &subscriptionSyncAdapterSpy{}
-		reconciler := &syncReconcilerSpy{}
-		service := &Service{
-			billingService:          billingService,
-			reconciler:              reconciler,
-			subscriptionService:     &subscriptionServiceSpy{view: deletedView},
-			subscriptionSyncAdapter: syncAdapter,
-			logger:                  testutils.NewDiscardLogger(t),
-			tracer:                  noop.NewTracerProvider().Tracer("test"),
-		}
-
-		err := service.SyncByView(
-			t.Context(),
-			deletedView,
-			time.Now(),
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
-		)
-
-		require.NoError(t, err)
-		require.True(t, billingService.withLockCalled)
-		require.True(t, reconciler.planCalled)
-		require.Len(t, syncAdapter.upserts, 1)
-		require.False(t, syncAdapter.upserts[0].HasBillables)
-	})
-}
-
-func newCustomCurrencySubscriptionView(t *testing.T) subscription.SubscriptionView {
-	customCurrency := currenciestestutils.NewManagedCurrency(t, "namespace", "custom-currency-id", "CREDITS")
-	rateCard := &productcatalog.FlatFeeRateCard{
-		RateCardMeta: productcatalog.RateCardMeta{
-			Key:      "custom-fee",
-			Name:     "Custom fee",
-			Currency: lo.ToPtr(customCurrency.Reference()),
-			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-				Amount: alpacadecimal.NewFromInt(1),
-			}),
-		},
-	}
-
-	subs := subscription.Subscription{
-		NamespacedID: models.NamespacedID{
-			Namespace: "namespace",
-			ID:        "subscription-id",
-		},
-		CustomerId: "customer-id",
-	}
-
-	return subscription.SubscriptionView{
-		Subscription: subs,
-		Spec: subscription.SubscriptionSpec{
-			Phases: map[string]*subscription.SubscriptionPhaseSpec{
-				"phase": {
-					ItemsByKey: map[string][]*subscription.SubscriptionItemSpec{
-						"custom-fee": {
-							{
-								CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
-									CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
-										PhaseKey: "phase",
-										ItemKey:  "custom-fee",
-										RateCard: rateCard,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func newFiatCurrencySubscriptionView(t *testing.T) subscription.SubscriptionView {
-	view := newCustomCurrencySubscriptionView(t)
-	view.Subscription.InvoiceCurrency = currencyx.Code("USD")
-	view.Spec.InvoiceCurrency = currencyx.Code("USD")
-
-	rateCard := view.Spec.Phases["phase"].ItemsByKey["custom-fee"][0].RateCard.(*productcatalog.FlatFeeRateCard)
-	rateCard.RateCardMeta.Currency = lo.ToPtr(currencies.NewCurrencyReference("USD"))
-
-	return view
+	require.NoError(t, err)
+	require.True(t, billingService.withLockCalled)
+	require.True(t, reconciler.planCalled)
+	require.Len(t, syncAdapter.upserts, 1)
+	require.False(t, syncAdapter.upserts[0].HasBillables)
 }
 
 type billingServiceSpy struct {
@@ -236,13 +82,7 @@ type subscriptionServiceSpy struct {
 }
 
 func (s *subscriptionServiceSpy) List(context.Context, subscription.ListSubscriptionsInput) (subscription.SubscriptionList, error) {
-	return subscription.SubscriptionList{
-		Items: []subscription.Subscription{s.view.Subscription},
-	}, nil
-}
-
-func (s *subscriptionServiceSpy) GetView(context.Context, models.NamespacedID) (subscription.SubscriptionView, error) {
-	return s.view, nil
+	return subscription.SubscriptionList{Items: []subscription.Subscription{s.view.Subscription}}, nil
 }
 
 type subscriptionSyncAdapterSpy struct {

--- a/openmeter/billing/worker/subscriptionsync/service/currency_boundary_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/currency_boundary_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func TestDeletedSubscriptionStillReconcilesAfterCustomCurrencySupport(t *testing.T) {
+func TestDeletedSubscriptionReconcilesBillingArtifacts(t *testing.T) {
 	// given:
 	// - a deleted subscription whose billing artifacts still need cleanup
 	// when:

--- a/openmeter/billing/worker/subscriptionsync/service/handlers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/handlers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -28,7 +27,6 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 			ctx,
 			newSubscriptionReferenceOrView(event.SubscriptionView),
 			now,
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
 		)
 		if err != nil {
 			return err
@@ -42,7 +40,6 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 		ctx,
 		newSubscriptionReferenceOrView(event.SubscriptionView),
 		*event.Spec.ActiveTo,
-		subscriptionsync.SkipCustomCurrencySubscriptions(),
 	)
 	if err != nil {
 		return err
@@ -82,7 +79,6 @@ func (s *Service) HandleInvoiceCreation(ctx context.Context, event *billing.Stan
 				ID:        subscriptionID,
 			}),
 			clock.Now(),
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
 		); err != nil {
 			return fmt.Errorf("syncing subscription[%s]: %w", subscriptionID, err)
 		}
@@ -98,7 +94,6 @@ func (s *Service) HandleDeletedEvent(ctx context.Context, event *subscription.De
 		ctx,
 		newSubscriptionReferenceOrView(event.Subscription.NamespacedID),
 		clock.Now(),
-		subscriptionsync.SkipCustomCurrencySubscriptions(),
 	)
 	return err
 }

--- a/openmeter/billing/worker/subscriptionsync/service/handlers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/handlers.go
@@ -40,10 +40,10 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 		return err
 	}
 
-	// Continuation or a later cancellation supersedes this event. Its old end
-	// must not truncate charges already provisioned by a newer sync. The newer
-	// lifecycle event and periodic reconciler own synchronization of that state.
-	if current.ActiveTo == nil || !current.ActiveTo.Equal(*event.Spec.ActiveTo) {
+	// Cancellation and continuation update the root subscription timestamp,
+	// even when a later cancellation reuses the same end date. Ignore older
+	// events so their horizon cannot reconcile a newer subscription state.
+	if current.UpdatedAt.After(event.Subscription.UpdatedAt) {
 		return nil
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/handlers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/handlers.go
@@ -40,19 +40,23 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 		return err
 	}
 
-	// Cancellation and continuation update the root subscription timestamp,
-	// even when a later cancellation reuses the same end date. Ignore older
-	// events so their horizon cannot reconcile a newer subscription state.
+	refOrView := newSubscriptionReferenceOrView(event.SubscriptionView)
+	asOf := *event.Spec.ActiveTo
+
+	// Cancellation and continuation update the root timestamp, but annotation
+	// writes can also advance it after cancellation (for example, plan changes).
+	// An older snapshot must use the current cancellation and horizon instead of
+	// dropping valid billing work or replaying obsolete subscription state.
 	if current.UpdatedAt.After(event.Subscription.UpdatedAt) {
-		return nil
+		if current.ActiveTo == nil {
+			return nil
+		}
+		refOrView = newSubscriptionReferenceOrView(current.NamespacedID)
+		asOf = *current.ActiveTo
 	}
 
 	// Let's sync up to the end of the subscription
-	err = s.synchronizeSubscriptionAndInvoiceCustomer(
-		ctx,
-		newSubscriptionReferenceOrView(event.SubscriptionView),
-		*event.Spec.ActiveTo,
-	)
+	err = s.synchronizeSubscriptionAndInvoiceCustomer(ctx, refOrView, asOf)
 	if err != nil {
 		return err
 	}

--- a/openmeter/billing/worker/subscriptionsync/service/handlers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/handlers.go
@@ -35,8 +35,20 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 		return errors.New("active_to is required for canceled events")
 	}
 
+	current, err := s.getSubscription(ctx, event.Subscription.NamespacedID)
+	if err != nil {
+		return err
+	}
+
+	// Continuation or a later cancellation supersedes this event. Its old end
+	// must not truncate charges already provisioned by a newer sync. The newer
+	// lifecycle event and periodic reconciler own synchronization of that state.
+	if current.ActiveTo == nil || !current.ActiveTo.Equal(*event.Spec.ActiveTo) {
+		return nil
+	}
+
 	// Let's sync up to the end of the subscription
-	err := s.synchronizeSubscriptionAndInvoiceCustomer(
+	err = s.synchronizeSubscriptionAndInvoiceCustomer(
 		ctx,
 		newSubscriptionReferenceOrView(event.SubscriptionView),
 		*event.Spec.ActiveTo,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
@@ -140,11 +140,19 @@ func (c patchCollectionRouter) ResolveDefaultCollection(target targetstate.State
 	}
 
 	if !enabled {
+		if target.Currency.IsCustom() {
+			return nil, fmt.Errorf("custom currency subscription items require the charges service [currency=%s]", target.Currency.GetCode())
+		}
+
 		return c.lineCollection, nil
 	}
 
 	// If credit then invoice is not enabled, we return the lineCollection.
 	if target.Subscription.SettlementMode == productcatalog.CreditThenInvoiceSettlementMode && !c.creditThenInvoiceEnabled {
+		if target.Currency.IsCustom() {
+			return nil, fmt.Errorf("custom currency credit-then-invoice subscription items require charge-based credit-then-invoice billing [currency=%s]", target.Currency.GetCode())
+		}
+
 		return c.lineCollection, nil
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/featuregate"
@@ -39,6 +40,8 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 		enableCredits           bool
 		rateCard                productcatalog.RateCard
 		expectedCollection      any
+		customCurrency          bool
+		wantErr                 bool
 	}{
 		{
 			name:               "credit only flat fee uses flat fee charges",
@@ -85,6 +88,31 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 			rateCard:                usageRateCard,
 			expectedCollection:      &usageBasedChargeCollection{},
 		},
+		{
+			name:           "custom currency requires charges",
+			settlementMode: productcatalog.CreditOnlySettlementMode,
+			rateCard:       flatRateCard,
+			customCurrency: true,
+			wantErr:        true,
+		},
+		{
+			name:                    "custom currency credit then invoice requires charge billing",
+			settlementMode:          productcatalog.CreditThenInvoiceSettlementMode,
+			enableCredits:           true,
+			enableCreditThenInvoice: false,
+			rateCard:                flatRateCard,
+			customCurrency:          true,
+			wantErr:                 true,
+		},
+		{
+			name:                    "custom currency credit then invoice uses charges",
+			settlementMode:          productcatalog.CreditThenInvoiceSettlementMode,
+			enableCredits:           true,
+			enableCreditThenInvoice: true,
+			rateCard:                flatRateCard,
+			customCurrency:          true,
+			expectedCollection:      &flatFeeChargeCollection{},
+		},
 	}
 
 	for _, tt := range testCases {
@@ -102,7 +130,17 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			collection, err := router.ResolveDefaultCollection(testTargetStateItem(tt.settlementMode, tt.rateCard))
+			target := testTargetStateItem(tt.settlementMode, tt.rateCard)
+			if tt.customCurrency {
+				target.Currency = currenciestestutils.NewManagedCurrency(t, "namespace", "custom-currency-id", "CREDITS")
+			}
+
+			collection, err := router.ResolveDefaultCollection(target)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
 			require.NoError(t, err)
 			require.IsType(t, tt.expectedCollection, collection)
 		})

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
@@ -11,8 +11,11 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -141,4 +144,44 @@ func logChargesPatches(ctx context.Context, log *slog.Logger, patches charges.Ap
 	for _, intent := range patches.Creates {
 		log.InfoContext(ctx, "creating charge", "intent", intent)
 	}
+}
+
+func newChargeCostBasisIntent(target targetstate.StateItem) (*costbasis.Intent, error) {
+	if !target.Currency.IsCustom() || target.Subscription.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return nil, nil
+	}
+
+	fiatCurrency, err := currencyx.NewFiatCurrency(target.Subscription.InvoiceCurrency)
+	if err != nil {
+		return nil, fmt.Errorf("building invoice currency: %w", err)
+	}
+
+	if !target.Subscription.CostBasisMode.IsPinned() {
+		intent := costbasis.NewIntent(costbasis.DynamicIntent{FiatCurrency: fiatCurrency})
+		return &intent, nil
+	}
+
+	var costBasisID string
+	for _, pin := range target.Subscription.CostBasisPins {
+		if pin.CustomCurrencyID != target.Currency.ID || pin.InvoiceCurrency != target.Subscription.InvoiceCurrency {
+			continue
+		}
+
+		if costBasisID != "" {
+			return nil, fmt.Errorf("multiple pinned cost bases found for custom currency [currency_id=%s invoice_currency=%s]", target.Currency.ID, target.Subscription.InvoiceCurrency)
+		}
+
+		costBasisID = pin.CostBasis.ID
+	}
+
+	if costBasisID == "" {
+		return nil, fmt.Errorf("pinned cost basis not found for custom currency [currency_id=%s invoice_currency=%s]", target.Currency.ID, target.Subscription.InvoiceCurrency)
+	}
+
+	intent := costbasis.NewIntent(costbasis.PinnedIntent{
+		FiatCurrency:        fiatCurrency,
+		CurrencyCostBasisID: costBasisID,
+	})
+
+	return &intent, nil
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	chargesflatfee "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	chargesusagebased "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -21,6 +23,81 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestNewChargeCostBasisIntent(t *testing.T) {
+	customCurrency := currenciestestutils.NewManagedCurrency(t, "namespace", "custom-currency-id", "CREDITS")
+
+	t.Run("credit only custom currency has no cost basis", func(t *testing.T) {
+		target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestFlatRateCard())
+		target.Currency = customCurrency
+
+		intent, err := newChargeCostBasisIntent(target)
+
+		require.NoError(t, err)
+		require.Nil(t, intent)
+	})
+
+	t.Run("dynamic subscription maps to dynamic charge cost basis", func(t *testing.T) {
+		target := newChargePatchTestTarget(t, productcatalog.CreditThenInvoiceSettlementMode, newChargePatchTestFlatRateCard())
+		target.Currency = customCurrency
+		target.Subscription.CostBasisMode = subscription.CostBasisModeDynamic
+
+		intent, err := newChargeCostBasisIntent(target)
+
+		require.NoError(t, err)
+		require.NotNil(t, intent)
+		require.Equal(t, costbasis.ModeDynamic, intent.Kind())
+		fiatCurrency, err := intent.GetFiatCurrency()
+		require.NoError(t, err)
+		require.Equal(t, currencyx.FiatCode("USD"), fiatCurrency.GetFiatCode())
+
+		chargeIntent, err := newFlatFeeChargeIntent(target)
+		require.NoError(t, err)
+		flatFeeIntent, err := chargeIntent.AsFlatFeeIntent()
+		require.NoError(t, err)
+		require.NotNil(t, flatFeeIntent.CostBasis)
+		require.Equal(t, costbasis.ModeDynamic, flatFeeIntent.CostBasis.Kind())
+	})
+
+	t.Run("pinned subscription maps its selected resource", func(t *testing.T) {
+		target := newChargePatchTestTarget(t, productcatalog.CreditThenInvoiceSettlementMode, newChargePatchTestUsageRateCard())
+		target.Currency = customCurrency
+		target.Subscription.CostBasisMode = subscription.CostBasisModePinned
+		target.Subscription.CostBasisPins = []subscription.CostBasisPin{{
+			CustomCurrencyID: customCurrency.ID,
+			InvoiceCurrency:  "USD",
+			CostBasis: currencies.CostBasis{
+				NamespacedID: models.NamespacedID{Namespace: "namespace", ID: "currency-cost-basis-id"},
+			},
+		}}
+
+		intent, err := newChargeCostBasisIntent(target)
+
+		require.NoError(t, err)
+		require.NotNil(t, intent)
+		require.Equal(t, costbasis.ModePinned, intent.Kind())
+		pinned, err := intent.AsPinned()
+		require.NoError(t, err)
+		require.Equal(t, "currency-cost-basis-id", pinned.CurrencyCostBasisID)
+
+		chargeIntent, err := newUsageBasedChargeIntent(target)
+		require.NoError(t, err)
+		usageBasedIntent, err := chargeIntent.AsUsageBasedIntent()
+		require.NoError(t, err)
+		require.NotNil(t, usageBasedIntent.CostBasis)
+		require.Equal(t, costbasis.ModePinned, usageBasedIntent.CostBasis.Kind())
+	})
+
+	t.Run("missing subscription pin is rejected", func(t *testing.T) {
+		target := newChargePatchTestTarget(t, productcatalog.CreditThenInvoiceSettlementMode, newChargePatchTestFlatRateCard())
+		target.Currency = customCurrency
+		target.Subscription.CostBasisMode = subscription.CostBasisModePinned
+
+		_, err := newChargeCostBasisIntent(target)
+
+		require.ErrorContains(t, err, "pinned cost basis not found")
+	})
+}
 
 func TestFlatFeeCreditOnlyChargeCollectionShrinkEmitsNativePatch(t *testing.T) {
 	collection := newFlatFeeChargeCollection(1)

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
@@ -94,6 +94,11 @@ func newFlatFeeChargeIntent(target targetstate.StateItem) (charges.ChargeIntent,
 		return charges.ChargeIntent{}, err
 	}
 
+	costBasis, err := newChargeCostBasisIntent(target)
+	if err != nil {
+		return charges.ChargeIntent{}, fmt.Errorf("mapping cost basis: %w", err)
+	}
+
 	return charges.NewChargeIntent(chargesflatfee.Intent{
 		Intent: chargesmeta.Intent{
 			ManagedBy:         billing.SubscriptionManagedLine,
@@ -131,5 +136,6 @@ func newFlatFeeChargeIntent(target targetstate.StateItem) (charges.ChargeIntent,
 		},
 		FeatureKey:     featureKey,
 		SettlementMode: target.Subscription.SettlementMode,
+		CostBasis:      costBasis,
 	}), nil
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
@@ -101,6 +101,11 @@ func newUsageBasedChargeIntent(target targetstate.StateItem) (charges.ChargeInte
 		return charges.ChargeIntent{}, err
 	}
 
+	costBasis, err := newChargeCostBasisIntent(target)
+	if err != nil {
+		return charges.ChargeIntent{}, fmt.Errorf("mapping cost basis: %w", err)
+	}
+
 	return charges.NewChargeIntent(chargesusagebased.Intent{
 		Intent: chargesmeta.Intent{
 			ManagedBy:         billing.SubscriptionManagedLine,
@@ -137,5 +142,6 @@ func newUsageBasedChargeIntent(target targetstate.StateItem) (charges.ChargeInte
 		},
 		SettlementMode: target.Subscription.SettlementMode,
 		FeatureKey:     featureKey,
+		CostBasis:      costBasis,
 	}), nil
 }

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -64,7 +64,6 @@ func (s *Service) HandleSubscriptionSyncEvent(ctx context.Context, event *subscr
 		ctx,
 		newSubscriptionReferenceOrView(event.Subscription),
 		time.Now(),
-		subscriptionsync.SkipCustomCurrencySubscriptions(),
 	)
 }
 
@@ -113,7 +112,6 @@ func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscri
 		}
 
 		var subsView *subscription.SubscriptionView
-		hasCustomCurrencyBillables := false
 		if subs.IsDeleted() {
 			subsView = nil
 		} else if refOrView.Type() == SubscriptionReferenceTypeView {
@@ -123,17 +121,17 @@ func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscri
 			}
 
 			subsView = &view
-			hasCustomCurrencyBillables = view.Spec.HasCustomCurrencyBillables()
-			if !hasCustomCurrencyBillables {
-				// Event-carried views can be older than the current subscription state.
-				// Check persisted state before allowing billing so a pre-edit fiat view
-				// cannot bypass the custom-currency boundary after a later edit.
-				currentView, err := s.subscriptionService.GetView(ctx, subscriptionID)
-				if err != nil {
-					return nil, err
-				}
+			currentView, err := s.subscriptionService.GetView(ctx, subscriptionID)
+			if err != nil {
+				return nil, err
+			}
 
-				hasCustomCurrencyBillables = currentView.Spec.HasCustomCurrencyBillables()
+			// Currency definitions are runtime-only snapshots and are deliberately not
+			// serialized into subscription events. Reload custom-priced views before
+			// planning so billing has authoritative identity and precision, and so a
+			// delayed event cannot reconcile obsolete custom-currency state.
+			if view.Spec.HasCustomCurrencyBillables() || currentView.Spec.HasCustomCurrencyBillables() {
+				subsView = &currentView
 			}
 		} else {
 			view, err := s.subscriptionService.GetView(ctx, subscriptionID)
@@ -142,23 +140,6 @@ func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscri
 			}
 
 			subsView = &view
-			hasCustomCurrencyBillables = view.Spec.HasCustomCurrencyBillables()
-		}
-
-		if hasCustomCurrencyBillables {
-			err := fmt.Errorf("%w [namespace=%s subscription_id=%s]", subscriptionsync.ErrCustomCurrencyBillingNotSupported, subscriptionID.Namespace, subscriptionID.ID)
-			if options.SkipCustomCurrencySubscriptions {
-				s.logger.InfoContext(ctx, "subscription uses custom-currency priced items, skipping billing sync",
-					"namespace", subscriptionID.Namespace,
-					"subscription_id", subscriptionID.ID,
-				)
-
-				// A nil result also prevents the wrapping automatic path from invoicing
-				// unrelated pending lines for this subscription's customer.
-				return nil, nil
-			}
-
-			return nil, models.NewGenericConflictError(err)
 		}
 
 		res := &synchronizeSubscriptionResult{

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currencyadapter "github.com/openmeterio/openmeter/openmeter/currencies/adapter"
+	currencyservice "github.com/openmeterio/openmeter/openmeter/currencies/service"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
@@ -160,6 +162,113 @@ func (s *CreditThenInvoiceTestSuite) BeforeTest(suiteName, testName string) {
 
 	_, err = s.LedgerResolver.CreateCustomerAccounts(s.T().Context(), s.Customer.GetID())
 	s.NoError(err)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestCustomCurrencyPinnedCostBasisProvisioning() {
+	// given:
+	// - a custom-currency flat fee settled through credit then invoice
+	// - a subscription that pins the effective custom-to-USD cost basis
+	// when:
+	// - subscription sync provisions future billing periods
+	// then:
+	// - every charge keeps the custom currency and the subscription's pinned cost-basis resource
+	ctx := s.testContext()
+	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
+	startAt := s.mustParseTime("2024-02-01T00:00:00Z")
+	syncUntil := s.mustParseTime("2024-02-15T00:00:00Z")
+
+	clock.SetTime(setupAt)
+	defer clock.ResetTime()
+
+	currencyAdapter, err := currencyadapter.New(currencyadapter.Config{Client: s.DBClient})
+	s.NoError(err)
+	currencyService, err := currencyservice.New(currencyAdapter)
+	s.NoError(err)
+	customCurrency, err := currencyService.CreateCurrency(ctx, currenciestestutils.NewCreateCurrencyInput(
+		s.Namespace,
+		"CREDITS",
+		"Credits",
+		"CR",
+	))
+	s.NoError(err)
+	pinnedCostBasis, err := currencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
+		Namespace:  s.Namespace,
+		CurrencyID: customCurrency.ID,
+		FiatCode:   "USD",
+		Rate:       alpacadecimal.NewFromInt(2),
+	})
+	s.NoError(err)
+
+	createdPlan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{Namespace: s.Namespace},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Custom Currency Credit Then Invoice",
+				Key:            "custom-currency-credit-then-invoice",
+				Version:        1,
+				Currency:       customCurrency.Reference(),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+			},
+			Phases: []productcatalog.Phase{{
+				PhaseMeta: s.phaseMeta("first-phase", ""),
+				RateCards: productcatalog.RateCards{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Name: "flat-fee",
+							Key:  "flat-fee",
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      alpacadecimal.NewFromInt(25),
+								PaymentTerm: productcatalog.InAdvancePaymentTerm,
+							}),
+						},
+						BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+					},
+				},
+			}},
+		},
+	})
+	s.NoError(err)
+
+	subscriptionPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, s.Namespace, productcatalogsubscription.PlanRefInput{
+		Key:     createdPlan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+	subscriptionView, err := s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing:        subscription.Timing{Custom: lo.ToPtr(startAt)},
+			Name:          "custom-currency-pinned",
+			CostBasisMode: subscription.CostBasisModePinned,
+		},
+		Namespace:  s.Namespace,
+		CustomerID: s.Customer.ID,
+	}, subscriptionPlan)
+	s.NoError(err)
+	s.Len(subscriptionView.Subscription.CostBasisPins, 1)
+	s.Equal(pinnedCostBasis.ID, subscriptionView.Subscription.CostBasisPins[0].CostBasis.ID)
+
+	s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
+
+	result, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Namespace:       s.Namespace,
+		SubscriptionIDs: []string{subscriptionView.Subscription.ID},
+		ChargeTypes:     []chargesmeta.ChargeType{chargesmeta.ChargeTypeFlatFee},
+	})
+	s.NoError(err)
+	s.Len(result.Items, 2)
+	for _, item := range result.Items {
+		charge, err := item.AsFlatFeeCharge()
+		s.NoError(err)
+		s.True(charge.Intent.GetCurrency().IsCustom())
+		s.Equal(customCurrency.ID, charge.Intent.GetCurrency().ID)
+
+		costBasisIntent := charge.Intent.GetCostBasisIntent()
+		s.NotNil(costBasisIntent)
+		pinned, err := costBasisIntent.AsPinned()
+		s.NoError(err)
+		s.Equal(pinnedCostBasis.ID, pinned.CurrencyCostBasisID)
+	}
 }
 
 func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -20,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -113,26 +113,50 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (State, error) {
 			return State{}, fmt.Errorf("correcting period start for upcoming lines: %w", err)
 		}
 
-		currency, err := currencyx.NewCurrencyBuilder(currencyx.CurrencyTypeFiat).
-			WithCode(subs.Subscription.InvoiceCurrency).
-			Build()
+		items, err := slicesx.MapWithErr(inScopeLines, func(item SubscriptionItemWithPeriods) (StateItem, error) {
+			currency, err := resolveSubscriptionItemCurrency(item, subs.Subscription.InvoiceCurrency)
+			if err != nil {
+				return StateItem{}, fmt.Errorf("resolving currency for item [%s]: %w", item.UniqueID, err)
+			}
+
+			return StateItem{
+				SubscriptionItemWithPeriods:  item,
+				Currency:                     currency,
+				Subscription:                 subs.Subscription,
+				SubscriptionEndProrationMode: input.SubscriptionEndProrationMode,
+			}, nil
+		})
 		if err != nil {
-			return State{}, fmt.Errorf("getting currency calculator: %w", err)
+			return State{}, err
 		}
 
 		return State{
-			Items: lo.Map(inScopeLines, func(item SubscriptionItemWithPeriods, _ int) StateItem {
-				return StateItem{
-					SubscriptionItemWithPeriods: item,
-					// TODO[later]: Once subscriptions supports custom currencies, we need to use the currency from the subscription item.
-					Currency:                     currencies.Currency{Currency: currency},
-					Subscription:                 subs.Subscription,
-					SubscriptionEndProrationMode: input.SubscriptionEndProrationMode,
-				}
-			}),
+			Items:                  items,
 			MaxGenerationTimeLimit: upcomingLinesResult.SubscriptionMaxGenerationTimeLimit,
 		}, nil
 	})
+}
+
+func resolveSubscriptionItemCurrency(item SubscriptionItemWithPeriods, invoiceCurrency currencyx.Code) (currencies.Currency, error) {
+	reference := item.Spec.RateCard.AsMeta().Currency
+	if reference == nil {
+		return currencies.NewFiatCurrency(invoiceCurrency)
+	}
+
+	if err := reference.Validate(); err != nil {
+		return currencies.Currency{}, err
+	}
+
+	if reference.IsFiat() {
+		return currencies.NewFiatCurrency(reference.GetCode())
+	}
+
+	currency, ok := reference.CustomCurrency()
+	if !ok {
+		return currencies.Currency{}, fmt.Errorf("custom currency reference is not resolved: %s", reference)
+	}
+
+	return currency.Clone(), nil
 }
 
 type collectResult struct {

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstateitem_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstateitem_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -161,6 +163,63 @@ func newExpectedLineTestStateItem(t *testing.T, fiatCurrency currencies.Currency
 		},
 		Currency: fiatCurrency,
 	}
+}
+
+func TestResolveSubscriptionItemCurrency(t *testing.T) {
+	newItem := func(reference *currencies.CurrencyReference) SubscriptionItemWithPeriods {
+		return SubscriptionItemWithPeriods{
+			SubscriptionItemView: subscription.SubscriptionItemView{
+				Spec: subscription.SubscriptionItemSpec{
+					CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+						CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+							RateCard: &productcatalog.FlatFeeRateCard{RateCardMeta: productcatalog.RateCardMeta{
+								Currency: reference,
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("legacy item falls back to invoice currency", func(t *testing.T) {
+		currency, err := resolveSubscriptionItemCurrency(newItem(nil), currencyx.Code("USD"))
+
+		require.NoError(t, err)
+		require.True(t, currency.IsFiat())
+		require.Equal(t, currencyx.Code("USD"), currency.GetCode())
+	})
+
+	t.Run("fiat item keeps its materialized currency", func(t *testing.T) {
+		reference := currencies.NewCurrencyReference("EUR")
+		currency, err := resolveSubscriptionItemCurrency(newItem(&reference), currencyx.Code("USD"))
+
+		require.NoError(t, err)
+		require.True(t, currency.IsFiat())
+		require.Equal(t, currencyx.Code("EUR"), currency.GetCode())
+	})
+
+	t.Run("custom item keeps its managed currency snapshot", func(t *testing.T) {
+		managedCurrency := currenciestestutils.NewManagedCurrency(t, "namespace", "custom-currency-id", "CREDITS")
+		reference := managedCurrency.Reference()
+		currency, err := resolveSubscriptionItemCurrency(newItem(&reference), currencyx.Code("USD"))
+
+		require.NoError(t, err)
+		require.True(t, currency.IsCustom())
+		require.Equal(t, managedCurrency.ID, currency.ID)
+		require.Equal(t, managedCurrency.GetCode(), currency.GetCode())
+	})
+
+	t.Run("unresolved custom item is rejected", func(t *testing.T) {
+		reference := currencies.CurrencyReference{
+			Code:             "CREDITS",
+			CustomCurrencyID: lo.ToPtr("custom-currency-id"),
+		}
+
+		_, err := resolveSubscriptionItemCurrency(newItem(&reference), currencyx.Code("USD"))
+
+		require.ErrorContains(t, err, "custom currency reference is not resolved")
+	})
 }
 
 func TestStateItemShouldProrateSubscriptionEndMode(t *testing.T) {

--- a/openmeter/billing/worker/worker.go
+++ b/openmeter/billing/worker/worker.go
@@ -167,7 +167,6 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 				ctx,
 				event.SubscriptionView,
 				time.Now(),
-				subscriptionsync.SkipCustomCurrencySubscriptions(),
 			)
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.CancelledEvent) error {
@@ -193,7 +192,6 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 				ctx,
 				event.SubscriptionView,
 				time.Now(),
-				subscriptionsync.SkipCustomCurrencySubscriptions(),
 			)
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.UpdatedEvent) error {
@@ -205,7 +203,6 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 				ctx,
 				event.UpdatedView,
 				time.Now(),
-				subscriptionsync.SkipCustomCurrencySubscriptions(),
 			)
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.SubscriptionSyncEvent) error {

--- a/openmeter/subscription/repo/subscriptionitemrepo.go
+++ b/openmeter/subscription/repo/subscriptionitemrepo.go
@@ -78,6 +78,7 @@ func (r *subscriptionItemRepo) GetForSubscriptionAt(ctx context.Context, input s
 			Where(getItemForSubscriptionAtFilter(input)).
 			WithPhase().
 			WithTaxCode().
+			WithCustomCurrency().
 			All(ctx)
 		if err != nil {
 			return nil, err
@@ -109,6 +110,7 @@ func (r *subscriptionItemRepo) GetForSubscriptionsAt(ctx context.Context, input 
 			)).
 			WithPhase().
 			WithTaxCode().
+			WithCustomCurrency().
 			All(ctx)
 		if err != nil {
 			return nil, err
@@ -139,6 +141,7 @@ func (r *subscriptionItemRepo) GetByID(ctx context.Context, id models.Namespaced
 			)).
 			WithPhase().
 			WithTaxCode().
+			WithCustomCurrency().
 			Only(ctx)
 
 		if db.IsNotFound(err) {

--- a/openmeter/subscription/repo/subscriptionitemrepo_test.go
+++ b/openmeter/subscription/repo/subscriptionitemrepo_test.go
@@ -175,7 +175,7 @@ func TestSubscriptionItemCustomCurrencyPersistence(t *testing.T) {
 	require.Equal(t, customCurrency, createdCurrency.GetCode())
 	require.NotNil(t, createdCurrency.CustomCurrencyID)
 	require.Equal(t, managedCurrency.ID, *createdCurrency.CustomCurrencyID)
-	require.False(t, createdCurrency.IsResolved())
+	require.True(t, createdCurrency.IsResolved())
 
 	customItemRow, err := dbDeps.DBClient.SubscriptionItem.Get(t.Context(), created.ID)
 	require.NoError(t, err)
@@ -192,5 +192,5 @@ func TestSubscriptionItemCustomCurrencyPersistence(t *testing.T) {
 	require.Equal(t, customCurrency, reloadedCurrency.GetCode())
 	require.NotNil(t, reloadedCurrency.CustomCurrencyID)
 	require.Equal(t, managedCurrency.ID, *reloadedCurrency.CustomCurrencyID)
-	require.False(t, reloadedCurrency.IsResolved())
+	require.True(t, reloadedCurrency.IsResolved())
 }

--- a/test/subscription/custom_currency_backfill_test.go
+++ b/test/subscription/custom_currency_backfill_test.go
@@ -1,0 +1,125 @@
+package subscription_test
+
+import (
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestSubscriptionCustomCurrencyBackfillAcrossPeriods(t *testing.T) {
+	// given: two funded monthly fees followed by two separately collected advances.
+	clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+	f := setupCustomCurrencyFlatFeeSubscription(t)
+	ctx := t.Context()
+	for month := time.February; month <= time.May; month++ {
+		at := time.Date(2026, month, 1, 0, 0, 0, 0, time.UTC)
+		clock.FreezeTime(at)
+		require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, f.view, at))
+		_, err := f.chargesService.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: f.view.Customer.GetID()})
+		require.NoError(t, err)
+	}
+	ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.Len(t, ids, 4)
+	chargeByMonth := map[time.Month]string{}
+	for _, id := range ids {
+		result, err := f.chargesService.GetByID(ctx, charges.GetByIDInput{ChargeID: chargesmeta.ChargeID{Namespace: f.view.Subscription.Namespace, ID: id}})
+		require.NoError(t, err)
+		charge, err := result.AsFlatFeeCharge()
+		require.NoError(t, err)
+		chargeByMonth[charge.Intent.GetEffectiveServicePeriod().From.Month()] = id
+	}
+	require.Len(t, chargeByMonth, 4)
+
+	// when: a late purchase can cover all of April and only half of May.
+	at := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	clock.FreezeTime(at)
+	period := timeutil.ClosedPeriod{From: at, To: at}
+	fiat, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+	purchases, err := f.chargesService.Create(ctx, charges.CreateInput{
+		Namespace: f.view.Subscription.Namespace,
+		Intents: charges.ChargeIntents{charges.NewChargeIntent(creditpurchase.Intent{
+			Intent: chargesmeta.Intent{ManagedBy: billing.ManuallyManagedLine, CustomerID: f.view.Customer.ID, Currency: f.currency},
+			IntentMutableFields: creditpurchase.IntentMutableFields{
+				IntentMutableFields: chargesmeta.IntentMutableFields{Name: "Monthly advance backfill", ServicePeriod: period, FullServicePeriod: period, BillingPeriod: period},
+				CreditAmount:        decimal.NewFromInt(15), EffectiveAt: &at,
+				Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus}),
+			},
+			CostBasis: creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: decimal.NewFromFloat(0.5)})),
+		})},
+	})
+	require.NoError(t, err)
+	require.Len(t, purchases, 1)
+	purchaseID, err := purchases[0].GetChargeID()
+	require.NoError(t, err)
+	for _, status := range []payment.Status{payment.StatusAuthorized, payment.StatusSettled} {
+		_, err = f.chargesService.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{ChargeID: purchaseID, TargetPaymentState: status})
+		require.NoError(t, err)
+	}
+
+	// then: ledger and lineage agree per period, not just in the customer total.
+	expected := map[string]float64{chargeByMonth[time.April]: 10, chargeByMonth[time.May]: 5}
+	buckets, err := f.ledgerDeps.HistoricalLedger.GetBalanceBuckets(ctx, ledger.BalanceBucketQuery{
+		Namespace: f.view.Subscription.Namespace,
+		Filters: ledger.Filters{
+			AccountID: lo.ToPtr(f.business.EarningsAccount.ID().ID), SourceChargeID: mo.Some(&purchaseID.ID),
+			Route: ledger.RouteFilter{Currency: f.currency.Reference(), CostBasis: mo.Some(lo.ToPtr(decimal.NewFromFloat(0.5))), CostBasisCurrency: mo.Some(lo.ToPtr(currencyx.Code("USD")))},
+		},
+		GroupBy: []string{ledger.BalanceBucketGroupBySpendChargeID},
+	})
+	require.NoError(t, err)
+	booked := map[string]float64{}
+	for _, bucket := range buckets {
+		booked[lo.FromPtr(bucket.GroupByValues[ledger.BalanceBucketGroupBySpendChargeID])] += bucket.SettledAmount.InexactFloat64()
+	}
+	require.Equal(t, expected, booked)
+	roots, err := f.lineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{Namespace: f.view.Subscription.Namespace, CustomerID: f.view.Customer.ID, Currency: f.currency.Reference()})
+	require.NoError(t, err)
+	recognized := map[string]float64{}
+	uncovered := map[string]float64{}
+	for _, root := range roots {
+		if root.OriginKind != creditrealization.LineageOriginKindAdvance {
+			continue
+		}
+		for _, segment := range root.Segments {
+			switch segment.State {
+			case creditrealization.LineageSegmentStateEarningsRecognized:
+				require.Equal(t, creditrealization.LineageSegmentStateAdvanceBackfilled, lo.FromPtr(segment.SourceState))
+				recognized[root.ChargeID] += segment.Amount.InexactFloat64()
+			case creditrealization.LineageSegmentStateAdvanceUncovered:
+				uncovered[root.ChargeID] += segment.Amount.InexactFloat64()
+			default:
+				t.Fatalf("unexpected advance state %q", segment.State)
+			}
+		}
+	}
+	require.Equal(t, expected, recognized)
+	require.Equal(t, map[string]float64{chargeByMonth[time.May]: 5}, uncovered)
+	requireCustomCurrencyAccountBalance(t, f, f.business.EarningsAccount, 35)
+	beforeEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	_, err = f.chargesService.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: f.view.Customer.GetID()})
+	require.NoError(t, err)
+	afterEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeEntries, afterEntries)
+	assertNoSubscriptionInvoices(t, f.testDeps, f.view.Customer.ID)
+}

--- a/test/subscription/custom_currency_billing_test.go
+++ b/test/subscription/custom_currency_billing_test.go
@@ -1,0 +1,621 @@
+package subscription_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
+	const namespace = "test-namespace"
+
+	setupAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	startsAt := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	invoiceAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	usageAt := startsAt.Add(14 * 24 * time.Hour)
+
+	tests := []struct {
+		name                  string
+		settlementMode        productcatalog.SettlementMode
+		costBasisMode         subscription.CostBasisMode
+		planCurrency          currencyx.Code
+		customItem            bool
+		mixedFiatItem         bool
+		createCostBasis       bool
+		createReplacementRate bool
+		expectInvoice         bool
+		expectInvoiceTotal    float64
+		expectCustomLineTotal float64
+		expectFiatLineTotal   float64
+		expectCostBasisKind   costbasis.Mode
+	}{
+		{
+			name:           "credit only custom plan needs no cost basis and never invoices overage",
+			settlementMode: productcatalog.CreditOnlySettlementMode,
+			costBasisMode:  subscription.CostBasisModeDynamic,
+			planCurrency:   "CREDITS",
+		},
+		{
+			name:                  "credit then invoice custom plan converts uncovered usage dynamically",
+			settlementMode:        productcatalog.CreditThenInvoiceSettlementMode,
+			costBasisMode:         subscription.CostBasisModeDynamic,
+			planCurrency:          "CREDITS",
+			createCostBasis:       true,
+			expectInvoice:         true,
+			expectInvoiceTotal:    4,
+			expectCustomLineTotal: 4,
+			expectCostBasisKind:   costbasis.ModeDynamic,
+		},
+		{
+			name:                  "credit then invoice custom plan keeps its pinned cost basis after a replacement",
+			settlementMode:        productcatalog.CreditThenInvoiceSettlementMode,
+			costBasisMode:         subscription.CostBasisModePinned,
+			planCurrency:          "CREDITS",
+			createCostBasis:       true,
+			createReplacementRate: true,
+			expectInvoice:         true,
+			expectInvoiceTotal:    4,
+			expectCustomLineTotal: 4,
+			expectCostBasisKind:   costbasis.ModePinned,
+		},
+		{
+			name:                  "fiat plan routes a custom currency item through dynamic conversion",
+			settlementMode:        productcatalog.CreditThenInvoiceSettlementMode,
+			costBasisMode:         subscription.CostBasisModeDynamic,
+			planCurrency:          "USD",
+			customItem:            true,
+			createCostBasis:       true,
+			expectInvoice:         true,
+			expectInvoiceTotal:    4,
+			expectCustomLineTotal: 4,
+			expectCostBasisKind:   costbasis.ModeDynamic,
+		},
+		{
+			name:                  "mixed fiat and custom items share one fiat invoice while only custom usage is converted",
+			settlementMode:        productcatalog.CreditThenInvoiceSettlementMode,
+			costBasisMode:         subscription.CostBasisModePinned,
+			planCurrency:          "USD",
+			customItem:            true,
+			mixedFiatItem:         true,
+			createCostBasis:       true,
+			createReplacementRate: true,
+			expectInvoice:         true,
+			expectInvoiceTotal:    7,
+			expectCustomLineTotal: 4,
+			expectFiatLineTotal:   3,
+			expectCostBasisKind:   costbasis.ModePinned,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			// - a subscription whose usage is 5 units at 2 CREDITS per unit
+			// - only 2 CREDITS are available to cover its 10 CREDITS charge
+			// - the billing profile and settlement mode select whether an overage can become a USD invoice
+			clock.FreezeTime(setupAt)
+			defer clock.UnFreeze()
+
+			handler := newSubscriptionCurrencyUsageHandler(map[currencyx.Code]decimal.Decimal{
+				"CREDITS": decimal.NewFromInt(2),
+			})
+			deps := setup(t, setupConfig{
+				usageBasedHandler:       handler,
+				lineageService:          noOpChargeLineageService{},
+				enableCreditThenInvoice: true,
+			})
+			defer deps.cleanup(t)
+			provisionSubscriptionDefaultTaxCodes(t, deps, namespace)
+
+			profileInput := minimalCreateProfileInputTemplate(deps.sandboxApp.GetID())
+			profileInput.WorkflowConfig.Collection.Interval = datetime.MustParseDuration(t, "P1D")
+			profileInput.WorkflowConfig.Invoicing.AutoAdvance = false
+			_, err := deps.billingService.CreateProfile(t.Context(), profileInput)
+			require.NoError(t, err)
+
+			customCurrency, err := deps.CurrencyService.CreateCurrency(t.Context(), currenciestestutils.NewCreateCurrencyInput(
+				namespace, "CREDITS", "Credits", "CR",
+			))
+			require.NoError(t, err)
+
+			var pinnedCostBasisID string
+			if tc.createCostBasis {
+				createdCostBasis, err := deps.CurrencyService.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+					Namespace:  namespace,
+					CurrencyID: customCurrency.ID,
+					FiatCode:   "USD",
+					Rate:       decimal.NewFromFloat(0.5),
+				})
+				require.NoError(t, err)
+				pinnedCostBasisID = createdCostBasis.ID
+			}
+
+			features := deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+			createdPlan := createUsageSubscriptionPlan(t, deps, usageSubscriptionPlanInput{
+				Namespace:      namespace,
+				Key:            "custom-currency-billing",
+				PlanCurrency:   tc.planCurrency,
+				CustomCurrency: customCurrency,
+				CustomItem:     tc.customItem,
+				MixedFiatItem:  tc.mixedFiatItem,
+				Features:       features,
+				EffectiveFrom:  setupAt.Add(-time.Second),
+			})
+
+			customer := createUSDSubscriptionCustomer(t, deps, namespace, "custom-currency-billing")
+			createdSubscription, err := createCustomCurrencySubscription(
+				t,
+				deps,
+				createdPlan,
+				customer.ID,
+				startsAt,
+				tc.settlementMode,
+				tc.costBasisMode,
+			)
+			require.NoError(t, err)
+
+			if tc.createReplacementRate {
+				replacementEffectiveFrom := setupAt.Add(15 * 24 * time.Hour)
+				_, err = deps.CurrencyService.CreateCostBasis(t.Context(), currencies.CreateCostBasisInput{
+					Namespace:     namespace,
+					CurrencyID:    customCurrency.ID,
+					FiatCode:      "USD",
+					Rate:          decimal.NewFromFloat(0.75),
+					EffectiveFrom: &replacementEffectiveFrom,
+				})
+				require.NoError(t, err)
+			}
+
+			view, err := deps.subscriptionService.GetView(t.Context(), createdSubscription.NamespacedID)
+			require.NoError(t, err)
+			require.Equal(t, currencyx.Code("USD"), view.Subscription.InvoiceCurrency)
+			assertSubscriptionItemCurrencies(t, view, customCurrency.ID, tc.mixedFiatItem)
+
+			serializedView, err := json.Marshal(view)
+			require.NoError(t, err)
+			var eventView subscription.SubscriptionView
+			require.NoError(t, json.Unmarshal(serializedView, &eventView))
+
+			// when:
+			// - the serialized subscription event is synchronized through the charge backend twice
+			// - usage is realized at the end of the billing period
+			require.NoError(t, deps.subscriptionSyncService.SyncByView(t.Context(), eventView, invoiceAt))
+			chargeIDsBeforeRetry := listSubscriptionChargeIDs(t, deps, createdSubscription.ID)
+			require.NotEmpty(t, chargeIDsBeforeRetry)
+			require.NoError(t, deps.subscriptionSyncService.SyncByView(t.Context(), eventView, invoiceAt))
+			require.Equal(t, chargeIDsBeforeRetry, listSubscriptionChargeIDs(t, deps, createdSubscription.ID))
+
+			assertSubscriptionChargeCurrenciesAndCostBasis(
+				t,
+				deps,
+				createdSubscription.ID,
+				customCurrency.ID,
+				tc.expectCostBasisKind,
+				pinnedCostBasisID,
+			)
+
+			deps.MockStreamingConnector.AddSimpleEvent(
+				subscriptiontestutils.ExampleFeatureMeterSlug,
+				5,
+				usageAt,
+			)
+			clock.FreezeTime(invoiceAt)
+
+			if tc.settlementMode == productcatalog.CreditOnlySettlementMode {
+				_, err = deps.chargesService.AdvanceCharges(t.Context(), charges.AdvanceChargesInput{
+					Customer: customer.GetID(),
+				})
+				require.NoError(t, err)
+			} else {
+				invoices, err := deps.billingService.InvoicePendingLines(t.Context(), billing.InvoicePendingLinesInput{
+					Customer: customer.GetID(),
+					AsOf:     &invoiceAt,
+				})
+				require.NoError(t, err)
+				require.Len(t, invoices, 1)
+				assertCustomCurrencyInvoice(t, invoices[0], tc.expectInvoiceTotal, tc.expectCustomLineTotal, tc.expectFiatLineTotal)
+			}
+
+			// then:
+			// - credit-only usage is fully realized without creating billing artifacts
+			// - credit-then-invoice usage consumes 2 CREDITS and invoices only the converted remainder
+			if tc.expectInvoice {
+				require.Equal(t, float64(2), handler.allocated("CREDITS").InexactFloat64())
+			} else {
+				require.Equal(t, float64(10), handler.allocated("CREDITS").InexactFloat64())
+				assertNoSubscriptionInvoices(t, deps, customer.ID)
+			}
+		})
+	}
+}
+
+type usageSubscriptionPlanInput struct {
+	Namespace      string
+	Key            string
+	PlanCurrency   currencyx.Code
+	CustomCurrency currencies.Currency
+	CustomItem     bool
+	MixedFiatItem  bool
+	Features       []feature.Feature
+	EffectiveFrom  time.Time
+}
+
+func createUsageSubscriptionPlan(t *testing.T, deps testDeps, input usageSubscriptionPlanInput) plan.Plan {
+	t.Helper()
+	require.NotEmpty(t, input.Features)
+
+	month := datetime.MustParseDuration(t, "P1M")
+	customItem := input.PlanCurrency == input.CustomCurrency.GetCode() || input.CustomItem
+	customRateCard := &productcatalog.UsageBasedRateCard{
+		RateCardMeta: productcatalog.RateCardMeta{
+			Key:     input.Features[0].Key,
+			Name:    "Custom usage",
+			Feature: productcatalog.NewFeatureReference(&input.Features[0].ID, &input.Features[0].Key),
+			Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: decimal.NewFromInt(2),
+			}),
+		},
+		BillingCadence: month,
+	}
+	if input.CustomItem && input.PlanCurrency != input.CustomCurrency.GetCode() {
+		customRateCard.RateCardMeta.Currency = lo.ToPtr(input.CustomCurrency.Reference())
+	}
+	require.True(t, customItem)
+
+	rateCards := productcatalog.RateCards{customRateCard}
+	if input.MixedFiatItem {
+		require.GreaterOrEqual(t, len(input.Features), 2)
+		rateCards = append(rateCards, &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:     input.Features[1].Key,
+				Name:    "Fiat usage",
+				Feature: productcatalog.NewFeatureReference(&input.Features[1].ID, &input.Features[1].Key),
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: decimal.NewFromFloat(0.6),
+				}),
+			},
+			BillingCadence: month,
+		})
+	}
+
+	createdPlan, err := deps.PlanService.CreatePlan(t.Context(), plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{Namespace: input.Namespace},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Key:            input.Key,
+				Name:           "Custom currency billing",
+				Currency:       currencies.NewCurrencyReference(input.PlanCurrency),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: month,
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{{
+				PhaseMeta: productcatalog.PhaseMeta{Key: "default", Name: "Default"},
+				RateCards: rateCards,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	createdPlan, err = deps.PlanService.PublishPlan(t.Context(), plan.PublishPlanInput{
+		NamespacedID: createdPlan.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: &input.EffectiveFrom,
+		},
+	})
+	require.NoError(t, err)
+
+	return *createdPlan
+}
+
+func assertSubscriptionItemCurrencies(t *testing.T, view subscription.SubscriptionView, customCurrencyID string, expectFiatItem bool) {
+	t.Helper()
+
+	phase, ok := view.GetPhaseByKey("default")
+	require.True(t, ok)
+	customItems := phase.ItemsByKey[subscriptiontestutils.ExampleFeatureKey]
+	require.Len(t, customItems, 1)
+	customCurrency := customItems[0].SubscriptionItem.RateCard.AsMeta().Currency
+	require.NotNil(t, customCurrency)
+	require.Equal(t, customCurrencyID, lo.FromPtr(customCurrency.CustomCurrencyID))
+
+	if expectFiatItem {
+		fiatItems := phase.ItemsByKey[subscriptiontestutils.ExampleFeatureKey2]
+		require.Len(t, fiatItems, 1)
+		fiatCurrency := fiatItems[0].SubscriptionItem.RateCard.AsMeta().Currency
+		require.NotNil(t, fiatCurrency)
+		require.True(t, fiatCurrency.IsFiat())
+		require.Equal(t, currencyx.Code("USD"), fiatCurrency.GetCode())
+	}
+}
+
+func listSubscriptionChargeIDs(t *testing.T, deps testDeps, subscriptionID string) []string {
+	t.Helper()
+
+	result, err := deps.chargesService.ListCharges(t.Context(), charges.ListChargesInput{
+		Page:            pagination.Page{PageNumber: 1, PageSize: 100},
+		Namespace:       "test-namespace",
+		SubscriptionIDs: []string{subscriptionID},
+		OrderBy:         "id",
+	})
+	require.NoError(t, err)
+
+	chargeIDs := make([]string, 0, len(result.Items))
+	for _, charge := range result.Items {
+		chargeID, err := charge.GetChargeID()
+		require.NoError(t, err)
+		chargeIDs = append(chargeIDs, chargeID.ID)
+	}
+
+	return chargeIDs
+}
+
+func assertSubscriptionChargeCurrenciesAndCostBasis(
+	t *testing.T,
+	deps testDeps,
+	subscriptionID string,
+	customCurrencyID string,
+	expectKind costbasis.Mode,
+	expectPinnedCostBasisID string,
+) {
+	t.Helper()
+
+	result, err := deps.chargesService.ListCharges(t.Context(), charges.ListChargesInput{
+		Page:            pagination.Page{PageNumber: 1, PageSize: 100},
+		Namespace:       "test-namespace",
+		SubscriptionIDs: []string{subscriptionID},
+		ChargeTypes:     []chargesmeta.ChargeType{chargesmeta.ChargeTypeUsageBased},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	customCharges := 0
+	fiatCharges := 0
+	for _, item := range result.Items {
+		charge, err := item.AsUsageBasedCharge()
+		require.NoError(t, err)
+		if charge.Intent.GetCurrency().IsFiat() {
+			fiatCharges++
+			require.Nil(t, charge.Intent.GetCostBasisIntent())
+			continue
+		}
+
+		customCharges++
+		require.Equal(t, customCurrencyID, charge.Intent.GetCurrency().ID)
+		costBasisIntent := charge.Intent.GetCostBasisIntent()
+		if expectKind == "" {
+			require.Nil(t, costBasisIntent)
+			continue
+		}
+
+		require.NotNil(t, costBasisIntent)
+		require.Equal(t, expectKind, costBasisIntent.Kind())
+		if expectKind == costbasis.ModePinned {
+			pinned, err := costBasisIntent.AsPinned()
+			require.NoError(t, err)
+			require.Equal(t, expectPinnedCostBasisID, pinned.CurrencyCostBasisID)
+		}
+	}
+	require.Positive(t, customCharges)
+	if fiatCharges > 0 {
+		require.Equal(t, costbasis.ModePinned, expectKind)
+	}
+}
+
+func assertCustomCurrencyInvoice(t *testing.T, invoice billing.StandardInvoice, expectedTotal, expectedCustomTotal, expectedFiatTotal float64) {
+	t.Helper()
+
+	require.Equal(t, currencyx.FiatCode("USD"), invoice.Currency)
+	require.Equal(t, expectedTotal, invoice.Totals.Total.InexactFloat64())
+
+	lines := invoice.Lines.OrEmpty()
+	expectedLineCount := 1
+	if expectedFiatTotal > 0 {
+		expectedLineCount++
+	}
+	require.Len(t, lines, expectedLineCount)
+
+	customLine, found := lo.Find(lines, func(line *billing.StandardLine) bool {
+		return line.Name == "Custom usage"
+	})
+	require.True(t, found)
+	require.Equal(t, currencyx.FiatCode("USD"), customLine.Currency)
+	require.Equal(t, expectedCustomTotal, customLine.Totals.Total.InexactFloat64())
+	require.Len(t, customLine.DetailedLines, 1)
+	require.Equal(t, float64(8), customLine.DetailedLines[0].Quantity.InexactFloat64())
+	require.Equal(t, float64(0.5), customLine.DetailedLines[0].PerUnitAmount.InexactFloat64())
+
+	if expectedFiatTotal > 0 {
+		fiatLine, found := lo.Find(lines, func(line *billing.StandardLine) bool {
+			return line.Name == "Fiat usage"
+		})
+		require.True(t, found)
+		require.Equal(t, expectedFiatTotal, fiatLine.Totals.Total.InexactFloat64())
+	}
+}
+
+func assertNoSubscriptionInvoices(t *testing.T, deps testDeps, customerID string) {
+	t.Helper()
+
+	standardInvoices, err := deps.billingService.ListInvoices(t.Context(), billing.ListInvoicesInput{
+		Page:         pagination.Page{PageNumber: 1, PageSize: 100},
+		Namespace:    "test-namespace",
+		OnlyStandard: true,
+		Expand:       billing.InvoiceExpandAll,
+	})
+	require.NoError(t, err)
+	require.Empty(t, standardInvoices.Items)
+
+	gatheringInvoices, err := deps.billingService.ListGatheringInvoices(t.Context(), billing.ListGatheringInvoicesInput{
+		Page:      pagination.Page{PageNumber: 1, PageSize: 100},
+		Namespace: "test-namespace",
+		Customers: []string{customerID},
+		Expand:    billing.GatheringInvoiceExpandAll,
+	})
+	require.NoError(t, err)
+	require.Empty(t, gatheringInvoices.Items)
+}
+
+func provisionSubscriptionDefaultTaxCodes(t *testing.T, deps testDeps, namespace string) {
+	t.Helper()
+
+	invoicing, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       taxcode.ProviderDefaultTaxCodeKey,
+		Name:      "Provider Default",
+	})
+	require.NoError(t, err)
+	creditGrant, err := deps.TaxCodeService.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "default-credit-grant",
+		Name:      "Default Credit Grant",
+	})
+	require.NoError(t, err)
+
+	_, err = deps.TaxCodeService.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            namespace,
+		InvoicingTaxCodeID:   invoicing.ID,
+		CreditGrantTaxCodeID: creditGrant.ID,
+	})
+	require.NoError(t, err)
+}
+
+type subscriptionCurrencyUsageHandler struct {
+	usagebased.Handler
+
+	mu                  sync.Mutex
+	remaining           map[currencyx.Code]decimal.Decimal
+	allocatedByCurrency map[currencyx.Code]decimal.Decimal
+}
+
+func newSubscriptionCurrencyUsageHandler(available map[currencyx.Code]decimal.Decimal) *subscriptionCurrencyUsageHandler {
+	handlers := chargestestutils.NewMockHandlers()
+	return &subscriptionCurrencyUsageHandler{
+		Handler:             handlers.UsageBased,
+		remaining:           available,
+		allocatedByCurrency: map[currencyx.Code]decimal.Decimal{},
+	}
+}
+
+func (h *subscriptionCurrencyUsageHandler) OnCreditsOnlyUsageAccrued(
+	_ context.Context,
+	input usagebased.CreditsOnlyUsageAccruedInput,
+) (creditrealization.CreateAllocationInputs, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	amount := input.AmountToAllocate
+	currency := input.Charge.Intent.GetCurrency().GetCode()
+	if input.Charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode {
+		remaining := h.remaining[currency]
+		if amount.GreaterThan(remaining) {
+			amount = remaining
+		}
+		h.remaining[currency] = remaining.Sub(amount)
+	}
+
+	if amount.IsZero() {
+		return nil, nil
+	}
+
+	h.allocatedByCurrency[currency] = h.allocatedByCurrency[currency].Add(amount)
+	return creditrealization.CreateAllocationInputs{{
+		ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
+		LedgerTransaction: ledgertransaction.GroupReference{
+			TransactionGroupID: ulid.Make().String(),
+		},
+		Amount: amount,
+	}}, nil
+}
+
+func (h *subscriptionCurrencyUsageHandler) OnAllocateFiatOverageCredits(
+	context.Context,
+	usagebased.AllocateFiatOverageCreditsInput,
+) (creditrealization.CreateAllocationInputs, error) {
+	return nil, nil
+}
+
+func (h *subscriptionCurrencyUsageHandler) allocated(currency currencyx.Code) decimal.Decimal {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.allocatedByCurrency[currency]
+}
+
+type noOpChargeLineageService struct{}
+
+var _ lineage.Service = (*noOpChargeLineageService)(nil)
+
+func (noOpChargeLineageService) CreateInitialLineages(context.Context, lineage.CreateInitialLineagesInput) error {
+	return nil
+}
+
+func (noOpChargeLineageService) LoadActiveSegmentsByRealizationID(
+	context.Context,
+	string,
+	[]string,
+) (lineage.ActiveSegmentsByRealizationID, error) {
+	return lineage.ActiveSegmentsByRealizationID{}, nil
+}
+
+func (noOpChargeLineageService) LoadLineagesByCustomer(
+	context.Context,
+	lineage.LoadLineagesByCustomerInput,
+) ([]lineage.Lineage, error) {
+	return nil, nil
+}
+
+func (noOpChargeLineageService) PersistCorrectionLineageSegments(
+	context.Context,
+	lineage.PersistCorrectionLineageSegmentsInput,
+) error {
+	return nil
+}
+
+func (noOpChargeLineageService) BackfillAdvanceLineageSegments(
+	context.Context,
+	lineage.BackfillAdvanceLineageSegmentsInput,
+) error {
+	return nil
+}
+
+func (noOpChargeLineageService) CloseSegment(context.Context, string, time.Time) error {
+	return nil
+}
+
+func (noOpChargeLineageService) CreateSegment(context.Context, lineage.CreateSegmentInput) error {
+	return nil
+}

--- a/test/subscription/custom_currency_billing_test.go
+++ b/test/subscription/custom_currency_billing_test.go
@@ -1,28 +1,25 @@
 package subscription_test
 
 import (
-	"context"
 	"encoding/json"
-	"sync"
 	"testing"
 	"time"
 
 	decimal "github.com/alpacahq/alpacadecimal"
-	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
-	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
@@ -34,6 +31,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
@@ -74,6 +72,18 @@ func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
 			expectInvoice:         true,
 			expectInvoiceTotal:    4,
 			expectCustomLineTotal: 4,
+			expectCostBasisKind:   costbasis.ModeDynamic,
+		},
+		{
+			name:                  "dynamic custom pricing uses the replacement rate at realization",
+			settlementMode:        productcatalog.CreditThenInvoiceSettlementMode,
+			costBasisMode:         subscription.CostBasisModeDynamic,
+			planCurrency:          "CREDITS",
+			createCostBasis:       true,
+			createReplacementRate: true,
+			expectInvoice:         true,
+			expectInvoiceTotal:    6,
+			expectCustomLineTotal: 6,
 			expectCostBasisKind:   costbasis.ModeDynamic,
 		},
 		{
@@ -126,14 +136,7 @@ func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
 			clock.FreezeTime(setupAt)
 			defer clock.UnFreeze()
 
-			handler := newSubscriptionCurrencyUsageHandler(map[currencyx.Code]decimal.Decimal{
-				"CREDITS": decimal.NewFromInt(2),
-			})
-			deps := setup(t, setupConfig{
-				usageBasedHandler:       handler,
-				lineageService:          noOpChargeLineageService{},
-				enableCreditThenInvoice: true,
-			})
+			deps := setup(t, setupConfig{enableCharges: true, enableCreditThenInvoice: true})
 			defer deps.cleanup(t)
 			provisionSubscriptionDefaultTaxCodes(t, deps, namespace)
 
@@ -173,6 +176,24 @@ func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
 			})
 
 			customer := createUSDSubscriptionCustomer(t, deps, namespace, "custom-currency-billing")
+			_, err = deps.ledgerDeps.ResolversService.EnsureBusinessAccounts(t.Context(), namespace)
+			require.NoError(t, err)
+			accounts, err := deps.ledgerDeps.ResolversService.CreateCustomerAccounts(t.Context(), customer.GetID())
+			require.NoError(t, err)
+			period := timeutil.ClosedPeriod{From: setupAt, To: setupAt}
+			grants, err := deps.chargesService.Create(t.Context(), charges.CreateInput{
+				Namespace: namespace,
+				Intents: charges.ChargeIntents{charges.NewChargeIntent(creditpurchase.Intent{
+					Intent: chargesmeta.Intent{ManagedBy: billing.ManuallyManagedLine, CustomerID: customer.ID, Currency: customCurrency},
+					IntentMutableFields: creditpurchase.IntentMutableFields{
+						IntentMutableFields: chargesmeta.IntentMutableFields{Name: "Initial custom credits", ServicePeriod: period, FullServicePeriod: period, BillingPeriod: period},
+						CreditAmount:        decimal.NewFromInt(2), EffectiveAt: &setupAt,
+						Settlement: creditpurchase.NewSettlement(creditpurchase.PromotionalSettlement{}),
+					},
+				})},
+			})
+			require.NoError(t, err)
+			require.Len(t, grants, 1)
 			createdSubscription, err := createCustomCurrencySubscription(
 				t,
 				deps,
@@ -249,10 +270,107 @@ func TestSubscriptionSyncCustomCurrencyBilling(t *testing.T) {
 			// then:
 			// - credit-only usage is fully realized without creating billing artifacts
 			// - credit-then-invoice usage consumes 2 CREDITS and invoices only the converted remainder
-			if tc.expectInvoice {
-				require.Equal(t, float64(2), handler.allocated("CREDITS").InexactFloat64())
-			} else {
-				require.Equal(t, float64(10), handler.allocated("CREDITS").InexactFloat64())
+			expectedAllocated := float64(2)
+			if !tc.expectInvoice {
+				expectedAllocated = 10
+				assertNoSubscriptionInvoices(t, deps, customer.ID)
+			}
+			balance, err := deps.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), accounts.FBOAccount, ledger.RouteFilter{Currency: customCurrency.Reference()}, ledger.BalanceQuery{})
+			require.NoError(t, err)
+			require.Equal(t, float64(0), balance.InexactFloat64())
+			if !tc.expectInvoice {
+				advance, err := deps.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), accounts.ReceivableAccount, ledger.RouteFilter{Currency: customCurrency.Reference()}, ledger.BalanceQuery{})
+				require.NoError(t, err)
+				require.Equal(t, float64(-8), advance.InexactFloat64())
+			}
+
+			lineages, err := deps.lineageService.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{Namespace: namespace, CustomerID: customer.ID, Currency: customCurrency.Reference()})
+			require.NoError(t, err)
+			require.NotEmpty(t, lineages)
+			allocated := decimal.Zero
+			for _, entry := range lineages {
+				for _, segment := range entry.Segments {
+					allocated = allocated.Add(segment.Amount)
+				}
+			}
+			require.Equal(t, expectedAllocated, allocated.InexactFloat64())
+			// Retrying synchronization and advancement must preserve the journal,
+			// not just stable charge identifiers.
+			beforeEntries, err := deps.DBDeps.DBClient.LedgerEntry.Query().Count(t.Context())
+			require.NoError(t, err)
+			require.NoError(t, deps.subscriptionSyncService.SyncByView(t.Context(), eventView, invoiceAt))
+			_, err = deps.chargesService.AdvanceCharges(t.Context(), charges.AdvanceChargesInput{Customer: customer.GetID()})
+			require.NoError(t, err)
+			afterEntries, err := deps.DBDeps.DBClient.LedgerEntry.Query().Count(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, beforeEntries, afterEntries)
+			if !tc.expectInvoice {
+				// A paid purchase backfills the subscription's uncovered advance;
+				// payment settlement must recognize the paid native spend exactly once.
+				backfillAt := invoiceAt.Add(time.Minute)
+				clock.FreezeTime(backfillAt)
+				period := timeutil.ClosedPeriod{From: backfillAt, To: backfillAt}
+				fiat, err := currencyx.NewFiatCurrency("USD")
+				require.NoError(t, err)
+				purchases, err := deps.chargesService.Create(t.Context(), charges.CreateInput{
+					Namespace: namespace,
+					Intents: charges.ChargeIntents{charges.NewChargeIntent(creditpurchase.Intent{
+						Intent: chargesmeta.Intent{ManagedBy: billing.ManuallyManagedLine, CustomerID: customer.ID, Currency: customCurrency},
+						IntentMutableFields: creditpurchase.IntentMutableFields{
+							IntentMutableFields: chargesmeta.IntentMutableFields{Name: "Advance backfill", ServicePeriod: period, FullServicePeriod: period, BillingPeriod: period},
+							CreditAmount:        decimal.NewFromInt(8), EffectiveAt: &backfillAt,
+							Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus}),
+						},
+						CostBasis: creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: decimal.NewFromFloat(0.5)})),
+					})},
+				})
+				require.NoError(t, err)
+				require.Len(t, purchases, 1)
+				purchaseID, err := purchases[0].GetChargeID()
+				require.NoError(t, err)
+				for _, status := range []payment.Status{payment.StatusAuthorized, payment.StatusSettled} {
+					_, err = deps.chargesService.HandleCreditPurchaseExternalPaymentStateTransition(t.Context(), charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{ChargeID: purchaseID, TargetPaymentState: status})
+					require.NoError(t, err)
+				}
+				advance, err := deps.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), accounts.ReceivableAccount, ledger.RouteFilter{Currency: customCurrency.Reference()}, ledger.BalanceQuery{})
+				require.NoError(t, err)
+				require.Equal(t, float64(0), advance.InexactFloat64())
+				backfilled, err := deps.lineageService.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{Namespace: namespace, CustomerID: customer.ID, Currency: customCurrency.Reference()})
+				require.NoError(t, err)
+				business, err := deps.ledgerDeps.ResolversService.GetBusinessAccounts(t.Context(), namespace)
+				require.NoError(t, err)
+				earnings, err := deps.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), business.EarningsAccount, ledger.RouteFilter{Currency: customCurrency.Reference()}, ledger.BalanceQuery{})
+				require.NoError(t, err)
+				require.Equal(t, float64(8), earnings.InexactFloat64())
+				accrued, err := deps.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), accounts.AccruedAccount, ledger.RouteFilter{Currency: customCurrency.Reference()}, ledger.BalanceQuery{})
+				require.NoError(t, err)
+				require.Equal(t, float64(2), accrued.InexactFloat64())
+
+				// Nil-cost-basis promotional credits remain deferred. Recognition
+				// must belong entirely to the paid backfill, matching the journal.
+				require.Len(t, backfilled, 2)
+				for _, entry := range backfilled {
+					require.Len(t, entry.Segments, 1)
+					segment := entry.Segments[0]
+					switch entry.OriginKind {
+					case creditrealization.LineageOriginKindRealCredit:
+						require.Equal(t, float64(2), segment.Amount.InexactFloat64())
+						require.Equal(t, creditrealization.LineageSegmentStateRealCredit, segment.State)
+					case creditrealization.LineageOriginKindAdvance:
+						require.Equal(t, float64(8), segment.Amount.InexactFloat64())
+						require.Equal(t, creditrealization.LineageSegmentStateEarningsRecognized, segment.State)
+						require.Equal(t, creditrealization.LineageSegmentStateAdvanceBackfilled, lo.FromPtr(segment.SourceState))
+					default:
+						t.Fatalf("unexpected lineage origin %q", entry.OriginKind)
+					}
+				}
+				beforeEntries, err = deps.DBDeps.DBClient.LedgerEntry.Query().Count(t.Context())
+				require.NoError(t, err)
+				_, err = deps.chargesService.AdvanceCharges(t.Context(), charges.AdvanceChargesInput{Customer: customer.GetID()})
+				require.NoError(t, err)
+				afterEntries, err = deps.DBDeps.DBClient.LedgerEntry.Query().Count(t.Context())
+				require.NoError(t, err)
+				require.Equal(t, beforeEntries, afterEntries)
 				assertNoSubscriptionInvoices(t, deps, customer.ID)
 			}
 		})
@@ -456,7 +574,7 @@ func assertCustomCurrencyInvoice(t *testing.T, invoice billing.StandardInvoice, 
 	require.Equal(t, expectedCustomTotal, customLine.Totals.Total.InexactFloat64())
 	require.Len(t, customLine.DetailedLines, 1)
 	require.Equal(t, float64(8), customLine.DetailedLines[0].Quantity.InexactFloat64())
-	require.Equal(t, float64(0.5), customLine.DetailedLines[0].PerUnitAmount.InexactFloat64())
+	require.Equal(t, expectedCustomTotal/8, customLine.DetailedLines[0].PerUnitAmount.InexactFloat64())
 
 	if expectedFiatTotal > 0 {
 		fiatLine, found := lo.Find(lines, func(line *billing.StandardLine) bool {
@@ -511,111 +629,4 @@ func provisionSubscriptionDefaultTaxCodes(t *testing.T, deps testDeps, namespace
 		CreditGrantTaxCodeID: creditGrant.ID,
 	})
 	require.NoError(t, err)
-}
-
-type subscriptionCurrencyUsageHandler struct {
-	usagebased.Handler
-
-	mu                  sync.Mutex
-	remaining           map[currencyx.Code]decimal.Decimal
-	allocatedByCurrency map[currencyx.Code]decimal.Decimal
-}
-
-func newSubscriptionCurrencyUsageHandler(available map[currencyx.Code]decimal.Decimal) *subscriptionCurrencyUsageHandler {
-	handlers := chargestestutils.NewMockHandlers()
-	return &subscriptionCurrencyUsageHandler{
-		Handler:             handlers.UsageBased,
-		remaining:           available,
-		allocatedByCurrency: map[currencyx.Code]decimal.Decimal{},
-	}
-}
-
-func (h *subscriptionCurrencyUsageHandler) OnCreditsOnlyUsageAccrued(
-	_ context.Context,
-	input usagebased.CreditsOnlyUsageAccruedInput,
-) (creditrealization.CreateAllocationInputs, error) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	amount := input.AmountToAllocate
-	currency := input.Charge.Intent.GetCurrency().GetCode()
-	if input.Charge.Intent.GetSettlementMode() == productcatalog.CreditThenInvoiceSettlementMode {
-		remaining := h.remaining[currency]
-		if amount.GreaterThan(remaining) {
-			amount = remaining
-		}
-		h.remaining[currency] = remaining.Sub(amount)
-	}
-
-	if amount.IsZero() {
-		return nil, nil
-	}
-
-	h.allocatedByCurrency[currency] = h.allocatedByCurrency[currency].Add(amount)
-	return creditrealization.CreateAllocationInputs{{
-		ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
-		LedgerTransaction: ledgertransaction.GroupReference{
-			TransactionGroupID: ulid.Make().String(),
-		},
-		Amount: amount,
-	}}, nil
-}
-
-func (h *subscriptionCurrencyUsageHandler) OnAllocateFiatOverageCredits(
-	context.Context,
-	usagebased.AllocateFiatOverageCreditsInput,
-) (creditrealization.CreateAllocationInputs, error) {
-	return nil, nil
-}
-
-func (h *subscriptionCurrencyUsageHandler) allocated(currency currencyx.Code) decimal.Decimal {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	return h.allocatedByCurrency[currency]
-}
-
-type noOpChargeLineageService struct{}
-
-var _ lineage.Service = (*noOpChargeLineageService)(nil)
-
-func (noOpChargeLineageService) CreateInitialLineages(context.Context, lineage.CreateInitialLineagesInput) error {
-	return nil
-}
-
-func (noOpChargeLineageService) LoadActiveSegmentsByRealizationID(
-	context.Context,
-	string,
-	[]string,
-) (lineage.ActiveSegmentsByRealizationID, error) {
-	return lineage.ActiveSegmentsByRealizationID{}, nil
-}
-
-func (noOpChargeLineageService) LoadLineagesByCustomer(
-	context.Context,
-	lineage.LoadLineagesByCustomerInput,
-) ([]lineage.Lineage, error) {
-	return nil, nil
-}
-
-func (noOpChargeLineageService) PersistCorrectionLineageSegments(
-	context.Context,
-	lineage.PersistCorrectionLineageSegmentsInput,
-) error {
-	return nil
-}
-
-func (noOpChargeLineageService) BackfillAdvanceLineageSegments(
-	context.Context,
-	lineage.BackfillAdvanceLineageSegmentsInput,
-) error {
-	return nil
-}
-
-func (noOpChargeLineageService) CloseSegment(context.Context, string, time.Time) error {
-	return nil
-}
-
-func (noOpChargeLineageService) CreateSegment(context.Context, lineage.CreateSegmentInput) error {
-	return nil
 }

--- a/test/subscription/custom_currency_lifecycle_test.go
+++ b/test/subscription/custom_currency_lifecycle_test.go
@@ -159,6 +159,60 @@ func TestSubscriptionCustomCurrencyRealizedCancellation(t *testing.T) {
 	assertNoSubscriptionInvoices(t, f.testDeps, f.view.Customer.ID)
 }
 
+func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
+	for _, cancelAgain := range []bool{false, true} {
+		name := "continued"
+		if cancelAgain {
+			name = "canceled again later"
+		}
+		t.Run(name, func(t *testing.T) {
+			// given: a cancellation event queued before continuation and a newer sync.
+			clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+			defer clock.UnFreeze()
+			f := setupCustomCurrencyFlatFeeSubscription(t)
+			ctx := t.Context()
+			clock.FreezeTime(time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC))
+			_, err := f.subscriptionService.Cancel(ctx, f.view.Subscription.NamespacedID, subscription.Timing{Enum: lo.ToPtr(subscription.TimingNextBillingCycle)})
+			require.NoError(t, err)
+			canceled, err := f.subscriptionService.GetView(ctx, f.view.Subscription.NamespacedID)
+			require.NoError(t, err)
+			event := subscription.NewCancelledEvent(ctx, canceled)
+			_, err = f.subscriptionService.Continue(ctx, f.view.Subscription.NamespacedID)
+			require.NoError(t, err)
+			if cancelAgain {
+				clock.FreezeTime(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+				_, err = f.subscriptionService.Cancel(ctx, f.view.Subscription.NamespacedID, subscription.Timing{Enum: lo.ToPtr(subscription.TimingNextBillingCycle)})
+				require.NoError(t, err)
+			}
+			current, err := f.subscriptionService.GetView(ctx, f.view.Subscription.NamespacedID)
+			require.NoError(t, err)
+			horizon := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+			require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, current, horizon))
+			ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+			require.GreaterOrEqual(t, len(ids), 3)
+			states, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
+			require.NoError(t, err)
+			require.Len(t, states, 1)
+			beforeEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+			require.NoError(t, err)
+
+			// when: the obsolete cancellation is delivered and retried.
+			for range 2 {
+				require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, &event))
+				// then: the newer schedule and its accounting remain intact.
+				require.Equal(t, ids, listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID))
+				afterEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+				require.NoError(t, err)
+				require.Equal(t, beforeEntries, afterEntries)
+				afterStates, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
+				require.NoError(t, err)
+				require.Len(t, afterStates, 1)
+				require.Equal(t, states[0].NextSyncAfter, afterStates[0].NextSyncAfter)
+			}
+		})
+	}
+}
+
 func TestSubscriptionCustomCurrencyScheduledDeletion(t *testing.T) {
 	// given: future custom charges already exist for a scheduled subscription.
 	clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))

--- a/test/subscription/custom_currency_lifecycle_test.go
+++ b/test/subscription/custom_currency_lifecycle_test.go
@@ -160,12 +160,16 @@ func TestSubscriptionCustomCurrencyRealizedCancellation(t *testing.T) {
 }
 
 func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
-	for _, cancelAgain := range []bool{false, true} {
-		name := "continued"
-		if cancelAgain {
-			name = "canceled again later"
-		}
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		cancelMonth     time.Month
+		expectedCharges int
+	}{
+		{name: "continued", expectedCharges: 4},
+		{name: "canceled again later", cancelMonth: time.April, expectedCharges: 3},
+		{name: "canceled again for the same date", cancelMonth: time.February, expectedCharges: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			// given: a cancellation event queued before continuation and a newer sync.
 			clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 			defer clock.UnFreeze()
@@ -177,19 +181,24 @@ func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
 			canceled, err := f.subscriptionService.GetView(ctx, f.view.Subscription.NamespacedID)
 			require.NoError(t, err)
 			event := subscription.NewCancelledEvent(ctx, canceled)
+			clock.FreezeTime(time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC))
 			_, err = f.subscriptionService.Continue(ctx, f.view.Subscription.NamespacedID)
 			require.NoError(t, err)
-			if cancelAgain {
-				clock.FreezeTime(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+			if tc.cancelMonth != 0 {
+				clock.FreezeTime(time.Date(2026, tc.cancelMonth, 17, 0, 0, 0, 0, time.UTC))
 				_, err = f.subscriptionService.Cancel(ctx, f.view.Subscription.NamespacedID, subscription.Timing{Enum: lo.ToPtr(subscription.TimingNextBillingCycle)})
 				require.NoError(t, err)
 			}
 			current, err := f.subscriptionService.GetView(ctx, f.view.Subscription.NamespacedID)
 			require.NoError(t, err)
+			require.True(t, current.Subscription.UpdatedAt.After(event.Subscription.UpdatedAt))
+			if tc.cancelMonth == time.February {
+				require.Equal(t, event.Spec.ActiveTo, current.Spec.ActiveTo)
+			}
 			horizon := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 			require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, current, horizon))
 			ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
-			require.GreaterOrEqual(t, len(ids), 3)
+			require.Len(t, ids, tc.expectedCharges)
 			states, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
 			require.NoError(t, err)
 			require.Len(t, states, 1)
@@ -197,6 +206,7 @@ func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
 			require.NoError(t, err)
 
 			// when: the obsolete cancellation is delivered and retried.
+			clock.FreezeTime(clock.Now().Add(time.Minute))
 			for range 2 {
 				require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, &event))
 				// then: the newer schedule and its accounting remain intact.
@@ -207,7 +217,7 @@ func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
 				afterStates, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
 				require.NoError(t, err)
 				require.Len(t, afterStates, 1)
-				require.Equal(t, states[0].NextSyncAfter, afterStates[0].NextSyncAfter)
+				require.Equal(t, states, afterStates)
 			}
 		})
 	}

--- a/test/subscription/custom_currency_lifecycle_test.go
+++ b/test/subscription/custom_currency_lifecycle_test.go
@@ -1,6 +1,7 @@
 package subscription_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -23,7 +24,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -159,6 +162,83 @@ func TestSubscriptionCustomCurrencyRealizedCancellation(t *testing.T) {
 	assertNoSubscriptionInvoices(t, f.testDeps, f.view.Customer.ID)
 }
 
+// Capture the same snapshot Cancel publishes, then let later workflow writes
+// receive a newer root timestamp instead of hiding them behind a frozen clock.
+type cancellationSnapshotHook struct {
+	subscription.NoOpSubscriptionCommandHook
+	event *subscription.CancelledEvent
+}
+
+func (h *cancellationSnapshotHook) AfterCancel(ctx context.Context, view subscription.SubscriptionView) error {
+	h.event = lo.ToPtr(subscription.NewCancelledEvent(ctx, view))
+	clock.FreezeTime(clock.Now().Add(time.Second))
+	return nil
+}
+
+func TestSubscriptionCustomCurrencyPlanChangeReconcilesCancellation(t *testing.T) {
+	// given: a realized fee and future charges on the subscription being replaced.
+	clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+	f := setupCustomCurrencyFlatFeeSubscription(t)
+	ctx := t.Context()
+	require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, f.view, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)))
+	ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.Len(t, ids, 2)
+	clock.FreezeTime(f.view.Subscription.ActiveFrom)
+	_, err := f.chargesService.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: f.view.Customer.GetID()})
+	require.NoError(t, err)
+	requireCustomCurrencyAccountBalance(t, f, f.business.EarningsAccount, 10)
+	hook := &cancellationSnapshotHook{}
+	require.NoError(t, f.subscriptionService.RegisterHook(hook))
+	month := datetime.MustParseDuration(t, "P1M")
+	planInput := pcsubscription.PlanInput{}
+	planInput.FromInput(&plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{Namespace: f.view.Subscription.Namespace},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{Name: "Replacement", Currency: f.currency.Reference(), SettlementMode: productcatalog.CreditOnlySettlementMode, BillingCadence: month},
+			Phases: []productcatalog.Phase{{PhaseMeta: productcatalog.PhaseMeta{Key: "default", Name: "Default"}, RateCards: productcatalog.RateCards{&productcatalog.FlatFeeRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{Key: "flat-fee", Name: "Replacement fee", Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{Amount: decimal.NewFromInt(20), PaymentTerm: productcatalog.InAdvancePaymentTerm})}, BillingCadence: &month,
+			}}}},
+		},
+	})
+
+	// when: plan replacement annotates the old root after publishing cancellation.
+	cancelAt := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	clock.FreezeTime(cancelAt)
+	changed, err := f.pcSubscriptionService.Change(ctx, pcsubscription.ChangeSubscriptionRequest{
+		ID: f.view.Subscription.NamespacedID,
+		WorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)}, Name: "Replacement", CostBasisMode: subscription.CostBasisModeDynamic,
+		},
+		PlanInput: planInput, SettlementMode: lo.ToPtr(productcatalog.CreditOnlySettlementMode),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hook.event)
+	require.True(t, changed.Current.UpdatedAt.After(hook.event.Subscription.UpdatedAt))
+	require.Equal(t, changed.Next.Subscription.ID, lo.FromPtr(subscription.AnnotationParser.GetSupersedingSubscriptionID(changed.Current.Annotations)))
+	require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, hook.event))
+
+	// then: annotation-only freshness does not suppress the old fee's correction.
+	remaining := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.Len(t, remaining, 1)
+	require.Contains(t, ids, remaining[0])
+	result, err := f.chargesService.GetByID(ctx, charges.GetByIDInput{ChargeID: chargesmeta.ChargeID{Namespace: f.view.Subscription.Namespace, ID: remaining[0]}})
+	require.NoError(t, err)
+	charge, err := result.AsFlatFeeCharge()
+	require.NoError(t, err)
+	require.Equal(t, cancelAt, charge.Intent.GetEffectiveServicePeriod().To)
+	require.Equal(t, float64(5), charge.State.AmountAfterProration.InexactFloat64())
+	requireCustomCurrencyAccountBalance(t, f, f.accounts.FBOAccount, 15)
+	requireCustomCurrencyAccountBalance(t, f, f.business.EarningsAccount, 5)
+	beforeEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, hook.event))
+	afterEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeEntries, afterEntries)
+	require.Equal(t, remaining, listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID))
+}
+
 func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
@@ -217,7 +297,14 @@ func TestSubscriptionCustomCurrencyStaleCancellation(t *testing.T) {
 				afterStates, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
 				require.NoError(t, err)
 				require.Len(t, afterStates, 1)
-				require.Equal(t, states, afterStates)
+				if current.Spec.ActiveTo == nil {
+					require.Equal(t, states, afterStates)
+				} else {
+					require.Equal(t, states[0].HasBillables, afterStates[0].HasBillables)
+					require.Equal(t, clock.Now().UTC(), afterStates[0].SyncedAt)
+					require.NotNil(t, afterStates[0].NextSyncAfter)
+					require.False(t, afterStates[0].NextSyncAfter.Before(*current.Spec.ActiveTo))
+				}
 			}
 		})
 	}

--- a/test/subscription/custom_currency_lifecycle_test.go
+++ b/test/subscription/custom_currency_lifecycle_test.go
@@ -1,0 +1,205 @@
+package subscription_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/currencies"
+	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type customCurrencyFlatFeeFixture struct {
+	testDeps
+	currency currencies.Currency
+	view     subscription.SubscriptionView
+	accounts ledger.CustomerAccounts
+	business ledger.BusinessAccounts
+}
+
+// Build a subscription with a paid source so cancellation exercises recognized
+// credit corrections, including the source's cost basis and currency identity.
+func setupCustomCurrencyFlatFeeSubscription(t *testing.T) customCurrencyFlatFeeFixture {
+	t.Helper()
+	const ns = "test-namespace"
+	deps := setup(t, setupConfig{enableCharges: true})
+	t.Cleanup(func() { deps.cleanup(t) })
+	provisionSubscriptionDefaultTaxCodes(t, deps, ns)
+	_, err := deps.billingService.CreateProfile(t.Context(), minimalCreateProfileInputTemplate(deps.sandboxApp.GetID()))
+	require.NoError(t, err)
+	credits, err := deps.CurrencyService.CreateCurrency(t.Context(), currenciestestutils.NewCreateCurrencyInput(ns, "CREDITS", "Credits", "CR"))
+	require.NoError(t, err)
+	customer := createUSDSubscriptionCustomer(t, deps, ns, "flat-fee-lifecycle")
+	business, err := deps.ledgerDeps.ResolversService.EnsureBusinessAccounts(t.Context(), ns)
+	require.NoError(t, err)
+	accounts, err := deps.ledgerDeps.ResolversService.CreateCustomerAccounts(t.Context(), customer.GetID())
+	require.NoError(t, err)
+	at := clock.Now()
+	period := timeutil.ClosedPeriod{From: at, To: at}
+	fiat, err := currencyx.NewFiatCurrency("USD")
+	require.NoError(t, err)
+	grants, err := deps.chargesService.Create(t.Context(), charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{charges.NewChargeIntent(creditpurchase.Intent{
+			Intent: chargesmeta.Intent{ManagedBy: billing.ManuallyManagedLine, CustomerID: customer.ID, Currency: credits},
+			IntentMutableFields: creditpurchase.IntentMutableFields{
+				IntentMutableFields: chargesmeta.IntentMutableFields{Name: "Paid credits", ServicePeriod: period, FullServicePeriod: period, BillingPeriod: period},
+				CreditAmount:        decimal.NewFromInt(20), EffectiveAt: &at,
+				Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus}),
+			},
+			CostBasis: creditpurchase.NewCostBasis(costbasis.NewIntent(costbasis.ManualIntent{FiatCurrency: fiat, Rate: decimal.NewFromFloat(0.5)})),
+		})},
+	})
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	grantID, err := grants[0].GetChargeID()
+	require.NoError(t, err)
+	for _, status := range []payment.Status{payment.StatusAuthorized, payment.StatusSettled} {
+		_, err = deps.chargesService.HandleCreditPurchaseExternalPaymentStateTransition(t.Context(), charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{ChargeID: grantID, TargetPaymentState: status})
+		require.NoError(t, err)
+	}
+	month := datetime.MustParseDuration(t, "P1M")
+	createdPlan, err := deps.PlanService.CreatePlan(t.Context(), plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{Namespace: ns},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{Key: "flat-fee-lifecycle", Name: "Custom flat fee", Currency: credits.Reference(), SettlementMode: productcatalog.CreditOnlySettlementMode, BillingCadence: month, ProRatingConfig: productcatalog.ProRatingConfig{Enabled: true, Mode: productcatalog.ProRatingModeProratePrices}},
+			Phases: []productcatalog.Phase{{PhaseMeta: productcatalog.PhaseMeta{Key: "default", Name: "Default"}, RateCards: productcatalog.RateCards{&productcatalog.FlatFeeRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{Key: "flat-fee", Name: "Custom flat fee", Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{Amount: decimal.NewFromInt(10), PaymentTerm: productcatalog.InAdvancePaymentTerm})}, BillingCadence: &month,
+			}}}},
+		},
+	})
+	require.NoError(t, err)
+	createdPlan, err = deps.PlanService.PublishPlan(t.Context(), plan.PublishPlanInput{NamespacedID: createdPlan.NamespacedID, EffectivePeriod: productcatalog.EffectivePeriod{EffectiveFrom: lo.ToPtr(at.Add(-time.Second))}})
+	require.NoError(t, err)
+	created, err := createCustomCurrencySubscription(t, deps, *createdPlan, customer.ID, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), productcatalog.CreditOnlySettlementMode, subscription.CostBasisModeDynamic)
+	require.NoError(t, err)
+	view, err := deps.subscriptionService.GetView(t.Context(), created.NamespacedID)
+	require.NoError(t, err)
+	return customCurrencyFlatFeeFixture{testDeps: deps, currency: credits, view: view, accounts: accounts, business: business}
+}
+
+func TestSubscriptionCustomCurrencyRealizedCancellation(t *testing.T) {
+	// given: an in-advance custom fee funded by paid credits and an old serialized event.
+	clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+	f := setupCustomCurrencyFlatFeeSubscription(t)
+	ctx := t.Context()
+	raw, err := json.Marshal(f.view)
+	require.NoError(t, err)
+	var staleView subscription.SubscriptionView
+	require.NoError(t, json.Unmarshal(raw, &staleView))
+	horizon := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, f.view, horizon))
+	ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.GreaterOrEqual(t, len(ids), 2)
+	clock.FreezeTime(f.view.Subscription.ActiveFrom)
+	_, err = f.chargesService.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: f.view.Customer.GetID()})
+	require.NoError(t, err)
+	requireCustomCurrencyAccountBalance(t, f, f.accounts.FBOAccount, 10)
+	requireCustomCurrencyAccountBalance(t, f, f.business.EarningsAccount, 10)
+
+	// when: cancellation halves the realized period, then the obsolete event is replayed.
+	cancelAt := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	clock.FreezeTime(cancelAt)
+	_, err = f.subscriptionService.Cancel(ctx, f.view.Subscription.NamespacedID, subscription.Timing{Enum: lo.ToPtr(subscription.TimingImmediate)})
+	require.NoError(t, err)
+	canceled, err := f.subscriptionService.GetView(ctx, f.view.Subscription.NamespacedID)
+	require.NoError(t, err)
+	event := subscription.NewCancelledEvent(ctx, canceled)
+	require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, &event))
+
+	// then: only half the original spend remains, with a single immutable correction.
+	remaining := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.Len(t, remaining, 1)
+	require.Contains(t, ids, remaining[0])
+	result, err := f.chargesService.GetByID(ctx, charges.GetByIDInput{ChargeID: chargesmeta.ChargeID{Namespace: f.view.Subscription.Namespace, ID: remaining[0]}})
+	require.NoError(t, err)
+	charge, err := result.AsFlatFeeCharge()
+	require.NoError(t, err)
+	require.Equal(t, cancelAt, charge.Intent.GetEffectiveServicePeriod().To)
+	require.Equal(t, float64(5), charge.State.AmountAfterProration.InexactFloat64())
+	requireCustomCurrencyAccountBalance(t, f, f.accounts.FBOAccount, 15)
+	requireCustomCurrencyAccountBalance(t, f, f.business.EarningsAccount, 5)
+	beforeLineage, err := f.lineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{Namespace: f.view.Subscription.Namespace, CustomerID: f.view.Customer.ID, Currency: f.currency.Reference()})
+	require.NoError(t, err)
+	require.NotEmpty(t, beforeLineage)
+	beforeEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.NoError(t, f.subscriptionSyncService.HandleCancelledEvent(ctx, &event))
+	require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, staleView, horizon))
+	require.Equal(t, remaining, listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID))
+	afterEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeEntries, afterEntries)
+	afterLineage, err := f.lineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{Namespace: f.view.Subscription.Namespace, CustomerID: f.view.Customer.ID, Currency: f.currency.Reference()})
+	require.NoError(t, err)
+	require.Equal(t, beforeLineage, afterLineage)
+	assertNoSubscriptionInvoices(t, f.testDeps, f.view.Customer.ID)
+}
+
+func TestSubscriptionCustomCurrencyScheduledDeletion(t *testing.T) {
+	// given: future custom charges already exist for a scheduled subscription.
+	clock.FreezeTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	defer clock.UnFreeze()
+	f := setupCustomCurrencyFlatFeeSubscription(t)
+	ctx := t.Context()
+	horizon := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, f.view, horizon))
+	ids := listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID)
+	require.NotEmpty(t, ids)
+	// when: deletion and its event are processed twice, then an older view arrives.
+	require.NoError(t, f.subscriptionService.Delete(ctx, f.view.Subscription.NamespacedID))
+	event := subscription.NewDeletedEvent(ctx, f.view)
+	require.NoError(t, f.subscriptionSyncService.HandleDeletedEvent(ctx, &event))
+	beforeEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.NoError(t, f.subscriptionSyncService.HandleDeletedEvent(ctx, &event))
+	require.NoError(t, f.subscriptionSyncService.SyncByView(ctx, f.view, horizon))
+	// then: no future charges are resurrected and no accounting effects are duplicated.
+	require.Empty(t, listSubscriptionChargeIDs(t, f.testDeps, f.view.Subscription.ID))
+	states, err := f.subscriptionSyncService.GetSyncStates(ctx, []models.NamespacedID{f.view.Subscription.NamespacedID})
+	require.NoError(t, err)
+	require.Len(t, states, 1)
+	require.False(t, states[0].HasBillables)
+	for _, id := range ids {
+		result, err := f.chargesService.GetByID(ctx, charges.GetByIDInput{ChargeID: chargesmeta.ChargeID{Namespace: f.view.Subscription.Namespace, ID: id}})
+		require.NoError(t, err)
+		charge, err := result.AsFlatFeeCharge()
+		require.NoError(t, err)
+		require.Equal(t, flatfee.StatusDeleted, charge.Status)
+	}
+	afterEntries, err := f.DBDeps.DBClient.LedgerEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeEntries, afterEntries)
+	requireCustomCurrencyAccountBalance(t, f, f.accounts.FBOAccount, 20)
+	assertNoSubscriptionInvoices(t, f.testDeps, f.view.Customer.ID)
+}
+
+func requireCustomCurrencyAccountBalance(t *testing.T, f customCurrencyFlatFeeFixture, account ledger.Account, expected float64) {
+	t.Helper()
+	balance, err := f.ledgerDeps.HistoricalLedger.GetAccountBalance(t.Context(), account, ledger.RouteFilter{Currency: f.currency.Reference(), CostBasis: mo.Some(lo.ToPtr(decimal.NewFromFloat(0.5))), CostBasisCurrency: mo.Some(lo.ToPtr(currencyx.Code("USD")))}, ledger.BalanceQuery{})
+	require.NoError(t, err)
+	require.Equal(t, expected, balance.InexactFloat64())
+}

--- a/test/subscription/custom_currency_test.go
+++ b/test/subscription/custom_currency_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
@@ -31,7 +30,7 @@ func TestCustomCurrencySubscriptionLifecycle(t *testing.T) {
 	// - subscriptions are started in each supported settlement and cost-basis mode
 	// then:
 	// - the persisted subscription keeps USD for invoicing and the managed currency on its item
-	// - conversion eligibility and billing's temporary safety boundary are enforced end to end
+	// - conversion eligibility and cost-basis persistence are enforced end to end
 	const namespace = "test-namespace"
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -127,20 +126,7 @@ func TestCustomCurrencySubscriptionLifecycle(t *testing.T) {
 		require.NotNil(t, itemCurrency)
 		require.NotNil(t, itemCurrency.CustomCurrencyID, "persisted custom item currency must reload with its managed ID")
 		require.Equal(t, customCurrency.ID, *itemCurrency.CustomCurrencyID)
-
-		// Billing conversion is deliberately outside this PR. Explicit callers see the
-		// unsupported boundary; automatic reconciliation skips the whole subscription.
-		err = deps.subscriptionSyncService.SyncByView(t.Context(), view, startsAt)
-		require.ErrorIs(t, err, subscriptionsync.ErrCustomCurrencyBillingNotSupported)
-		require.True(t, models.IsGenericConflictError(err))
-
-		err = deps.subscriptionSyncService.SyncByView(
-			t.Context(),
-			view,
-			startsAt,
-			subscriptionsync.SkipCustomCurrencySubscriptions(),
-		)
-		require.NoError(t, err)
+		require.True(t, itemCurrency.IsResolved(), "billing consumers need the immutable custom currency snapshot")
 	})
 
 	t.Run("credit then invoice resolves dynamic and pinned cost bases", func(t *testing.T) {

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	billinglineengine "github.com/openmeterio/openmeter/openmeter/billing/lineengine"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
@@ -48,13 +52,18 @@ type testDeps struct {
 	subscriptionWorkflowService subscriptionworkflow.Service
 	subscriptionSyncService     subscriptionsync.Service
 	billingService              billing.Service
+	chargesService              charges.Service
 	sandboxApp                  app.App
 	cleanup                     func(t *testing.T) // Cleanup function
 }
 
-type setupConfig struct{}
+type setupConfig struct {
+	usageBasedHandler       usagebased.Handler
+	lineageService          lineage.Service
+	enableCreditThenInvoice bool
+}
 
-func setup(t *testing.T, _ setupConfig) testDeps {
+func setup(t *testing.T, config setupConfig) testDeps {
 	t.Helper()
 
 	// Let's build the dependencies
@@ -157,6 +166,26 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 
 	billingService = billingService.WithInvoiceCalculator(invoiceCalculator)
 
+	var chargesService charges.Service
+	if config.usageBasedHandler != nil {
+		handlers := chargestestutils.NewMockHandlers()
+		stack, err := chargestestutils.NewServices(t, chargestestutils.Config{
+			Client:                deps.DBDeps.DBClient,
+			Logger:                slog.Default(),
+			BillingService:        billingService,
+			FeatureMeterResolver:  featureMeterResolver,
+			CustomerService:       deps.CustomerService,
+			StreamingConnector:    deps.MockStreamingConnector,
+			TaxCodeService:        taxCodeService,
+			FlatFeeHandler:        handlers.FlatFee,
+			CreditPurchaseHandler: handlers.CreditPurchase,
+			UsageBasedHandler:     config.usageBasedHandler,
+			LineageService:        config.lineageService,
+		})
+		require.NoError(t, err)
+		chargesService = stack.ChargesService
+	}
+
 	subscriptionSyncAdapter, err := subscriptionsyncadapter.New(subscriptionsyncadapter.Config{
 		Client: deps.DBDeps.DBClient,
 	})
@@ -165,10 +194,14 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 	subscriptionSyncService, err := subscriptionsyncservice.New(subscriptionsyncservice.Config{
 		BillingService:          billingService,
 		LegacyBillingLineEngine: legacyBillingLineEngine,
+		ChargesService:          chargesService,
 		Logger:                  slog.Default(),
 		Tracer:                  noop.NewTracerProvider().Tracer("test"),
 		SubscriptionSyncAdapter: subscriptionSyncAdapter,
 		SubscriptionService:     deps.SubscriptionService,
+		FeatureFlags: subscriptionsyncservice.FeatureFlags{
+			EnableCreditThenInvoice: config.enableCreditThenInvoice,
+		},
 		FeatureGate: featuregate.NewFeatureGateChecker(featuregate.NewNoop(), featuregate.Flags{
 			featuregate.CtxKeyCredits: string(featuregate.CtxKeyCredits),
 		}, map[featuregate.FeatureFlag]bool{featuregate.CtxKeyCredits: true}),
@@ -218,6 +251,7 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 		cleanup:                     dbDeps.Cleanup,
 		subscriptionSyncService:     subscriptionSyncService,
 		billingService:              billingService,
+		chargesService:              chargesService,
 		sandboxApp:                  sandboxApp,
 	}
 }

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -16,11 +16,12 @@ import (
 	appservice "github.com/openmeterio/openmeter/openmeter/app/service"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
-	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
+	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	billinglineengine "github.com/openmeterio/openmeter/openmeter/billing/lineengine"
 	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	billingsequenceadapter "github.com/openmeterio/openmeter/openmeter/billing/sequence/adapter"
@@ -30,6 +31,14 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	subscriptionsyncadapter "github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/adapter"
 	subscriptionsyncservice "github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service"
+	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
+	ledgerbreakage "github.com/openmeterio/openmeter/openmeter/ledger/breakage"
+	ledgerbreakageadapter "github.com/openmeterio/openmeter/openmeter/ledger/breakage/adapter"
+	ledgerchargeadapter "github.com/openmeterio/openmeter/openmeter/ledger/chargeadapter"
+	ledgercollector "github.com/openmeterio/openmeter/openmeter/ledger/collector"
+	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
+	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
 	pcsubscriptionservice "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
@@ -53,13 +62,14 @@ type testDeps struct {
 	subscriptionSyncService     subscriptionsync.Service
 	billingService              billing.Service
 	chargesService              charges.Service
+	ledgerDeps                  ledgertestutils.Deps
+	lineageService              lineage.Service
 	sandboxApp                  app.App
 	cleanup                     func(t *testing.T) // Cleanup function
 }
 
 type setupConfig struct {
-	usageBasedHandler       usagebased.Handler
-	lineageService          lineage.Service
+	enableCharges           bool
 	enableCreditThenInvoice bool
 }
 
@@ -167,8 +177,33 @@ func setup(t *testing.T, config setupConfig) testDeps {
 	billingService = billingService.WithInvoiceCalculator(invoiceCalculator)
 
 	var chargesService charges.Service
-	if config.usageBasedHandler != nil {
-		handlers := chargestestutils.NewMockHandlers()
+	var ledgerDeps ledgertestutils.Deps
+	var lineageService lineage.Service
+	if config.enableCharges {
+		logger := testutils.NewLogger(t)
+		ledgerDeps, err = ledgertestutils.InitDeps(deps.DBDeps.DBClient, logger)
+		require.NoError(t, err)
+		resolverDeps := transactions.ResolverDependencies{AccountService: ledgerDeps.ResolversService, AccountCatalog: ledgerDeps.AccountService, BalanceQuerier: ledgerDeps.HistoricalLedger}
+		transactionManager := enttx.NewCreator(deps.DBDeps.DBClient)
+		lineageAdapter, err := lineageadapter.New(lineageadapter.Config{Client: deps.DBDeps.DBClient})
+		require.NoError(t, err)
+		lineageService, err = lineageservice.New(lineageservice.Config{Adapter: lineageAdapter})
+		require.NoError(t, err)
+		breakageAdapter, err := ledgerbreakageadapter.New(ledgerbreakageadapter.Config{Client: deps.DBDeps.DBClient})
+		require.NoError(t, err)
+		breakageService, err := ledgerbreakage.NewService(ledgerbreakage.Config{Adapter: breakageAdapter, Dependencies: resolverDeps})
+		require.NoError(t, err)
+		collector, err := ledgercollector.NewService(ledgercollector.Config{
+			Ledger: ledgerDeps.HistoricalLedger, Dependencies: resolverDeps, Breakage: breakageService,
+			AccountLocker: ledgerDeps.AccountService, TransactionManager: transactionManager,
+		})
+		require.NoError(t, err)
+		revenueRecognizer, err := recognizer.NewService(recognizer.Config{
+			Ledger: ledgerDeps.HistoricalLedger, Dependencies: resolverDeps, Lineage: lineageService, TransactionManager: transactionManager,
+		})
+		require.NoError(t, err)
+		creditPurchaseHandler, err := ledgerchargeadapter.NewCreditPurchaseHandler(ledgerDeps.HistoricalLedger, ledgerDeps.HistoricalLedger, ledgerDeps.ResolversService, ledgerDeps.AccountService, breakageService, transactionManager)
+		require.NoError(t, err)
 		stack, err := chargestestutils.NewServices(t, chargestestutils.Config{
 			Client:                deps.DBDeps.DBClient,
 			Logger:                slog.Default(),
@@ -177,10 +212,12 @@ func setup(t *testing.T, config setupConfig) testDeps {
 			CustomerService:       deps.CustomerService,
 			StreamingConnector:    deps.MockStreamingConnector,
 			TaxCodeService:        taxCodeService,
-			FlatFeeHandler:        handlers.FlatFee,
-			CreditPurchaseHandler: handlers.CreditPurchase,
-			UsageBasedHandler:     config.usageBasedHandler,
-			LineageService:        config.lineageService,
+			FlatFeeHandler:        ledgerchargeadapter.NewFlatFeeHandler(ledgerDeps.HistoricalLedger, resolverDeps, collector),
+			CreditPurchaseHandler: creditPurchaseHandler,
+			UsageBasedHandler:     ledgerchargeadapter.NewUsageBasedHandler(ledgerDeps.HistoricalLedger, resolverDeps, collector),
+			LineageService:        lineageService,
+			RecognizerService:     revenueRecognizer,
+			SubscriptionService:   deps.SubscriptionService,
 		})
 		require.NoError(t, err)
 		chargesService = stack.ChargesService
@@ -252,6 +289,8 @@ func setup(t *testing.T, config setupConfig) testDeps {
 		subscriptionSyncService:     subscriptionSyncService,
 		billingService:              billingService,
 		chargesService:              chargesService,
+		ledgerDeps:                  ledgerDeps,
+		lineageService:              lineageService,
 		sandboxApp:                  sandboxApp,
 	}
 }


### PR DESCRIPTION
Custom-currency subscription items now synchronize through charges while invoices remain fiat-denominated. Dynamic cost basis resolves during charge realization; pinned cost basis survives catalog-rate replacement. Missing required charge configuration produces retryable sync errors instead of silently skipping custom subscriptions.

Continuation of #4986 on a separate branch, rebased onto main after #5083, #5092 and #5100 merged. The experimental provenance rewrite in #5085 is excluded.

- Use real ledger, collector, lineage, recognizer and subscription services in integration tests.
- Cover dynamic/pinned pricing, catalog-rate replacement, mixed fiat/custom invoices, native advances, paid-credit cancellation and scheduled deletion.
- Compare cancellation-event root `UpdatedAt` with current state. For older snapshots, reconcile still-canceled subscriptions by ID through the current end date; ignore cancellation work if continued. This preserves cancellation after annotation writes during plan changes. Regressions cover continuation, later/same-date cancellation, plan-change fee correction and retries.
- Exercise #5092 through four monthly subscription fees: a later 15-credit purchase covers the older 10-credit advance and 5 of the newer one. Assert matching ledger and lineage amounts per charge and idempotent advancement.

## Recognition regression

#5100 fixes the source-attribution blocker independently. The retained real-service subscription regression now passes unchanged: after spending 2 promotional credits plus an 8-credit advance and purchasing the paid backfill, lineage retains 2 promotional credits and attributes all 8 recognized credits to the paid backfill, matching the journal.

## Validation

- Full root Go suite with PostgreSQL, Svix and ClickHouse configured: 8,069 tests, 8 skips, no failures. Migration checks pass.
- All 27 subscription integration tests pass, including the retained promotional-credit/paid-backfill regression, FIFO backfill, stale cancellation, plan-change fee correction and retry coverage.
- SDK build/vet/tests pass. Scoped subscription-sync/subscription lint, SDK lint and E2E module vet/lint pass.
- Live E2E scenarios were not run locally.
- All six subscription commits replayed onto the #5100 merge without patch changes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables subscription-managed custom-currency items to synchronize through charge-backed billing while retaining fiat invoice settlement.
- Resolves item-level currency snapshots and maps dynamic or pinned subscription cost bases into charge intents.
- Makes missing charge configuration an explicit retryable synchronization failure instead of silently skipping custom-currency subscriptions.
- Reconciles stale cancellation events against the authoritative current lifecycle boundary.
- Adds production-backed coverage for custom-currency billing, lifecycle behavior, backfill allocation, and catalog-rate replacement.
- Aligns earnings recognition journal postings with the exact lineage-backed accrued sources.

<h3>Confidence Score: 4/5</h3>

The implementation appears behaviorally sound, but the explicit frozen-clock cleanup requirement in the backfill regression remains unsatisfied and must be fixed before merging.

The previously failing real-service lineage regression is addressed by selecting exact accrued sources for both journal postings and lineage transitions, and the stale-cancellation findings are resolved by using a consistent current view and horizon. The unresolved backfill-test thread remains outstanding: additional `clock.FreezeTime(...)` calls are still not immediately paired with `defer clock.UnFreeze()` in their scopes.

**Files Needing Attention:** test/subscription/custom_currency_backfill_test.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/worker/subscriptionsync/service/sync.go | Removes the custom-currency skip boundary and reloads authoritative custom-currency views before reconciliation. |
| openmeter/billing/worker/subscriptionsync/service/handlers.go | Reconciles stale cancellation events using the current subscription view and matching cancellation horizon. |
| openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go | Maps dynamic and pinned subscription cost-basis configuration into custom-currency charge intents. |
| openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go | Resolves each subscription item's effective fiat or managed custom currency for target generation. |
| openmeter/subscription/repo/subscriptionitemrepo.go | Loads custom-currency relationships so persisted subscription items reconstruct resolved currency snapshots. |
| test/subscription/custom_currency_backfill_test.go | Adds multi-period backfill accounting coverage but retains the previously reported frozen-clock cleanup rule violation. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[Subscription item] --> C{Item currency}
    C -->|Fiat| B[Invoice or charge-backed billing]
    C -->|Managed custom currency| Q[Charge intent in native currency]
    S --> M{Settlement mode}
    M -->|Credit only| Q
    M -->|Credit then invoice| K{Cost-basis mode}
    K -->|Dynamic| D[Resolve cost basis at realization]
    K -->|Pinned| P[Retain selected cost-basis resource]
    D --> Q
    P --> Q
    Q --> R[Charge realization]
    R --> L[Credit and ledger effects]
    R -->|Uncovered overage| I[Fiat invoice line]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(subscription): reconcile current can..."](https://github.com/openmeterio/openmeter/commit/cd504abd38c88cd72a954fdf2c2c824648ea2e46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61183121)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Credit and ledger accounting](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-and-ledger-accounting.md)
- Knowledge Base — [Subscription lifecycle](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/subscription-lifecycle.md)
</details>


<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom-currency subscriptions can now synchronize and generate charges.
  * Subscription items preserve their configured currencies and dynamic or pinned cost-basis settings.
  * Deleted subscriptions reconcile their billing records and outstanding billables.

* **Bug Fixes**
  * Cancellation handling now uses the latest subscription state, preventing stale events from causing incorrect billing.
  * Subscription items now reload with resolved custom-currency data.
  * Added safeguards for unsupported custom-currency settlement scenarios.

* **Documentation**
  * Clarified subscription synchronization behavior, currency handling, and cost-basis limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->