### PR TITLE
fix(ledger): preserve source attribution in earnings lineage

### DIFF
--- a/openmeter/billing/charges/lineage/adapter/lineage.go
+++ b/openmeter/billing/charges/lineage/adapter/lineage.go
@@ -130,7 +130,7 @@ func (a *adapter) LoadLineagesByCustomer(ctx context.Context, input lineage.Load
 		}
 
 		mapped := lo.Map(lineages, mapLineage)
-		if err := tx.loadAdvanceOriginalGroups(ctx, input.Namespace, mapped); err != nil {
+		if err := tx.loadOriginalAllocations(ctx, input.Namespace, mapped); err != nil {
 			return nil, err
 		}
 		return mapped, nil
@@ -312,14 +312,12 @@ func mapSegment(segment *entdb.CreditRealizationLineageSegment) lineage.Segment 
 	}
 }
 
-// Original allocation references distinguish a legacy nil-spend collection from
-// a current charge-specific collection even when they share account routes.
-func (a *adapter) loadAdvanceOriginalGroups(ctx context.Context, namespace string, roots []lineage.Lineage) error {
+// Original allocation references identify the collected source bucket within a
+// group, including legacy collections without spend provenance.
+func (a *adapter) loadOriginalAllocations(ctx context.Context, namespace string, roots []lineage.Lineage) error {
 	var ids []string
 	for _, root := range roots {
-		if root.OriginKind == creditrealization.LineageOriginKindAdvance {
-			ids = append(ids, root.RootRealizationID)
-		}
+		ids = append(ids, root.RootRealizationID)
 	}
 	if len(ids) == 0 {
 		return nil
@@ -333,14 +331,18 @@ func (a *adapter) loadAdvanceOriginalGroups(ctx context.Context, namespace strin
 		return err
 	}
 	groups := make(map[string]string, len(flat)+len(usage))
+	sortHints := make(map[string]int, len(flat)+len(usage))
 	for _, allocation := range flat {
 		groups[allocation.ID] = allocation.LedgerTransactionGroupID
+		sortHints[allocation.ID] = allocation.SortHint
 	}
 	for _, allocation := range usage {
 		groups[allocation.ID] = allocation.LedgerTransactionGroupID
+		sortHints[allocation.ID] = allocation.SortHint
 	}
 	for i := range roots {
 		roots[i].OriginalTransactionGroupID = groups[roots[i].RootRealizationID]
+		roots[i].OriginalAllocationSortHint = sortHints[roots[i].RootRealizationID]
 	}
 	return nil
 }

--- a/openmeter/billing/charges/lineage/service.go
+++ b/openmeter/billing/charges/lineage/service.go
@@ -267,6 +267,7 @@ type Lineage struct {
 	// CreatedAt is the immutable recording time of the original collection occurrence.
 	CreatedAt                  time.Time
 	OriginalTransactionGroupID string
+	OriginalAllocationSortHint int
 	ID                         string
 	ChargeID                   string
 	RootRealizationID          string

--- a/openmeter/ledger/README.md
+++ b/openmeter/ledger/README.md
@@ -64,7 +64,11 @@ facts stored independently from the journal.
 - Credit-backed earnings recognition consumes only accrued buckets whose
   source credit and spend charge are both present and distinct. Buckets without
   that provenance - including invoice-backed accrued value and unbackfilled
-  advances - remain deferred.
+  advances - remain deferred. Unknown-cost promotional credits also remain
+  deferred. Recognition maps each segment to its original allocation bucket or
+  recorded backfill group, preserving source, spend, currency, and tax route.
+  The same selected slices drive journal postings and lineage transitions;
+  customer-wide recognized totals cannot be redistributed across lineages.
 
 Credit-purchase backfill uses the charge domain's original advance occurrences
 in order, bounded by their matching receivable and accrued routes. The ledger

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -715,10 +715,12 @@ func newFlatFeeHandlerTestEnv(t *testing.T) *flatFeeHandlerTestEnv {
 	})
 	require.NoError(t, err)
 
-	lineageService, err := lineageservice.New(lineageservice.Config{
+	dbLineage, err := lineageservice.New(lineageservice.Config{
 		Adapter: lineageAdapter,
 	})
 	require.NoError(t, err)
+
+	lineageService := &ledgertestutils.LineageWithAllocations{Service: dbLineage}
 
 	recognizerService, err := recognizer.NewService(recognizer.Config{
 		Ledger:             base.Deps.HistoricalLedger,

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -585,7 +585,7 @@ func newUsageBasedHandlerTestEnv(t *testing.T) *usageBasedHandlerTestEnv {
 	})
 	require.NoError(t, err)
 
-	lineageService, err := lineageservice.New(lineageservice.Config{
+	dbLineage, err := lineageservice.New(lineageservice.Config{
 		Adapter: lineageAdapter,
 	})
 	require.NoError(t, err)
@@ -595,6 +595,8 @@ func newUsageBasedHandlerTestEnv(t *testing.T) *usageBasedHandlerTestEnv {
 		AccountCatalog: base.Deps.AccountService,
 		BalanceQuerier: base.Deps.HistoricalLedger,
 	}
+	lineageService := &ledgertestutils.LineageWithAllocations{Service: dbLineage}
+
 	recognizerService, err := recognizer.NewService(recognizer.Config{
 		Ledger:             base.Deps.HistoricalLedger,
 		Dependencies:       deps,

--- a/openmeter/ledger/recognizer/recognize.go
+++ b/openmeter/ledger/recognizer/recognize.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
@@ -25,7 +24,6 @@ var recognizableSegmentStates = map[creditrealization.LineageSegmentState]bool{
 type lineageEligible struct {
 	lineage  lineage.Lineage
 	segments []lineage.Segment
-	amount   alpacadecimal.Decimal
 }
 
 func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInput) (RecognizeEarningsResult, error) {
@@ -50,12 +48,19 @@ func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInp
 			return RecognizeEarningsResult{}, nil
 		}
 
-		totalEligible := alpacadecimal.Zero
-		for _, e := range eligible {
-			totalEligible = totalEligible.Add(e.amount)
+		sources, allocations, err := s.planRecognition(ctx, in, eligible)
+		if err != nil {
+			return RecognizeEarningsResult{}, fmt.Errorf("plan recognition: %w", err)
+		}
+		actualAmount := alpacadecimal.Zero
+		for _, allocation := range allocations {
+			actualAmount = actualAmount.Add(allocation.amount)
+		}
+		if !actualAmount.IsPositive() {
+			return RecognizeEarningsResult{}, nil
 		}
 
-		// Resolve the recognition template against the actual ledger accrued balance.
+		// Resolve postings for the exact accrued slices selected for these segments.
 		resolved, err := transactions.ResolveTransactions(
 			ctx,
 			s.deps,
@@ -65,7 +70,8 @@ func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInp
 			},
 			transactions.RecognizeEarningsFromAttributableAccruedTemplate{
 				At:       in.At,
-				Amount:   totalEligible,
+				Amount:   actualAmount,
+				Sources:  sources,
 				Currency: in.Currency.Reference(),
 			},
 		)
@@ -73,12 +79,6 @@ func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInp
 			return RecognizeEarningsResult{}, fmt.Errorf("resolve recognition: %w", err)
 		}
 		if len(resolved) == 0 {
-			return RecognizeEarningsResult{}, nil
-		}
-
-		// Compute actual recognized amount from the template output entries.
-		actualAmount := sumPositiveEntries(resolved)
-		if !actualAmount.IsPositive() {
 			return RecognizeEarningsResult{}, nil
 		}
 
@@ -95,9 +95,8 @@ func (s *service) RecognizeEarnings(ctx context.Context, in RecognizeEarningsInp
 
 		groupID := group.ID().ID
 
-		// Allocate actual recognized amount back to lineages in deterministic order
-		// and transition their segments to earnings_recognized.
-		if err := s.allocateRecognition(ctx, eligible, actualAmount, groupID, in.At); err != nil {
+		// Persist exactly the segments that supplied the committed postings.
+		if err := s.allocateRecognition(ctx, allocations, groupID, in.At); err != nil {
 			return RecognizeEarningsResult{}, fmt.Errorf("allocate recognition: %w", err)
 		}
 
@@ -115,20 +114,17 @@ func collectEligibleLineages(lineages []lineage.Lineage) []lineageEligible {
 
 	for _, l := range lineages {
 		var segments []lineage.Segment
-		amount := alpacadecimal.Zero
 
 		for _, seg := range l.Segments {
 			if recognizableSegmentStates[seg.State] && seg.Amount.IsPositive() {
 				segments = append(segments, seg)
-				amount = amount.Add(seg.Amount)
 			}
 		}
 
-		if amount.IsPositive() {
+		if len(segments) > 0 {
 			out = append(out, lineageEligible{
 				lineage:  l,
 				segments: segments,
-				amount:   amount,
 			})
 		}
 	}
@@ -140,83 +136,47 @@ func collectEligibleLineages(lineages []lineage.Lineage) []lineageEligible {
 	return out
 }
 
-// allocateRecognition distributes the actual recognized amount across eligible
-// lineages and transitions their segments to earnings_recognized.
-func (s *service) allocateRecognition(ctx context.Context, eligible []lineageEligible, actualAmount alpacadecimal.Decimal, groupID string, at time.Time) error {
-	remaining := actualAmount
+// allocateRecognition transitions the preselected source segments atomically with
+// their journal postings and preserves the backing needed by correction.
+func (s *service) allocateRecognition(ctx context.Context, allocations []recognitionAllocation, groupID string, at time.Time) error {
 	now := at.Truncate(time.Microsecond)
-
-	for _, e := range eligible {
-		if !remaining.IsPositive() {
-			break
+	for _, allocation := range allocations {
+		seg := allocation.segment
+		consumed := allocation.amount
+		// Close the source segment before recreating its remainder and
+		// recognized portion. This keeps the active segment set non-overlapping.
+		if err := s.lnge.CloseSegment(ctx, seg.ID, now); err != nil {
+			return fmt.Errorf("close segment %s: %w", seg.ID, err)
 		}
 
-		lineageAlloc := minDecimal(e.amount, remaining)
-		segRemaining := lineageAlloc
-
-		for _, seg := range e.segments {
-			if !segRemaining.IsPositive() {
-				break
-			}
-
-			consumed := minDecimal(seg.Amount, segRemaining)
-
-			// Close the source segment before recreating its remainder and
-			// recognized portion. This keeps the active segment set non-overlapping.
-			if err := s.lnge.CloseSegment(ctx, seg.ID, now); err != nil {
-				return fmt.Errorf("close segment %s: %w", seg.ID, err)
-			}
-
-			// If partial consumption, create remainder in original state.
-			remainder := seg.Amount.Sub(consumed)
-			if remainder.IsPositive() {
-				if err := s.lnge.CreateSegment(ctx, lineage.CreateSegmentInput{
-					LineageID:                 seg.LineageID,
-					Amount:                    remainder,
-					State:                     seg.State,
-					BackingTransactionGroupID: seg.BackingTransactionGroupID,
-				}); err != nil {
-					return fmt.Errorf("create remainder segment: %w", err)
-				}
-			}
-
-			// Create earnings_recognized segment for the consumed portion.
-			// Source fields let correction unwind recognition back to the prior state.
-			sourceState := seg.State
+		// If partial consumption, create remainder in original state.
+		remainder := seg.Amount.Sub(consumed)
+		if remainder.IsPositive() {
 			if err := s.lnge.CreateSegment(ctx, lineage.CreateSegmentInput{
-				LineageID:                       seg.LineageID,
-				Amount:                          consumed,
-				State:                           creditrealization.LineageSegmentStateEarningsRecognized,
-				BackingTransactionGroupID:       &groupID,
-				SourceState:                     &sourceState,
-				SourceBackingTransactionGroupID: seg.BackingTransactionGroupID,
+				LineageID:                 seg.LineageID,
+				Amount:                    remainder,
+				State:                     seg.State,
+				BackingTransactionGroupID: seg.BackingTransactionGroupID,
 			}); err != nil {
-				return fmt.Errorf("create recognized segment: %w", err)
+				return fmt.Errorf("create remainder segment: %w", err)
 			}
-
-			segRemaining = segRemaining.Sub(consumed)
 		}
 
-		remaining = remaining.Sub(lineageAlloc)
+		// Create earnings_recognized segment for the consumed portion.
+		// Source fields let correction unwind recognition back to the prior state.
+		sourceState := seg.State
+		if err := s.lnge.CreateSegment(ctx, lineage.CreateSegmentInput{
+			LineageID:                       seg.LineageID,
+			Amount:                          consumed,
+			State:                           creditrealization.LineageSegmentStateEarningsRecognized,
+			BackingTransactionGroupID:       &groupID,
+			SourceState:                     &sourceState,
+			SourceBackingTransactionGroupID: seg.BackingTransactionGroupID,
+		}); err != nil {
+			return fmt.Errorf("create recognized segment: %w", err)
+		}
 	}
-
 	return nil
-}
-
-// sumPositiveEntries sums positive entry amounts across resolved transaction inputs.
-// For recognition this is the total amount credited to earnings accounts.
-func sumPositiveEntries(inputs []ledger.TransactionInput) alpacadecimal.Decimal {
-	total := alpacadecimal.Zero
-
-	for _, input := range inputs {
-		for _, entry := range input.EntryInputs() {
-			if entry.Amount().IsPositive() {
-				total = total.Add(entry.Amount())
-			}
-		}
-	}
-
-	return total
 }
 
 func minDecimal(a, b alpacadecimal.Decimal) alpacadecimal.Decimal {

--- a/openmeter/ledger/recognizer/service_test.go
+++ b/openmeter/ledger/recognizer/service_test.go
@@ -28,8 +28,9 @@ import (
 
 type recognizerTestEnv struct {
 	*ledgertestutils.IntegrationEnv
-	recognizer recognizer.Service
-	lineage    lineage.Service
+	recognizer  recognizer.Service
+	lineage     lineage.Service
+	lastGroupID string
 }
 
 func newRecognizerTestEnv(t *testing.T) *recognizerTestEnv {
@@ -47,10 +48,12 @@ func newRecognizerTestEnv(t *testing.T) *recognizerTestEnv {
 	})
 	require.NoError(t, err)
 
-	lngeSvc, err := lineageservice.New(lineageservice.Config{
+	dbLineage, err := lineageservice.New(lineageservice.Config{
 		Adapter: lngeAdapter,
 	})
 	require.NoError(t, err)
+
+	lngeSvc := &ledgertestutils.LineageWithAllocations{Service: dbLineage}
 
 	recSvc, err := recognizer.NewService(recognizer.Config{
 		Ledger:             base.Deps.HistoricalLedger,
@@ -93,8 +96,9 @@ func (e *recognizerTestEnv) resolveAndCommit(t *testing.T, templates ...transact
 	)
 	require.NoError(t, err)
 
-	_, err = e.Deps.HistoricalLedger.CommitGroup(t.Context(), transactions.GroupInputs(e.Namespace, nil, inputs...))
+	group, err := e.Deps.HistoricalLedger.CommitGroup(t.Context(), transactions.GroupInputs(e.Namespace, nil, inputs...))
 	require.NoError(t, err)
+	e.lastGroupID = group.ID().ID
 }
 
 // ensureCharge creates a minimal charge record in the DB if it doesn't exist.
@@ -137,7 +141,7 @@ func (e *recognizerTestEnv) createLineageForRealization(t *testing.T, chargeID, 
 						To:   clock.Now(),
 					},
 					LedgerTransaction: ledgertransaction.GroupReference{
-						TransactionGroupID: "test-group-" + realizationID,
+						TransactionGroupID: e.lastGroupID,
 					},
 					Annotations: creditrealization.LineageAnnotations(originKind),
 				},
@@ -334,5 +338,78 @@ func TestRecognizeEarnings_DeterministicAllocationAndSegmentTransition(t *testin
 			require.NotNil(t, seg.SourceState)
 			require.Equal(t, creditrealization.LineageSegmentStateRealCredit, *seg.SourceState)
 		}
+	}
+}
+
+func TestRecognizeEarnings_AccruedSourceIsolation(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		alreadyRecognized int64
+	}{
+		{name: "matching source only"},
+		{name: "partially available source", alreadyRecognized: 15},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newRecognizerTestEnv(t)
+			currency := currenciestestutils.NewFiatCurrency(t, env.Currency)
+			costBasis := alpacadecimal.NewFromInt(1)
+			spend, source := testID(), testID()
+
+			// given: one allocation has lineage, and an unrelated source/spend
+			// shares its accrued subaccount. Existing journal recognition may
+			// leave less live accrued than the lineage's face amount.
+			env.resolveAndCommit(t, transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
+				At: env.Now(), Amount: alpacadecimal.NewFromInt(40), Currency: env.CurrencyReference(), CostBasis: &costBasis,
+				SourceChargeID: &source, SpendChargeID: &spend,
+			})
+			env.createLineageForRealization(t, spend, testID(), currency, alpacadecimal.NewFromInt(40), creditrealization.LineageOriginKindRealCredit)
+			if tc.alreadyRecognized > 0 {
+				env.resolveAndCommit(t, transactions.RecognizeEarningsFromAttributableAccruedTemplate{
+					At: env.Now(), Amount: alpacadecimal.NewFromInt(tc.alreadyRecognized), Currency: env.CurrencyReference(),
+				})
+			}
+			// This source sorts before the tracked one, so scalar recognition
+			// would consume it even when the tracked source has enough balance.
+			unrelatedSource, unrelatedSpend := "00000000000000000000000001", testID()
+			env.resolveAndCommit(t, transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
+				At: env.Now(), Amount: alpacadecimal.NewFromInt(10), Currency: env.CurrencyReference(), CostBasis: &costBasis,
+				SourceChargeID: &unrelatedSource, SpendChargeID: &unrelatedSpend,
+			})
+
+			// when: recognition selects only the allocation's actual remaining source.
+			result, err := env.recognizer.RecognizeEarnings(t.Context(), recognizer.RecognizeEarningsInput{
+				CustomerID: env.CustomerID, At: env.Now(), Currency: currency,
+			})
+			require.NoError(t, err)
+			require.Equal(t, float64(40-tc.alreadyRecognized), result.RecognizedAmount.InexactFloat64())
+
+			// then: all postings have the allocation's source/spend, unrelated
+			// accrued remains deferred, and any partial segment retains its state.
+			for _, entry := range env.TransactionGroupEntries(t, result.LedgerGroupID) {
+				require.Equal(t, &source, entry.SourceChargeID)
+				require.Equal(t, &spend, entry.SpendChargeID)
+			}
+			require.Equal(t, float64(10), env.SumBalance(t, env.AccruedSubAccountWithCostBasis(t, &costBasis)).InexactFloat64())
+			roots, err := env.lineage.LoadLineagesByCustomer(t.Context(), lineage.LoadLineagesByCustomerInput{
+				Namespace: env.Namespace, CustomerID: env.CustomerID.ID, Currency: env.CurrencyReference(),
+			})
+			require.NoError(t, err)
+			require.Len(t, roots, 1)
+			amounts := make(map[creditrealization.LineageSegmentState]float64)
+			for _, segment := range roots[0].Segments {
+				amounts[segment.State] += segment.Amount.InexactFloat64()
+				if segment.State == creditrealization.LineageSegmentStateEarningsRecognized {
+					require.Equal(t, &result.LedgerGroupID, segment.BackingTransactionGroupID)
+					require.NotNil(t, segment.SourceState)
+					require.Equal(t, creditrealization.LineageSegmentStateRealCredit, *segment.SourceState)
+				}
+			}
+			require.Equal(t, float64(40-tc.alreadyRecognized), amounts[creditrealization.LineageSegmentStateEarningsRecognized])
+			require.Equal(t, float64(tc.alreadyRecognized), amounts[creditrealization.LineageSegmentStateRealCredit])
+			retry, err := env.recognizer.RecognizeEarnings(t.Context(), recognizer.RecognizeEarningsInput{CustomerID: env.CustomerID, At: env.Now(), Currency: currency})
+			require.NoError(t, err)
+			require.Zero(t, retry.RecognizedAmount.InexactFloat64())
+			require.Empty(t, retry.LedgerGroupID)
+		})
 	}
 }

--- a/openmeter/ledger/recognizer/sources.go
+++ b/openmeter/ledger/recognizer/sources.go
@@ -1,0 +1,211 @@
+package recognizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type accruedKey struct {
+	subAccountID   string
+	sourceChargeID string
+	spendChargeID  string
+}
+
+func entryAccruedKey(entry ledger.EntryInput) accruedKey {
+	return accruedKey{entry.PostingAddress().SubAccountID(), lo.FromPtr(entry.SourceChargeID()), lo.FromPtr(entry.SpendChargeID())}
+}
+
+type recognitionAllocation struct {
+	segment lineage.Segment
+	amount  alpacadecimal.Decimal
+}
+
+// planRecognition intersects each segment's original backing with live accrued
+// balances. Both the postings and segment transitions use this one selection;
+// a customer-wide total cannot transfer recognition between unrelated sources.
+func (s *service) planRecognition(ctx context.Context, in RecognizeEarningsInput, eligible []lineageEligible) ([]transactions.PostingAmount, []recognitionAllocation, error) {
+	accounts, err := s.deps.AccountService.GetCustomerAccounts(ctx, in.CustomerID)
+	if err != nil {
+		return nil, nil, err
+	}
+	accountID := accounts.AccruedAccount.ID().ID
+	buckets, err := s.deps.BalanceQuerier.GetBalanceBuckets(ctx, ledger.BalanceBucketQuery{
+		Namespace: in.CustomerID.Namespace,
+		Filters:   ledger.Filters{AccountID: &accountID, Route: ledger.RouteFilter{Currency: in.Currency.Reference()}},
+		GroupBy:   []string{ledger.BalanceBucketGroupBySourceChargeID, ledger.BalanceBucketGroupBySpendChargeID},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("load accrued balances: %w", err)
+	}
+	available := make(map[accruedKey]alpacadecimal.Decimal)
+	for _, bucket := range buckets {
+		key := accruedKey{bucket.Address.SubAccountID(), lo.FromPtr(bucket.GroupByValues[ledger.BalanceBucketGroupBySourceChargeID]), lo.FromPtr(bucket.GroupByValues[ledger.BalanceBucketGroupBySpendChargeID])}
+		available[key] = bucket.SettledAmount
+	}
+
+	groups := make(map[string]ledger.TransactionGroup)
+	var sources []transactions.PostingAmount
+	sourceIndexes := make(map[accruedKey]int)
+	var allocations []recognitionAllocation
+	for _, e := range eligible {
+		original, err := s.recognitionGroup(ctx, in.CustomerID.Namespace, e.lineage.OriginalTransactionGroupID, groups)
+		if err != nil {
+			return nil, nil, err
+		}
+		collected, err := allocationAccruedSources(original, e.lineage.OriginalAllocationSortHint)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, segment := range e.segments {
+			backing := collected
+			if segment.State == creditrealization.LineageSegmentStateAdvanceBackfilled {
+				group, err := s.recognitionGroup(ctx, in.CustomerID.Namespace, lo.FromPtr(segment.BackingTransactionGroupID), groups)
+				if err != nil {
+					return nil, nil, err
+				}
+				backing = backfilledAccruedSources(group, collected)
+			}
+			remaining := segment.Amount
+			for _, source := range backing {
+				entry := source.entry
+				key := entryAccruedKey(entry)
+				if entry.PostingAddress().Route().Route().CostBasis == nil || key.sourceChargeID == "" || key.spendChargeID == "" || key.sourceChargeID == key.spendChargeID {
+					continue
+				}
+				take := minDecimal(remaining, minDecimal(source.amount, available[key]))
+				if !take.IsPositive() {
+					continue
+				}
+				if index, ok := sourceIndexes[key]; ok {
+					sources[index].Amount = sources[index].Amount.Add(take)
+				} else {
+					sourceIndexes[key] = len(sources)
+					sources = append(sources, transactions.PostingAmount{
+						Address: entry.PostingAddress(), Amount: take,
+						Identity: ledger.EntryIdentityParts{SourceChargeID: entry.SourceChargeID(), SpendChargeID: entry.SpendChargeID()},
+					})
+				}
+				available[key] = available[key].Sub(take)
+				remaining = remaining.Sub(take)
+			}
+			if amount := segment.Amount.Sub(remaining); amount.IsPositive() {
+				allocations = append(allocations, recognitionAllocation{segment: segment, amount: amount})
+			}
+		}
+	}
+	return sources, allocations, nil
+}
+
+func (s *service) recognitionGroup(ctx context.Context, namespace, id string, groups map[string]ledger.TransactionGroup) (ledger.TransactionGroup, error) {
+	if id == "" {
+		return nil, fmt.Errorf("recognition lineage is missing its allocation or backing transaction group")
+	}
+	if group, ok := groups[id]; ok {
+		return group, nil
+	}
+	group, err := s.ledger.GetTransactionGroup(ctx, models.NamespacedID{Namespace: namespace, ID: id})
+	if err != nil {
+		return nil, fmt.Errorf("load recognition source group: %w", err)
+	}
+	groups[id] = group
+	return group, nil
+}
+
+type accruedSource struct {
+	entry  ledger.Entry
+	amount alpacadecimal.Decimal
+}
+
+// SortHint has the same collection contract used by correction: one allocation
+// per negative FBO subaccount in transaction/entry order. A group can contain
+// both promotional and paid collections, so group membership alone is insufficient.
+func allocationAccruedSources(group ledger.TransactionGroup, sortHint int) ([]accruedSource, error) {
+	index := 0
+	for _, tx := range group.Transactions() {
+		direction, err := ledger.TransactionDirectionFromAnnotations(tx.Annotations())
+		if err != nil {
+			return nil, err
+		}
+		if direction != ledger.TransactionDirectionForward {
+			continue
+		}
+		var subAccounts []string
+		bySubAccount := make(map[string][]ledger.Entry)
+		for _, entry := range tx.Entries() {
+			if entry.PostingAddress().AccountType() != ledger.AccountTypeCustomerFBO || !entry.Amount().IsNegative() {
+				continue
+			}
+			id := entry.PostingAddress().SubAccountID()
+			if _, ok := bySubAccount[id]; !ok {
+				subAccounts = append(subAccounts, id)
+			}
+			bySubAccount[id] = append(bySubAccount[id], entry)
+		}
+		for _, id := range subAccounts {
+			if index != sortHint {
+				index++
+				continue
+			}
+			var out []accruedSource
+			for _, fbo := range bySubAccount[id] {
+				remaining := fbo.Amount().Abs()
+				for _, accrued := range tx.Entries() {
+					if accrued.PostingAddress().AccountType() != ledger.AccountTypeCustomerAccrued || !accrued.Amount().IsPositive() {
+						continue
+					}
+					if lo.FromPtr(fbo.SourceChargeID()) != lo.FromPtr(accrued.SourceChargeID()) || lo.FromPtr(fbo.SpendChargeID()) != lo.FromPtr(accrued.SpendChargeID()) || !sameFundingRoute(fbo.PostingAddress().Route().Route(), accrued.PostingAddress().Route().Route()) {
+						continue
+					}
+					amount := minDecimal(remaining, accrued.Amount())
+					if amount.IsPositive() {
+						out = append(out, accruedSource{accrued, amount})
+						remaining = remaining.Sub(amount)
+					}
+				}
+			}
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("allocation sort hint %d out of range for recognition source group", sortHint)
+}
+
+func sameFundingRoute(left, right ledger.Route) bool {
+	if !left.Currency.Equal(right.Currency) || lo.FromPtr(left.CostBasisCurrency) != lo.FromPtr(right.CostBasisCurrency) {
+		return false
+	}
+	if left.CostBasis == nil || right.CostBasis == nil {
+		return left.CostBasis == nil && right.CostBasis == nil
+	}
+	return left.CostBasis.Equal(*right.CostBasis)
+}
+
+// A purchase can fund several spends and tax routes. Only its positive accrued
+// translation for this original allocation backs the segment.
+func backfilledAccruedSources(group ledger.TransactionGroup, original []accruedSource) []accruedSource {
+	var out []accruedSource
+	for _, tx := range group.Transactions() {
+		for _, entry := range tx.Entries() {
+			if entry.PostingAddress().AccountType() != ledger.AccountTypeCustomerAccrued || !entry.Amount().IsPositive() {
+				continue
+			}
+			route := entry.PostingAddress().Route().Route()
+			for _, source := range original {
+				originalRoute := source.entry.PostingAddress().Route().Route()
+				if lo.FromPtr(entry.SpendChargeID()) == lo.FromPtr(source.entry.SpendChargeID()) && route.Currency.Equal(originalRoute.Currency) && lo.FromPtr(route.TaxCode) == lo.FromPtr(originalRoute.TaxCode) && lo.FromPtr(route.TaxBehavior) == lo.FromPtr(originalRoute.TaxBehavior) {
+					out = append(out, accruedSource{entry, entry.Amount()})
+					break
+				}
+			}
+		}
+	}
+	return out
+}

--- a/openmeter/ledger/testutils/lineage.go
+++ b/openmeter/ledger/testutils/lineage.go
@@ -1,0 +1,44 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+)
+
+// LineageWithAllocations retains the allocation references supplied by direct
+// ledger/handler tests, which do not persist charge runs. Lineage state itself
+// still uses the real database-backed service. Full lifecycle tests load these
+// references from the charge allocation tables.
+type LineageWithAllocations struct {
+	lineage.Service
+	allocations map[string]creditrealization.Realization
+}
+
+func (s *LineageWithAllocations) CreateInitialLineages(ctx context.Context, input lineage.CreateInitialLineagesInput) error {
+	if err := s.Service.CreateInitialLineages(ctx, input); err != nil {
+		return err
+	}
+	if s.allocations == nil {
+		s.allocations = make(map[string]creditrealization.Realization)
+	}
+	for _, realization := range input.Realizations {
+		s.allocations[realization.ID] = realization
+	}
+	return nil
+}
+
+func (s *LineageWithAllocations) LoadLineagesByCustomer(ctx context.Context, input lineage.LoadLineagesByCustomerInput) ([]lineage.Lineage, error) {
+	roots, err := s.Service.LoadLineagesByCustomer(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	for i := range roots {
+		if allocation, ok := s.allocations[roots[i].RootRealizationID]; ok {
+			roots[i].OriginalTransactionGroupID = allocation.LedgerTransaction.TransactionGroupID
+			roots[i].OriginalAllocationSortHint = allocation.SortHint
+		}
+	}
+	return roots, nil
+}

--- a/openmeter/ledger/transactions/earnings.go
+++ b/openmeter/ledger/transactions/earnings.go
@@ -21,6 +21,9 @@ type RecognizeEarningsFromAttributableAccruedTemplate struct {
 	At       time.Time
 	Amount   alpacadecimal.Decimal
 	Currency currencies.CurrencyReference
+	// Sources, when provided, are the accrued slices already selected by the
+	// caller within its transaction. Nil selects from attributable balances.
+	Sources []PostingAmount
 }
 
 func (t RecognizeEarningsFromAttributableAccruedTemplate) Validate() error {
@@ -36,6 +39,25 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) Validate() error {
 		return fmt.Errorf("currency: %w", err)
 	}
 
+	if t.Sources != nil {
+		total := alpacadecimal.Zero
+		for i, source := range t.Sources {
+			if source.Address == nil || source.Address.AccountType() != ledger.AccountTypeCustomerAccrued {
+				return fmt.Errorf("sources[%d]: customer accrued address is required", i)
+			}
+			route := source.Address.Route().Route()
+			if !route.Currency.Equal(t.Currency) || route.CostBasis == nil || !isCreditBackedAccruedIdentity(source.Identity) {
+				return fmt.Errorf("sources[%d]: known-cost credit-backed accrued in the recognition currency is required", i)
+			}
+			if err := ledger.ValidateTransactionAmount(source.Amount); err != nil {
+				return fmt.Errorf("sources[%d]: %w", i, err)
+			}
+			total = total.Add(source.Amount)
+		}
+		if !total.Equal(t.Amount) {
+			return fmt.Errorf("source total %s does not match recognition amount %s", total, t.Amount)
+		}
+	}
 	return nil
 }
 
@@ -109,9 +131,17 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) entryRoutePairingKey(e
 }
 
 func (t RecognizeEarningsFromAttributableAccruedTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
-	collections, err := collectFromAttributableCustomerAccrued(ctx, customerID, t.Currency, t.Amount, resolvers)
-	if err != nil {
-		return nil, fmt.Errorf("collect from attributable accrued: %w", err)
+	var collections []postingAddressAmount
+	if t.Sources == nil {
+		var err error
+		collections, err = collectFromAttributableCustomerAccrued(ctx, customerID, t.Currency, t.Amount, resolvers)
+		if err != nil {
+			return nil, fmt.Errorf("collect from attributable accrued: %w", err)
+		}
+	} else {
+		for _, source := range t.Sources {
+			collections = append(collections, postingAddressAmount{address: source.Address, amount: source.Amount, identity: source.Identity})
+		}
 	}
 	if len(collections) == 0 {
 		return nil, nil

--- a/test/credits/recognition_lineage_test.go
+++ b/test/credits/recognition_lineage_test.go
@@ -1,0 +1,164 @@
+package credits
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+func (s *CustomCurrencyCreditsSuite) TestPaidBackfillRecognitionLeavesPromotionalCreditsDeferred() {
+	for _, tc := range []struct {
+		name    string
+		amounts []int64
+	}{
+		{name: "full backfill", amounts: []int64{8}},
+		{name: "partial backfills", amounts: []int64{3, 5}},
+	} {
+		s.Run(tc.name, func() {
+			t := s.T()
+			ctx := t.Context()
+			ns := s.GetUniqueNamespace("paid-backfill-recognition")
+			defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+			customer := s.CreateLedgerBackedCustomer(ns, "test-subject")
+			sandbox := s.InstallSandboxApp(t, ns)
+			s.ProvisionBillingProfile(ctx, ns, sandbox.GetID(),
+				billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+			)
+			feature := s.SetupApiRequestsTotalFeature(ctx, ns)
+			t.Cleanup(feature.Cleanup)
+			tokens := s.createCustomCurrency(ns, "TOKENS")
+			start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := start.AddDate(0, 1, 0)
+			clock.FreezeTime(start)
+			defer clock.UnFreeze()
+
+			// given: ten credits of usage consume two promotional credits with no cost
+			// basis and create an eight-credit advance in the same managed currency.
+			promo := s.createCustomCurrencyCreditPurchase(ctx, customCurrencyCreditPurchaseInput{
+				Namespace: ns, Customer: customer.GetID(), Currency: tokens,
+				Amount: alpacadecimal.NewFromInt(2), At: start, Name: "Promotional credits",
+				Settlement: creditpurchase.NewSettlement(creditpurchase.PromotionalSettlement{}),
+				TaxConfig:  productcatalog.TaxCodeConfig{TaxCodeID: defaults.CreditGrantTaxCodeID},
+			})
+			s.MockStreamingConnector.AddSimpleEvent(feature.Feature.Key, 10, start.Add(time.Hour))
+			clock.FreezeTime(end.Add(3 * 24 * time.Hour))
+			usage := s.createCustomCurrencyUsageCharge(ctx, customCurrencyUsageChargeInput{
+				Namespace: ns, Customer: customer.GetID(), Currency: tokens,
+				ServicePeriod: timeutil.ClosedPeriod{From: start, To: end}, FeatureKey: feature.Feature.Key,
+				UnitPrice: alpacadecimal.NewFromInt(1), SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Name: "Credit-only usage", TaxConfig: productcatalog.TaxCodeConfig{TaxCodeID: defaults.InvoicingTaxCodeID},
+			})
+
+			// when: paid purchases at USD 0.5 backfill the advance, with recognition
+			// and an unchanged retry after every purchase.
+			amountByBacking := make(map[string]float64)
+			recognitionByBacking := make(map[string]string)
+			earningsBySource := make(map[string]float64)
+			for _, amount := range tc.amounts {
+				clock.FreezeTime(clock.Now().Add(time.Minute))
+				purchase := s.createCustomCurrencyCreditPurchase(ctx, customCurrencyCreditPurchaseInput{
+					Namespace: ns, Customer: customer.GetID(), Currency: tokens,
+					Amount: alpacadecimal.NewFromInt(amount), At: clock.Now(), Name: "Paid backfill",
+					Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus}),
+					CostBasis:  creditpurchase.NewCostBasis(s.newManualCostBasis(alpacadecimal.NewFromFloat(0.5))),
+					TaxConfig:  productcatalog.TaxCodeConfig{TaxCodeID: defaults.CreditGrantTaxCodeID},
+				})
+				purchase = s.settleExternalCreditPurchase(ctx, purchase.GetChargeID())
+				result, err := s.RevenueRecognizer.RecognizeEarnings(ctx, recognizer.RecognizeEarningsInput{
+					CustomerID: customer.GetID(), Currency: tokens, At: clock.Now(),
+				})
+				s.Require().NoError(err)
+				s.Equal(float64(amount), result.RecognizedAmount.InexactFloat64())
+				backing := purchase.Realizations.CreditGrantRealization.TransactionGroupID
+				amountByBacking[backing] = float64(amount)
+				recognitionByBacking[backing] = result.LedgerGroupID
+				earningsBySource[sourceSpendChargeBucketKey(&purchase.ID, &usage.ID)] = float64(amount)
+				retry, err := s.RevenueRecognizer.RecognizeEarnings(ctx, recognizer.RecognizeEarningsInput{
+					CustomerID: customer.GetID(), Currency: tokens, At: clock.Now(),
+				})
+				s.Require().NoError(err)
+				s.Zero(retry.RecognizedAmount.InexactFloat64())
+				s.Empty(retry.LedgerGroupID)
+			}
+
+			// then: journal and lineage agree on the paid source, leaving the entire
+			// promotional allocation deferred. Retain the exact 2/8 segment assertion.
+			accounts := s.mustCustomerAccounts(customer.GetID())
+			business, err := s.LedgerResolver.GetBusinessAccounts(ctx, ns)
+			s.Require().NoError(err)
+			s.requireAccountBalance(business.EarningsAccount, ledger.RouteFilter{Currency: tokens.Reference()}, 8, "paid earnings")
+			s.requireEarningsSourceSpendBalanceBuckets(ns, ledger.RouteFilter{Currency: tokens.Reference()}, earningsBySource)
+			s.requireAccountBalance(accounts.AccruedAccount, ledger.RouteFilter{Currency: tokens.Reference()}, 2, "promotional accrued")
+			s.requireCustomerAccruedSourceSpendBalanceBuckets(customer.GetID(), ledger.RouteFilter{Currency: tokens.Reference()}, map[string]float64{
+				sourceSpendChargeBucketKey(&promo.ID, &usage.ID): 2,
+			})
+			roots, err := s.LineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{
+				Namespace: ns, CustomerID: customer.ID, Currency: tokens.Reference(),
+			})
+			s.Require().NoError(err)
+			s.Require().Len(roots, 2)
+			for _, root := range roots {
+				switch root.OriginKind {
+				case creditrealization.LineageOriginKindRealCredit:
+					s.Require().Len(root.Segments, 1)
+					s.Equal(float64(2), root.Segments[0].Amount.InexactFloat64())
+					s.Equal(creditrealization.LineageSegmentStateRealCredit, root.Segments[0].State)
+				case creditrealization.LineageOriginKindAdvance:
+					s.Require().Len(root.Segments, len(tc.amounts))
+					seen := make(map[string]float64)
+					for _, segment := range root.Segments {
+						backing := lo.FromPtr(segment.SourceBackingTransactionGroupID)
+						s.Equal(creditrealization.LineageSegmentStateEarningsRecognized, segment.State)
+						s.Equal(creditrealization.LineageSegmentStateAdvanceBackfilled, lo.FromPtr(segment.SourceState))
+						s.Equal(recognitionByBacking[backing], lo.FromPtr(segment.BackingTransactionGroupID))
+						seen[backing] = segment.Amount.InexactFloat64()
+					}
+					s.Equal(amountByBacking, seen)
+				default:
+					t.Fatalf("unexpected lineage origin %q", root.OriginKind)
+				}
+			}
+
+			// when: the spend is refunded after recognition.
+			// then: each paid backing and the promotional source unwind independently.
+			err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+				CustomerID: customer.GetID(),
+				PatchesByChargeID: map[string]charges.Patch{
+					usage.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{ChangeSource: billing.ChangeSourceSystem, Policy: meta.RefundAsCreditsDeletePolicy})),
+				},
+			})
+			s.Require().NoError(err)
+			s.requireAccountBalance(business.EarningsAccount, ledger.RouteFilter{Currency: tokens.Reference()}, 0, "refunded earnings")
+			s.requireAccountBalance(accounts.AccruedAccount, ledger.RouteFilter{Currency: tokens.Reference()}, 0, "refunded accrued")
+			s.requireAccountBalance(accounts.FBOAccount, ledger.RouteFilter{Currency: tokens.Reference()}, 10, "refunded credit")
+			roots, err = s.LineageService.LoadLineagesByCustomer(ctx, lineage.LoadLineagesByCustomerInput{Namespace: ns, CustomerID: customer.ID, Currency: tokens.Reference()})
+			s.Require().NoError(err)
+			for _, root := range roots {
+				s.Empty(root.Segments)
+			}
+
+			// A retry after correction cannot recognize refunded value.
+			retry, err := s.RevenueRecognizer.RecognizeEarnings(ctx, recognizer.RecognizeEarningsInput{
+				CustomerID: customer.GetID(), Currency: tokens, At: clock.Now(),
+			})
+			s.Require().NoError(err)
+			s.Zero(retry.RecognizedAmount.InexactFloat64())
+			s.Empty(retry.LedgerGroupID)
+		})
+	}
+}


### PR DESCRIPTION
A spend of 2 promotional custom-currency credits plus an 8-credit advance, followed by an 8-credit paid backfill at USD 0.5, left the journal at 8 earnings / 2 deferred accrued while lineage incorrectly marked 2 promotional + 6 paid credits recognized. The real-service regression was reproduced on the base before the fix.

Recognition now selects accrued slices from each lineage's original allocation bucket or recorded backfill group, preserving source, spend, currency, cost basis, and tax route. One selection drives both journal postings and segment transitions, with the original backing retained for correction. This changes forward recognition; it does not repair historical misattributed segments.

Validation:

- Full root Go suite in the CI shell, PostgreSQL enabled and `-tags=dynamic`: 8,017 tests, 9 skipped, zero failures. Notification/Svix passed; no exclusion added.
- v3 Go SDK build, vet, and tests passed.
- Root, SDK, and e2e Go lint plus e2e vet passed. The e2e lint step was rerun with `--allow-serial-runners` after process-lock contention.
- Regression covers the exact promotional/paid split, 3+5 partial backfills, source/backing identity, refunds, and retries after recognition and correction.
- Recognizer coverage also checks unrelated accrued sources on the same subaccount and partially available source balances.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Earnings recognition now tracks and posts against the exact eligible source allocations.
  - Recognition supports explicitly selected accrued sources with validation for currency, cost basis, funding route, and amount.
  - Backfilled advances are matched to their recorded backing sources, preserving source and allocation details.

- **Bug Fixes**
  - Prevented unrelated accrued balances from being recognized.
  - Promotional credits without a known cost basis remain deferred during paid backfill recognition.

- **Documentation**
  - Clarified credit-backed earnings recognition behavior and lineage consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes earnings recognition to derive both ledger postings and lineage transitions from the same source-attributed accrued slices.

- Loads each lineage's original allocation transaction group and allocation sort hint.
- Selects recognizable accrued value by source, spend, route, and backfill group.
- Preserves prior segment state and backing references for correction.
- Adds focused recognizer and end-to-end coverage for promotional credits, paid backfills, partial recognition, retries, and refunds.
- Introduces one repository validation-convention violation that should be corrected before merging.

<h3>Confidence Score: 4/5</h3>

The recognition behavior appears sound, but the explicit repository validation requirement in `openmeter/ledger/transactions/earnings.go` must be satisfied before merging.

Source selection, journal posting, and lineage transition amounts remain aligned, and the investigated attribution and lifecycle paths did not establish a behavioral regression; the remaining finding is the newly added immediate-return validation logic.

**Files Needing Attention:** openmeter/ledger/transactions/earnings.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| openmeter/ledger/recognizer/sources.go | Adds source-aware recognition planning that intersects lineage backing with live accrued source/spend buckets. |
| openmeter/ledger/recognizer/recognize.go | Uses one recognition allocation plan for both journal postings and lineage segment transitions. |
| openmeter/billing/charges/lineage/adapter/lineage.go | Hydrates original transaction-group and allocation-sort references for loaded lineages. |
| openmeter/ledger/transactions/earnings.go | Supports caller-selected accrued slices, but the new validation branches violate the repository's aggregated-validation convention. |
| test/credits/recognition_lineage_test.go | Covers source-preserving paid backfill recognition, partial backfills, retries, and correction through the real service lifecycle. |


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Earnings recognizer
    participant L as Lineage service
    participant B as Ledger balance query
    participant G as Original/backfill groups
    participant J as Ledger journal

    R->>L: Load eligible lineage segments
    R->>B: Load accrued buckets by source and spend
    R->>G: Load each segment's allocation or backfill group
    G-->>R: Original source, route, and backing
    R->>R: Intersect segment backing with live accrued buckets
    R->>J: Commit selected source slices to earnings
    R->>L: Transition the same selected slices
    Note over J,L: Journal postings and lineage transitions commit atomically
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20openmeterio%2Fopenmeter%20PR%20%235100%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=openmeterio%2Fopenmeter&pr=5100&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fledger%2Ftransactions%2Fearnings.go%3A42-59%0A**Validation%20errors%20return%20early**%0A%0AThe%20new%20%60Sources%60%20validation%20returns%20a%20plain%20%60fmt.Errorf%60%20as%20soon%20as%20it%20encounters%20the%20first%20invalid%20source.%20This%20violates%20the%20repository%20directive%20that%20%60Validate%28%29%60%20methods%20collect%20field%20errors%20and%20return%20them%20through%20%60models.NewNillableGenericValidationError%28errors.Join%28...%29%29%60%2C%20so%20the%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22codex%2Ffix-recognition-lineage-attribution%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-recognition-lineage-attribution%22.%0A%0A%23%23%23%20Issue%201%0Aopenmeter%2Fledger%2Ftransactions%2Fearnings.go%3A42-59%0A**Validation%20errors%20return%20early**%0A%0AThe%20new%20%60Sources%60%20validation%20returns%20a%20plain%20%60fmt.Errorf%60%20as%20soon%20as%20it%20encounters%20the%20first%20invalid%20source.%20This%20violates%20the%20repository%20directive%20that%20%60Validate%28%29%60%20methods%20collect%20field%20errors%20and%20return%20them%20through%20%60models.NewNillableGenericValidationError%28errors.Join%28...%29%29%60%2C%20so%20the%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5100&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
openmeter/ledger/transactions/earnings.go:42-59
**Validation errors return early**

The new `Sources` validation returns a plain `fmt.Errorf` as soon as it encounters the first invalid source. This violates the repository directive that `Validate()` methods collect field errors and return them through `models.NewNillableGenericValidationError(errors.Join(...))`, so the repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ledger): preserve source attribution..."](https://github.com/openmeterio/openmeter/commit/cce64706ef234d2ccf58ccc2ebce39f53a5a6db1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61592640)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/openmeterio/openmeter/blob/main/AGENTS.md))
- Knowledge Base — [Credit and ledger accounting](https://app.greptile.com/openmeter/-/custom-context/knowledge-base/openmeterio/openmeter/-/docs/credit-and-ledger-accounting.md)

<!-- /greptile_comment -->