### PR TITLE
feat(billing): gate usage invoice assignment

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -262,6 +262,12 @@ one.
   boundary. A billing standard line expects line-period and pre-line-period
   quantities, so charge mappers translate rather than copy it. Translation
   reads the referenced run's persisted quantity, or zero for the first run.
+- An invoice-backed usage-based charge with a current realization run excludes
+  its gathering lines from assignment to another invoice. The charge records a
+  critical validation issue identifying the current invoice and line; repeated
+  collection attempts remain idempotent. The issue is removed when lifecycle
+  progress releases the current run, and a later collection retry can create
+  the next realization normally.
 - Corrections reconcile against persisted allocations in the same realization
   run and monetary domain, preserving lineage to the facts previously billed
   or posted.

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -2016,7 +2016,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		// when:
 		// - billing tries to invoice pending lines again before the first invoice is issued
 		// then:
-		// - the request is rejected and no additional run or invoice is created
+		// - the pending line is excluded and the active run is recorded on the charge
 		s.MockStreamingConnector.AddSimpleEvent(
 			meterSlug,
 			5,
@@ -2025,19 +2025,23 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		clock.FreezeTime(secondPartialAttemptAt)
 
 		// when
-		_, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(secondPartialAttemptAt),
 		})
 
 		// then
-		s.Error(err)
-		s.ErrorAs(err, &billing.ValidationError{})
-		s.ErrorIs(err, usagebased.ErrActiveRealizationRunAlreadyExists)
+		s.NoError(err)
+		s.Empty(invoices)
 
 		charge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusActiveRealizationWaitingForCollection, charge.Status)
 		s.Len(charge.Realizations, 1)
+		s.Require().Len(charge.ValidationIssues, 1)
+		s.Equal(usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun, charge.ValidationIssues[0].Code)
+		s.Equal(usagebased.ValidationIssueComponentLineEngine, charge.ValidationIssues[0].Component)
+		s.Equal(partialInvoice.ID, charge.ValidationIssues[0].Attributes["invoice_id"])
+		s.Equal(partialInvoice.Lines.OrEmpty()[0].ID, charge.ValidationIssues[0].Attributes["line_id"])
 
 		currentRun, runErr := charge.GetCurrentRealizationRun()
 		s.NoError(runErr)
@@ -2127,6 +2131,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 
 		charge = s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusActive, charge.Status)
+		s.Empty(charge.ValidationIssues)
 	})
 
 	s.Run("when the final invoice is created and the final realization completes after the service period", func() {
@@ -2400,7 +2405,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingParti
 		// when:
 		// - billing tries to invoice pending lines for the final period
 		// then:
-		// - final realization is blocked by the active-run invariant
+		// - final realization is excluded and the active run is recorded on the charge
 		s.MockStreamingConnector.AddSimpleEvent(
 			meterSlug,
 			5,
@@ -2415,13 +2420,32 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingParti
 		})
 
 		// then
-		s.Error(err)
-		s.ErrorAs(err, &billing.ValidationError{})
-		s.ErrorIs(err, usagebased.ErrActiveRealizationRunAlreadyExists)
-		s.Nil(invoices)
+		s.NoError(err)
+		s.Empty(invoices)
 
 		charge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusActiveRealizationProcessing, charge.Status)
+		s.Require().Len(charge.ValidationIssues, 1)
+		s.Equal(billing.ValidationIssueSeverityCritical, charge.ValidationIssues[0].Severity)
+		s.Equal(usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun, charge.ValidationIssues[0].Code)
+		s.Equal(usagebased.ValidationIssueComponentLineEngine, charge.ValidationIssues[0].Component)
+		s.Contains(charge.ValidationIssues[0].Message, "must be completed before")
+		s.Equal(partialInvoice.ID, charge.ValidationIssues[0].Attributes["invoice_id"])
+		s.Equal(partialInvoice.Lines.OrEmpty()[0].ID, charge.ValidationIssues[0].Attributes["line_id"])
+
+		// when
+		// collection retries while the same run is still active
+		invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+
+		// then
+		// the gate remains idempotent
+		s.NoError(err)
+		s.Empty(invoices)
+		charge = s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Len(charge.ValidationIssues, 1)
 
 		invoicesResult, listErr := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
 			Namespace: ns,
@@ -2454,6 +2478,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingParti
 
 		charge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusActive, charge.Status)
