### PR TITLE
fix(e2e): stabilize multi-subject usage aggregation

### DIFF
--- a/e2e/multisubject_test.go
+++ b/e2e/multisubject_test.go
@@ -218,19 +218,15 @@ func TestMultiSubject(t *testing.T) {
 	})
 
 	t.Run("Should aggregate usage across all subjects", func(t *testing.T) {
-		// Let's ingest usage for each subject
-		// Make clickhouse's job easier by sending events within a fix time range
 		now := time.Now()
 
 		for _, subjectKey := range subjectKeys {
-			timestamp := gofakeit.DateRange(now, now.Add(time.Second*2))
-
 			ev := cloudevents.New()
 			ev.SetID(gofakeit.UUID())
 			ev.SetSource("my-app")
 			ev.SetType("multi_subject")
 			ev.SetSubject(subjectKey)
-			ev.SetTime(timestamp)
+			ev.SetTime(now)
 
 			resp, err := client.IngestEventWithResponse(context.Background(), ev)
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes the recurring failure in `TestMultiSubject/Should_aggregate_usage_across_all_subjects`.

The test generated event timestamps between the captured current time and two seconds in the future. Near a minute boundary, the unbounded meter query could include a future event while the entitlement query correctly excluded it from its rounded, exclusive time range. Both events now use the captured current time, keeping the two assertions over the same usage window.

## Validation

- `go vet -C e2e ./...`
- E2E module `golangci-lint run -v ./...`
- `make etoe` repeated five times; the affected multi-subject aggregation subtest passed 5/5

The full E2E suite encountered an unrelated existing timeout in `TestPlan/Should_create_only_ONE_subscription_per_customer,_even_if_we_spam_the_API_in_a_short_period_of_time` during each repetition.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the multi-subject usage aggregation E2E test by assigning every generated subject event the same captured current timestamp instead of selecting timestamps up to two seconds in the future.
- Keeps meter and entitlement assertions within a consistent usage window.
- Preserves distinct events through unique event IDs and storage row IDs.
- Removes comments describing the superseded randomized timestamp behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the deterministic timestamp remains inside both queried usage windows and does not collapse distinct events.

The changed test timestamp removes the future-event race while unique event IDs, per-row storage IDs, and row-count aggregation preserve all subject events.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| e2e/multisubject_test.go | Replaces randomized near-future event timestamps with one captured current timestamp, avoiding minute-boundary inconsistencies without changing event identity or aggregation semantics. |

<sub>Reviews (1): Last reviewed commit: ["fix(e2e): stabilize multi-subject usage ..."](https://github.com/openmeterio/openmeter/commit/cc7e1e094d2ff6a8ecba1862aa8a951b09e9844f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61646777)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multi-subject usage aggregation test data to use a consistent timestamp for all events.
  * Simplified test timing behavior for more deterministic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->