### PR TITLE
feat(ci): add on-call emergency PR approvals

### DIFF
--- a/.github/tools/urgent-prod-fix/README.md
+++ b/.github/tools/urgent-prod-fix/README.md
@@ -1,0 +1,65 @@
+# Emergency production fix approval
+
+An active member of `@openmeterio/openmeter-oncall` can apply `urgent-prod-fix`
+to request a bot approval for an internal, non-draft PR targeting `main`. The
+PR author must be an active OpenMeter organization member and the source branch
+must belong to `openmeterio/openmeter`. Membership lookup failures deny approval.
+
+The bot approves the revision present when the label was applied. It never merges
+or enables auto-merge. Existing required CI checks continue to apply. After an
+engineer merges a PR with an emergency approval for that revision, the workflow
+posts its PR, merge commit, and authorization review links to Slack without
+mentions. Existing auto-merge, if enabled by a user, can still react to an approval.
+
+## Setup
+
+1. Create an organization-owned GitHub App for emergency approvals. Disable its
+   webhook; GitHub Actions handles events. Grant repository **Pull requests:
+   read and write** and organization **Members: read-only** permissions. Install
+   it on `openmeterio/openmeter` only. No branch-protection bypass is needed.
+2. Add its client ID as the repository Actions variable `URGENT_FIX_APP_CLIENT_ID`.
+3. Generate an App private key and store the complete PEM as the repository
+   Actions secret `URGENT_FIX_APP_PRIVATE_KEY`.
+4. Configure `URGENT_FIX_SLACK_WEBHOOK_URL` as a repository Actions secret.
+5. Create the `urgent-prod-fix` PR label and manage authorized users in the
+   `openmeter-oncall` team. Team membership authorizes requests regardless of
+   who is currently on a PagerDuty shift; there is no schedule synchronization.
+6. Keep **Dismiss stale pull request approvals when new commits are pushed**
+   enabled on `main`. If review dismissal is restricted, allow the App to dismiss
+   its emergency reviews. Keep the existing required status checks.
+
+The privileged workflow checks out `github.workflow_sha`, never the PR head.
+Tests run separately without the App credentials, only for PRs changing `.github/`.
+Protect access to the App key
+and changes to the workflow and helper: they are part of the authorization boundary.
+
+## Operation and limits
+
+Pushing to an open PR automatically removes `urgent-prod-fix`, preserving other
+labels. Wait for the push workflow to finish, then reapply the label to request
+approval for the new revision. After a failed request, remove and reapply it.
+Re-running a labeled-event job cannot issue a new approval.
+The workflow dismisses its own invalid approvals on pushes, label removal, or
+conversion to draft; it does not dismiss human reviews. GitHub's stale-review
+protection provides immediate invalidation for code-changing pushes.
+
+Label removal and draft changes are processed asynchronously; they are not an
+atomic merge lock. Membership is checked when approval is requested, not
+continuously afterward. Removing someone from the team does not revoke an
+already-submitted approval; dismiss that review explicitly if needed.
+
+Slack notification failures fail the closed-event job. Rerun that job to retry;
+a retry after an ambiguous network failure can produce a duplicate message.
+Notification uses the matching bot review, so removing a label after merge does
+not suppress the post-merge notification. This does not track review completion.
+
+Before rollout, validate App approval counting, review dismissal, and Slack
+delivery on an internal test PR with the actual installation. Do not merge until
+the checks pass and a human is ready to review the change.
+
+## Local validation
+
+```sh
+python3 -B -m unittest discover -s .github/tools/urgent-prod-fix -p 'test_*.py'
+actionlint .github/workflows/urgent-prod-fix.yaml .github/workflows/urgent-prod-fix-tests.yaml
+```

