### PR TITLE
Feat/pr 5084 ci validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -305,7 +306,8 @@ jobs:
           cache: pnpm
           cache-dependency-path: api/spec/pnpm-lock.yaml
 
-      - name: Verify Depot Go cache and runner tools
+      - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -315,6 +317,9 @@ jobs:
           fi
 
           echo "Using ${cache_program}"
+
+      - name: Verify runner tools
+        run: |
           yq --version
 
       - name: Ensure code generators are run
@@ -418,6 +423,7 @@ jobs:
             ${{ runner.os }}-openmeter-go-modules-
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -479,6 +485,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -523,6 +530,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -590,6 +598,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -663,6 +672,7 @@ jobs:
           skip-cache: true
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -875,6 +885,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -985,6 +996,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -1123,6 +1135,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 

--- a/openmeter/llmcost/adapter/price.go
+++ b/openmeter/llmcost/adapter/price.go
@@ -121,7 +121,7 @@ func (a *adapter) ResolvePrice(ctx context.Context, input llmcost.ResolvePriceIn
 		).
 		Order(
 			// Prioritize namespace overrides
-			pricedb.ByNamespace(sql.OrderDesc()),
+			pricedb.ByNamespace(sql.OrderDesc(), sql.OrderNullsLast()),
 			// Then effective from
 			pricedb.ByEffectiveFrom(sql.OrderDesc()),
 		).

--- a/openmeter/llmcost/adapter/price_test.go
+++ b/openmeter/llmcost/adapter/price_test.go
@@ -1,0 +1,86 @@
+package adapter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/llmcost"
+	llmcostadapter "github.com/openmeterio/openmeter/openmeter/llmcost/adapter"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
+	t.Helper()
+
+	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
+	dbClient := testDB.EntDriver.Client()
+
+	t.Cleanup(func() {
+		_ = dbClient.Close()
+		testDB.Close(t)
+	})
+
+	adapter, err := llmcostadapter.New(llmcostadapter.Config{
+		Client: dbClient,
+		Logger: testutils.NewDiscardLogger(t),
+	})
+	require.NoError(t, err)
+
+	return adapter, dbClient
+}
+
+func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
+	ctx := context.Background()
+	adapter, _ := newLLMCostTestAdapter(t)
+
+	effectiveFrom := time.Now().Add(-time.Hour)
+
+	globalPrice := llmcost.Price{
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+		ModelName: "GPT Test",
+		Pricing: llmcost.ModelPricing{
+			InputPerToken:  alpacadecimal.NewFromFloat(0.001),
+			OutputPerToken: alpacadecimal.NewFromFloat(0.002),
+		},
+		Currency:      "USD",
+		Source:        llmcost.PriceSourceSystem,
+		EffectiveFrom: effectiveFrom,
+	}
+	require.NoError(t, adapter.UpsertGlobalPrice(ctx, globalPrice))
+
+	override, err := adapter.CreateOverride(ctx, llmcost.CreateOverrideInput{
+		Namespace: "ns-1",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+		ModelName: "GPT Test",
+		Pricing: llmcost.ModelPricing{
+			InputPerToken:  alpacadecimal.NewFromFloat(0.010),
+			OutputPerToken: alpacadecimal.NewFromFloat(0.020),
+		},
+		Currency:      "USD",
+		EffectiveFrom: effectiveFrom,
+	})
+	require.NoError(t, err)
+
+	resolved, err := adapter.ResolvePrice(ctx, llmcost.ResolvePriceInput{
+		Namespace: "ns-1",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, override.ID, resolved.ID, "namespace override must win over the global price")
+
+	resolvedGlobal, err := adapter.ResolvePrice(ctx, llmcost.ResolvePriceInput{
+		Namespace: "ns-2",
+		Provider:  "openai",
+		ModelID:   "gpt-test",
+	})
+	require.NoError(t, err)
+	require.Equal(t, resolvedGlobal.Pricing.InputPerToken.String(), globalPrice.Pricing.InputPerToken.String(), "namespaces without an override resolve to the global price")
+}

--- a/openmeter/llmcost/adapter/price_test.go
+++ b/openmeter/llmcost/adapter/price_test.go
@@ -1,22 +1,18 @@
 package adapter_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/llmcost"
 	llmcostadapter "github.com/openmeterio/openmeter/openmeter/llmcost/adapter"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 )
 
-func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
-	t.Helper()
-
+func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
 	testDB := testutils.InitPostgresDB(t, testutils.PostgresDBStateEntMigrated)
 	dbClient := testDB.EntDriver.Client()
 
@@ -31,13 +27,7 @@ func newLLMCostTestAdapter(t *testing.T) (llmcost.Adapter, *db.Client) {
 	})
 	require.NoError(t, err)
 
-	return adapter, dbClient
-}
-
-func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
-	ctx := context.Background()
-	adapter, _ := newLLMCostTestAdapter(t)
-
+	ctx := t.Context()
 	effectiveFrom := time.Now().Add(-time.Hour)
 
 	globalPrice := llmcost.Price{
@@ -82,5 +72,5 @@ func TestAdapterResolvePricePrefersNamespaceOverride(t *testing.T) {
 		ModelID:   "gpt-test",
 	})
 	require.NoError(t, err)
-	require.Equal(t, resolvedGlobal.Pricing.InputPerToken.String(), globalPrice.Pricing.InputPerToken.String(), "namespaces without an override resolve to the global price")
+	require.Equal(t, globalPrice.Pricing.InputPerToken.InexactFloat64(), resolvedGlobal.Pricing.InputPerToken.InexactFloat64(), "namespaces without an override resolve to the global price")
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->

<!--
## Checklist

- [ ] I updated the relevant package README, or this change does not affect
      domain behavior, ownership, lifecycle semantics, or a cross-domain
      contract.
-->




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects LLM price resolution so namespace-specific overrides take precedence over global prices and adjusts CI cache validation to support fork pull requests.
- Orders null namespaces after namespace-specific prices and adds a PostgreSQL-backed regression test.
- Skips Depot Go cache verification for fork pull requests while retaining it for trusted runs.
- Keeps runner-tool verification unconditional before OpenAPI generation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or repository-rule violations identified.

Namespace override ordering is corrected and regression-tested, while the latest CI changes consistently skip unavailable Depot cache validation only for fork pull requests and preserve required runner-tool checks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Gates Depot cache checks for fork pull requests and separates unconditional runner-tool validation. |
| openmeter/llmcost/adapter/price.go | Uses NULLS LAST ordering so namespace overrides are selected before global prices. |
| openmeter/llmcost/adapter/price_test.go | Adds integration coverage for namespace override precedence and global fallback. |

<sub>Reviews (2): Last reviewed commit: ["fix(ci): allow local Go cache for fork p..."](https://github.com/openmeterio/openmeter/commit/d9925b215712bda72d0d8914aa6e677b36c10759) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61280113)</sub>

<!-- /greptile_comment -->