### PR TITLE
fix(customer): improve customer billing endpoint error handling

### DIFF
--- a/api/v3/handlers/customers/billing/convert.go
+++ b/api/v3/handlers/customers/billing/convert.go
@@ -2,10 +2,18 @@
 package customersbilling
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/oapi-codegen/nullable"
 	apilegacy "github.com/openmeterio/openmeter/api"
 	api "github.com/openmeterio/openmeter/api/v3"
+	"github.com/openmeterio/openmeter/api/v3/apierrors"
+	"github.com/openmeterio/openmeter/openmeter/app"
+	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/samber/lo"
 )
 
 // goverter:variables
@@ -61,4 +69,40 @@ var (
 
 func ResolveIDFromCustomerId(namespacedID customer.CustomerID) string {
 	return namespacedID.ID
+}
+
+func fromAPIBillingAppCustomerData(ctx context.Context, application app.App, data app.CustomerData) (*api.BillingAppCustomerData, error) {
+	if data == nil {
+		return nil, nil
+	}
+
+	switch application.GetType() {
+	case app.AppTypeStripe:
+		if stripeData, ok := data.(appstripe.CustomerData); ok {
+			// TODO: we don't have metadata on the stripe customer data yet
+			return &api.BillingAppCustomerData{
+				Stripe: nullable.NewNullableWithValue(api.BillingAppCustomerDataStripe{
+					CustomerId:             &stripeData.StripeCustomerID,
+					DefaultPaymentMethodId: stripeData.StripeDefaultPaymentMethodID,
+				}),
+			}, nil
+		}
+
+		return nil, nil
+	case app.AppTypeCustomInvoicing:
+		if invoicingData, ok := data.(appcustominvoicing.CustomerData); ok {
+			return &api.BillingAppCustomerData{
+				ExternalInvoicing: nullable.NewNullableWithValue(api.BillingAppCustomerDataExternalInvoicing{
+					Labels: (*api.Labels)(lo.ToPtr(invoicingData.Metadata.ToMap())),
+				}),
+			}, nil
+		}
+
+		return nil, nil
+	case app.AppTypeSandbox:
+		// No app data
+		return nil, nil
+	default:
+		return nil, apierrors.NewInternalError(ctx, fmt.Errorf("unsupported app type: %s", application.GetType()))
+	}
 }

--- a/api/v3/handlers/customers/billing/convert.go
+++ b/api/v3/handlers/customers/billing/convert.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/oapi-codegen/nullable"
+	"github.com/samber/lo"
+
 	apilegacy "github.com/openmeterio/openmeter/api"
 	api "github.com/openmeterio/openmeter/api/v3"
 	"github.com/openmeterio/openmeter/api/v3/apierrors"
@@ -13,7 +15,6 @@ import (
 	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/samber/lo"
 )
 
 // goverter:variables
@@ -72,36 +73,51 @@ func ResolveIDFromCustomerId(namespacedID customer.CustomerID) string {
 }
 
 func fromAPIBillingAppCustomerData(ctx context.Context, application app.App, data app.CustomerData) (*api.BillingAppCustomerData, error) {
-	if data == nil {
-		return nil, nil
-	}
+	appData := &api.BillingAppCustomerData{}
 
 	switch application.GetType() {
 	case app.AppTypeStripe:
-		if stripeData, ok := data.(appstripe.CustomerData); ok {
-			// TODO: we don't have metadata on the stripe customer data yet
-			return &api.BillingAppCustomerData{
-				Stripe: nullable.NewNullableWithValue(api.BillingAppCustomerDataStripe{
-					CustomerId:             &stripeData.StripeCustomerID,
-					DefaultPaymentMethodId: stripeData.StripeDefaultPaymentMethodID,
-				}),
-			}, nil
+		// data is nil when the customer has no stripe data for the configured
+		// payment app
+		if data == nil {
+			appData.Stripe = nullable.NewNullNullable[api.BillingAppCustomerDataStripe]()
+			return appData, nil
 		}
 
-		return nil, nil
+		// The handler selected the app by type, so the type must match. A
+		// mismatch is a programming error, not a "no data" state.
+		stripeData, ok := data.(appstripe.CustomerData)
+		if !ok {
+			return nil, apierrors.NewInternalError(ctx, fmt.Errorf("stripe app returned %T, want appstripe.CustomerData", data))
+		}
+
+		// TODO: we don't have metadata on the stripe customer data yet
+		appData.Stripe = nullable.NewNullableWithValue(api.BillingAppCustomerDataStripe{
+			CustomerId:             &stripeData.StripeCustomerID,
+			DefaultPaymentMethodId: stripeData.StripeDefaultPaymentMethodID,
+		})
+		return appData, nil
+
 	case app.AppTypeCustomInvoicing:
-		if invoicingData, ok := data.(appcustominvoicing.CustomerData); ok {
-			return &api.BillingAppCustomerData{
-				ExternalInvoicing: nullable.NewNullableWithValue(api.BillingAppCustomerDataExternalInvoicing{
-					Labels: (*api.Labels)(lo.ToPtr(invoicingData.Metadata.ToMap())),
-				}),
-			}, nil
+		if data == nil {
+			appData.ExternalInvoicing = nullable.NewNullNullable[api.BillingAppCustomerDataExternalInvoicing]()
+			return appData, nil
 		}
 
-		return nil, nil
+		invoicingData, ok := data.(appcustominvoicing.CustomerData)
+		if !ok {
+			return nil, apierrors.NewInternalError(ctx, fmt.Errorf("custom invoicing app returned %T, want appcustominvoicing.CustomerData", data))
+		}
+
+		appData.ExternalInvoicing = nullable.NewNullableWithValue(api.BillingAppCustomerDataExternalInvoicing{
+			Labels: (*api.Labels)(lo.ToPtr(invoicingData.Metadata.ToMap())),
+		})
+		return appData, nil
+
 	case app.AppTypeSandbox:
-		// No app data
+		// No app data.
 		return nil, nil
+
 	default:
 		return nil, apierrors.NewInternalError(ctx, fmt.Errorf("unsupported app type: %s", application.GetType()))
 	}

--- a/api/v3/handlers/customers/billing/get_billing.go
+++ b/api/v3/handlers/customers/billing/get_billing.go
@@ -2,17 +2,11 @@ package customersbilling
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-
-	"github.com/oapi-codegen/nullable"
-	"github.com/samber/lo"
 
 	api "github.com/openmeterio/openmeter/api/v3"
 	"github.com/openmeterio/openmeter/api/v3/apierrors"
 	"github.com/openmeterio/openmeter/openmeter/app"
-	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
-	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
@@ -55,8 +49,6 @@ func (h *handler) GetCustomerBilling() GetCustomerBillingHandler {
 				return resp, err
 			}
 
-			appData := api.BillingAppCustomerData{}
-
 			// TODO: Only one app ID can be in the billing profile right now.
 			// We pick the payment app for now.
 			application := override.MergedProfile.Apps.Payment
@@ -64,48 +56,26 @@ func (h *handler) GetCustomerBilling() GetCustomerBillingHandler {
 				CustomerID: request.CustomerID,
 			})
 			if err != nil {
-				if app.IsAppCustomerPreConditionError(err) {
-					// The profile names this app as payment app, but the customer has no
-					// data for it yet. This is a supported state; show it as unconfigured.
-					data = nil
-				} else {
+				if !app.IsAppCustomerPreConditionError(err) {
 					return resp, err
 				}
+
+				// The profile names this app as payment app, but the customer has no
+				// data for it yet. This is a supported state; show it as unconfigured.
+				data = nil // (untyped nil)
 			}
 
-			switch application.GetType() {
-			case app.AppTypeStripe:
-				if stripeData, ok := data.(appstripe.CustomerData); ok {
-					// TODO: we don't have metadata on the stripe customer data yet
-					appData.Stripe = nullable.NewNullableWithValue(api.BillingAppCustomerDataStripe{
-						CustomerId:             &stripeData.StripeCustomerID,
-						DefaultPaymentMethodId: stripeData.StripeDefaultPaymentMethodID,
-					})
-				} else {
-					appData.Stripe = nullable.NewNullNullable[api.BillingAppCustomerDataStripe]()
-				}
-			case app.AppTypeCustomInvoicing:
-				if invoicingData, ok := data.(appcustominvoicing.CustomerData); ok {
-					appData.ExternalInvoicing = nullable.NewNullableWithValue(api.BillingAppCustomerDataExternalInvoicing{
-						Labels: (*api.Labels)(lo.ToPtr(invoicingData.Metadata.ToMap())),
-					})
-				} else {
-					appData.ExternalInvoicing = nullable.NewNullNullable[api.BillingAppCustomerDataExternalInvoicing]()
-				}
-			case app.AppTypeSandbox:
-				// No app data
-			default:
-				return resp, apierrors.NewInternalError(ctx, fmt.Errorf("unsupported app type: %s", application.GetType()))
+			apiAppData, err := fromAPIBillingAppCustomerData(ctx, application, data)
+			if err != nil {
+				return resp, err
 			}
 
-			resp = GetCustomerBillingResponse{
+			return GetCustomerBillingResponse{
 				BillingProfile: &api.BillingProfileReference{
 					Id: override.MergedProfile.ID,
 				},
-				AppData: &appData,
-			}
-
-			return resp, nil
+				AppData: apiAppData,
+			}, nil
 		},
 		commonhttp.JSONResponseEncoderWithStatus[GetCustomerBillingResponse](http.StatusOK),
 		httptransport.AppendOptions(

--- a/api/v3/handlers/customers/billing/get_billing.go
+++ b/api/v3/handlers/customers/billing/get_billing.go
@@ -64,23 +64,33 @@ func (h *handler) GetCustomerBilling() GetCustomerBillingHandler {
 				CustomerID: request.CustomerID,
 			})
 			if err != nil {
-				return resp, err
+				if app.IsAppCustomerPreConditionError(err) {
+					// The profile names this app as payment app, but the customer has no
+					// data for it yet. This is a supported state; show it as unconfigured.
+					data = nil
+				} else {
+					return resp, err
+				}
 			}
 
 			switch application.GetType() {
 			case app.AppTypeStripe:
-				if data, ok := data.(appstripe.CustomerData); ok {
+				if stripeData, ok := data.(appstripe.CustomerData); ok {
 					// TODO: we don't have metadata on the stripe customer data yet
 					appData.Stripe = nullable.NewNullableWithValue(api.BillingAppCustomerDataStripe{
-						CustomerId:             &data.StripeCustomerID,
-						DefaultPaymentMethodId: data.StripeDefaultPaymentMethodID,
+						CustomerId:             &stripeData.StripeCustomerID,
+						DefaultPaymentMethodId: stripeData.StripeDefaultPaymentMethodID,
 					})
+				} else {
+					appData.Stripe = nullable.NewNullNullable[api.BillingAppCustomerDataStripe]()
 				}
 			case app.AppTypeCustomInvoicing:
-				if data, ok := data.(appcustominvoicing.CustomerData); ok {
+				if invoicingData, ok := data.(appcustominvoicing.CustomerData); ok {
 					appData.ExternalInvoicing = nullable.NewNullableWithValue(api.BillingAppCustomerDataExternalInvoicing{
-						Labels: (*api.Labels)(lo.ToPtr(data.Metadata.ToMap())),
+						Labels: (*api.Labels)(lo.ToPtr(invoicingData.Metadata.ToMap())),
 					})
+				} else {
+					appData.ExternalInvoicing = nullable.NewNullNullable[api.BillingAppCustomerDataExternalInvoicing]()
 				}
 			case app.AppTypeSandbox:
 				// No app data

--- a/test/app/stripe/customerbilling_v3_test.go
+++ b/test/app/stripe/customerbilling_v3_test.go
@@ -2,6 +2,7 @@ package appstripe
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -51,7 +52,7 @@ func TestCustomerBillingV3(t *testing.T) {
 
 	router := newCustomerBillingRouter(t, env, namespace)
 
-	getStripeData := func(cus *customer.Customer) (appstripe.CustomerData, error) {
+	getStripeData := func(ctx context.Context, cus *customer.Customer) (appstripe.CustomerData, error) {
 		return env.AppStripe().GetStripeCustomerData(ctx, appstripe.GetStripeCustomerDataInput{
 			AppID:      stripeApp.GetID(),
 			CustomerID: cus.GetID(),
@@ -59,7 +60,7 @@ func TestCustomerBillingV3(t *testing.T) {
 	}
 
 	// Stripe customer IDs are unique per app, so every seeding gets its own.
-	seedStripeData := func(t *testing.T, cus *customer.Customer, stripeCustomerID string) {
+	seedStripeData := func(ctx context.Context, t *testing.T, cus *customer.Customer, stripeCustomerID string) {
 		t.Helper()
 
 		env.StripeAppClient().
@@ -74,6 +75,8 @@ func TestCustomerBillingV3(t *testing.T) {
 	}
 
 	t.Run("Should set billing profile without app data", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer with no stripe app data
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
@@ -91,11 +94,13 @@ func TestCustomerBillingV3(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, pinnedProfile.ID, override.MergedProfile.ID)
 
-		_, err = getStripeData(cus)
+		_, err = getStripeData(ctx, cus)
 		require.Error(t, err, "no stripe customer data should have been created")
 	})
 
 	t.Run("Should reject stripe app data without customer id", func(t *testing.T) {
+		ctx := t.Context()
+
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
@@ -107,6 +112,8 @@ func TestCustomerBillingV3(t *testing.T) {
 	})
 
 	t.Run("Should upsert stripe app data", func(t *testing.T) {
+		ctx := t.Context()
+
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
@@ -120,17 +127,19 @@ func TestCustomerBillingV3(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-		data, err := getStripeData(cus)
+		data, err := getStripeData(ctx, cus)
 		require.NoError(t, err)
 		require.Equal(t, "cus_upsert", data.StripeCustomerID)
 	})
 
 	t.Run("Should leave stripe app data unchanged when stripe is omitted", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer with existing stripe app data
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_keep_billing")
+		seedStripeData(ctx, t, cus, "cus_keep_billing")
 
 		// when updating billing with an app data object that omits stripe
 		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing",
@@ -139,17 +148,19 @@ func TestCustomerBillingV3(t *testing.T) {
 		// then the request is a no-op and the stored stripe data stays
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-		data, err := getStripeData(cus)
+		data, err := getStripeData(ctx, cus)
 		require.NoError(t, err)
 		require.Equal(t, "cus_keep_billing", data.StripeCustomerID)
 	})
 
 	t.Run("Should leave stripe app data unchanged when stripe is omitted on app-data endpoint", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer with existing stripe app data
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_keep_app_data")
+		seedStripeData(ctx, t, cus, "cus_keep_app_data")
 
 		// when updating app data with an empty object that omits stripe
 		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing/app-data",
@@ -158,17 +169,19 @@ func TestCustomerBillingV3(t *testing.T) {
 		// then the request is a no-op and the stored stripe data stays
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-		data, err := getStripeData(cus)
+		data, err := getStripeData(ctx, cus)
 		require.NoError(t, err)
 		require.Equal(t, "cus_keep_app_data", data.StripeCustomerID)
 	})
 
 	t.Run("Should wipe stripe app data with explicit null", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer with existing stripe app data
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_wipe_billing")
+		seedStripeData(ctx, t, cus, "cus_wipe_billing")
 
 		// when updating billing with an explicit stripe null
 		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing",
@@ -177,47 +190,63 @@ func TestCustomerBillingV3(t *testing.T) {
 		// then the stripe customer data is deleted
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-		_, err = getStripeData(cus)
+		_, err = getStripeData(ctx, cus)
 		require.Error(t, err, "stripe customer data should have been wiped")
 	})
 
 	t.Run("Should wipe stripe app data with explicit null on app-data endpoint", func(t *testing.T) {
+		ctx := t.Context()
+
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_wipe_app_data")
+		seedStripeData(ctx, t, cus, "cus_wipe_app_data")
 
 		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing/app-data",
 			`{"stripe":null}`)
 
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
 
-		_, err = getStripeData(cus)
+		_, err = getStripeData(ctx, cus)
 		require.Error(t, err, "stripe customer data should have been wiped")
 	})
 
 	t.Run("Should return stripe app data on get", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer with existing stripe app data
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_get_billing")
+		seedStripeData(ctx, t, cus, "cus_get_billing")
 
 		// when reading the customer billing
 		rec := doJSONRequest(router, http.MethodGet, "/openmeter/customers/"+cus.ID+"/billing", "")
 
 		// then the response returns the stripe customer id
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-		require.Contains(t, rec.Body.String(), `"customer_id":"cus_get_billing"`)
+
+		var got api.BillingCustomerData
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.NotNil(t, got.AppData)
+		require.True(t, got.AppData.Stripe.IsSpecified())
+		require.False(t, got.AppData.Stripe.IsNull())
+
+		stripeData, err := got.AppData.Stripe.Get()
+		require.NoError(t, err)
+		require.NotNil(t, stripeData.CustomerId)
+		require.Equal(t, "cus_get_billing", *stripeData.CustomerId)
 	})
 
 	t.Run("Should return null stripe app data on get after a wipe", func(t *testing.T) {
+		ctx := t.Context()
+
 		// given a customer whose stripe app data was wiped while the profile
 		// still names stripe as the payment app
 		cus, err := env.Fixture().setupCustomer(ctx, namespace)
 		require.NoError(t, err)
 
-		seedStripeData(t, cus, "cus_get_after_wipe")
+		seedStripeData(ctx, t, cus, "cus_get_after_wipe")
 
 		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing",
 			`{"app_data":{"stripe":null}}`)
@@ -228,7 +257,12 @@ func TestCustomerBillingV3(t *testing.T) {
 
 		// then the read succeeds and reports the stripe app data as explicit null
 		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
-		require.Contains(t, rec.Body.String(), `"stripe":null`)
+
+		var got api.BillingCustomerData
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+		require.NotNil(t, got.AppData)
+		require.True(t, got.AppData.Stripe.IsSpecified())
+		require.True(t, got.AppData.Stripe.IsNull())
 	})
 }
 

--- a/test/app/stripe/customerbilling_v3_test.go
+++ b/test/app/stripe/customerbilling_v3_test.go
@@ -195,6 +195,41 @@ func TestCustomerBillingV3(t *testing.T) {
 		_, err = getStripeData(cus)
 		require.Error(t, err, "stripe customer data should have been wiped")
 	})
+
+	t.Run("Should return stripe app data on get", func(t *testing.T) {
+		// given a customer with existing stripe app data
+		cus, err := env.Fixture().setupCustomer(ctx, namespace)
+		require.NoError(t, err)
+
+		seedStripeData(t, cus, "cus_get_billing")
+
+		// when reading the customer billing
+		rec := doJSONRequest(router, http.MethodGet, "/openmeter/customers/"+cus.ID+"/billing", "")
+
+		// then the response returns the stripe customer id
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		require.Contains(t, rec.Body.String(), `"customer_id":"cus_get_billing"`)
+	})
+
+	t.Run("Should return null stripe app data on get after a wipe", func(t *testing.T) {
+		// given a customer whose stripe app data was wiped while the profile
+		// still names stripe as the payment app
+		cus, err := env.Fixture().setupCustomer(ctx, namespace)
+		require.NoError(t, err)
+
+		seedStripeData(t, cus, "cus_get_after_wipe")
+
+		rec := doJSONRequest(router, http.MethodPut, "/openmeter/customers/"+cus.ID+"/billing",
+			`{"app_data":{"stripe":null}}`)
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+		// when reading the customer billing
+		rec = doJSONRequest(router, http.MethodGet, "/openmeter/customers/"+cus.ID+"/billing", "")
+
+		// then the read succeeds and reports the stripe app data as explicit null
+		require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+		require.Contains(t, rec.Body.String(), `"stripe":null`)
+	})
 }
 
 func newCustomerBillingRouter(t *testing.T, env TestEnv, namespace string) http.Handler {
@@ -231,6 +266,9 @@ func newCustomerBillingRouter(t *testing.T, env TestEnv, namespace string) http.
 	})
 	router.Put("/openmeter/customers/{customerId}/billing/app-data", func(w http.ResponseWriter, r *http.Request) {
 		handler.UpdateCustomerBillingAppData().With(chi.URLParam(r, "customerId")).ServeHTTP(w, r)
+	})
+	router.Get("/openmeter/customers/{customerId}/billing", func(w http.ResponseWriter, r *http.Request) {
+		handler.GetCustomerBilling().With(chi.URLParam(r, "customerId")).ServeHTTP(w, r)
 	})
 
 	return router


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Customer billing requests now correctly handle unconfigured customer data.
  - Billing responses accurately represent unavailable or cleared data as explicit null values.
  - Stripe billing lookups now reliably return stored customer IDs and default payment method details.
  - Custom invoicing billing data now includes external invoicing metadata.

- **Tests**
  - Added coverage for retrieving Stripe billing details and verifying responses after billing data is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves the customer billing GET endpoint so missing app-specific customer data is treated as a supported unconfigured state and represented explicitly in the response.
- Converts Stripe and custom-invoicing customer data into typed API app-data variants.
- Preserves explicit `null` for configured apps without customer data.
- Returns internal errors for unexpected app-data types or unsupported app types.
- Adds typed Stripe response tests covering stored data and the post-clear null state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no outstanding correctness, security, or repository-rule violations remain.

The current implementation preserves the configured app’s explicit-null response state, validates app-data type mismatches, and tests the response through typed API models. All three previous threads were manually resolved without explanatory replies, and the current code also addresses their reported concerns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| api/v3/handlers/customers/billing/convert.go | Adds typed conversion of billing app customer data while preserving explicit-null states and rejecting invalid type combinations. |
| api/v3/handlers/customers/billing/get_billing.go | Treats missing app customer data as unconfigured and delegates response conversion to the typed mapping helper. |
| test/app/stripe/customerbilling_v3_test.go | Adds typed GET assertions for populated and cleared Stripe billing data and scopes test operations to each subtest context. |

<sub>Reviews (5): Last reviewed commit: ["fix(customer): fix convert function"](https://github.com/openmeterio/openmeter/commit/f332a254034d899c9b81a8aff41463350deccd41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61525132)</sub>

**Context used:**

- Knowledge Base — [Customer, namespace, and portal services](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/customer-namespace-and-portal.md)
- Knowledge Base — [API and runtime composition](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/api-and-runtime-composition.md)

<!-- /greptile_comment -->