### PR TITLE
fix(ci): allow local Go cache for fork pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,6 +243,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -305,7 +306,8 @@ jobs:
           cache: pnpm
           cache-dependency-path: api/spec/pnpm-lock.yaml
 
-      - name: Verify Depot Go cache and runner tools
+      - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -315,6 +317,9 @@ jobs:
           fi
 
           echo "Using ${cache_program}"
+
+      - name: Verify runner tools
+        run: |
           yq --version
 
       - name: Ensure code generators are run
@@ -418,6 +423,7 @@ jobs:
             ${{ runner.os }}-openmeter-go-modules-
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -479,6 +485,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -523,6 +530,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -590,6 +598,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -663,6 +672,7 @@ jobs:
           skip-cache: true
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -875,6 +885,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -985,6 +996,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 
@@ -1123,6 +1135,7 @@ jobs:
           cache: false
 
       - name: Verify Depot Go cache
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           cache_program="$(go env GOCACHEPROG)"
 


### PR DESCRIPTION
## Summary

- keep the Depot Go cache assertion for pushes and pull requests originating from this repository
- skip that assertion for external fork pull requests, where `GOCACHEPROG` is not exposed, and let Go use its local cache
- keep runner tool verification unconditional

## Root cause

The CI optimization in #5072 made the Depot Go cache assertion fatal in all pull request contexts. External fork runs receive the same upstream Go toolchain but do not receive `GOCACHEPROG`, so build, lint, test, generator, SDK, and migration jobs stopped before performing their actual work.

## Validation

- full external-fork CI passed on #5097, including build, lint, test, generators, SDK, migrations, container images, Quickstart, and both E2E variants
- `git diff --check` passed
- `actionlint` reports only the three existing repository-template references using `$/.github/workflows/...`; this change introduces no new workflow lint findings

No Jira ticket.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows external fork pull requests to use Go's local cache while preserving Depot cache enforcement for pushes and same-repository pull requests.
- Applies the fork-aware condition consistently to all ten Depot Go cache verification steps.
- Separates runner-tool verification so it remains unconditional.
- Preserves existing build, generator, SDK, test, migration, lint, Quickstart, and E2E job behavior outside the cache assertion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the fork-specific cache fallback applied consistently across all affected jobs.

No actionable failures were found; the condition matches established workflow patterns, covers every relevant cache assertion, and preserves unconditional runner-tool validation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Consistently skips Depot Go cache assertions for fork pull requests while keeping runner-tool verification unconditional. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): allow local Go cache for fork p..."](https://github.com/openmeterio/openmeter/commit/cf8e237133b78c7f2ca42d6066bfe0cec967b492) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61286709)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved validation behavior for pull requests from external repositories.
  * Runner tool checks now run independently, while cache verification is limited to trusted sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->