--- a/.github/tools/urgent-prod-fix/review.py
+++ b/.github/tools/urgent-prod-fix/review.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+REPOSITORY = "openmeterio/openmeter"
+LABEL = "urgent-prod-fix"
+MARKER = "<!-- openmeter-urgent-prod-fix -->"
+
+
+class GitHub:
+    def __init__(self, token: str):
+        self.token = token
+
+    def request(self, method: str, path: str, body=None):
+        request = Request(
+            f"https://api.github.com{path}",
+            data=None if body is None else json.dumps(body).encode(),
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urlopen(request, timeout=30) as response:
+            return json.load(response)
+
+    def reviews(self, path: str):
+        page = 1
+        while True:
+            reviews = self.request("GET", f"{path}/reviews?per_page=100&page={page}")
+            yield from reviews
+            if len(reviews) < 100:
+                return
+            page += 1
+
+
+def require_member(github, path: str):
+    if github.request("GET", path).get("state") != "active":
+        raise ValueError("An active organization/team membership is required")
+
+
+def eligible(pr, sha: str) -> bool:
+    return (
+        pr["state"] == "open"
+        and not pr["draft"]
+        and pr["base"]["repo"]["full_name"] == REPOSITORY
+        and pr["base"]["ref"] == "main"
+        and (pr["head"]["repo"] or {}).get("full_name") == REPOSITORY
+        and pr["head"]["sha"] == sha
+        and pr["user"]["type"] == "User"
+        and any(label["name"] == LABEL for label in pr["labels"])
+    )
+
+
+def emergency_reviews(github, path: str, bot: str):
+    return [
+        review
+        for review in github.reviews(path)
+        if review["user"]["login"] == bot
+        and review["user"]["type"] == "Bot"
+        and review["state"] == "APPROVED"
+        and (review.get("body") or "").startswith(MARKER)
+    ]
+
+
+def dismiss(github, path: str, review):
+    github.request(
+        "PUT",
+        f"{path}/reviews/{review['id']}/dismissals",
+        {"message": "Emergency request invalidated; reapply urgent-prod-fix to request a new approval."},
+    )
+
+
+def notify_slack(pr, review):
+    webhook = os.environ["URGENT_FIX_SLACK_WEBHOOK_URL"]
+    if not webhook:
+        raise ValueError("URGENT_FIX_SLACK_WEBHOOK_URL is not configured")
+    # PR titles and bodies are untrusted Slack markup, including possible mentions.
+    text = (
+        f"Urgent production fix merged: https://github.com/{REPOSITORY}/pull/{pr['number']}\n"
+        f"Merged commit: {pr['merge_commit_sha']}\n"
+        f"Emergency authorization: {review['html_url']}\n"
+        "Engineering: please review the changes post-merge."
+    )
+    request = Request(
+        webhook,
+        data=json.dumps({"text": text, "unfurl_links": False, "unfurl_media": False}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    # Network exceptions can contain the secret webhook URL.
+    try:
+        with urlopen(request, timeout=30) as response:
+            if response.read().decode().strip() != "ok":
+                raise ValueError("Slack rejected the notification; rerun this closed-event job")
+    except (HTTPError, URLError, TimeoutError):
+        raise ValueError("Slack notification failed; rerun this closed-event job") from None
+
+
+def process(github, event, bot: str, run_attempt: str):
+    if event["repository"]["full_name"] != REPOSITORY:
+        raise ValueError("Unexpected repository")
+    action = event["action"]
+    if action not in {"labeled", "unlabeled", "synchronize", "converted_to_draft", "closed"}:
+        return
+    if action in {"labeled", "unlabeled"} and event["label"]["name"] != LABEL:
+        return
+
+    path = f"/repos/{REPOSITORY}/pulls/{int(event['number'])}"
+    pr = github.request("GET", path)
+    reviews = emergency_reviews(github, path, bot)
+
+    if action == "closed":
+        if event["pull_request"]["merged"] and pr["merged"]:
+            matching = [r for r in reviews if r["commit_id"] == pr["head"]["sha"]]
+            if matching:
+                notify_slack(pr, matching[-1])
+        return
+
+    if action != "labeled":
+        if action == "synchronize" and pr["state"] == "open":
+            if any(label["name"] == LABEL for label in pr["labels"]):
+                try:
+                    github.request(
+                        "DELETE",
+                        f"/repos/{REPOSITORY}/issues/{int(event['number'])}/labels/{LABEL}",
+                    )
+                except HTTPError as error:
+                    if error.code != 404:
+                        raise
+                pr["labels"] = [label for label in pr["labels"] if label["name"] != LABEL]
+
+        for review in reviews:
+            if not eligible(pr, review["commit_id"]):
+                dismiss(github, path, review)
+        return
+
+    if run_attempt != "1":
+        raise ValueError("Reapply urgent-prod-fix instead of rerunning an approval request")
+    sha = event["pull_request"]["head"]["sha"]
+    if not eligible(pr, sha):
+        raise ValueError("Request requires a labeled, internal, non-draft PR to main at the original revision")
+    if event["sender"]["type"] != "User":
+        raise ValueError("Only a human openmeter-oncall team member can request approval")
+    requester = quote(event["sender"]["login"], safe="")
+    author = quote(pr["user"]["login"], safe="")
+    require_member(github, f"/orgs/openmeterio/teams/openmeter-oncall/memberships/{requester}")
+    require_member(github, f"/orgs/openmeterio/memberships/{author}")
+    pr = github.request("GET", path)
+    if not eligible(pr, sha):
+        raise ValueError("PR changed during authorization; reapply urgent-prod-fix")
+    if any(review["commit_id"] == sha for review in reviews):
+        return
+    review = github.request(
+        "POST",
+        f"{path}/reviews",
+        {
+            "event": "APPROVE",
+            "commit_id": sha,
+            "body": (
+                f"{MARKER}\nEmergency approval requested by @{requester} "
+                f"(verified member of @openmeterio/openmeter-oncall) for `{sha}`.\n\n"
+                "Human code review is deferred until after merge. Required CI checks still apply."
+            ),
+        },
+    )
+    current = github.request("GET", path)
+    if not current["merged"] and not eligible(current, sha):
+        dismiss(github, path, review)
+        raise ValueError("PR changed while approval was submitted; emergency approval dismissed")
+
+
+if __name__ == "__main__":
+    try:
+        process(
+            GitHub(os.environ["URGENT_FIX_TOKEN"]),
+            json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text()),
+            os.environ["URGENT_FIX_BOT"],
+            os.environ["GITHUB_RUN_ATTEMPT"],
+        )
+    except (ValueError, HTTPError, URLError, TimeoutError) as error:
+        print(f"Emergency review failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/tools/urgent-prod-fix/test_review.py
+++ b/.github/tools/urgent-prod-fix/test_review.py
@@ -1,0 +1,228 @@
+import copy
+import io
+import json
+import unittest
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError, URLError
+
+import review
+
+
+class EmergencyReviewTest(unittest.TestCase):
+    def setUp(self):
+        self.bot = "emergency[bot]"
+        self.path = "/repos/openmeterio/openmeter/pulls/123"
+        self.pr = {
+            "number": 123,
+            "state": "open",
+            "draft": False,
+            "merged": False,
+            "merge_commit_sha": "b" * 40,
+            "base": {"ref": "main", "repo": {"full_name": review.REPOSITORY}},
+            "head": {"sha": "a" * 40, "repo": {"full_name": review.REPOSITORY}},
+            "user": {"login": "author", "type": "User"},
+            "labels": [{"name": review.LABEL}],
+        }
+        self.event = {
+            "number": 123,
+            "action": "labeled",
+            "repository": {"full_name": review.REPOSITORY},
+            "pull_request": copy.deepcopy(self.pr),
+            "label": {"name": review.LABEL},
+            "sender": {"login": "turip", "type": "User"},
+        }
+        self.approval = {
+            "id": 456,
+            "user": {"login": self.bot, "type": "Bot"},
+            "state": "APPROVED",
+            "commit_id": self.pr["head"]["sha"],
+            "body": review.MARKER,
+            "html_url": "https://github.com/openmeterio/openmeter/pull/123#pullrequestreview-456",
+        }
+        self.github = Mock()
+        self.github.reviews.return_value = []
+        self.github.request.side_effect = self.respond
+
+    def respond(self, method, path, body=None):
+        if method == "GET" and path == self.path:
+            return copy.deepcopy(self.pr)
+        if method == "GET" and "/memberships/" in path:
+            return {"state": "active"}
+        if method == "POST" and path == f"{self.path}/reviews":
+            return copy.deepcopy(self.approval)
+        if method == "PUT" and path.endswith("/dismissals"):
+            return {}
+        if method == "DELETE" and path == "/repos/openmeterio/openmeter/issues/123/labels/urgent-prod-fix":
+            self.pr["labels"] = [label for label in self.pr["labels"] if label["name"] != review.LABEL]
+            return copy.deepcopy(self.pr["labels"])
+        raise AssertionError((method, path, body))
+
+    def test_authorized_request_approves_exact_revision_without_merge(self):
+        review.process(self.github, self.event, self.bot, "1")
+        writes = [call for call in self.github.request.call_args_list if call.args[0] != "GET"]
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0].args[:2], ("POST", f"{self.path}/reviews"))
+        self.assertEqual(writes[0].args[2]["commit_id"], "a" * 40)
+        self.assertEqual(writes[0].args[2]["event"], "APPROVE")
+        self.github.request.assert_any_call(
+            "GET", "/orgs/openmeterio/teams/openmeter-oncall/memberships/turip"
+        )
+        self.github.request.assert_any_call("GET", "/orgs/openmeterio/memberships/author")
+
+    def test_rejects_ineligible_prs_without_writing(self):
+        for change in [
+            {"draft": True},
+            {"state": "closed"},
+            {"labels": []},
+            {"head": {"sha": "b" * 40, "repo": {"full_name": review.REPOSITORY}}},
+            {"head": {"sha": "a" * 40, "repo": {"full_name": "outsider/openmeter"}}},
+            {"head": {"sha": "a" * 40, "repo": None}},
+            {"base": {"ref": "release", "repo": {"full_name": review.REPOSITORY}}},
+            {"user": {"login": "bot", "type": "Bot"}},
+        ]:
+            with self.subTest(change=change):
+                self.pr = copy.deepcopy(self.event["pull_request"])
+                self.pr.update(change)
+                self.github.reset_mock()
+                with self.assertRaises(ValueError):
+                    review.process(self.github, self.event, self.bot, "1")
+                self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    def test_membership_failures_deny_approval(self):
+        for rejected_path in ["teams/openmeter-oncall/memberships/turip", "memberships/author"]:
+            for failure in ["pending", 403, 404, 500]:
+                with self.subTest(path=rejected_path, failure=failure):
+                    def respond(method, path, body=None):
+                        if path.endswith(rejected_path):
+                            if failure == "pending":
+                                return {"state": "pending"}
+                            raise HTTPError(path, failure, "denied", {}, None)
+                        return self.respond(method, path, body)
+
+                    self.github.reset_mock()
+                    self.github.request.side_effect = respond
+                    with self.assertRaises((ValueError, HTTPError)):
+                        review.process(self.github, self.event, self.bot, "1")
+                    self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    def test_rerun_cannot_reuse_request(self):
+        with self.assertRaises(ValueError):
+            review.process(self.github, self.event, self.bot, "2")
+        self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    def test_bot_cannot_request_approval(self):
+        self.event["sender"]["type"] = "Bot"
+        with self.assertRaises(ValueError):
+            review.process(self.github, self.event, self.bot, "1")
+
+    def test_changed_revision_during_submission_is_dismissed(self):
+        def respond(method, path, body=None):
+            result = self.respond(method, path, body)
+            if method == "POST":
+                self.pr["head"]["sha"] = "b" * 40
+            return result
+
+        self.github.request.side_effect = respond
+        with self.assertRaises(ValueError):
+            review.process(self.github, self.event, self.bot, "1")
+        self.assertEqual(self.github.request.call_args.args[:2], ("PUT", f"{self.path}/reviews/456/dismissals"))
+
+    def test_push_or_label_removal_dismisses_only_emergency_approval(self):
+        for action in ["synchronize", "unlabeled"]:
+            with self.subTest(action=action):
+                self.event["action"] = action
+                self.pr["labels"] = []
+                human_review = copy.deepcopy(self.approval)
+                human_review["id"] = 789
+                human_review["user"] = {"login": "turip", "type": "User"}
+                self.github.reviews.return_value = [self.approval, human_review]
+                self.github.reset_mock()
+                review.process(self.github, self.event, self.bot, "1")
+                writes = [c for c in self.github.request.call_args_list if c.args[0] != "GET"]
+                self.assertEqual(len(writes), 1)
+                self.assertEqual(writes[0].args[1], f"{self.path}/reviews/456/dismissals")
+
+    def test_delayed_invalidation_does_not_dismiss_current_approval(self):
+        self.event["action"] = "unlabeled"
+        self.github.reviews.return_value = [self.approval]
+        review.process(self.github, self.event, self.bot, "1")
+        self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    def test_push_removes_only_emergency_label_and_dismisses_approval(self):
+        self.event["action"] = "synchronize"
+        self.pr["labels"].append({"name": "kind/bug"})
+        self.github.reviews.return_value = [self.approval]
+        review.process(self.github, self.event, self.bot, "1")
+        self.assertEqual(self.pr["labels"], [{"name": "kind/bug"}])
+        writes = [c for c in self.github.request.call_args_list if c.args[0] != "GET"]
+        self.assertEqual([c.args[:2] for c in writes], [
+            ("DELETE", "/repos/openmeterio/openmeter/issues/123/labels/urgent-prod-fix"),
+            ("PUT", f"{self.path}/reviews/456/dismissals"),
+        ])
+
+    def test_push_without_label_or_after_close_does_not_remove_labels(self):
+        self.event["action"] = "synchronize"
+        for change in [{"labels": []}, {"state": "closed"}]:
+            with self.subTest(change=change):
+                self.pr = copy.deepcopy(self.event["pull_request"])
+                self.pr.update(change)
+                self.github.reset_mock()
+                review.process(self.github, self.event, self.bot, "1")
+                self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    def test_concurrent_label_removal_still_dismisses_approval(self):
+        self.event["action"] = "synchronize"
+        self.github.reviews.return_value = [self.approval]
+
+        def respond(method, path, body=None):
+            if method == "DELETE":
+                raise HTTPError(path, 404, "already removed", {}, io.BytesIO())
+            return self.respond(method, path, body)
+
+        self.github.request.side_effect = respond
+        review.process(self.github, self.event, self.bot, "1")
+        self.assertEqual(self.github.request.call_args.args[:2], ("PUT", f"{self.path}/reviews/456/dismissals"))
+
+    def test_existing_approval_is_not_duplicated(self):
+        self.github.reviews.return_value = [self.approval]
+        review.process(self.github, self.event, self.bot, "1")
+        self.assertTrue(all(c.args[0] == "GET" for c in self.github.request.call_args_list))
+
+    @patch.object(review, "notify_slack")
+    def test_only_merged_emergency_revision_notifies(self, notify):
+        self.event["action"] = "closed"
+        self.github.reviews.return_value = [self.approval]
+        review.process(self.github, self.event, self.bot, "1")
+        notify.assert_not_called()
+        self.event["pull_request"]["merged"] = True
+        self.pr["merged"] = True
+        self.pr["state"] = "closed"
+        self.pr["labels"] = []
+        review.process(self.github, self.event, self.bot, "1")
+        notify.assert_called_once_with(self.pr, self.approval)
+        notify.reset_mock()
+        self.pr["head"]["sha"] = "c" * 40
+        review.process(self.github, self.event, self.bot, "1")
+        notify.assert_not_called()
+
+    @patch.dict(review.os.environ, {"URGENT_FIX_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/secret"})
+    @patch.object(review, "urlopen")
+    def test_slack_excludes_untrusted_mentions_and_hides_webhook_errors(self, urlopen):
+        self.pr["title"] = "<!channel>"
+        urlopen.return_value.__enter__.return_value = io.BytesIO(b"ok")
+        review.notify_slack(self.pr, self.approval)
+        payload = json.loads(urlopen.call_args.args[0].data)
+        self.assertNotIn("<!channel>", payload["text"])
+        urlopen.side_effect = URLError("https://hooks.slack.com/services/secret")
+        with self.assertRaises(ValueError) as error:
+            review.notify_slack(self.pr, self.approval)
+        self.assertNotIn("secret", str(error.exception))
+
+    def test_review_listing_paginates(self):
+        github = review.GitHub("unused")
+        github.request = Mock(side_effect=[[{}] * 100, [self.approval]])
+        self.assertEqual(len(list(github.reviews(self.path))), 101)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/urgent-prod-fix-tests.yaml
+++ b/.github/workflows/urgent-prod-fix-tests.yaml
@@ -1,0 +1,24 @@
+name: Emergency approval policy tests
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  urgent-prod-fix-tests:
+    name: Emergency approval policy tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: python3 -B -m unittest discover -s .github/tools/urgent-prod-fix -p 'test_*.py'

--- a/.github/workflows/urgent-prod-fix.yaml
+++ b/.github/workflows/urgent-prod-fix.yaml
@@ -1,0 +1,49 @@
+name: Urgent production fix
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [labeled, unlabeled, synchronize, converted_to_draft, closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: urgent-prod-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  review:
+    if: >-
+      github.repository == 'openmeterio/openmeter' &&
+      (github.event.label.name == 'urgent-prod-fix' ||
+       github.event.action == 'synchronize' ||
+       github.event.action == 'converted_to_draft' ||
+       (github.event.action == 'closed' && github.event.pull_request.merged))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted workflow revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/tools/urgent-prod-fix
+
+      - name: Create reviewer token
+        id: reviewer
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.URGENT_FIX_APP_CLIENT_ID }}
+          private-key: ${{ secrets.URGENT_FIX_APP_PRIVATE_KEY }}
+          owner: openmeterio
+          repositories: openmeter
+          permission-pull-requests: write
+          permission-members: read
+
+      - name: Process emergency review
+        run: python3 .github/tools/urgent-prod-fix/review.py
+        env:
+          URGENT_FIX_TOKEN: ${{ steps.reviewer.outputs.token }}
+          URGENT_FIX_BOT: ${{ steps.reviewer.outputs.app-slug }}[bot]
+          URGENT_FIX_SLACK_WEBHOOK_URL: ${{ secrets.URGENT_FIX_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Overview

Allow an active member of `@openmeterio/openmeter-oncall` to request a bot approval by applying `urgent-prod-fix` to an internal PR targeting `main`. This lets on-call engineers defer human review during a production incident while retaining the existing required CI checks. The bot does not merge or enable auto-merge.

Approval is tied to the requested commit. Pushes remove the emergency label and invalidate the bot approval; an on-call engineer must reapply the label for the new revision. After an emergency-approved PR merges, an incoming Slack webhook posts the PR, merged commit, and authorization review links without mentions.

## Notes for reviewer

- Authorization uses live on-call team membership and active organization membership for the PR author. Forks, external authors, bot requesters, drafts, and changed revisions are rejected.
- The privileged workflow executes only the trusted workflow revision. Policy tests run separately without App credentials, and only for PRs changing `.github/**`.
- Existing branch protection remains unchanged. Approval invalidation on label removal is asynchronous; membership removal does not retroactively dismiss an existing approval. These limits and notification retry behavior are documented in the helper README.
- Setup pending: install the GitHub App with Pull requests write and organization Members read permissions, configure `URGENT_FIX_APP_CLIENT_ID` and `URGENT_FIX_APP_PRIVATE_KEY`, and create the `urgent-prod-fix` label. The Slack webhook secret and `openmeter-oncall` team have been configured.
- Before rollout, verify that the installed App's approval counts toward branch protection, its reviews can be dismissed, and post-merge Slack delivery works.

Validation: all 15 policy tests passed, workflow actionlint passed, and whitespace checks passed. Live GitHub App and Slack validation has not been performed.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62076279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/openmeter/-/pull-requests/openmeterio/openmeter/5105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The implementation appears safe to merge, subject to completing the documented live GitHub App, branch-protection, and Slack rollout validation.

<details><summary><h3>Summary</h3></summary>

- Restricts approval requests to active on-call users, active organization-member authors, internal non-draft pull requests targeting `main`, and the exact labeled revision.
- Removes the emergency label and dismisses invalid approvals when the revision or pull-request state changes.
- Sends a post-merge Slack notification containing the pull request, merged commit, and authorization review links.
- Adds isolated policy tests and operational documentation covering setup, trust boundaries, and known asynchronous behavior.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant O as On-call engineer
  participant G as GitHub
  participant W as Trusted workflow
  participant A as GitHub App
  participant S as Slack

  O->>G: Apply urgent-prod-fix label
  G->>W: pull_request_target labeled event
  W->>A: Create installation token
  W->>G: Verify PR, requester, author, and head SHA
  W->>G: Approve exact head commit
  alt New commit, label removal, or draft conversion
    G->>W: Invalidation event
    W->>G: Remove label and dismiss bot approval
  else Approved revision is merged
    G->>W: closed event
    W->>G: Find matching emergency review
    W->>S: Post merge and authorization links
  end
```
</details>

<!-- /greptile_comment -->