+		s.Empty(charge.ValidationIssues)
 	})
 
 	s.Run("when invoice pending lines is retried after the partial invoice approval", func() {

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -36,9 +36,12 @@ type Persistence[CHARGE any, BASE any] struct {
 	Refetch    func(ctx context.Context, chargeID meta.ChargeID) (CHARGE, error)
 }
 
+type UpdateBaseHandler[BASE any] func(BASE) BASE
+
 type Config[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] struct {
-	Charge      CHARGE
-	Persistence Persistence[CHARGE, BASE]
+	Charge             CHARGE
+	Persistence        Persistence[CHARGE, BASE]
+	UpdateBaseHandlers []UpdateBaseHandler[BASE]
 }
 
 type StateMachine[CHARGE any] interface {
@@ -81,6 +84,12 @@ func (c Config[CHARGE, BASE, STATUS]) Validate() error {
 
 	if c.Persistence.Refetch == nil {
 		errs = append(errs, errors.New("persistence.refetch is required"))
+	}
+
+	for idx, handler := range c.UpdateBaseHandlers {
+		if handler == nil {
+			errs = append(errs, fmt.Errorf("update base handlers[%d] is required", idx))
+		}
 	}
 
 	return errors.Join(errs...)
@@ -198,7 +207,12 @@ func (m *Machine[CHARGE, BASE, STATUS]) fireAndActivate(ctx context.Context, tri
 		return err
 	}
 
-	updatedBase, err := m.config.Persistence.UpdateBase(ctx, m.Charge.GetBase())
+	base := m.Charge.GetBase()
+	for _, handler := range m.config.UpdateBaseHandlers {
+		base = handler(base)
+	}
+
+	updatedBase, err := m.config.Persistence.UpdateBase(ctx, base)
 	if err != nil {
 		return fmt.Errorf("persist charge: %w", err)
 	}

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -92,7 +92,7 @@ func (c Config[CHARGE, BASE, STATUS]) Validate() error {
 		}
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type Machine[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] struct {

--- a/openmeter/billing/charges/statemachine/machine_test.go
+++ b/openmeter/billing/charges/statemachine/machine_test.go
@@ -604,6 +604,69 @@ func TestMachine_AdvanceUntilStablePersistsPostActivationBase(t *testing.T) {
 	require.Equal(t, 8, charge.GetBase().Revision)
 }
 
+func TestMachine_AdvanceUntilStableAppliesUpdateBaseHandlersBeforePersistence(t *testing.T) {
+	// given
+	// a machine with ordered base update handlers and activation logic that mutates the base
+	var persistedBase fakeBase
+	machine, err := New(Config[fakeCharge, fakeBase, fakeStatus]{
+		Charge: newFakeCharge(fakeStatusCreated),
+		Persistence: Persistence[fakeCharge, fakeBase]{
+			UpdateBase: func(_ context.Context, base fakeBase) (fakeBase, error) {
+				persistedBase = base
+
+				return base, nil
+			},
+			Refetch: func(context.Context, meta.ChargeID) (fakeCharge, error) {
+				return fakeCharge{}, nil
+			},
+		},
+		UpdateBaseHandlers: []UpdateBaseHandler[fakeBase]{
+			func(base fakeBase) fakeBase {
+				base.Revision++
+
+				return base
+			},
+			func(base fakeBase) fakeBase {
+				base.Revision *= 2
+
+				return base
+			},
+		},
+	})
+	require.NoError(t, err)
+	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+	machine.Configure(fakeStatusActive).OnActive(func(context.Context) error {
+		machine.Charge = machine.Charge.WithBase(fakeBase{Revision: 7})
+
+		return nil
+	})
+
+	// when
+	err = machine.AdvanceUntilStable(t.Context())
+
+	// then
+	require.NoError(t, err)
+	require.Equal(t, 16, persistedBase.Revision)
+	require.Equal(t, persistedBase, machine.GetCharge().GetBase())
+}
+
+func TestNewRejectsNilUpdateBaseHandler(t *testing.T) {
+	_, err := New(Config[fakeCharge, fakeBase, fakeStatus]{
+		Charge: newFakeCharge(fakeStatusCreated),
+		Persistence: Persistence[fakeCharge, fakeBase]{
+			UpdateBase: func(_ context.Context, base fakeBase) (fakeBase, error) {
+				return base, nil
+			},
+			Refetch: func(context.Context, meta.ChargeID) (fakeCharge, error) {
+				return fakeCharge{}, nil
+			},
+		},
+		UpdateBaseHandlers: []UpdateBaseHandler[fakeBase]{nil},
+	})
+
+	require.ErrorContains(t, err, "update base handlers[0] is required")
+}
+
 func TestMachine_FireAndAdvanceUntilStablePropagatesActivationErrors(t *testing.T) {
 	// Given:
 	// a machine whose activation callback fails after a valid transition fires.

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -48,11 +48,13 @@ type UpdateChargeValidationIssuesInput struct {
 }
 
 func (i UpdateChargeValidationIssuesInput) Validate() error {
+	var errs []error
+
 	if err := i.ChargeID.Validate(); err != nil {
-		return fmt.Errorf("charge ID: %w", err)
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
 	}
 
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type RealizationRunAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -32,12 +33,26 @@ type ChargeCostBasisAdapter interface {
 type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
+	UpdateChargeValidationIssues(ctx context.Context, input UpdateChargeValidationIssuesInput) error
 	CreateChargeOverride(ctx context.Context, charge ChargeBase, override IntentMutableFields) (ChargeBase, error)
 	DeleteChargeOverride(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, input GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)
+}
+
+type UpdateChargeValidationIssuesInput struct {
+	ChargeID         meta.ChargeID
+	ValidationIssues billing.ValidationIssues
+}
+
+func (i UpdateChargeValidationIssuesInput) Validate() error {
+	if err := i.ChargeID.Validate(); err != nil {
+		return fmt.Errorf("charge ID: %w", err)
+	}
+
+	return nil
 }
 
 type RealizationRunAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -95,6 +95,29 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 	})
 }
 
+func (a *adapter) UpdateChargeValidationIssues(ctx context.Context, input usagebased.UpdateChargeValidationIssuesInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		update := tx.db.ChargeUsageBased.UpdateOneID(input.ChargeID.ID).
+			Where(dbchargeusagebased.NamespaceEQ(input.ChargeID.Namespace))
+
+		if len(input.ValidationIssues) == 0 {
+			update = update.ClearValidationIssues()
+		} else {
+			update = update.SetValidationIssues(input.ValidationIssues)
+		}
+
+		if _, err := update.Save(ctx); err != nil {
+			return fmt.Errorf("updating validation issues for usage based charge[%s]: %w", input.ChargeID.ID, err)
+		}
+
+		return nil
+	})
+}
+
 func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge usagebased.Charge, newSubscriptionItemID string) (usagebased.Charge, error) {
 	if err := charge.ManagedModel.Validate(); err != nil {
 		return usagebased.Charge{}, err

--- a/openmeter/billing/charges/usagebased/const.go
+++ b/openmeter/billing/charges/usagebased/const.go
@@ -1,7 +1,14 @@
 package usagebased
 
-import "time"
+import (
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
 
 const (
 	InternalCollectionPeriod time.Duration = time.Minute
+
+	ValidationIssueCodeInvoiceAssignmentBlockedActiveRun = "usage_based_invoice_assignment_blocked_active_run"
+	ValidationIssueComponentLineEngine                   = billing.ComponentName("charges.usagebased.lineengine")
 )

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -55,7 +55,7 @@ func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInv
 		return nil, fmt.Errorf("charge %s is not credit_then_invoice", config.Charge.ID)
 	}
 
-	stateMachine, err := newStateMachineBase(config)
+	stateMachine, err := newStateMachineBase(config, clearInvoiceAssignmentIssueWithoutCurrentRun)
 	if err != nil {
 		return nil, fmt.Errorf("new state machine: %w", err)
 	}

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
@@ -38,8 +39,91 @@ func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineB
 	return !input.AsOf.Before(input.ResolvedBillablePeriod.To), nil
 }
 
-func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
-	return nil, nil
+func (e *LineEngine) GateInvoiceAssignment(ctx context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
+	namespace := input.Lines[0].Namespace
+	chargeIDs := make([]string, 0, len(input.Lines))
+	linesByChargeID := make(map[string]billing.GatheringLines)
+	for _, line := range input.Lines {
+		if line.Namespace != namespace {
+			return nil, fmt.Errorf("usage based gathering line[%s] namespace %s does not match namespace %s", line.ID, line.Namespace, namespace)
+		}
+
+		if line.ChargeID == nil || *line.ChargeID == "" {
+			return nil, fmt.Errorf("usage based gathering line[%s]: charge ID is required", line.ID)
+		}
+
+		if _, ok := linesByChargeID[*line.ChargeID]; !ok {
+			chargeIDs = append(chargeIDs, *line.ChargeID)
+		}
+		linesByChargeID[*line.ChargeID] = append(linesByChargeID[*line.ChargeID], line)
+	}
+
+	charges, err := e.service.GetByIDs(ctx, usagebased.GetByIDsInput{
+		Namespace: namespace,
+		IDs:       chargeIDs,
+		Expands:   meta.Expands{meta.ExpandRealizations},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting usage based charges for invoice assignment: %w", err)
+	}
+
+	chargesByID := lo.KeyBy(charges, func(charge usagebased.Charge) string {
+		return charge.ID
+	})
+	result := make(billing.GateInvoiceAssignmentResult)
+	for _, chargeID := range chargeIDs {
+		charge, ok := chargesByID[chargeID]
+		if !ok {
+			return nil, fmt.Errorf("usage based charge[%s] not found for invoice assignment", chargeID)
+		}
+
+		if charge.State.CurrentRealizationRunID == nil {
+			if charge.ValidationIssues.HasWithComponentCode(
+				usagebased.ValidationIssueComponentLineEngine,
+				usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun,
+			) {
+				if err := e.service.adapter.UpdateChargeValidationIssues(ctx, usagebased.UpdateChargeValidationIssuesInput{
+					ChargeID: charge.GetChargeID(),
+					ValidationIssues: charge.ValidationIssues.Without(
+						usagebased.ValidationIssueComponentLineEngine,
+						usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun,
+					),
+				}); err != nil {
+					return nil, err
+				}
+			}
+
+			continue
+		}
+
+		currentRun, err := charge.GetCurrentRealizationRun()
+		if err != nil {
+			return nil, fmt.Errorf("getting current realization run for usage based charge[%s]: %w", charge.ID, err)
+		}
+
+		validationIssue, err := newActiveRunInvoiceAssignmentIssue(currentRun)
+		if err != nil {
+			return nil, fmt.Errorf("building invoice assignment validation issue for usage based charge[%s]: %w", charge.ID, err)
+		}
+		if !charge.ValidationIssues.HasWithComponentCode(validationIssue.Component, validationIssue.Code) {
+			if err := e.service.adapter.UpdateChargeValidationIssues(ctx, usagebased.UpdateChargeValidationIssuesInput{
+				ChargeID:         charge.GetChargeID(),
+				ValidationIssues: append(slices.Clone(charge.ValidationIssues), validationIssue),
+			}); err != nil {
+				return nil, err
+			}
+		}
+
+		for _, line := range linesByChargeID[chargeID] {
+			result[line.GetLineID()] = billing.InvoiceAssignmentGateResponse{ExcludeFromInvoice: true}
+		}
+	}
+
+	return result, nil
 }
 
 func (e *LineEngine) SplitGatheringLine(_ context.Context, input billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -99,7 +99,10 @@ func (c StateMachineConfig) Validate() error {
 	return errors.Join(errs...)
 }
 
-func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
+func newStateMachineBase(
+	config StateMachineConfig,
+	updateBaseHandlers ...chargestatemachine.UpdateBaseHandler[usagebased.ChargeBase],
+) (*stateMachine, error) {
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("config: %w", err)
 	}
@@ -116,11 +119,10 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	}
 
 	machine, err := chargestatemachine.New(chargestatemachine.Config[usagebased.Charge, usagebased.ChargeBase, usagebased.Status]{
-		Charge: config.Charge,
+		Charge:             config.Charge,
+		UpdateBaseHandlers: updateBaseHandlers,
 		Persistence: chargestatemachine.Persistence[usagebased.Charge, usagebased.ChargeBase]{
-			UpdateBase: func(ctx context.Context, base usagebased.ChargeBase) (usagebased.ChargeBase, error) {
-				return out.Adapter.UpdateCharge(ctx, base)
-			},
+			UpdateBase: out.Adapter.UpdateCharge,
 			Refetch: func(ctx context.Context, chargeID meta.ChargeID) (usagebased.Charge, error) {
 				return out.Adapter.GetByID(ctx, usagebased.GetByIDInput{
 					ChargeID: chargeID,

--- a/openmeter/billing/charges/usagebased/service/validationissues.go
+++ b/openmeter/billing/charges/usagebased/service/validationissues.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+const (
+	activeRunInvoiceAssignmentIssueMessage = "an ongoing realization run must be completed before this charge can be assigned to another invoice"
+)
+
+// clearInvoiceAssignmentIssueWithoutCurrentRun removes the invoice-assignment issue after the
+// charge releases its current realization run. The issue is valid only while that run blocks assignment.
+func clearInvoiceAssignmentIssueWithoutCurrentRun(base usagebased.ChargeBase) usagebased.ChargeBase {
+	if base.State.CurrentRealizationRunID == nil && base.ValidationIssues.HasWithComponentCode(
+		usagebased.ValidationIssueComponentLineEngine,
+		usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun,
+	) {
+		base.ValidationIssues = base.ValidationIssues.Without(
+			usagebased.ValidationIssueComponentLineEngine,
+			usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun,
+		)
+	}
+
+	return base
+}
+
+func newActiveRunInvoiceAssignmentIssue(run usagebased.RealizationRun) (billing.ValidationIssue, error) {
+	if run.InvoiceID == nil || *run.InvoiceID == "" {
+		return billing.ValidationIssue{}, fmt.Errorf("current realization run[%s] invoice ID is required", run.ID.ID)
+	}
+
+	if run.LineID == nil || *run.LineID == "" {
+		return billing.ValidationIssue{}, fmt.Errorf("current realization run[%s] line ID is required", run.ID.ID)
+	}
+
+	// TODO: add structured charge field context when billing validation issues support models.FieldDescriptor.
+	return billing.ValidationIssue{
+		Severity:  billing.ValidationIssueSeverityCritical,
+		Message:   activeRunInvoiceAssignmentIssueMessage,
+		Code:      usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun,
+		Component: usagebased.ValidationIssueComponentLineEngine,
+		Attributes: models.Annotations{
+			"invoice_id": *run.InvoiceID,
+			"line_id":    *run.LineID,
+		},
+	}, nil
+}

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -226,6 +227,20 @@ func ValidationWithAttributes(attributes models.Annotations, err error) error {
 }
 
 type ValidationIssues []ValidationIssue
+
+func (v ValidationIssues) HasWithComponentCode(component ComponentName, code string) bool {
+	return slices.ContainsFunc(v, func(issue ValidationIssue) bool {
+		return issue.Component == component && issue.Code == code
+	})
+}
+
+func (v ValidationIssues) Without(component ComponentName, code string) ValidationIssues {
+	issues := slices.DeleteFunc(slices.Clone(v), func(issue ValidationIssue) bool {
+		return issue.Component == component && issue.Code == code
+	})
+
+	return issues
+}
 
 // ToValidationIssues converts an error into a list of validation issues
 // If the error is nil, it returns nil

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -54,6 +54,54 @@ func TestValidationIssueAttributes(t *testing.T) {
 	})
 }
 
+func TestValidationIssuesHasWithComponentCode(t *testing.T) {
+	existing := ValidationIssue{
+		Severity:  ValidationIssueSeverityWarning,
+		Message:   "existing",
+		Code:      "existing",
+		Component: "component",
+	}
+	issues := ValidationIssues{existing}
+
+	require.True(t, issues.HasWithComponentCode(existing.Component, existing.Code))
+	require.False(t, issues.HasWithComponentCode("other", existing.Code))
+	require.False(t, issues.HasWithComponentCode(existing.Component, "other"))
+}
+
+func TestValidationIssuesWithout(t *testing.T) {
+	issue := ValidationIssue{
+		Severity:  ValidationIssueSeverityCritical,
+		Message:   "blocked",
+		Code:      "blocked",
+		Component: "component",
+	}
+	otherComponentIssue := issue
+	otherComponentIssue.Component = "other"
+	existing := ValidationIssue{
+		Severity:  ValidationIssueSeverityWarning,
+		Message:   "existing",
+		Code:      "existing",
+		Component: "component",
+	}
+
+	t.Run("removes every issue with the code and component", func(t *testing.T) {
+		original := ValidationIssues{issue, existing, otherComponentIssue, issue}
+
+		issues := original.Without(issue.Component, issue.Code)
+
+		require.Equal(t, ValidationIssues{existing, otherComponentIssue}, issues)
+		require.Len(t, original, 4)
+	})
+
+	t.Run("keeps the collection unchanged when the issue is absent", func(t *testing.T) {
+		original := ValidationIssues{existing, otherComponentIssue}
+
+		issues := original.Without(issue.Component, issue.Code)
+
+		require.Equal(t, original, issues)
+	})
+}
+
 func TestValidationWithAttributes(t *testing.T) {
 	baseIssue := ValidationIssue{
 		Severity: ValidationIssueSeverityWarning,

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -90,7 +90,7 @@ func TestValidationIssuesWithout(t *testing.T) {
 		issues := original.Without(issue.Component, issue.Code)
 
 		require.Equal(t, ValidationIssues{existing, otherComponentIssue}, issues)
-		require.Len(t, original, 4)
+		require.Equal(t, ValidationIssues{issue, existing, otherComponentIssue, issue}, original)
 	})
 
 	t.Run("keeps the collection unchanged when the issue is absent", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- gate usage-based gathering lines while a realization run is active
- persist and clear the charge validation issue through usage-based lifecycle transitions
- make state-machine base update handlers available to credit-then-invoice charges

## Validation
- make lint-go-fast
- focused usage-based and state-machine tests
- make test-nocache (the Svix-dependent notification test failed because the local Svix service was unavailable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Progressive billing no longer fails when invoice collection overlaps an active realization run.
  - A critical validation issue identifies the affected invoice and line while preventing duplicate invoice assignment.
  - Repeated collection attempts remain idempotent.
  - Validation issues clear automatically once the blocking invoice progresses, allowing subsequent collection to create the next realization.
  - Charge updates now apply configured base-value transformations before saving.

- **Documentation**
  - Documented realization and time semantics for invoice-backed usage-based charge collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents usage-based gathering lines from being assigned to another invoice while their charge has an active realization run.
- Excludes blocked lines from collection without failing the entire collection request.
- Persists an idempotent critical validation issue containing the blocking invoice and line identifiers.
- Clears the assignment issue when charge lifecycle progress releases the current run.
- Adds ordered state-machine base-update handlers and lifecycle-focused test coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no new actionable defects identified in the changes since the previous review.

The recent validation changes preserve nil behavior for valid inputs while adding the repository-standard generic validation classification for invalid inputs. The earlier stale validation-issue replacement concern was manually resolved after turip accepted the concurrency risk and stated that settlement-specific lock domains would be addressed separately so this PR could remain focused on invoice-assignment gating.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/lineengine.go | Adds invoice-assignment gating and idempotent persistence or removal of the active-run validation issue. |
| openmeter/billing/charges/usagebased/service/validationissues.go | Defines the structured assignment issue and lifecycle cleanup handler. |
| openmeter/billing/charges/statemachine/machine.go | Adds validated, ordered base-update handlers applied before persistence. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Registers assignment-issue cleanup for credit-then-invoice charge transitions. |
| openmeter/billing/charges/usagebased/adapter/charge.go | Adds scoped persistence for replacing or clearing charge validation issues. |
| openmeter/billing/charges/service/usagebased_test.go | Covers blocked collection, retry idempotency, issue attributes, and lifecycle cleanup. |
| openmeter/billing/validationissue.go | Adds immutable component-and-code lookup and removal helpers for validation issues. |


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    G[Gathering usage line] --> Gate{Current realization run?}
    Gate -->|No| Assign[Eligible for invoice assignment]
    Gate -->|Yes| Exclude[Exclude gathering line]
    Exclude --> Issue[Persist assignment validation issue]
    Issue --> Progress[Advance charge lifecycle]
    Progress --> Release[Release current run]
    Release --> Clear[Clear assignment issue]
    Clear --> Retry[Later collection can assign line]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): align validation issue che..."](https://github.com/openmeterio/openmeter/commit/366b6476f03a32fc6efedb99ab3b2c0b993c5047) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61232576)</sub>

**Context used:**

- Knowledge Base — [Billing and invoicing](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/billing-and-invoicing.md)
- Knowledge Base — [Invoice workflows and rating](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/invoice-workflows-and-rating.md)

<!-- /greptile_comment -->