### PR TITLE
fix(billing): defer usage feature pinning until activation

### DIFF
--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -211,17 +211,19 @@ func NewChargesFlatFeeService(
 	lineageService lineage.Service,
 	metaAdapter meta.Adapter,
 	locker *lockr.Locker,
+	featureMeterResolver *billingfeaturemeterservice.Resolver,
 	ratingService rating.Service,
 	currenciesService currencies.Service,
 ) (flatfee.Service, error) {
 	flatFeeSvc, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       flatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: ratingService,
-		Currencies:    currenciesService,
+		Adapter:              flatFeeAdapter,
+		Handler:              flatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: featureMeterResolver,
+		RatingService:        ratingService,
+		Currencies:           currenciesService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create charges flat fee service: %w", err)
@@ -488,7 +490,7 @@ func newChargesRegistry(
 		return nil, err
 	}
 
-	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker, ratingService, currenciesService)
+	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker, featureMeterResolver, ratingService, currenciesService)
 	if err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -81,6 +81,11 @@ persist engine-owned state explaining its decision; when every candidate is
 blocked, collection succeeds without creating an invoice so those writes can
 commit. Gate errors abort collection and roll back its writes.
 
+Billability is also engine-owned. Billing submits each engine's subset of one
+gathering invoice as an ordered batch. The engine resolves any feature or charge
+dependencies it needs before returning one eligibility decision and billable
+period per input in the same order.
+
 Engine callbacks operate on groups of lines. When a callback replaces lines,
 billing requires it to preserve the input line IDs before accepting the
 result. API-originated line edits and system-originated reconciliation are

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -84,7 +84,9 @@ commit. Gate errors abort collection and roll back its writes.
 Billability is also engine-owned. Billing submits each engine's subset of one
 gathering invoice as an ordered batch. The engine resolves any feature or charge
 dependencies it needs before returning one eligibility decision and billable
-period per input in the same order.
+period per input in the same order. Missing feature or meter dependencies are
+reported as validation issues while billability falls back to non-progressive
+eligibility; operational dependency failures still abort collection.
 
 Engine callbacks operate on groups of lines. When a callback replaces lines,
 billing requires it to preserve the input line IDs before accepting the

--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -149,9 +149,15 @@ invoice validation issue.
   complete, not merely that rating or line creation finished.
 - Lifecycle entry points run in database transactions. Flat-fee and usage-based
   advancement and patching also take charge-scoped locks.
-- Charge creation resolves every supplied feature reference before persistence.
-  Usage-based features require a meter; flat-fee features are optional and may
-  be meterless.
+- Each concrete charge type resolves its supplied feature references before
+  persistence. Usage-based features require a meter; flat-fee features are
+  optional and may be meterless. A usage-based charge created by key persists
+  only the canonical key and snapshots its feature ID when it activates. An
+  explicitly supplied feature ID is pinned at creation and activation preserves
+  it; when both are supplied, the key must match the feature resolved by ID.
+- Customer-charge reads resolve the current feature by key when a preactivation
+  usage charge has no pinned ID. That ID is an API projection rather than
+  persisted state and may change until activation snapshots it.
 - Charge state machines do not expose invoice patches through a separate peek
   or drain operation. A caller must choose an invoice-aware
   `*UntilInvoicePatchesOrStable` operation, which stops at the first invoice

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -13,6 +13,7 @@ import (
 	creditpurchasemodels "github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 var _ billing.LineEngine = (*LineEngine)(nil)
@@ -30,7 +31,7 @@ func (e *LineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLi
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
 		if line.SplitLineGroupID != nil {
 			return billing.IsLineBillableAsOfResult{}, billing.ValidationError{Err: billing.ErrInvoiceProgressiveBillingNotSupported}
 		}

--- a/openmeter/billing/charges/creditpurchase/service/lineengine.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	creditpurchasemodels "github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -24,14 +25,25 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeCreditPurchase
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	// Billing enforces that credit purchases are never progressively billed, so there is no
-	// engine-side partial-period filtering to do here.
-	return true, nil
+	return lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+		if line.SplitLineGroupID != nil {
+			return billing.IsLineBillableAsOfResult{}, billing.ValidationError{Err: billing.ErrInvoiceProgressiveBillingNotSupported}
+		}
+
+		if line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration).After(input.AsOf.Truncate(streaming.MinimumWindowSizeDuration)) {
+			return billing.IsLineBillableAsOfResult{}, nil
+		}
+
+		return billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}, nil
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/lineengine_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestLineEngineDoesNotImplementLineCalculator(t *testing.T) {
@@ -17,6 +22,71 @@ func TestLineEngineDoesNotImplementLineCalculator(t *testing.T) {
 	require.Equal(t, billing.LineEngineTypeChargeCreditPurchase, lineEngine.GetLineEngineType())
 	_, implementsLineCalculator := lineEngine.(billing.LineCalculator)
 	require.False(t, implementsLineCalculator)
+}
+
+func TestAreLinesBillableAsOfPreservesResultsWithValidationIssues(t *testing.T) {
+	// Given a batch with valid credit-purchase lines around an unsupported split line.
+	firstPeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+	}
+	lastPeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC),
+	}
+	firstChargeID := "charge-1"
+	firstLine := billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+			ID:              "line-1",
+			Name:            "credit purchase",
+		},
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeChargeCreditPurchase,
+		InvoiceID:     "invoice-id",
+		Currency:      currencyx.FiatCode("USD"),
+		ServicePeriod: firstPeriod,
+		InvoiceAt:     firstPeriod.From,
+		Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount: alpacadecimal.NewFromInt(10),
+		}),
+		ChargeID: &firstChargeID,
+	}}
+	splitLine := firstLine
+	splitLine.ID = "line-2"
+	splitChargeID := "charge-2"
+	splitLine.ChargeID = &splitChargeID
+	splitLineGroupID := "split-group"
+	splitLine.SplitLineGroupID = &splitLineGroupID
+	lastLine := firstLine
+	lastLine.ID = "line-3"
+	lastChargeID := "charge-3"
+	lastLine.ChargeID = &lastChargeID
+	lastLine.ServicePeriod = lastPeriod
+	lastLine.InvoiceAt = lastPeriod.From
+	engine := &LineEngine{}
+
+	// When a valid line, an invalid split line, and another valid line are checked together.
+	results, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: firstLine.Namespace},
+				ID:              firstLine.InvoiceID,
+			},
+		}},
+		AsOf:  lastPeriod.To,
+		Lines: billing.GatheringLines{firstLine, splitLine, lastLine},
+	})
+
+	// Then the validation issue is returned without losing the ordered per-line results.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{billing.ErrInvoiceProgressiveBillingNotSupported}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{
+		{Billable: true, BillablePeriod: firstPeriod},
+		{},
+		{Billable: true, BillablePeriod: lastPeriod},
+	}, results)
 }
 
 func TestPopulateInvoiceCreditPurchaseStandardLineRejectsUnresolvedCostBasis(t *testing.T) {

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -41,9 +40,8 @@ type FlatFeeService interface {
 }
 
 type CreateInput struct {
-	Namespace     string
-	Intents       []Intent
-	FeatureMeters billingfeaturemeter.FeatureMeters
+	Namespace string
+	Intents   []Intent
 }
 
 func (i CreateInput) Validate() error {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -29,6 +29,11 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		return nil, nil
 	}
 
+	featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
+	if err != nil {
+		return nil, err
+	}
+
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]flatfee.ChargeWithGatheringLine, error) {
 		now := clock.Now().UTC()
 		// Let's create all the flat fee charges in bulk
@@ -61,7 +66,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 			var featureID *string
 			if featureRef != nil {
-				featureMeter, err := input.FeatureMeters.Get(chargeIntent)
+				featureMeter, err := featureMeters.Get(chargeIntent)
 				if err != nil {
 					return flatfee.IntentWithInitialStatus{}, fmt.Errorf("resolve flat fee feature %+v: %w", *featureRef, err)
 				}

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
@@ -12,6 +13,7 @@ import (
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
@@ -28,12 +30,56 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeFlatFee
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return true, nil
+	chargeIDs, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (string, error) {
+		if line.ChargeID == nil || *line.ChargeID == "" {
+			return "", fmt.Errorf("flat fee gathering line[%s]: charge id is required", line.ID)
+		}
+
+		return *line.ChargeID, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	charges, err := e.service.GetByIDs(ctx, flatfee.GetByIDsInput{
+		Namespace: input.Invoice.Namespace,
+		IDs:       chargeIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting flat fee charges for billability: %w", err)
+	}
+
+	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, charges...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters for flat fee charges: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, index int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		charge := charges[index]
+		if charge.GetFeatureMeterRef() != nil {
+			_, err := featureMeters.Get(charge)
+			// This becomes a validation issue on the resulting standard invoice, but we still need to provide
+			// the result too.
+			errs = append(errs, err)
+		}
+
+		result, err := e.service.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/flatfee/service/lineengine_test.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine_test.go
@@ -1,15 +1,228 @@
 package service
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestAreLinesBillableAsOfUsesBillingRating(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	ratingService := &billabilityRatingService{
+		result: billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: period,
+		},
+	}
+	featureMeterResolver := newFlatFeeBillabilityFeatureMeterResolver(t)
+	const chargeID = "charge-id"
+	engine := &LineEngine{service: &service{
+		adapter:              &flatFeeBillabilityAdapter{charges: []flatfee.Charge{newFlatFeeBillabilityCharge("namespace", chargeID, nil)}},
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        ratingService,
+	}}
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "line-id",
+				Name:            "flat fee",
+			},
+			ManagedBy:     billing.SystemManagedLine,
+			Engine:        billing.LineEngineTypeChargeFlatFee,
+			InvoiceID:     "invoice-id",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.From,
+			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(10),
+			}),
+			ChargeID: lo.ToPtr(chargeID),
+		},
+	}
+
+	ctx, err := transaction.SetDriverOnContext(t.Context(), flatFeeBillabilityTransaction{})
+	require.NoError(t, err)
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:               period.From,
+		ProgressiveBilling: true,
+		Lines:              billing.GatheringLines{line},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{ratingService.result}, results)
+	require.Len(t, ratingService.inputs, 1)
+	require.Equal(t, line.ID, ratingService.inputs[0].Line.GetID())
+	require.True(t, ratingService.inputs[0].ProgressiveBilling)
+	require.Nil(t, ratingService.inputs[0].Feature)
+	require.Nil(t, ratingService.inputs[0].Meter)
+}
+
+func TestAreLinesBillableAsOfValidatesChargeFeature(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	const chargeID = "charge-id"
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+				ID:              "line-id",
+				Name:            "flat fee",
+			},
+			ManagedBy:     billing.SystemManagedLine,
+			Engine:        billing.LineEngineTypeChargeFlatFee,
+			InvoiceID:     "invoice-id",
+			Currency:      currencyx.FiatCode("USD"),
+			ServicePeriod: period,
+			InvoiceAt:     period.From,
+			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(10),
+			}),
+			ChargeID: lo.ToPtr(chargeID),
+		},
+	}
+	ratingService := &billabilityRatingService{result: billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: period,
+	}}
+	engine := &LineEngine{service: &service{
+		adapter: &flatFeeBillabilityAdapter{charges: []flatfee.Charge{
+			newFlatFeeBillabilityCharge("namespace", chargeID, lo.ToPtr("missing-feature")),
+		}},
+		featureMeterResolver: newFlatFeeBillabilityFeatureMeterResolver(t),
+		ratingService:        ratingService,
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), flatFeeBillabilityTransaction{})
+	require.NoError(t, err)
+
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:  period.From,
+		Lines: billing.GatheringLines{line},
+	})
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  "feature[missing-feature]: invoice line: feature not found",
+		Path:     "/charges/charge-id",
+	}}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{{
+		Billable:       true,
+		BillablePeriod: period,
+	}}, results)
+	require.Len(t, ratingService.inputs, 1)
+}
+
+type flatFeeBillabilityAdapter struct {
+	flatfee.Adapter
+	charges []flatfee.Charge
+}
+
+func (a *flatFeeBillabilityAdapter) GetByIDs(_ context.Context, input flatfee.GetByIDsInput) ([]flatfee.Charge, error) {
+	return lo.MapErr(input.IDs, func(chargeID string, _ int) (flatfee.Charge, error) {
+		charge, ok := lo.Find(a.charges, func(charge flatfee.Charge) bool {
+			return charge.Namespace == input.Namespace && charge.ID == chargeID
+		})
+		if !ok {
+			return flatfee.Charge{}, fmt.Errorf("charge[%s] not found", chargeID)
+		}
+
+		return charge, nil
+	})
+}
+
+type flatFeeBillabilityFeatureService struct{}
+
+func (flatFeeBillabilityFeatureService) ListFeatures(context.Context, feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+	return pagination.Result[feature.Feature]{}, nil
+}
+
+type flatFeeBillabilityMeterService struct{}
+
+func (flatFeeBillabilityMeterService) ListMeters(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	return pagination.Result[meter.Meter]{}, nil
+}
+
+func newFlatFeeBillabilityFeatureMeterResolver(t *testing.T) *featuremeterservice.Resolver {
+	t.Helper()
+
+	resolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: flatFeeBillabilityFeatureService{},
+		MeterService:   flatFeeBillabilityMeterService{},
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+
+	return resolver
+}
+
+func newFlatFeeBillabilityCharge(namespace, chargeID string, featureID *string) flatfee.Charge {
+	return flatfee.Charge{ChargeBase: flatfee.ChargeBase{
+		ManagedResource: meta.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              chargeID,
+		},
+		State: flatfee.State{FeatureID: featureID},
+	}}
+}
+
+type flatFeeBillabilityTransaction struct{}
+
+func (flatFeeBillabilityTransaction) Commit() error    { return nil }
+func (flatFeeBillabilityTransaction) Rollback() error  { return nil }
+func (flatFeeBillabilityTransaction) SavePoint() error { return nil }
+
+type billabilityRatingService struct {
+	result billing.IsLineBillableAsOfResult
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *billabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return s.result, nil
+}
+
+func (*billabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
 
 func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T) {
 	servicePeriod := timeutil.ClosedPeriod{

--- a/openmeter/billing/charges/flatfee/service/service.go
+++ b/openmeter/billing/charges/flatfee/service/service.go
@@ -12,19 +12,21 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
+	billingfeaturemeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
 type Config struct {
-	Adapter       flatfee.Adapter
-	Handler       flatfee.Handler
-	Lineage       lineage.Service
-	MetaAdapter   meta.Adapter
-	Locker        *lockr.Locker
-	RatingService rating.Service
-	Currencies    currencies.Service
+	Adapter              flatfee.Adapter
+	Handler              flatfee.Handler
+	Lineage              lineage.Service
+	MetaAdapter          meta.Adapter
+	Locker               *lockr.Locker
+	RatingService        rating.Service
+	FeatureMeterResolver *billingfeaturemeterservice.Resolver
+	Currencies           currencies.Service
 }
 
 func (c Config) Validate() error {
@@ -52,6 +54,10 @@ func (c Config) Validate() error {
 
 	if c.RatingService == nil {
 		errs = append(errs, errors.New("rating service cannot be null"))
+	}
+
+	if c.FeatureMeterResolver == nil {
+		errs = append(errs, errors.New("feature meter resolver cannot be null"))
 	}
 
 	if c.Currencies == nil {
@@ -84,12 +90,14 @@ func New(config Config) (flatfee.Service, error) {
 	}
 
 	svc := &service{
-		adapter:           config.Adapter,
-		handler:           config.Handler,
-		metaAdapter:       config.MetaAdapter,
-		locker:            config.Locker,
-		realizations:      realizations,
-		costbasisResolver: costbasisResolver,
+		adapter:              config.Adapter,
+		handler:              config.Handler,
+		metaAdapter:          config.MetaAdapter,
+		locker:               config.Locker,
+		ratingService:        config.RatingService,
+		featureMeterResolver: config.FeatureMeterResolver,
+		realizations:         realizations,
+		costbasisResolver:    costbasisResolver,
 	}
 	svc.creditNotesSupported.Store(charges.CreditNotesSupportedByLineUpdater)
 
@@ -101,6 +109,8 @@ type service struct {
 	handler              flatfee.Handler
 	metaAdapter          meta.Adapter
 	locker               *lockr.Locker
+	ratingService        rating.Service
+	featureMeterResolver *billingfeaturemeterservice.Resolver
 	realizations         *flatfeerealizations.Service
 	creditNotesSupported atomic.Bool
 	costbasisResolver    costbasis.Resolver

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -90,10 +90,7 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 				return nil, fmt.Errorf("get customer override: %w", err)
 			}
 
-			featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, chargesByType.usageBased...)
-			if err != nil {
-				return nil, fmt.Errorf("resolve feature meters: %w", err)
-			}
+			featureMeters := s.featureMeterResolver.ResolveLazy(ctx, input.Customer.Namespace, chargesByType.usageBased...)
 
 			for _, charge := range chargesByType.usageBased {
 				result, err := s.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -264,7 +264,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditThenInvo
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 
 	customCurrency := s.createTestCustomCurrency(ctx, ns)
-	featureMeters := s.createFeatureMeters(ctx, ns, "custom-cti-feature")
+	s.createFeatureMeters(ctx, ns, "custom-cti-feature")
 
 	clock.FreezeTime(usageBasedIntentServicePeriod.From)
 	defer clock.UnFreeze()
@@ -279,7 +279,6 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditThenInvo
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-cti", "custom-cti-feature", productcatalog.CreditThenInvoiceSettlementMode, &costBasisIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 
@@ -303,7 +302,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditOnlyReco
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 
 	customCurrency := s.createTestCustomCurrency(ctx, ns)
-	featureMeters := s.createFeatureMeters(ctx, ns, "custom-credit-only-feature")
+	s.createFeatureMeters(ctx, ns, "custom-credit-only-feature")
 
 	clock.FreezeTime(usageBasedIntentServicePeriod.From)
 	defer clock.UnFreeze()
@@ -313,7 +312,6 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditOnlyReco
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-credit-only", "custom-credit-only-feature", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -504,10 +504,7 @@ func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace stri
 
 	featureMeters, err := s.featureMeterResolver.Resolve(ctx, namespace, featureReferences...)
 	if err != nil {
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return nil, fmt.Errorf("resolving features: %w", systemErr)
-		}
+		return nil, fmt.Errorf("resolving features: %w", err)
 	}
 
 	for _, featureReference := range featureReferences {
@@ -517,18 +514,15 @@ func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace stri
 		}
 
 		featureMeter, err := featureMeters.Get(featureReference)
-		if err != nil {
-			_, systemErr := billing.ToValidationIssues(err)
-			if systemErr != nil {
-				return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, systemErr)
-			}
+		if err != nil && !billing.IsValidationIssueOnly(err) {
+			return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, err)
+		}
 
-			// Feature expansion is best-effort. A missing feature is omitted so
-			// the API retains its ID/key fallback, while other validation issues
-			// can still return a usable feature below.
-			if featureMeter.Feature.ID == "" {
-				continue
-			}
+		// Feature expansion is best-effort. A missing feature is omitted so
+		// the API retains its ID/key fallback, while other validation issues
+		// can still return a usable feature below.
+		if featureMeter.Feature.ID == "" {
+			continue
 		}
 
 		out[featureRef.IDOrKey] = featureMeter.Feature

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/samber/lo"
@@ -16,12 +17,10 @@ import (
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
-	"github.com/openmeterio/openmeter/pkg/ref"
 )
 
 func (s *service) CreateCustomerCharge(ctx context.Context, input charges.CreateCustomerChargeInput) (charges.CustomerCharge, error) {
@@ -83,7 +82,7 @@ func (s *service) CreateCustomerCharge(ctx context.Context, input charges.Create
 	// The API response includes the realization view (the whole service period
 	// is outstanding on a fresh charge), so it is built here just like on the
 	// list path. No expands apply on the create path.
-	return buildCustomerCharge(created[0], customerChargeEntities{})
+	return s.buildCustomerCharge(ctx, created[0], customerChargeEntities{}, meta.ExpandNone)
 }
 
 func (s *service) DeleteCustomerCharge(ctx context.Context, input charges.DeleteCustomerChargeInput) error {
@@ -284,7 +283,7 @@ func (s *service) ListCustomerCharges(ctx context.Context, input charges.ListCus
 	}
 
 	customerCharges, err := lo.MapErr(listed.Items, func(charge charges.Charge, _ int) (charges.CustomerCharge, error) {
-		return buildCustomerCharge(charge, entities)
+		return s.buildCustomerCharge(ctx, charge, entities, listInput.Expands)
 	})
 	if err != nil {
 		return charges.ListCustomerChargesResult{}, err
@@ -304,7 +303,7 @@ func (s *service) ListCustomerCharges(ctx context.Context, input charges.ListCus
 // domain charge, the entities loaded for the applied expands, and the
 // resolved realization history of its type. Credit purchase charges only
 // receive the customer.
-func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities) (charges.CustomerCharge, error) {
+func (s *service) buildCustomerCharge(ctx context.Context, charge charges.Charge, entities customerChargeEntities, expands meta.Expands) (charges.CustomerCharge, error) {
 	out := charges.CustomerCharge{
 		Charge: charge,
 		// The listing is scoped to a single customer, so every charge on the
@@ -326,9 +325,23 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 
 		out.UsageBasedRealizations = resolved
 
-		if featureRef := ub.GetFeatureMeterRef(); featureRef != nil {
-			if feat, ok := entities.featuresByRef[featureRef.IDOrKey]; ok {
-				out.Feature = &feat
+		if entities.featureMeters != nil {
+			featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(ub))
+			if err == nil {
+				if ub.State.FeatureID == "" {
+					ub.State.FeatureID = featureMeter.Feature.ID
+					out.Charge = charges.NewCharge(ub)
+				}
+
+				if expands.Has(meta.ExpandFeature) {
+					out.Feature = &featureMeter.Feature
+				}
+			} else {
+				s.logger.WarnContext(ctx, "failed to resolve customer charge feature",
+					slog.String("namespace", ub.Namespace),
+					slog.String("charge_id", ub.ID),
+					slog.String("error", err.Error()),
+				)
 			}
 		}
 
@@ -350,9 +363,10 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 
 		out.FlatFeeRealizations = resolved
 
-		if featureRef := ff.GetFeatureRef(); featureRef != nil {
-			if feat, ok := entities.featuresByRef[*featureRef]; ok {
-				out.Feature = &feat
+		if expands.Has(meta.ExpandFeature) && entities.featureMeters != nil && ff.GetFeatureMeterRef() != nil {
+			featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(ff))
+			if err == nil {
+				out.Feature = &featureMeter.Feature
 			}
 		}
 
@@ -369,9 +383,10 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 // customerChargeReferences collects the entity references a page of charges
 // points at, so the facade bulk-loads each kind once.
 type customerChargeReferences struct {
-	featureReferences []billingfeaturemeter.FeatureReferenceGetter
-	subscriptionIDs   []string
-	invoiceIDs        []string
+	featureReferences   []billingfeaturemeter.FeatureReferenceGetter
+	hasMissingFeatureID bool
+	subscriptionIDs     []string
+	invoiceIDs          []string
 }
 
 func collectCustomerChargeReferences(items charges.Charges) (customerChargeReferences, error) {
@@ -379,7 +394,7 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 
 	for _, item := range items {
 		if item.GetFeatureMeterRef() != nil {
-			out.featureReferences = append(out.featureReferences, item)
+			out.featureReferences = append(out.featureReferences, billingfeaturemeter.WithoutMeters(item))
 		}
 
 		switch item.Type() {
@@ -391,6 +406,11 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 
 			if sub := ub.Intent.GetSubscription(); sub != nil {
 				out.subscriptionIDs = append(out.subscriptionIDs, sub.SubscriptionID)
+			}
+
+			// When the charge is created with feature key only, we need to resolve the feature ID.
+			if ub.State.FeatureID == "" {
+				out.hasMissingFeatureID = true
 			}
 
 			for _, run := range ub.Realizations {
@@ -431,7 +451,7 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 // one customer, so the customer is a single entity rather than a map.
 type customerChargeEntities struct {
 	customer          *customer.Customer
-	featuresByRef     map[ref.IDOrKey]feature.Feature
+	featureMeters     billingfeaturemeter.FeatureMeters
 	subscriptionsByID map[string]subscription.Subscription
 	invoiceLinesByID  map[string]billing.StandardInvoice
 }
@@ -447,8 +467,8 @@ func (s *service) loadCustomerChargeEntities(ctx context.Context, namespace stri
 		}
 	}
 
-	if expands.Has(meta.ExpandFeature) {
-		entities.featuresByRef, err = s.listCustomerChargeFeatures(ctx, namespace, refs.featureReferences)
+	if expands.Has(meta.ExpandFeature) || refs.hasMissingFeatureID {
+		entities.featureMeters, err = s.featureMeterResolver.Resolve(ctx, namespace, refs.featureReferences...)
 		if err != nil {
 			return customerChargeEntities{}, fmt.Errorf("loading features: %w", err)
 		}
@@ -491,44 +511,6 @@ func (s *service) getCustomerChargeCustomer(ctx context.Context, namespace strin
 	}
 
 	return lo.ToPtr(listed.Items[0]), nil
-}
-
-// listCustomerChargeFeatures bulk-loads the referenced features for the
-// feature expand. Refs mix resolved IDs (active charges) and keys (created
-// charges), which feature meter resolution handles natively.
-func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace string, featureReferences []billingfeaturemeter.FeatureReferenceGetter) (map[ref.IDOrKey]feature.Feature, error) {
-	out := make(map[ref.IDOrKey]feature.Feature, len(featureReferences))
-	if len(featureReferences) == 0 {
-		return out, nil
-	}
-
-	featureMeters, err := s.featureMeterResolver.Resolve(ctx, namespace, featureReferences...)
-	if err != nil {
-		return nil, fmt.Errorf("resolving features: %w", err)
-	}
-
-	for _, featureReference := range featureReferences {
-		featureRef := featureReference.GetFeatureMeterRef()
-		if featureRef == nil {
-			continue
-		}
-
-		featureMeter, err := featureMeters.Get(featureReference)
-		if err != nil && !billing.IsValidationIssueOnly(err) {
-			return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, err)
-		}
-
-		// Feature expansion is best-effort. A missing feature is omitted so
-		// the API retains its ID/key fallback, while other validation issues
-		// can still return a usable feature below.
-		if featureMeter.Feature.ID == "" {
-			continue
-		}
-
-		out[featureRef.IDOrKey] = featureMeter.Feature
-	}
-
-	return out, nil
 }
 
 // listCustomerChargeSubscriptions bulk-loads the referenced subscriptions for

--- a/openmeter/billing/charges/service/api_attach_test.go
+++ b/openmeter/billing/charges/service/api_attach_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -12,17 +13,18 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	billingfeaturemeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-// TestBuildCustomerCharge exercises the pure assembly step against an
+// TestBuildCustomerCharge exercises the assembly step against an
 // in-memory charge: the DB-backed facade suite cannot create a charge with a
 // subscription reference (FK to real subscription rows), so the
 // subscription/invoice attach wiring is covered here instead.
@@ -84,14 +86,24 @@ func TestBuildCustomerCharge(t *testing.T) {
 	}
 
 	entities := customerChargeEntities{
-		customer:          &customer.Customer{ManagedResource: models.ManagedResource{ID: "cust-1", Name: "Attach Customer"}},
-		featuresByRef:     map[ref.IDOrKey]feature.Feature{{ID: "feat-1"}: {ID: "feat-1", Name: "Attach Feature"}},
+		customer: &customer.Customer{ManagedResource: models.ManagedResource{ID: "cust-1", Name: "Attach Customer"}},
+		featureMeters: billingfeaturemeterservice.FeatureMeterCollection{
+			ByID: map[string]billingfeaturemeter.FeatureMeter{
+				"feat-1": {Feature: feature.Feature{ID: "feat-1", Name: "Attach Feature"}},
+			},
+		},
 		subscriptionsByID: map[string]subscription.Subscription{"sub-1": {NamespacedID: models.NamespacedID{Namespace: "ns", ID: "sub-1"}, Name: "Attach Subscription"}},
 		invoiceLinesByID:  map[string]billing.StandardInvoice{"line-1": {}},
 	}
+	service := &service{logger: slog.New(slog.DiscardHandler)}
 
 	// when attaching the loaded entities
-	out, err := buildCustomerCharge(charges.NewCharge(charge), entities)
+	out, err := service.buildCustomerCharge(t.Context(), charges.NewCharge(charge), entities, meta.Expands{
+		meta.ExpandCustomer,
+		meta.ExpandFeature,
+		meta.ExpandSubscription,
+		meta.ExpandRealizationInvoice,
+	})
 	require.NoError(t, err)
 
 	// then every expanded member resolves from its loaded entity, and the
@@ -110,7 +122,7 @@ func TestBuildCustomerCharge(t *testing.T) {
 	require.Nil(t, out.UsageBasedRealizations[1].Invoice, "the outstanding projection never has an invoice")
 
 	// and without loaded entities every expanded member stays nil
-	bare, err := buildCustomerCharge(charges.NewCharge(charge), customerChargeEntities{})
+	bare, err := service.buildCustomerCharge(t.Context(), charges.NewCharge(charge), customerChargeEntities{}, meta.ExpandNone)
 	require.NoError(t, err)
 	require.Nil(t, bare.Customer)
 	require.Nil(t, bare.Feature)

--- a/openmeter/billing/charges/service/api_list_customcurrency_test.go
+++ b/openmeter/billing/charges/service/api_list_customcurrency_test.go
@@ -64,13 +64,14 @@ func (s *CustomerChargeCustomCurrencyListTestSuite) enableFlatFeeCustomCurrencyS
 	lineageMock.On("BackfillAdvanceLineageSegments", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	customCurrencyFlatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       s.FlatFeeAdapter,
-		Handler:       s.FlatFeeTestHandler,
-		Lineage:       lineageMock,
-		MetaAdapter:   s.MetaAdapter,
-		Locker:        s.Locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-		Currencies:    s.CurrencyService,
+		Adapter:              s.FlatFeeAdapter,
+		Handler:              s.FlatFeeTestHandler,
+		Lineage:              lineageMock,
+		MetaAdapter:          s.MetaAdapter,
+		Locker:               s.Locker,
+		FeatureMeterResolver: s.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+		Currencies:           s.CurrencyService,
 	})
 	s.Require().NoError(err)
 

--- a/openmeter/billing/charges/service/api_list_test.go
+++ b/openmeter/billing/charges/service/api_list_test.go
@@ -75,16 +75,22 @@ func (s *CustomerChargeAPIListTestSuite) TestFeatureExpansionValidationPolicy() 
 
 		// when:
 		// - the customer charge facade expands the feature
-		featuresByRef, err := service.listCustomerChargeFeatures(
+		references, err := collectCustomerChargeReferences(charges.Charges{reference})
+		require.NoError(s.T(), err)
+		entities, err := service.loadCustomerChargeEntities(
 			s.T().Context(),
 			namespace,
-			[]billingfeaturemeter.FeatureReferenceGetter{reference},
+			"",
+			references,
+			meta.Expands{meta.ExpandFeature},
 		)
 
 		// then:
-		// - the resolver's validation issue does not discard its usable feature
+		// - feature-only resolution does not require a meter
 		require.NoError(s.T(), err)
-		require.Equal(s.T(), featureEntity, featuresByRef[reference.GetFeatureMeterRef().IDOrKey])
+		featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(reference))
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), featureEntity, featureMeter.Feature)
 	})
 
 	s.Run("catalog system error aborts expansion", func() {
@@ -100,10 +106,14 @@ func (s *CustomerChargeAPIListTestSuite) TestFeatureExpansionValidationPolicy() 
 
 		// when:
 		// - the customer charge facade expands the feature
-		_, err := service.listCustomerChargeFeatures(
+		references, err := collectCustomerChargeReferences(charges.Charges{reference})
+		require.NoError(s.T(), err)
+		_, err = service.loadCustomerChargeEntities(
 			s.T().Context(),
 			namespace,
-			[]billingfeaturemeter.FeatureReferenceGetter{reference},
+			"",
+			references,
+			meta.Expands{meta.ExpandFeature},
 		)
 
 		// then:
@@ -131,7 +141,10 @@ func newCustomerChargeFeatureTestService(t *testing.T, features []feature.Featur
 	})
 	require.NoError(t, err)
 
-	return &service{featureMeterResolver: resolver}
+	return &service{
+		logger:               slog.New(slog.DiscardHandler),
+		featureMeterResolver: resolver,
+	}
 }
 
 func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
@@ -299,12 +312,17 @@ func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
 		// - feature expansion resolves that charge
 		references, err := collectCustomerChargeReferences(charges.Charges{staleCharge})
 		require.NoError(s.T(), err)
-		featuresByRef, err := s.Charges.listCustomerChargeFeatures(ctx, namespace, references.featureReferences)
+		entities, err := s.Charges.loadCustomerChargeEntities(ctx, namespace, cust.ID, references, meta.Expands{meta.ExpandFeature})
+		require.NoError(s.T(), err)
+		customerCharge, err := s.Charges.buildCustomerCharge(ctx, staleCharge, entities, meta.Expands{meta.ExpandFeature})
 
 		// then:
 		// - the missing feature is omitted so the facade can retain its ID-only fallback
 		require.NoError(s.T(), err)
-		require.Empty(s.T(), featuresByRef)
+		require.Nil(s.T(), customerCharge.Feature)
+		resolvedCharge, err := customerCharge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usageCharge.State.FeatureID, resolvedCharge.State.FeatureID)
 	})
 
 	s.Run("the subscription side-loader serves the facade's bulk lookup", func() {
@@ -407,18 +425,17 @@ func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
 
 	s.Run("feature filters scope the listing", func() {
 		// given:
-		// - both charges reference the api-requests feature, created by key
-		//   (Create resolves and persists the feature ID)
+		// - both charges reference the api-requests feature by key without a pinned ID
 		// when:
 		// - listing filtered by feature id and by feature key
 		// then:
-		// - the matching feature returns every charge, a foreign one none
+		// - the ID does not match before activation, while the key returns every charge
 		byID := newListInput(meta.ExpandNone)
 		byID.FeatureID = &filter.FilterULID{FilterString: filter.FilterString{Eq: lo.ToPtr(feat.Feature.ID)}}
 
 		result, err := s.Charges.ListCustomerCharges(ctx, byID)
 		require.NoError(s.T(), err)
-		s.Len(result.Charges.Items, 2)
+		s.Empty(result.Charges.Items)
 
 		byKey := newListInput(meta.ExpandNone)
 		byKey.FeatureKey = &filter.FilterString{In: lo.ToPtr([]string{feat.Feature.Key, "another-feature"})}

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -193,13 +193,14 @@ func (s *BaseSuite) SetupSuite() {
 	}
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       flatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-		Currencies:    currencyService,
+		Adapter:              flatFeeAdapter,
+		Handler:              flatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: s.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+		Currencies:           currencyService,
 	})
 	s.NoError(err)
 

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -156,11 +156,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			return nil, err
 		}
 
-		createFeatureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
-		if err != nil {
-			return nil, fmt.Errorf("resolve create feature meters: %w", err)
-		}
-
 		createdCharges := make([]charges.WithIndex[charges.Charge], 0, len(input.Intents))
 		gatheringLinesToCreate := make([]gatheringLineWithCustomerID, 0, len(input.Intents))
 
@@ -170,7 +165,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			Intents: lo.Map(intentsByType.FlatFee, func(intent charges.WithIndex[flatfee.Intent], _ int) flatfee.Intent {
 				return intent.Value
 			}),
-			FeatureMeters: createFeatureMeters,
 		})
 		if err != nil {
 			return nil, err
@@ -201,7 +195,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			Intents: lo.Map(intentsByType.UsageBased, func(intent charges.WithIndex[usagebased.Intent], _ int) usagebased.Intent {
 				return intent.Value
 			}),
-			FeatureMeters: createFeatureMeters,
 		})
 		if err != nil {
 			return nil, err

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -464,7 +464,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateFlatFeeWithUnresolvableFeatureKeyRe
 	})
 
 	s.Require().Error(err)
-	s.ErrorContains(err, "resolve create feature meter")
+	s.ErrorContains(err, "resolve flat fee feature")
 	issue := requireFeatureMeterValidationIssue(s.T(), err, billing.ErrInvoiceLineFeatureNotFound.Code)
 	s.Empty(issue.Path)
 

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -187,7 +187,7 @@ func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureID
 	createdCharge, err := createdCharges[0].AsUsageBasedCharge()
 	s.NoError(err)
 	s.Equal(meta.ChargeStatusCreated, meta.ChargeStatus(createdCharge.Status))
-	s.Equal(featureV1.ID, createdCharge.State.FeatureID)
+	s.Empty(createdCharge.State.FeatureID)
 
 	s.archiveFeature(ctx, ns, featureV1.ID)
 	featureV2 := s.createFeature(ctx, ns, featureKey, meterV2.ID)

--- a/openmeter/billing/charges/service/flatfee_costbasis_test.go
+++ b/openmeter/billing/charges/service/flatfee_costbasis_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	dbchargeflatfeecostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeecostbasis"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -78,7 +77,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynamicCo
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "pinned", productcatalog.CreditThenInvoiceSettlementMode, &pinnedIntent),
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 3)
@@ -159,7 +157,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetrySafe
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-retry", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -289,7 +286,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeBeco
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-active", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -376,7 +372,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAndFia
 				Intents: []flatfee.Intent{
 					s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "mismatch-"+test.name, productcatalog.CreditThenInvoiceSettlementMode, &intent),
 				},
-				FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 			})
 			s.Require().ErrorContains(err, test.errorText)
 		})
@@ -407,7 +402,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeCrea
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().Error(err)
 	s.Require().Equal(0, s.countCostBases(namespace))
@@ -424,7 +418,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeRefe
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "credit-only", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -5568,13 +5568,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyWithCustomCurrency() {
 			Once()
 
 		customCurrencyFlatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-			Adapter:       s.FlatFeeAdapter,
-			Handler:       s.FlatFeeTestHandler,
-			Lineage:       lineageMock,
-			MetaAdapter:   s.MetaAdapter,
-			Locker:        s.Locker,
-			RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
-			Currencies:    s.CurrencyService,
+			Adapter:              s.FlatFeeAdapter,
+			Handler:              s.FlatFeeTestHandler,
+			Lineage:              lineageMock,
+			MetaAdapter:          s.MetaAdapter,
+			Locker:               s.Locker,
+			FeatureMeterResolver: s.FeatureMeterResolver,
+			RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),
+			Currencies:           s.CurrencyService,
 		})
 		s.Require().NoError(err)
 

--- a/openmeter/billing/charges/service/service.go
+++ b/openmeter/billing/charges/service/service.go
@@ -22,6 +22,7 @@ import (
 )
 
 type service struct {
+	logger  *slog.Logger
 	adapter charges.Adapter
 	// Note: if meta has a service layer, we should use it here instead of the adapter
 	metaAdapter          meta.Adapter
@@ -141,6 +142,7 @@ func New(config Config) (*service, error) {
 	}
 
 	svc := &service{
+		logger:                config.Logger,
 		adapter:               config.Adapter,
 		billingService:        config.BillingService,
 		invoiceUpdater:        invoiceUpdater,

--- a/openmeter/billing/charges/service/usagebased_costbasis_test.go
+++ b/openmeter/billing/charges/service/usagebased_costbasis_test.go
@@ -47,7 +47,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynami
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-modes")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "modes-feature")
+	s.createFeatureMeters(ctx, namespace, "modes-feature")
 	fiatCurrency := s.newFiatCurrency("USD")
 	pinnedCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
@@ -76,7 +76,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynami
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "pinned", "modes-feature", productcatalog.CreditThenInvoiceSettlementMode, &pinnedIntent),
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic", "modes-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 3)
@@ -141,7 +140,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetryS
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-retry")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "retry-feature")
+	s.createFeatureMeters(ctx, namespace, "retry-feature")
 	currencyCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
 		CurrencyID: currency.ID,
@@ -158,7 +157,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetryS
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-retry", "retry-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -218,7 +216,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeB
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 	_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "active-feature")
+	s.createFeatureMeters(ctx, namespace, "active-feature")
 	first, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
 		CurrencyID: currency.ID,
@@ -245,7 +243,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeB
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-active", "active-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -275,7 +272,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAnd
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-pinned-mismatch")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "mismatch-feature")
+	s.createFeatureMeters(ctx, namespace, "mismatch-feature")
 	otherCurrency, err := s.CurrencyService.CreateCurrency(ctx, currencies.CreateCurrencyInput{
 		Namespace: namespace,
 		CurrencyDetails: currencyx.CurrencyDetails{
@@ -331,7 +328,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAnd
 				Intents: []usagebased.Intent{
 					s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "mismatch-"+test.name, "mismatch-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 				},
-				FeatureMeters: featureMeters,
 			})
 			s.Require().ErrorContains(err, test.errorText)
 		})
@@ -351,7 +347,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeC
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-rollback")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "rollback-feature")
+	s.createFeatureMeters(ctx, namespace, "rollback-feature")
 	intent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 		Rate:         alpacadecimal.NewFromInt(2),
@@ -363,7 +359,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeC
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", "rollback-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", "rollback-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().Error(err)
 	s.Require().Equal(0, s.countCostBases(namespace))
@@ -375,13 +370,12 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeR
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-without-cost-basis")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "credit-only-feature")
+	s.createFeatureMeters(ctx, namespace, "credit-only-feature")
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "credit-only", "credit-only-feature", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -181,13 +181,14 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 	}
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:       flatFeeAdapter,
-		Handler:       config.FlatFeeHandler,
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
-		Currencies:    currencyService,
+		Adapter:              flatFeeAdapter,
+		Handler:              config.FlatFeeHandler,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: config.FeatureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
+		Currencies:           currencyService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating flat fee service: %w", err)

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -44,7 +44,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 		update := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetDiscounts(&baseIntent.Discounts).
-			SetFeatureID(charge.State.FeatureID).
+			SetOrClearFeatureID(lo.EmptyableToPtr(charge.State.FeatureID)).
 			SetOrClearIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 			SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
 			SetPrice(&baseIntent.Price).
@@ -438,13 +438,16 @@ func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, in
 		SetNillableDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 		SetNillableIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 		SetDiscounts(&baseIntent.Discounts).
-		SetFeatureID(intent.FeatureID).
 		SetRatingEngine(intent.RatingEngine).
 		SetPrice(&baseIntent.Price).
 		SetStatusDetailed(usagebased.Status(meta.ChargeStatusCreated)).
 		SetFeatureKey(baseIntent.FeatureKey).
 		SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
 		SetSettlementMode(baseIntent.SettlementMode)
+
+	if intent.FeatureID != "" {
+		create = create.SetFeatureID(intent.FeatureID)
+	}
 
 	if baseIntent.UnitConfig != nil {
 		create = create.SetUnitConfig(baseIntent.UnitConfig)

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -119,7 +119,7 @@ func fromDBBase(entity *entdb.ChargeUsageBased, chargeMeta meta.Charge) (usageba
 		State: usagebased.State{
 			CurrentRealizationRunID: entity.CurrentRealizationRunID,
 			AdvanceAfter:            entity.AdvanceAfter,
-			FeatureID:               entity.FeatureID,
+			FeatureID:               lo.FromPtr(entity.FeatureID),
 			RatingEngine:            entity.RatingEngine,
 			CostBasisID:             costBasisID,
 			ResolvedCostBasis:       resolvedCostBasis,

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -270,37 +270,9 @@ func (c Charge) GetCustomerID() customer.CustomerID {
 }
 
 func (c Charge) GetFeatureMeterRef() *billingfeaturemeter.FeatureMeterRef {
-	var featureRef ref.IDOrKey
-	switch c.Status {
-	case StatusCreated:
-		featureRef = ref.IDOrKey{
-			Key: c.Intent.GetBaseIntent().FeatureKey,
-		}
-	case StatusActive:
-		// Activation resolves by key before persisting the resolved feature ID.
-		if c.State.FeatureID != "" {
-			featureRef = ref.IDOrKey{
-				ID: c.State.FeatureID,
-			}
-		} else {
-			featureRef = ref.IDOrKey{
-				Key: c.Intent.GetBaseIntent().FeatureKey,
-			}
-		}
-	case StatusDeleted:
-		if c.State.FeatureID != "" {
-			featureRef = ref.IDOrKey{
-				ID: c.State.FeatureID,
-			}
-		} else {
-			featureRef = ref.IDOrKey{
-				Key: c.Intent.GetBaseIntent().FeatureKey,
-			}
-		}
-	default:
-		featureRef = ref.IDOrKey{
-			ID: c.State.FeatureID,
-		}
+	featureRef := ref.IDOrKey{ID: c.State.FeatureID}
+	if featureRef.ID == "" {
+		featureRef = ref.IDOrKey{Key: c.Intent.GetBaseIntent().FeatureKey}
 	}
 
 	if lo.IsEmpty(featureRef) {
@@ -814,10 +786,6 @@ func (s State) Validate() error {
 
 	if s.CurrentRealizationRunID != nil && *s.CurrentRealizationRunID == "" {
 		errs = append(errs, fmt.Errorf("current realization run ID must be non-empty"))
-	}
-
-	if s.FeatureID == "" {
-		errs = append(errs, fmt.Errorf("feature id must be set"))
 	}
 
 	if err := s.RatingEngine.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -270,15 +270,22 @@ func (c Charge) GetCustomerID() customer.CustomerID {
 }
 
 func (c Charge) GetFeatureMeterRef() *billingfeaturemeter.FeatureMeterRef {
-	// TODO: consolidate intent and persisted-charge feature reference handling once
-	// their creation-time and lifecycle-specific resolution semantics share one model.
-	// State.FeatureID is the persisted resolved feature snapshot used by active
-	// charges; created/deleted fallbacks resolve by key.
 	var featureRef ref.IDOrKey
 	switch c.Status {
 	case StatusCreated:
 		featureRef = ref.IDOrKey{
 			Key: c.Intent.GetBaseIntent().FeatureKey,
+		}
+	case StatusActive:
+		// Activation resolves by key before persisting the resolved feature ID.
+		if c.State.FeatureID != "" {
+			featureRef = ref.IDOrKey{
+				ID: c.State.FeatureID,
+			}
+		} else {
+			featureRef = ref.IDOrKey{
+				Key: c.Intent.GetBaseIntent().FeatureKey,
+			}
 		}
 	case StatusDeleted:
 		if c.State.FeatureID != "" {

--- a/openmeter/billing/charges/usagebased/charge_test.go
+++ b/openmeter/billing/charges/usagebased/charge_test.go
@@ -61,6 +61,14 @@ func TestChargeGetFeatureMeterRef(t *testing.T) {
 			},
 		},
 		{
+			name:   "active charge without a snapshot falls back to key",
+			status: StatusActive,
+			want: featuremeter.FeatureMeterRef{
+				IDOrKey:      ref.IDOrKey{Key: "feature-key"},
+				RequireMeter: true,
+			},
+		},
+		{
 			name:      "deleted charge resolves by snapshotted ID",
 			status:    StatusDeleted,
 			featureID: "feature-id",

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -46,19 +46,14 @@ type UsageBasedService interface {
 }
 
 type CreateInput struct {
-	Namespace     string
-	Intents       []Intent
-	FeatureMeters billingfeaturemeter.FeatureMeters
+	Namespace string
+	Intents   []Intent
 }
 
 func (i CreateInput) Validate() error {
 	var errs []error
 	if i.Namespace == "" {
 		errs = append(errs, errors.New("namespace is required"))
-	}
-
-	if len(i.Intents) > 0 && i.FeatureMeters == nil {
-		errs = append(errs, errors.New("feature meters are required"))
 	}
 
 	for idx, intent := range i.Intents {
@@ -89,10 +84,6 @@ func (i CreateIntent) Validate() error {
 
 	if err := i.Intent.Validate(); err != nil {
 		errs = append(errs, err)
-	}
-
-	if i.FeatureID == "" {
-		errs = append(errs, errors.New("feature id is required"))
 	}
 
 	if err := i.RatingEngine.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -27,6 +27,11 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 		return nil, nil
 	}
 
+	featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
+	if err != nil {
+		return nil, err
+	}
+
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]usagebased.ChargeWithGatheringLine, error) {
 		now := clock.Now().UTC()
 		createIntents, err := slicesx.MapWithErr(input.Intents, func(intent usagebased.Intent) (usagebased.CreateIntent, error) {
@@ -47,19 +52,30 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 				}
 			}
 
-			featureMeter, err := input.FeatureMeters.Get(chargeIntent)
+			featureMeter, err := featureMeters.Get(chargeIntent)
 			if err != nil {
-				return usagebased.CreateIntent{}, fmt.Errorf("resolve usage based feature for key %+v: %w", chargeIntent.GetFeatureRef(), err)
+				return usagebased.CreateIntent{}, fmt.Errorf("resolve usage based feature %+v: %w", chargeIntent.GetFeatureRef(), err)
 			}
 
-			// note: we must set the feature key on the intent, because no other place is setting it
-			// and we want to persist it
+			if chargeIntent.FeatureID != "" && chargeIntent.FeatureKey != "" && chargeIntent.FeatureKey != featureMeter.Feature.Key {
+				return usagebased.CreateIntent{}, models.NewGenericValidationError(fmt.Errorf(
+					"feature key %q does not match key %q resolved from feature id %q",
+					chargeIntent.FeatureKey,
+					featureMeter.Feature.Key,
+					chargeIntent.FeatureID,
+				))
+			}
+
+			featureID := ""
+			if chargeIntent.FeatureID != "" {
+				featureID = featureMeter.Feature.ID
+			}
 			chargeIntent.FeatureKey = featureMeter.Feature.Key
 
 			return usagebased.CreateIntent{
 				Intent:            chargeIntent.AsOverridableIntent(),
 				Annotations:       chargeIntent.Annotations,
-				FeatureID:         featureMeter.Feature.ID,
+				FeatureID:         featureID,
 				RatingEngine:      s.rater.GetPreferredRatingEngineFor(chargeIntent),
 				ResolvedCostBasis: resolvedCostBasis,
 			}, nil

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -1094,10 +1094,15 @@ func (s *CreditThenInvoiceStateMachine) StartInvoiceRun(
 		servicePeriodTo = meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
 		Charge:             s.Charge,
 		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               runType,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    servicePeriodTo,
@@ -1148,12 +1153,17 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
 		Charge:          s.Charge,
 		StoredAtLT:      storedAtLT,
 		ServicePeriodTo: currentRun.ServicePeriodTo,
 		Customer:        s.CustomerOverride,
-		FeatureMeter:    s.FeatureMeter,
+		FeatureMeter:    featureMeter,
 	})
 	if err != nil {
 		return fmt.Errorf("get detailed rating for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -692,7 +692,8 @@ func newCreditThenInvoiceStateMachineWithChargeForTest(t *testing.T, charge usag
 
 	out := &CreditThenInvoiceStateMachine{
 		stateMachine: &stateMachine{
-			Machine: machine,
+			Machine:       machine,
+			FeatureMeters: newFeatureMetersForChargeTest(charge),
 		},
 	}
 	out.configureStates()

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -409,10 +409,15 @@ func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) 
 		return fmt.Errorf("get stored at lt: %w", err)
 	}
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
 		Charge:             s.Charge,
 		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               usagebased.RealizationRunTypeFinalRealization,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To),
@@ -438,12 +443,17 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
 		Charge:          s.Charge,
 		StoredAtLT:      storedAtLT,
 		ServicePeriodTo: currentRun.ServicePeriodTo,
 		Customer:        s.CustomerOverride,
-		FeatureMeter:    s.FeatureMeter,
+		FeatureMeter:    featureMeter,
 	})
 	if err != nil {
 		return fmt.Errorf("get detailed rating for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -337,6 +337,7 @@ func newCreditsOnlyStateMachineWithChargeForTest(t *testing.T, charge usagebased
 			Machine:            machine,
 			Adapter:            adapter,
 			Runs:               runService,
+			FeatureMeters:      newFeatureMetersForChargeTest(charge),
 			CurrencyCalculator: cur,
 		},
 	}

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -31,12 +33,67 @@ func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeUsageBased
 }
 
-func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return !input.AsOf.Before(input.ResolvedBillablePeriod.To), nil
+	chargeIDs, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (string, error) {
+		if line.ChargeID == nil || *line.ChargeID == "" {
+			return "", fmt.Errorf("usage based gathering line[%s]: charge id is required", line.ID)
+		}
+
+		return *line.ChargeID, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	charges, err := e.service.GetByIDs(ctx, usagebased.GetByIDsInput{
+		Namespace: input.Invoice.Namespace,
+		IDs:       chargeIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting usage based charges for billability: %w", err)
+	}
+
+	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, charges...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters for usage based charges: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, index int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		charge := charges[index]
+		featureMeter, err := featureMeters.Get(charge)
+
+		ratingInput := rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		}
+		if err != nil {
+			// This becomes a validation issue on the resulting standard invoice, but we still need to provide
+			// the result too.
+			//
+			// Rating engine will resolve these usagebased items as if progressive billing was disabled as we don't
+			// know the underlying meter.
+			errs = append(errs, err)
+		} else {
+			ratingInput.Feature = &featureMeter.Feature
+			ratingInput.Meter = featureMeter.Meter
+		}
+
+		result, err := e.service.ratingService.ResolveBillablePeriod(ratingInput)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		// TODO: We should disallow billing in case the charge has a current realization run, so
+		// that we enforce that there are no multiple drafts for the same charge.
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *LineEngine) GateInvoiceAssignment(ctx context.Context, input billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -89,9 +89,6 @@ func (e *LineEngine) AreLinesBillableAsOf(ctx context.Context, input billing.Are
 			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
 		}
 
-		// TODO: We should disallow billing in case the charge has a current realization run, so
-		// that we enforce that there are no multiple drafts for the same charge.
-
 		return result, errors.Join(errs...)
 	})
 }

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -303,13 +304,15 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 		return nil, err
 	}
 
+	featureMeters := e.service.featureMeterResolver.ResolveLazy(ctx, input.Invoice.Namespace, lo.Values(chargesByID)...)
+
 	for _, stdLine := range stdLines {
 		charge, ok := chargesByID[*stdLine.ChargeID]
 		if !ok {
 			return nil, fmt.Errorf("usage based charge[%s] not found for gathering preview line[%s]", *stdLine.ChargeID, stdLine.ID)
 		}
 
-		previewResult, err := e.buildGatheringPreviewRun(ctx, charge, stdLine)
+		previewResult, err := e.buildGatheringPreviewRun(ctx, charge, featureMeters, stdLine)
 		if err != nil {
 			return nil, fmt.Errorf("building gathering preview run for line[%s]: %w", stdLine.ID, err)
 		}
@@ -330,7 +333,7 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 	return stdLines, nil
 }
 
-func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
+func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, featureMeters billingfeaturemeter.FeatureMeters, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
 	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf(
 			"usage based standard line[%s]: unsupported settlement mode for gathering preview: %s",
@@ -353,10 +356,15 @@ func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usageb
 		servicePeriodTo = meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
+	featureMeter, err := featureMeters.Get(charge)
+	if err != nil {
+		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+	}
+
 	return e.service.runs.BuildCreditThenInvoiceGatheringPreviewRun(ctx, usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunInput{
 		Charge:             charge,
 		CustomerOverride:   stateMachineConfig.CustomerOverride,
-		FeatureMeter:       stateMachineConfig.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               runType,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    servicePeriodTo,

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -374,14 +374,14 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	stdLines, err := slicesx.MapWithErr(input.Lines, func(stdLine *billing.StandardLine) (*billing.StandardLine, error) {
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(stdLine *billing.StandardLine, _ int) (*billing.StandardLine, error) {
 		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
 		if err != nil {
-			return nil, err
+			return stdLine, err
 		}
 
 		if stateMachine.GetCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-			return nil, fmt.Errorf(
+			return stdLine, fmt.Errorf(
 				"usage based standard line[%s]: unsupported settlement mode for standard invoice creation: %s",
 				stdLine.ID,
 				stateMachine.GetCharge().Intent.GetSettlementMode(),
@@ -392,11 +392,11 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		// still rely on the generic TriggerNext/AdvanceUntilStable flow before invoice-created
 		// lifecycle transitions take over.
 		if err := stateMachine.AdvanceUntilStable(ctx); err != nil {
-			return nil, fmt.Errorf("advancing usage based charge[%s]: %w", stateMachine.GetCharge().ID, err)
+			return stdLine, fmt.Errorf("advancing usage based charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
 
 		if stateMachine.GetCharge().State.CurrentRealizationRunID != nil {
-			return nil, billing.ValidationError{
+			return stdLine, billing.ValidationError{
 				Err: fmt.Errorf("line[%s]: %w", stdLine.ID, usagebased.ErrActiveRealizationRunAlreadyExists),
 			}
 		}
@@ -406,13 +406,13 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			InvoiceID:     input.Invoice.ID,
 			ServicePeriod: stdLine.Period,
 		}); err != nil {
-			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
+			return stdLine, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerInvoiceCreated, stateMachine.GetCharge().ID, err)
 		}
 
 		charge := stateMachine.GetCharge()
 		currentRun, err := charge.GetCurrentRealizationRun()
 		if err != nil {
-			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
+			return stdLine, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
 		}
 
 		if err := populateStandardLineFromRun(stdLine, populateStandardLineFromRunInput{
@@ -420,20 +420,15 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			Run:    currentRun,
 			Stage:  standardLinePopulationStageInvoiceCreated,
 		}); err != nil {
-			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
+			return stdLine, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
 		}
 
 		if err := stdLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
+			return stdLine, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
 		}
 
 		return stdLine, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return stdLines, nil
 }
 
 func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -576,15 +576,9 @@ func (e *LineEngine) createManualInvoiceLines(ctx context.Context, input billing
 
 	namespace := input.Invoice.GetInvoiceID().Namespace
 	intents := lo.Map(created, func(line manualCreatedInvoiceLine, _ int) usagebased.Intent { return line.intent })
-	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, namespace, intents...)
-	if err != nil {
-		return nil, fmt.Errorf("resolving manually created usage-based charge feature meters: %w", err)
-	}
-
 	createdCharges, err := e.service.Create(ctx, usagebased.CreateInput{
-		Namespace:     namespace,
-		Intents:       intents,
-		FeatureMeters: featureMeters,
+		Namespace: namespace,
+		Intents:   intents,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating manually managed usage-based charges: %w", err)

--- a/openmeter/billing/charges/usagebased/service/lineengine_test.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -128,6 +129,54 @@ func TestAreLinesBillableAsOfRequiresChargeID(t *testing.T) {
 
 	// Then the engine rejects the line before resolving charge dependencies.
 	require.ErrorContains(t, err, "charge id is required")
+}
+
+func TestAreLinesBillableAsOfFallsBackWhenChargeFeatureIsMissing(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newUsageBasedBillabilityLine("namespace", "line", "charge", period)
+	charge := newUsageBasedBillabilityCharge("namespace", "charge", "missing-feature")
+	featureMeterResolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: usageBasedBillabilityFeatureService{},
+		MeterService:   usageBasedBillabilityMeterService{},
+		Logger:         slog.Default(),
+	})
+	require.NoError(t, err)
+	engine := &LineEngine{service: &service{
+		adapter:              &usageBasedBillabilityAdapter{charges: []usagebased.Charge{charge}},
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        billingratingservice.New(billingratingservice.Config{}),
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), usageBasedBillabilityTransaction{})
+	require.NoError(t, err)
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+			ID:              line.InvoiceID,
+		},
+	}}
+
+	// Given a usage-based charge whose persisted feature no longer exists.
+	// When billability is checked with progressive billing enabled.
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice:            invoice,
+		AsOf:               period.From.Add(24 * time.Hour),
+		ProgressiveBilling: true,
+		Lines:              billing.GatheringLines{line},
+	})
+
+	// Then the engine returns a usable non-progressive result and the missing-feature validation issue.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  "feature[missing-feature]: invoice line: feature not found",
+		Path:     "/charges/charge",
+	}}, issues)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{{}}, results)
 }
 
 type usageBasedBillabilityAdapter struct {

--- a/openmeter/billing/charges/usagebased/service/lineengine_test.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -9,34 +11,223 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestLineEngineIsLineBillableAsOfSupportsPartialBillablePeriod(t *testing.T) {
-	engine := &LineEngine{}
+const usageBasedBillabilityInvoiceID = "invoice-id"
 
-	servicePeriod := timeutil.ClosedPeriod{
-		From: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
-		To:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+func TestAreLinesBillableAsOfResolvesChargeFeatureMeters(t *testing.T) {
+	periods := []timeutil.ClosedPeriod{
+		{From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{From: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)},
 	}
-	billablePeriod := timeutil.ClosedPeriod{
-		From: servicePeriod.From,
-		To:   time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+	lines := []billing.GatheringLine{
+		newUsageBasedBillabilityLine("namespace", "line-1", "charge-1", periods[0]),
+		newUsageBasedBillabilityLine("namespace", "line-2", "charge-2", periods[1]),
+	}
+	charges := []usagebased.Charge{
+		newUsageBasedBillabilityCharge("namespace", "charge-1", "feature-1"),
+		newUsageBasedBillabilityCharge("namespace", "charge-2", "feature-2"),
+	}
+	featureEntities := []feature.Feature{
+		{Namespace: "namespace", ID: "feature-1", Key: "charge-feature-1", MeterID: lo.ToPtr("meter-1")},
+		{Namespace: "namespace", ID: "feature-2", Key: "charge-feature-2", MeterID: lo.ToPtr("meter-2")},
+	}
+	meterEntities := []meter.Meter{
+		newUsageBasedBillabilityMeter("namespace", "meter-1"),
+		newUsageBasedBillabilityMeter("namespace", "meter-2"),
 	}
 
-	billable, err := engine.IsLineBillableAsOf(t.Context(), billing.IsLineBillableAsOfInput{
-		AsOf:                   billablePeriod.To,
-		ProgressiveBilling:     true,
-		ResolvedBillablePeriod: billablePeriod,
+	// Given usage-based gathering lines whose copied feature keys differ from
+	// the persisted feature snapshots owned by their charges.
+	adapter := &usageBasedBillabilityAdapter{charges: charges}
+	ratingService := &usageBasedBillabilityRatingService{}
+	featureMeterResolver, err := featuremeterservice.New(featuremeterservice.Config{
+		FeatureService: usageBasedBillabilityFeatureService{features: featureEntities},
+		MeterService:   usageBasedBillabilityMeterService{meters: meterEntities},
+		Logger:         slog.Default(),
 	})
 	require.NoError(t, err)
-	require.True(t, billable)
+	engine := &LineEngine{service: &service{
+		adapter:              adapter,
+		featureMeterResolver: featureMeterResolver,
+		ratingService:        ratingService,
+	}}
+	ctx, err := transaction.SetDriverOnContext(t.Context(), usageBasedBillabilityTransaction{})
+	require.NoError(t, err)
+
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+			ID:              usageBasedBillabilityInvoiceID,
+		},
+	}}
+
+	// When billability is resolved as an ordered batch.
+	results, err := engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+		Invoice:            invoice,
+		AsOf:               lines[len(lines)-1].InvoiceAt,
+		ProgressiveBilling: true,
+		Lines:              lines,
+	})
+
+	// Then rating receives the charge-owned feature and meter for each line,
+	// while results retain the original input order.
+	require.NoError(t, err)
+	require.Equal(t, []billing.IsLineBillableAsOfResult{
+		{Billable: true, BillablePeriod: periods[0]},
+		{Billable: true, BillablePeriod: periods[1]},
+	}, results)
+	require.Equal(t, []usagebased.GetByIDsInput{{
+		Namespace: "namespace",
+		IDs:       []string{"charge-1", "charge-2"},
+	}}, adapter.inputs)
+
+	ratingInputsByLineID := lo.SliceToMap(ratingService.inputs, func(input rating.ResolveBillablePeriodInput) (string, rating.ResolveBillablePeriodInput) {
+		return input.Line.GetID(), input
+	})
+	require.Equal(t, "feature-1", ratingInputsByLineID["line-1"].Feature.ID)
+	require.Equal(t, "meter-1", ratingInputsByLineID["line-1"].Meter.ID)
+	require.Equal(t, "feature-2", ratingInputsByLineID["line-2"].Feature.ID)
+	require.Equal(t, "meter-2", ratingInputsByLineID["line-2"].Meter.ID)
+}
+
+func TestAreLinesBillableAsOfRequiresChargeID(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	line := newUsageBasedBillabilityLine("namespace", "line", "charge", period)
+	line.ChargeID = nil
+
+	// Given a usage-based gathering line without its owning charge identity.
+	engine := &LineEngine{}
+
+	// When billability is requested.
+	_, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+		}},
+		AsOf:  line.InvoiceAt,
+		Lines: billing.GatheringLines{line},
+	})
+
+	// Then the engine rejects the line before resolving charge dependencies.
+	require.ErrorContains(t, err, "charge id is required")
+}
+
+type usageBasedBillabilityAdapter struct {
+	usagebased.Adapter
+
+	charges []usagebased.Charge
+	inputs  []usagebased.GetByIDsInput
+}
+
+func (a *usageBasedBillabilityAdapter) GetByIDs(_ context.Context, input usagebased.GetByIDsInput) ([]usagebased.Charge, error) {
+	a.inputs = append(a.inputs, input)
+
+	return lo.Filter(a.charges, func(charge usagebased.Charge, _ int) bool {
+		return charge.Namespace == input.Namespace && lo.Contains(input.IDs, charge.ID)
+	}), nil
+}
+
+type usageBasedBillabilityFeatureService struct {
+	features []feature.Feature
+}
+
+func (s usageBasedBillabilityFeatureService) ListFeatures(_ context.Context, params feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+	return pagination.Result[feature.Feature]{Items: lo.Filter(s.features, func(featureEntity feature.Feature, _ int) bool {
+		return featureEntity.Namespace == params.Namespace && (lo.Contains(params.IDsOrKeys, featureEntity.ID) || lo.Contains(params.IDsOrKeys, featureEntity.Key))
+	})}, nil
+}
+
+type usageBasedBillabilityMeterService struct {
+	meters []meter.Meter
+}
+
+func (s usageBasedBillabilityMeterService) ListMeters(_ context.Context, params meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	return pagination.Result[meter.Meter]{Items: lo.Filter(s.meters, func(meterEntity meter.Meter, _ int) bool {
+		return meterEntity.Namespace == params.Namespace && params.IDFilter != nil && lo.Contains(*params.IDFilter, meterEntity.ID)
+	})}, nil
+}
+
+type usageBasedBillabilityRatingService struct {
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *usageBasedBillabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: input.Line.GetServicePeriod(),
+	}, nil
+}
+
+func (*usageBasedBillabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
+
+type usageBasedBillabilityTransaction struct{}
+
+func (usageBasedBillabilityTransaction) Commit() error    { return nil }
+func (usageBasedBillabilityTransaction) Rollback() error  { return nil }
+func (usageBasedBillabilityTransaction) SavePoint() error { return nil }
+
+func newUsageBasedBillabilityCharge(namespace, chargeID, featureID string) usagebased.Charge {
+	return usagebased.Charge{ChargeBase: usagebased.ChargeBase{
+		ManagedResource: meta.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              chargeID,
+		},
+		Status: usagebased.StatusActive,
+		State:  usagebased.State{FeatureID: featureID},
+	}}
+}
+
+func newUsageBasedBillabilityMeter(namespace, meterID string) meter.Meter {
+	return meter.Meter{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              meterID,
+		},
+		Aggregation: meter.MeterAggregationSum,
+	}
+}
+
+func newUsageBasedBillabilityLine(namespace, lineID, chargeID string, period timeutil.ClosedPeriod) billing.GatheringLine {
+	return billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              lineID,
+			Name:            "usage",
+		},
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeChargeUsageBased,
+		InvoiceID:     usageBasedBillabilityInvoiceID,
+		Currency:      currencyx.FiatCode("USD"),
+		ServicePeriod: period,
+		InvoiceAt:     period.To,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+		FeatureKey: "line-feature-must-not-be-resolved",
+		ChargeID:   lo.ToPtr(chargeID),
+	}}
 }
 
 func TestLineEngineSplitGatheringLineKeepsChargeGroupingWithoutChildReferences(t *testing.T) {
@@ -72,9 +263,8 @@ func TestLineEngineSplitGatheringLineKeepsChargeGroupingWithoutChildReferences(t
 	}
 
 	result, err := engine.SplitGatheringLine(t.Context(), billing.SplitGatheringLineInput{
-		Line:          line,
-		FeatureMeters: billingtestFeatureMeters(),
-		SplitAt:       splitAt,
+		Line:    line,
+		SplitAt: splitAt,
 	})
 	require.NoError(t, err)
 
@@ -113,8 +303,4 @@ func TestValidateCustomCurrencyInvoiceLineDeleteAllowsDraftInvoice(t *testing.T)
 	}
 
 	require.NoError(t, validateCustomCurrencyInvoiceLineDelete(invoice, line.AsGenericLine(), run))
-}
-
-func billingtestFeatureMeters() billingfeaturemeter.FeatureMeters {
-	return featuremeterservice.FeatureMeterCollection{}
 }

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -32,7 +32,7 @@ type stateMachine struct {
 	Runs    *usagebasedrun.Service
 
 	CustomerOverride   billing.CustomerOverrideWithDetails
-	FeatureMeter       billingfeaturemeter.FeatureMeter
+	FeatureMeters      billingfeaturemeter.FeatureMeters
 	CurrencyCalculator currencyx.Currency
 	CostBasisResolver  costbasis.Resolver
 }
@@ -46,7 +46,7 @@ type StateMachineConfig struct {
 	Runs               *usagebasedrun.Service
 	Logger             *slog.Logger
 	CustomerOverride   billing.CustomerOverrideWithDetails
-	FeatureMeter       billingfeaturemeter.FeatureMeter
+	FeatureMeters      billingfeaturemeter.FeatureMeters
 	CurrencyCalculator currencyx.Currency
 	CostBasisResolver  costbasis.Resolver
 }
@@ -78,8 +78,8 @@ func (c StateMachineConfig) Validate() error {
 		errs = append(errs, fmt.Errorf("merged profile is required: %w", err))
 	}
 
-	if c.FeatureMeter.Meter == nil {
-		errs = append(errs, errors.New("feature meter is required"))
+	if c.FeatureMeters == nil {
+		errs = append(errs, errors.New("feature meters are required"))
 	}
 
 	if c.CurrencyCalculator == nil {
@@ -113,7 +113,7 @@ func newStateMachineBase(
 		Rater:              config.Rater,
 		Runs:               config.Runs,
 		CustomerOverride:   config.CustomerOverride,
-		FeatureMeter:       config.FeatureMeter,
+		FeatureMeters:      config.FeatureMeters,
 		CurrencyCalculator: config.CurrencyCalculator,
 		CostBasisResolver:  config.CostBasisResolver,
 	}
@@ -292,7 +292,12 @@ func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
 }
 
 func (s *stateMachine) SyncFeatureIDFromFeatureMeter(ctx context.Context) error {
-	s.Charge.State.FeatureID = s.FeatureMeter.Feature.ID
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge.State.FeatureID = featureMeter.Feature.ID
 	return nil
 }
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -292,6 +292,10 @@ func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
 }
 
 func (s *stateMachine) SyncFeatureIDFromFeatureMeter(ctx context.Context) error {
+	if s.Charge.State.FeatureID != "" {
+		return nil
+	}
+
 	featureMeter, err := s.FeatureMeters.Get(s.Charge)
 	if err != nil {
 		return err

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -253,16 +253,7 @@ func (s *service) getStateMachineConfigForChargeWithHints(ctx context.Context, c
 
 	featureMeters, hasFeatureMetersHint := hints.FeatureMeters.Get()
 	if !hasFeatureMetersHint {
-		var err error
-		featureMeters, err = s.featureMeterResolver.Resolve(ctx, charge.Namespace, charge)
-		if err != nil {
-			return StateMachineConfig{}, fmt.Errorf("resolve feature meters: %w", err)
-		}
-	}
-
-	featureMeter, err := featureMeters.Get(charge)
-	if err != nil {
-		return StateMachineConfig{}, fmt.Errorf("resolve feature meter: %w", err)
+		featureMeters = s.featureMeterResolver.ResolveLazy(ctx, charge.Namespace, charge)
 	}
 
 	currency := charge.Intent.GetCurrency()
@@ -273,7 +264,7 @@ func (s *service) getStateMachineConfigForChargeWithHints(ctx context.Context, c
 		Rater:              s.rater,
 		Runs:               s.runs,
 		CustomerOverride:   customerOverride,
-		FeatureMeter:       featureMeter,
+		FeatureMeters:      featureMeters,
 		CurrencyCalculator: currency,
 		CostBasisResolver:  s.costbasisResolver,
 	}, nil

--- a/openmeter/billing/charges/usagebased/service/triggers_test.go
+++ b/openmeter/billing/charges/usagebased/service/triggers_test.go
@@ -35,9 +35,9 @@ func TestGetStateMachineConfigUsesAuthoritativeFeatureMeters(t *testing.T) {
 		// given:
 		// - Advancement receives an authoritative feature-meter collection containing the charge feature.
 		// when:
-		// - The state-machine configuration resolves the charge feature.
+		// - The state-machine configuration is assembled.
 		// then:
-		// - It uses the supplied snapshot without consulting the feature service.
+		// - It retains the supplied snapshot without consulting the feature service.
 		featureMeter := billingfeaturemeter.FeatureMeter{
 			Feature: feature.Feature{
 				ID:  "feature-id",
@@ -56,24 +56,62 @@ func TestGetStateMachineConfigUsesAuthoritativeFeatureMeters(t *testing.T) {
 			FeatureMeters:    mo.Some[billingfeaturemeter.FeatureMeters](featureMeters),
 		})
 		require.NoError(t, err)
-		require.Equal(t, featureMeter, config.FeatureMeter)
+
+		resolved, err := config.FeatureMeters.Get(charge)
+		require.NoError(t, err)
+		require.Equal(t, featureMeter, resolved)
 	})
 
 	t.Run("when the supplied collection omits the charge feature", func(t *testing.T) {
 		// given:
 		// - Advancement receives an authoritative feature-meter collection without the charge feature.
 		// when:
-		// - The state-machine configuration resolves the charge feature.
+		// - The state-machine configuration is assembled.
 		// then:
-		// - It returns the snapshot lookup error instead of falling back to the feature service.
-		_, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
+		// - It retains the supplied snapshot, and its lookup error does not fall back to the feature service.
+		config, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
 			CustomerOverride: mo.Some(billing.CustomerOverrideWithDetails{}),
 			FeatureMeters: mo.Some[billingfeaturemeter.FeatureMeters](featuremeterservice.FeatureMeterCollection{
 				ByKey: map[string]billingfeaturemeter.FeatureMeter{},
 			}),
 		})
+		require.NoError(t, err)
+
+		_, err = config.FeatureMeters.Get(charge)
 		require.ErrorContains(t, err, "feature[feature-key]: invoice line: feature not found")
 	})
+}
+
+func newFeatureMetersForChargeTest(charge usagebased.Charge) billingfeaturemeter.FeatureMeters {
+	reference := charge.GetFeatureMeterRef()
+	if reference == nil {
+		return featuremeterservice.FeatureMeterCollection{
+			ByKey: map[string]billingfeaturemeter.FeatureMeter{},
+			ByID:  map[string]billingfeaturemeter.FeatureMeter{},
+		}
+	}
+
+	featureID := reference.IDOrKey.ID
+	if featureID == "" {
+		featureID = "feature-id"
+	}
+
+	featureMeter := billingfeaturemeter.FeatureMeter{
+		Feature: feature.Feature{
+			ID:  featureID,
+			Key: reference.IDOrKey.Key,
+		},
+		Meter: &meter.Meter{},
+	}
+	collection := featuremeterservice.FeatureMeterCollection{
+		ByKey: map[string]billingfeaturemeter.FeatureMeter{},
+		ByID:  map[string]billingfeaturemeter.FeatureMeter{featureID: featureMeter},
+	}
+	if reference.IDOrKey.Key != "" {
+		collection.ByKey[reference.IDOrKey.Key] = featureMeter
+	}
+
+	return collection
 }
 
 func TestApplyBaseIntentPatchForOverriddenChargeShrinksDeletedEffectiveCharge(t *testing.T) {

--- a/openmeter/billing/featuremeter/README.md
+++ b/openmeter/billing/featuremeter/README.md
@@ -66,3 +66,18 @@ The service subpackage constructs billing validation issues directly. Higher
 level billing services own the validation component and remain responsible for
 deciding whether a workflow can continue with the returned collection and
 validation issues.
+
+## Why resolution is lazy
+
+Charge advancement also acts as reconciliation and can inspect charges that
+are not due. Determining that no transition can fire does not require their
+feature or meter, so eager catalog resolution would let an unused missing meter
+or catalog outage block otherwise independent work.
+
+The lazy collection snapshots feature references and usable owner identities
+when it is created, then resolves the snapshot once on the first `Get` or
+`Has`. This preserves a consistent view for the operation without repeating
+catalog queries. `Get` returns resolution failures when the dependency is
+actually consumed, while `Has` reports false after a failed resolution. Missing
+features and meters therefore remain validation failures on paths that need
+them, and catalog system errors remain fatal.

--- a/openmeter/billing/featuremeter/featuremeter.go
+++ b/openmeter/billing/featuremeter/featuremeter.go
@@ -30,6 +30,32 @@ type FeatureReferenceGetter interface {
 	GetFeatureMeterRef() *FeatureMeterRef
 }
 
+type featureReferenceWithoutMeters struct {
+	reference FeatureReferenceGetter
+}
+
+func (r featureReferenceWithoutMeters) GetFeatureMeterRef() *FeatureMeterRef {
+	if r.reference == nil {
+		return nil
+	}
+
+	reference := r.reference.GetFeatureMeterRef()
+	if reference == nil {
+		return nil
+	}
+
+	withoutMeters := *reference
+	withoutMeters.RequireMeter = false
+
+	return &withoutMeters
+}
+
+// WithoutMeters returns a feature-only copy of a reference. The returned
+// reference deliberately does not retain the owner's identity.
+func WithoutMeters(reference FeatureReferenceGetter) FeatureReferenceGetter {
+	return featureReferenceWithoutMeters{reference: reference}
+}
+
 // FeatureReferenceOwner provides the stable identity of the billing entity that
 // owns a feature reference. Reference types without a stable identity must not
 // implement this interface.

--- a/openmeter/billing/featuremeter/featuremeter.go
+++ b/openmeter/billing/featuremeter/featuremeter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/ref"
+	"github.com/samber/lo"
 )
 
 type FeatureMeter struct {
@@ -44,4 +45,12 @@ type FeatureMeters interface {
 type FeatureMeterRef struct {
 	IDOrKey      ref.IDOrKey
 	RequireMeter bool
+}
+
+func (r *FeatureMeterRef) CloneIfPresent() *FeatureMeterRef {
+	if r == nil {
+		return nil
+	}
+
+	return lo.ToPtr(*r)
 }

--- a/openmeter/billing/featuremeter/service/lazy.go
+++ b/openmeter/billing/featuremeter/service/lazy.go
@@ -1,0 +1,81 @@
+package featuremeterservice
+
+import (
+	"context"
+
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	"github.com/openmeterio/openmeter/pkg/syncx"
+	"github.com/samber/lo"
+)
+
+type featureMeterReferenceSnapshot struct {
+	reference *billingfeaturemeter.FeatureMeterRef
+}
+
+func (s featureMeterReferenceSnapshot) GetFeatureMeterRef() *billingfeaturemeter.FeatureMeterRef {
+	return s.reference
+}
+
+type identifiedFeatureMeterReferenceSnapshot struct {
+	featureMeterReferenceSnapshot
+	identity billingfeaturemeter.FeatureReferenceIdentity
+}
+
+func (s identifiedFeatureMeterReferenceSnapshot) GetFeatureMeterOwner() billingfeaturemeter.FeatureReferenceIdentity {
+	return s.identity
+}
+
+type lazyFeatureMeters struct {
+	ctx     context.Context
+	resolve func(context.Context) (billingfeaturemeter.FeatureMeters, error)
+}
+
+func (l *lazyFeatureMeters) Get(reference billingfeaturemeter.FeatureReferenceGetter) (billingfeaturemeter.FeatureMeter, error) {
+	featureMeters, err := l.resolve(l.ctx)
+	if err != nil {
+		return billingfeaturemeter.FeatureMeter{}, err
+	}
+
+	return featureMeters.Get(reference)
+}
+
+func (l *lazyFeatureMeters) Has(reference billingfeaturemeter.FeatureReferenceGetter) bool {
+	featureMeters, err := l.resolve(l.ctx)
+	if err != nil {
+		return false
+	}
+
+	return featureMeters.Has(reference)
+}
+
+// ResolveLazy snapshots the requested references and resolves their feature-meter
+// collection when it is first queried.
+func (r Resolver) ResolveLazy[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) billingfeaturemeter.FeatureMeters {
+	references := lo.Map(targets, func(target T, _ int) billingfeaturemeter.FeatureReferenceGetter {
+		return snapshotFeatureMeterReference(target)
+	})
+
+	return &lazyFeatureMeters{
+		ctx: ctx,
+		resolve: syncx.OnceValues(func(ctx context.Context) (billingfeaturemeter.FeatureMeters, error) {
+			return r.Resolve(ctx, namespace, references...)
+		}),
+	}
+}
+
+func snapshotFeatureMeterReference(reference billingfeaturemeter.FeatureReferenceGetter) billingfeaturemeter.FeatureReferenceGetter {
+	snapshot := featureMeterReferenceSnapshot{reference: reference.GetFeatureMeterRef().CloneIfPresent()}
+	owner, ok := reference.(billingfeaturemeter.FeatureReferenceOwner)
+	if !ok {
+		return snapshot
+	}
+	identity := owner.GetFeatureMeterOwner()
+	if identity.Kind == "" || identity.ID == "" {
+		return snapshot
+	}
+
+	return identifiedFeatureMeterReferenceSnapshot{
+		featureMeterReferenceSnapshot: snapshot,
+		identity:                      identity,
+	}
+}

--- a/openmeter/billing/featuremeter/service/lazy_test.go
+++ b/openmeter/billing/featuremeter/service/lazy_test.go
@@ -1,0 +1,143 @@
+package featuremeterservice
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/ref"
+)
+
+type mutableIdentifiedFeatureMeterReference struct {
+	reference featuremeter.FeatureMeterRef
+	identity  featuremeter.FeatureReferenceIdentity
+}
+
+func (r *mutableIdentifiedFeatureMeterReference) GetFeatureMeterRef() *featuremeter.FeatureMeterRef {
+	return &r.reference
+}
+
+func (r *mutableIdentifiedFeatureMeterReference) GetFeatureMeterOwner() featuremeter.FeatureReferenceIdentity {
+	return r.identity
+}
+
+func TestResolverResolveLazy(t *testing.T) {
+	const namespace = "namespace"
+
+	t.Run("resolves once when first queried", func(t *testing.T) {
+		var featureCalls atomic.Int32
+		var featureIDsOrKeys []string
+		resolver, err := New(Config{
+			FeatureService: featureServiceStub{
+				listFeatures: func(_ context.Context, params feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+					featureCalls.Add(1)
+					featureIDsOrKeys = params.IDsOrKeys
+
+					return pagination.Result[feature.Feature]{Items: []feature.Feature{{ID: "feature-id", Key: "tokens"}}}, nil
+				},
+			},
+			MeterService: meterServiceStub{
+				listMeters: func(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+					return pagination.Result[meter.Meter]{}, nil
+				},
+			},
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		target := featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}})
+		resolved := resolver.ResolveLazy(t.Context(), namespace, target)
+		require.Zero(t, featureCalls.Load())
+
+		var waitGroup sync.WaitGroup
+		hasResults := make(chan bool, 10)
+		for range 10 {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				hasResults <- resolved.Has(target)
+			}()
+		}
+		waitGroup.Wait()
+		close(hasResults)
+		for has := range hasResults {
+			require.True(t, has)
+		}
+
+		featureMeter, err := resolved.Get(target)
+		require.NoError(t, err)
+		require.Equal(t, "feature-id", featureMeter.Feature.ID)
+		require.Equal(t, []string{"tokens"}, featureIDsOrKeys)
+		require.Equal(t, int32(1), featureCalls.Load())
+	})
+
+	t.Run("passes resolution failures through", func(t *testing.T) {
+		resolutionFailure := errors.New("catalog unavailable")
+		resolver, err := New(Config{
+			FeatureService: featureServiceStub{
+				listFeatures: func(context.Context, feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+					return pagination.Result[feature.Feature]{}, resolutionFailure
+				},
+			},
+			MeterService: meterServiceStub{
+				listMeters: func(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+					t.Fatal("meter service must not be called after feature resolution fails")
+
+					return pagination.Result[meter.Meter]{}, nil
+				},
+			},
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		target := featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}})
+		resolved := resolver.ResolveLazy(t.Context(), namespace, target)
+		_, getErr := resolved.Get(target)
+		require.ErrorIs(t, getErr, resolutionFailure)
+		require.False(t, resolved.Has(target))
+
+		_, repeatedGetErr := resolved.Get(target)
+		require.Same(t, getErr, repeatedGetErr)
+	})
+
+	t.Run("snapshots references and usable identities", func(t *testing.T) {
+		target := &mutableIdentifiedFeatureMeterReference{
+			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "original"}},
+			identity: featuremeter.FeatureReferenceIdentity{
+				Kind: featuremeter.FeatureReferenceKindCharges,
+				ID:   "charge-id",
+			},
+		}
+
+		snapshot := snapshotFeatureMeterReference(target)
+		target.reference.IDOrKey.Key = "mutated"
+		target.identity.ID = "mutated"
+
+		require.Equal(t, "original", snapshot.GetFeatureMeterRef().IDOrKey.Key)
+		_, err := (FeatureMeterCollection{}).Get(snapshot)
+		issues, systemErr := billing.ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, "/charges/charge-id", issues[0].Path)
+	})
+
+	t.Run("drops incomplete identities", func(t *testing.T) {
+		target := &mutableIdentifiedFeatureMeterReference{
+			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}},
+			identity:  featuremeter.FeatureReferenceIdentity{Kind: featuremeter.FeatureReferenceKindCharges},
+		}
+
+		snapshot := snapshotFeatureMeterReference(target)
+		_, ok := snapshot.(featuremeter.FeatureReferenceOwner)
+		require.False(t, ok)
+	})
+}

--- a/openmeter/billing/featuremeter/service/resolver.go
+++ b/openmeter/billing/featuremeter/service/resolver.go
@@ -68,12 +68,9 @@ type Resolver struct {
 	logger         *slog.Logger
 }
 
-// Resolve extracts and resolves the feature and meter dependencies of billing entities.
-//
-// When target validation fails, Resolve returns any feature-meter data it could
-// resolve alongside the error. Callers that can continue with partial data must
-// split the error with billing.ToValidationIssues and may continue only when the
-// returned system error is nil.
+// Resolve fetches the feature and meter dependencies of billing entities.
+// Missing features and required meters are reported by FeatureMeters.Get at the
+// operation that consumes each dependency.
 func (r Resolver) Resolve[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) (billingfeaturemeter.FeatureMeters, error) {
 	if namespace == "" {
 		return nil, models.NewGenericValidationError(errors.New("namespace is required"))
@@ -143,11 +140,27 @@ func (r Resolver) Resolve[T billingfeaturemeter.FeatureReferenceGetter](ctx cont
 		}
 	}
 
-	if err := validateReferences(resolved, targets); err != nil {
-		return resolved, err
+	return resolved, nil
+}
+
+// RequireFeatureMeters verifies that every supplied feature dependency can be
+// resolved, preserving each target's identity in the returned validation errors.
+func (r Resolver) RequireFeatureMeters[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) error {
+	featureMeters, err := r.Resolve(ctx, namespace, targets...)
+	if err != nil {
+		return err
 	}
 
-	return resolved, nil
+	errs := lo.Map(targets, func(target T, _ int) error {
+		if target.GetFeatureMeterRef() == nil {
+			return nil
+		}
+
+		_, err := featureMeters.Get(target)
+		return err
+	})
+
+	return errors.Join(errs...)
 }
 
 func collectUniqueFeatureMeterRefs[T billingfeaturemeter.FeatureReferenceGetter](references []T) []billingfeaturemeter.FeatureMeterRef {
@@ -175,19 +188,6 @@ func collectUniqueFeatureMeterRefs[T billingfeaturemeter.FeatureReferenceGetter]
 	)
 
 	return featureRefs
-}
-
-func validateReferences[T billingfeaturemeter.FeatureReferenceGetter](featureMeters billingfeaturemeter.FeatureMeters, targets []T) error {
-	errs := lo.FilterMap(targets, func(target T, _ int) (error, bool) {
-		if target.GetFeatureMeterRef() == nil {
-			return nil, false
-		}
-
-		_, err := featureMeters.Get(target)
-		return err, err != nil
-	})
-
-	return errors.Join(errs...)
 }
 
 func resolveFeatureMeters(features []feature.Feature) FeatureMeterCollection {

--- a/openmeter/billing/featuremeter/service/resolver_test.go
+++ b/openmeter/billing/featuremeter/service/resolver_test.go
@@ -165,7 +165,7 @@ func TestResolver(t *testing.T) {
 		require.Equal(t, meterID, byArchivedID.Meter.ID)
 	})
 
-	t.Run("returns partial results alongside validation errors", func(t *testing.T) {
+	t.Run("returns partial results without validating references", func(t *testing.T) {
 		// given:
 		// - one resolvable feature and one missing feature
 		targets := []featureMeterReference{
@@ -179,13 +179,15 @@ func TestResolver(t *testing.T) {
 		resolved, err := resolver.Resolve(t.Context(), namespace, targets...)
 
 		// then:
-		// - the resolved feature remains usable and the error contains validation issues only
+		// - resolution succeeds, the resolved feature remains usable, and validation is deferred to Get
 		require.NotNil(t, resolved)
+		require.NoError(t, err)
 		resolvedFeature, getErr := resolved.Get(targets[0])
 		require.NoError(t, getErr)
 		require.Equal(t, "feature-new", resolvedFeature.Feature.ID)
 
-		issues, systemErr := billing.ToValidationIssues(err)
+		_, getErr = resolved.Get(targets[1])
+		issues, systemErr := billing.ToValidationIssues(getErr)
 		require.NoError(t, systemErr)
 		require.Equal(t, billing.ValidationIssues{{
 			Severity: billing.ValidationIssueSeverityCritical,
@@ -194,7 +196,7 @@ func TestResolver(t *testing.T) {
 		}}, issues)
 	})
 
-	t.Run("returns meterless feature alongside validation error", func(t *testing.T) {
+	t.Run("returns meterless feature without validating meter requirements", func(t *testing.T) {
 		// given:
 		// - a feature exists but has no meter
 		resolver := newResolver(t, []string{"requests"}, nil)
@@ -208,13 +210,15 @@ func TestResolver(t *testing.T) {
 		resolved, err := resolver.Resolve(t.Context(), namespace, target)
 
 		// then:
-		// - the feature remains addressable and the missing meter is a validation-only error
+		// - resolution succeeds, the feature remains addressable, and Get enforces the meter requirement
 		require.NotNil(t, resolved)
+		require.NoError(t, err)
 		resolvedFeature, getErr := resolved.Get(featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: target.IDOrKey}))
 		require.NoError(t, getErr)
 		require.Equal(t, "feature-other", resolvedFeature.Feature.ID)
 
-		issues, systemErr := billing.ToValidationIssues(err)
+		_, getErr = resolved.Get(target)
+		issues, systemErr := billing.ToValidationIssues(getErr)
 		require.NoError(t, systemErr)
 		require.Equal(t, billing.ValidationIssues{{
 			Severity: billing.ValidationIssueSeverityCritical,
@@ -223,7 +227,7 @@ func TestResolver(t *testing.T) {
 		}}, issues)
 	})
 
-	t.Run("deduplicated lookup validates every original identified reference", func(t *testing.T) {
+	t.Run("require validates every original identified reference", func(t *testing.T) {
 		// given:
 		// - two gathering lines reference the same missing feature
 		resolver := newResolver(t, []string{"missing-feature"}, nil)
@@ -245,12 +249,11 @@ func TestResolver(t *testing.T) {
 		}
 
 		// when:
-		// - feature meters are resolved
-		resolved, err := resolver.Resolve(t.Context(), namespace, references...)
+		// - every feature meter is required
+		err := resolver.RequireFeatureMeters(t.Context(), namespace, references...)
 
 		// then:
 		// - the catalog lookup is deduplicated while each original line receives an issue
-		require.NotNil(t, resolved)
 		issues, systemErr := billing.ToValidationIssues(err)
 		require.NoError(t, systemErr)
 		require.ElementsMatch(t, []string{"/lines/line-1", "/lines/line-2"}, lo.Map(issues, func(issue billing.ValidationIssue, _ int) string {

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -1124,5 +1124,6 @@ func (i UpdateGatheringInvoiceInput) Validate() error {
 type PrepareBillableLinesInput = InvoicePendingLinesInput
 
 type PrepareBillableLinesResult struct {
-	LinesByCurrency map[currencyx.FiatCode]GatheringLines
+	LinesByCurrency            map[currencyx.FiatCode]GatheringLines
+	ValidationIssuesByCurrency map[currencyx.FiatCode]ValidationIssues
 }

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/samber/lo"
 
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -169,12 +168,39 @@ type (
 	OnPaymentSettledInput              = StandardLineEventInput
 )
 
-type IsLineBillableAsOfInput struct {
-	Line                   GatheringLine
-	AsOf                   time.Time
-	ProgressiveBilling     bool
-	FeatureMeters          billingfeaturemeter.FeatureMeters
-	ResolvedBillablePeriod timeutil.ClosedPeriod
+type AreLinesBillableAsOfInput struct {
+	Invoice            GatheringInvoice
+	AsOf               time.Time
+	ProgressiveBilling bool
+	Lines              GatheringLines
+}
+
+func (i AreLinesBillableAsOfInput) Validate() error {
+	var errs []error
+
+	if err := i.Invoice.GetInvoiceID().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invoice: %w", err))
+	}
+
+	if i.AsOf.IsZero() {
+		errs = append(errs, errors.New("as of is required"))
+	}
+
+	if err := i.Lines.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("lines: %w", err))
+	}
+
+	for index, line := range i.Lines {
+		if line.Namespace != i.Invoice.Namespace {
+			errs = append(errs, fmt.Errorf("line[%d]: namespace %s does not match invoice namespace %s", index, line.Namespace, i.Invoice.Namespace))
+		}
+
+		if line.InvoiceID != i.Invoice.ID {
+			errs = append(errs, fmt.Errorf("line[%d]: invoice ID %s does not match invoice ID %s", index, line.InvoiceID, i.Invoice.ID))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type IsLineBillableAsOfResult struct {
@@ -194,18 +220,6 @@ func (r IsLineBillableAsOfResult) Validate() error {
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
-func (i IsLineBillableAsOfInput) Validate() error {
-	if err := i.ResolvedBillablePeriod.Validate(); err != nil {
-		return fmt.Errorf("validating resolved billable period: %w", err)
-	}
-
-	if i.AsOf.IsZero() {
-		return fmt.Errorf("as of is required")
-	}
-
-	return nil
 }
 
 type GateInvoiceAssignmentInput struct {
@@ -256,9 +270,8 @@ func (r GateInvoiceAssignmentResult) Validate(input GateInvoiceAssignmentInput) 
 }
 
 type SplitGatheringLineInput struct {
-	Line          GatheringLine
-	FeatureMeters billingfeaturemeter.FeatureMeters
-	SplitAt       time.Time
+	Line    GatheringLine
+	SplitAt time.Time
 }
 
 func (i SplitGatheringLineInput) Validate() error {
@@ -270,10 +283,6 @@ func (i SplitGatheringLineInput) Validate() error {
 
 	if i.SplitAt.IsZero() {
 		errs = append(errs, fmt.Errorf("split at is required"))
-	}
-
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
 	}
 
 	return errors.Join(errs...)
@@ -304,8 +313,9 @@ type LineEngine interface {
 	// GetLineEngineType returns the discriminator owned by this engine implementation.
 	GetLineEngineType() LineEngineType
 
-	// IsLineBillableAsOf returns true if the line is billable as of the given time.
-	IsLineBillableAsOf(ctx context.Context, input IsLineBillableAsOfInput) (bool, error)
+	// AreLinesBillableAsOf returns one result for each line in the same order. Implementations may return usable
+	// results together with validation issues. Operational errors make the returned results unusable.
+	AreLinesBillableAsOf(ctx context.Context, input AreLinesBillableAsOfInput) ([]IsLineBillableAsOfResult, error)
 	// GateInvoiceAssignment decides which otherwise billable gathering lines may be assigned to an invoice.
 	// Implementations may persist engine-owned state explaining blocked decisions. Returning an error aborts
 	// invoice creation and rolls back those writes.

--- a/openmeter/billing/lineengine/engine_test.go
+++ b/openmeter/billing/lineengine/engine_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -134,6 +135,100 @@ func TestSnapshotLineQuantitiesRejectsResolverSystemErrors(t *testing.T) {
 	require.Nil(t, issues)
 	require.ErrorIs(t, systemErr, resolverErr)
 	require.Nil(t, line.UsageBased.Quantity)
+}
+
+func TestAreLinesBillableAsOfLocalizesFeatureMeterValidationIssues(t *testing.T) {
+	period := lineEngineOverrideTestPeriod()
+	engine, _ := newQuantitySnapshotTestEngine(t, nil, nil, nil)
+	ratingService := &lineEngineBillabilityRatingService{}
+	engine.ratingService = ratingService
+
+	lines := billing.GatheringLines{
+		billabilityGatheringLine("line-1", "missing-feature-1", period),
+		billabilityGatheringLine("line-2", "missing-feature-2", period),
+	}
+
+	// Given multiple legacy lines whose feature references cannot be resolved.
+	// When their billability is evaluated from the resolver's partial result.
+	results, err := engine.AreLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "namespace",
+				ID:        "invoice-id",
+				Name:      "invoice",
+				CreatedAt: period.From,
+				UpdatedAt: period.From,
+			}),
+		}},
+		AsOf:               period.From,
+		ProgressiveBilling: true,
+		Lines:              lines,
+	})
+
+	// Then every line receives a fallback result and its own localized validation issue.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.ElementsMatch(t, billing.ValidationIssues{
+		{
+			Severity: billing.ValidationIssueSeverityCritical,
+			Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+			Message:  "feature[missing-feature-1]: invoice line: feature not found",
+			Path:     "/lines/line-1",
+		},
+		{
+			Severity: billing.ValidationIssueSeverityCritical,
+			Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+			Message:  "feature[missing-feature-2]: invoice line: feature not found",
+			Path:     "/lines/line-2",
+		},
+	}, issues)
+	require.Len(t, results, len(lines))
+	require.Len(t, ratingService.inputs, len(lines))
+	for index := range lines {
+		require.True(t, results[index].Billable)
+		require.Equal(t, period, results[index].BillablePeriod)
+		require.Nil(t, ratingService.inputs[index].Feature)
+		require.Nil(t, ratingService.inputs[index].Meter)
+	}
+}
+
+type lineEngineBillabilityRatingService struct {
+	inputs []rating.ResolveBillablePeriodInput
+}
+
+func (s *lineEngineBillabilityRatingService) ResolveBillablePeriod(input rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
+	s.inputs = append(s.inputs, input)
+
+	return billing.IsLineBillableAsOfResult{
+		Billable:       true,
+		BillablePeriod: input.Line.GetServicePeriod(),
+	}, nil
+}
+
+func (*lineEngineBillabilityRatingService) GenerateDetailedLines(rating.StandardLineAccessor, ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
+	return rating.GenerateDetailedLinesResult{}, nil
+}
+
+func billabilityGatheringLine(id, featureKey string, period timeutil.ClosedPeriod) billing.GatheringLine {
+	return billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			Namespace: "namespace",
+			ID:        id,
+			Name:      id,
+			CreatedAt: period.From,
+			UpdatedAt: period.From,
+		}),
+		ManagedBy:     billing.SystemManagedLine,
+		Engine:        billing.LineEngineTypeInvoice,
+		InvoiceID:     "invoice-id",
+		Currency:      "USD",
+		ServicePeriod: period,
+		InvoiceAt:     period.From,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+		FeatureKey: featureKey,
+	}}
 }
 
 func TestLineEngineValidationErrorOwnsValidationIssues(t *testing.T) {

--- a/openmeter/billing/lineengine/quantitysnapshot.go
+++ b/openmeter/billing/lineengine/quantitysnapshot.go
@@ -53,12 +53,7 @@ func (e *Engine) SnapshotLineQuantity(ctx context.Context, input SnapshotLineQua
 func (e *Engine) SnapshotLineQuantities(ctx context.Context, invoice billing.StandardInvoice, lines billing.StandardLines) error {
 	featureMeters, err := e.featureMeterResolver.Resolve(ctx, invoice.Namespace, lines...)
 	if err != nil {
-		// Per-line snapshotting below surfaces validation issues with line identity,
-		// so only system errors abort the batch here.
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return fmt.Errorf("resolving feature meters: %w", systemErr)
-		}
+		return fmt.Errorf("resolving feature meters: %w", err)
 	}
 
 	if err := e.snapshotLineQuantitiesInParallel(ctx, invoice.Customer, lines, featureMeters); err != nil {

--- a/openmeter/billing/lineengine/stdinvoice.go
+++ b/openmeter/billing/lineengine/stdinvoice.go
@@ -2,12 +2,13 @@ package lineengine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
@@ -92,12 +93,41 @@ func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.Stan
 	return input.Lines, nil
 }
 
-func (e *Engine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *Engine) AreLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
 	if err := input.Validate(); err != nil {
-		return false, fmt.Errorf("validating input: %w", err)
+		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
-	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
+	featureMeters, err := e.featureMeterResolver.Resolve(ctx, input.Invoice.Namespace, input.Lines...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving feature meters: %w", err)
+	}
+
+	return slicesx.MapWithErrPreservingResults(input.Lines, func(line billing.GatheringLine, _ int) (billing.IsLineBillableAsOfResult, error) {
+		var errs []error
+		ratingInput := rating.ResolveBillablePeriodInput{
+			Line:               line,
+			ProgressiveBilling: input.ProgressiveBilling,
+			AsOf:               input.AsOf,
+		}
+
+		if line.GetFeatureMeterRef() != nil {
+			featureMeter, err := featureMeters.Get(line)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				ratingInput.Feature = &featureMeter.Feature
+				ratingInput.Meter = featureMeter.Meter
+			}
+		}
+
+		result, err := e.ratingService.ResolveBillablePeriod(ratingInput)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("resolving billable period for line[%s]: %w", line.ID, err))
+		}
+
+		return result, errors.Join(errs...)
+	})
 }
 
 func (e *Engine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/rating/line.go
+++ b/openmeter/billing/rating/line.go
@@ -6,7 +6,6 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -15,12 +14,10 @@ import (
 type PriceAccessor interface {
 	GetPrice() *productcatalog.Price
 	GetServicePeriod() timeutil.ClosedPeriod
-	GetFeatureKey() string
 }
 
 type GatheringLineAccessor interface {
 	PriceAccessor
-	billingfeaturemeter.FeatureReferenceGetter
 	GetSplitLineGroupID() *string
 	GetInvoiceAt() time.Time
 	GetID() string

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -1,14 +1,16 @@
 package rating
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
 type Service interface {
@@ -65,21 +67,33 @@ type ResolveBillablePeriodInput struct {
 	AsOf               time.Time
 	ProgressiveBilling bool
 	Line               GatheringLineAccessor
-	FeatureMeters      billingfeaturemeter.FeatureMeters
+	Feature            *feature.Feature
+	Meter              *meter.Meter
 }
 
 func (i ResolveBillablePeriodInput) Validate() error {
-	if i.Line == nil {
-		return fmt.Errorf("line is required")
-	}
+	var errs []error
 
-	if i.FeatureMeters == nil {
-		return fmt.Errorf("feature meters are required")
+	if i.Line == nil {
+		errs = append(errs, errors.New("line is required"))
+	} else {
+		price := i.Line.GetPrice()
+		if price == nil {
+			errs = append(errs, errors.New("line price is required"))
+		} else if price.Type() != productcatalog.FlatPriceType {
+			if i.Feature == nil {
+				errs = append(errs, errors.New("feature is required for metered lines"))
+			}
+
+			if i.Meter == nil {
+				errs = append(errs, errors.New("meter is required for metered lines"))
+			}
+		}
 	}
 
 	if i.AsOf.IsZero() {
-		return fmt.Errorf("as of is required")
+		errs = append(errs, errors.New("as of is required"))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/meter"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
@@ -80,14 +79,6 @@ func (i ResolveBillablePeriodInput) Validate() error {
 		price := i.Line.GetPrice()
 		if price == nil {
 			errs = append(errs, errors.New("line price is required"))
-		} else if price.Type() != productcatalog.FlatPriceType {
-			if i.Feature == nil {
-				errs = append(errs, errors.New("feature is required for metered lines"))
-			}
-
-			if i.Meter == nil {
-				errs = append(errs, errors.New("meter is required for metered lines"))
-			}
 		}
 	}
 

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type Service interface {
@@ -86,5 +87,5 @@ func (i ResolveBillablePeriodInput) Validate() error {
 		errs = append(errs, errors.New("as of is required"))
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
 func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (billing.IsLineBillableAsOfResult, error) {
@@ -24,14 +25,22 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 		return billing.IsLineBillableAsOfResult{}, fmt.Errorf("price is nil")
 	}
 
-	meterTypeAllowsProgressiveBilling := false
-	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling {
-		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters(in)
+	progressiveBillingAllowed := false
+	// We can allow progressive billing only if:
+	// - the line is not flat price (=> usage based)
+	// - the usage based line's features can be resolved
+	//
+	// As any usage-based line is billable in arrears, thus we are safe to continue with non-progressive billing.
+	//
+	// By allowing empty feature/meter for usage-based lines we can create a standard invoice which immediately
+	// enters into failed state, thus we are communicating the issue to the user.
+	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling && in.Feature != nil && in.Meter != nil {
+		progressiveBillingAllowed = isDependingOnIncreaseOnlyMeters(in)
 	}
 
-	// Force disable progressive billing if the meter type does not allow it
-	if !meterTypeAllowsProgressiveBilling {
-		in.ProgressiveBilling = false
+	in.ProgressiveBilling = progressiveBillingAllowed
+	if !in.ProgressiveBilling && in.AsOf.Truncate(streaming.MinimumWindowSizeDuration).Before(in.Line.GetInvoiceAt().Truncate(streaming.MinimumWindowSizeDuration)) {
+		return billing.IsLineBillableAsOfResult{}, nil
 	}
 
 	result, err := linePricer.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -26,12 +26,7 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 
 	meterTypeAllowsProgressiveBilling := false
 	if linePrice.Type() != productcatalog.FlatPriceType && in.ProgressiveBilling {
-		isDependingOnIncreaseOnlyMeters, err := isDependingOnIncreaseOnlyMeters(in)
-		if err != nil {
-			return billing.IsLineBillableAsOfResult{}, err
-		}
-
-		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters
+		meterTypeAllowsProgressiveBilling = isDependingOnIncreaseOnlyMeters(in)
 	}
 
 	// Force disable progressive billing if the meter type does not allow it
@@ -43,7 +38,8 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 		AsOf:               in.AsOf,
 		ProgressiveBilling: in.ProgressiveBilling,
 		Line:               in.Line,
-		FeatureMeters:      in.FeatureMeters,
+		Feature:            in.Feature,
+		Meter:              in.Meter,
 	})
 	if err != nil {
 		return billing.IsLineBillableAsOfResult{}, err
@@ -58,30 +54,13 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (b
 
 // isDependingOnIncreaseOnlyMeters checks if the line is depending on meters that can decrease the totals over time
 // (note: this is somewhat of a lie, as we can input negative values in events, which will have the same effect)
-func isDependingOnIncreaseOnlyMeters(in rating.ResolveBillablePeriodInput) (bool, error) {
-	featureKey := in.Line.GetFeatureKey()
-	if featureKey == "" {
-		return false, fmt.Errorf("feature key is required")
-	}
-
-	// Let's check if the underlying meter can be billed in a progressive manner
-	featureMeter, err := in.FeatureMeters.Get(in.Line)
-	if err != nil {
-		return false, err
-	}
-
-	if featureMeter.Meter == nil {
-		return false, fmt.Errorf("meter is nil for feature[%s]", featureKey)
-	}
-
-	meterEntity := *featureMeter.Meter
-
-	switch meterEntity.Aggregation {
+func isDependingOnIncreaseOnlyMeters(in rating.ResolveBillablePeriodInput) bool {
+	switch in.Meter.Aggregation {
 	case meter.MeterAggregationSum, meter.MeterAggregationCount,
 		meter.MeterAggregationMax, meter.MeterAggregationUniqueCount:
-		return true, nil
+		return true
 	default:
 		// Other types need to be billed in arrears truncated by window size
-		return false, nil
+		return false
 	}
 }

--- a/openmeter/billing/rating/service/billableperiod_test.go
+++ b/openmeter/billing/rating/service/billableperiod_test.go
@@ -1,0 +1,88 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	ratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestResolveBillablePeriodFallsBackToNonProgressiveBillingWithoutDependencies(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	invoiceAt := period.To.Add(24 * time.Hour)
+	line := billing.GatheringLine{GatheringLineBase: billing.GatheringLineBase{
+		ServicePeriod: period,
+		InvoiceAt:     invoiceAt,
+		Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}}
+	service := ratingservice.New(ratingservice.Config{})
+
+	t.Run("valid dependencies allow progressive billing", func(t *testing.T) {
+		// Given a progressively billable metered line with its rating dependencies.
+		asOf := period.From.Add(12 * time.Hour)
+
+		// When billability is resolved before the normal invoice time.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               asOf,
+			ProgressiveBilling: true,
+			Line:               line,
+			Feature:            &feature.Feature{},
+			Meter:              &meter.Meter{Aggregation: meter.MeterAggregationSum},
+		})
+
+		// Then the elapsed portion is billable progressively.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{
+			Billable: true,
+			BillablePeriod: timeutil.ClosedPeriod{
+				From: period.From,
+				To:   asOf,
+			},
+		}, result)
+	})
+
+	t.Run("missing dependencies defer billing until invoice at", func(t *testing.T) {
+		// Given the same line without a resolvable feature or meter.
+		// When billability is resolved after service completion but before InvoiceAt.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               period.To,
+			ProgressiveBilling: true,
+			Line:               line,
+		})
+
+		// Then progressive billing is disabled and the line is not yet billable.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{}, result)
+	})
+
+	t.Run("missing dependencies yield the full period at invoice at", func(t *testing.T) {
+		// Given the same line without a resolvable feature or meter.
+		// When its normal invoice time is reached.
+		result, err := service.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
+			AsOf:               invoiceAt,
+			ProgressiveBilling: true,
+			Line:               line,
+		})
+
+		// Then the complete service period is billable non-progressively.
+		require.NoError(t, err)
+		require.Equal(t, billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: period,
+		}, result)
+	})
+}

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -60,14 +60,13 @@ func TestResolveBillablePeriodInputValidate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("metered lines require a feature and meter", func(t *testing.T) {
+	t.Run("metered lines allow unresolved rating dependencies", func(t *testing.T) {
 		err := (rating.ResolveBillablePeriodInput{
 			AsOf: asOf,
 			Line: meteredLine,
 		}).Validate()
 
-		require.ErrorContains(t, err, "feature is required for metered lines")
-		require.ErrorContains(t, err, "meter is required for metered lines")
+		require.NoError(t, err)
 	})
 
 	t.Run("rating does not validate the feature meter association", func(t *testing.T) {

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -1,0 +1,86 @@
+package rating_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type gatheringLine struct {
+	price *productcatalog.Price
+}
+
+func (l gatheringLine) GetPrice() *productcatalog.Price {
+	return l.price
+}
+
+func (gatheringLine) GetServicePeriod() timeutil.ClosedPeriod {
+	return timeutil.ClosedPeriod{}
+}
+
+func (gatheringLine) GetSplitLineGroupID() *string {
+	return nil
+}
+
+func (gatheringLine) GetInvoiceAt() time.Time {
+	return time.Time{}
+}
+
+func (gatheringLine) GetID() string {
+	return "line"
+}
+
+func TestResolveBillablePeriodInputValidate(t *testing.T) {
+	flatLine := gatheringLine{
+		price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}
+	meteredLine := gatheringLine{
+		price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+			Amount: alpacadecimal.NewFromInt(1),
+		}),
+	}
+	asOf := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
+
+	t.Run("flat lines do not require feature dependencies", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: flatLine,
+		}).Validate()
+
+		require.NoError(t, err)
+	})
+
+	t.Run("metered lines require a feature and meter", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: meteredLine,
+		}).Validate()
+
+		require.ErrorContains(t, err, "feature is required for metered lines")
+		require.ErrorContains(t, err, "meter is required for metered lines")
+	})
+
+	t.Run("rating does not validate the feature meter association", func(t *testing.T) {
+		differentMeterID := "different-meter"
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: meteredLine,
+			Feature: &feature.Feature{
+				MeterID: &differentMeterID,
+			},
+			Meter: &meter.Meter{},
+		}).Validate()
+
+		require.NoError(t, err)
+	})
+}

--- a/openmeter/billing/rating/service_test.go
+++ b/openmeter/billing/rating/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -81,5 +82,23 @@ func TestResolveBillablePeriodInputValidate(t *testing.T) {
 		}).Validate()
 
 		require.NoError(t, err)
+	})
+
+	t.Run("missing line and as of return a generic validation error", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{}).Validate()
+
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "line is required")
+		require.ErrorContains(t, err, "as of is required")
+	})
+
+	t.Run("missing line price returns a generic validation error", func(t *testing.T) {
+		err := (rating.ResolveBillablePeriodInput{
+			AsOf: asOf,
+			Line: gatheringLine{},
+		}).Validate()
+
+		require.True(t, models.IsGenericValidationError(err))
+		require.ErrorContains(t, err, "line price is required")
 	})
 }

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -8,13 +8,8 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
-	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/meter"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -182,18 +177,8 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 			}
 		}
 
-		featureMeters, err := s.featureMeterResolver.Resolve(ctx, invoice.Namespace, invoice.Lines.OrEmpty()...)
-		if err != nil {
-			// Quantity snapshotting surfaces validation issues with line identity when
-			// these gathering lines are collected, so only system errors abort here.
-			_, systemErr := billing.ToValidationIssues(err)
-			if systemErr != nil {
-				return billing.GatheringInvoice{}, fmt.Errorf("resolving feature meters: %w", systemErr)
-			}
-		}
-
 		// Check if the new lines are still invoicable
-		if err := s.checkIfGatheringLinesAreInvoicable(ctx, invoice, customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling, featureMeters); err != nil {
+		if err := s.checkIfGatheringLinesAreInvoicable(ctx, invoice, customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling); err != nil {
 			return billing.GatheringInvoice{}, err
 		}
 
@@ -226,60 +211,33 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 	})
 }
 
-func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice billing.GatheringInvoice, progressiveBilling bool, featureMeters billingfeaturemeter.FeatureMeters) error {
+func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice billing.GatheringInvoice, progressiveBilling bool) error {
 	linesToCheck := lo.Filter(invoice.Lines.OrEmpty(), func(line billing.GatheringLine, _ int) bool {
 		return line.DeletedAt == nil
 	})
 
-	return errors.Join(
-		lo.Map(linesToCheck, func(line billing.GatheringLine, _ int) error {
-			if err := line.Validate(); err != nil {
-				return fmt.Errorf("validating line[%s]: %w", line.ID, err)
-			}
+	var errs []error
+	for _, line := range linesToCheck {
+		// Note: this is considered a low frequency operation, so we are not using the batch API here.
+		// Current implementation focuses on main use-cases and readability over the performance of this operation.
+		results, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            invoice,
+			AsOf:               line.InvoiceAt,
+			ProgressiveBilling: progressiveBilling,
+			Lines:              billing.GatheringLines{line},
+		})
+		if err != nil {
+			return err
+		}
 
-			featureEntity, meterEntity, err := resolveRatingDependencies(line, featureMeters)
-			if err != nil {
-				return fmt.Errorf("resolving rating dependencies for line[%s]: %w", line.ID, err)
-			}
-
-			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
-				Line:               line,
-				Feature:            featureEntity,
-				Meter:              meterEntity,
-				ProgressiveBilling: progressiveBilling,
-				AsOf:               line.InvoiceAt,
+		if len(results) != 1 || !results[0].Billable {
+			errs = append(errs, billing.ValidationError{
+				Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.InvoiceAt),
 			})
-			if err != nil {
-				return fmt.Errorf("checking if line[%s] can be invoiced: %w", line.ID, err)
-			}
-
-			if !result.Billable {
-				return billing.ValidationError{
-					Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.InvoiceAt),
-				}
-			}
-
-			return nil
-		})...,
-	)
-}
-
-func resolveRatingDependencies(line billing.GatheringLine, featureMeters billingfeaturemeter.FeatureMeters) (*feature.Feature, *meter.Meter, error) {
-	price := line.GetPrice()
-	if price == nil {
-		return nil, nil, errors.New("line price is required")
+		}
 	}
 
-	if price.Type() == productcatalog.FlatPriceType {
-		return nil, nil, nil
-	}
-
-	featureMeter, err := featureMeters.Get(line)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &featureMeter.Feature, featureMeter.Meter, nil
+	return errors.Join(errs...)
 }
 
 func (s *Service) GetGatheringInvoiceById(ctx context.Context, input billing.GetGatheringInvoiceByIdInput) (billing.GatheringInvoice, error) {

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -12,6 +12,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -233,9 +236,16 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 			if err := line.Validate(); err != nil {
 				return fmt.Errorf("validating line[%s]: %w", line.ID, err)
 			}
+
+			featureEntity, meterEntity, err := resolveRatingDependencies(line, featureMeters)
+			if err != nil {
+				return fmt.Errorf("resolving rating dependencies for line[%s]: %w", line.ID, err)
+			}
+
 			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
-				FeatureMeters:      featureMeters,
+				Feature:            featureEntity,
+				Meter:              meterEntity,
 				ProgressiveBilling: progressiveBilling,
 				AsOf:               line.InvoiceAt,
 			})
@@ -252,6 +262,24 @@ func (s Service) checkIfGatheringLinesAreInvoicable(ctx context.Context, invoice
 			return nil
 		})...,
 	)
+}
+
+func resolveRatingDependencies(line billing.GatheringLine, featureMeters billingfeaturemeter.FeatureMeters) (*feature.Feature, *meter.Meter, error) {
+	price := line.GetPrice()
+	if price == nil {
+		return nil, nil, errors.New("line price is required")
+	}
+
+	if price.Type() == productcatalog.FlatPriceType {
+		return nil, nil, nil
+	}
+
+	featureMeter, err := featureMeters.Get(line)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &featureMeter.Feature, featureMeter.Meter, nil
 }
 
 func (s *Service) GetGatheringInvoiceById(ctx context.Context, input billing.GetGatheringInvoiceByIdInput) (billing.GatheringInvoice, error) {

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -81,6 +81,7 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 					Customer:          input.Customer,
 					Currency:          currency,
 					Lines:             inScopeLines,
+					ValidationIssues:  billableLines.ValidationIssuesByCurrency[currency],
 					ForceAsyncAdvance: input.ForceAsyncAdvance,
 				})
 				if err != nil {
@@ -173,7 +174,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			// let's gather the in-scope lines and validate it
-			inScopeLinesByCurrency, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
+			inScopeLinesResult, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
 				GatheringInvoicesByCurrency: invoicesByCurrency,
 				LinesToInclude:              input.IncludePendingLines,
 				AsOf:                        asOf,
@@ -184,10 +185,13 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			linesToBeBilledByCurrency := make(map[currencyx.FiatCode]billing.GatheringLines)
+			validationIssuesByCurrency := make(map[currencyx.FiatCode]billing.ValidationIssues)
 			assignmentCandidateLineCount := 0
 			assignmentExcludedLineCount := 0
 
-			for currency, inScopeLines := range inScopeLinesByCurrency {
+			for currency, inScopeLines := range inScopeLinesResult.LinesByCurrency {
+				// Let's first make sure we have properly split the progressively billed
+				// lines into multiple lines on the gathering invoice if needed.
 				gatheringInvoice, ok := invoicesByCurrency[currency]
 				if !ok {
 					return nil, fmt.Errorf("gathering invoice for currency [%s] not found", currency)
@@ -220,6 +224,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 					inScopeLines = limitGatheringLinesForInvoice(inScopeLines, options.MaxLinesPerInvoice)
 				}
 
+				billabilityValidationIssues := inScopeLinesResult.ValidationIssuesByCurrency[currency]
 				// Step 1: Let's make sure we have lines properly split on the gathering invoice.
 				// Invariant: the gathering invoice is updated to contain the new lines if any were split.
 				prepareResults, err := s.prepareLinesToBill(ctx, prepareLinesToBillInput{
@@ -234,7 +239,24 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 					continue
 				}
 
+				if len(billabilityValidationIssues) > 0 {
+					_, billabilityErr := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+						Invoice:            prepareResults.GatheringInvoice,
+						AsOf:               asOf,
+						ProgressiveBilling: progressiveBilling,
+						Lines:              prepareResults.LinesToBill,
+					})
+					selectedValidationIssues, systemErr := billing.ToValidationIssues(billabilityErr)
+					if systemErr != nil {
+						return nil, fmt.Errorf("checking selected gathering line billability: %w", systemErr)
+					}
+					billabilityValidationIssues = selectedValidationIssues
+				}
+
 				linesToBeBilledByCurrency[currency] = prepareResults.LinesToBill
+				if len(billabilityValidationIssues) > 0 {
+					validationIssuesByCurrency[currency] = billabilityValidationIssues
+				}
 			}
 
 			totalLinesToBeBilled := 0
@@ -255,7 +277,8 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			return &billing.PrepareBillableLinesResult{
-				LinesByCurrency: linesToBeBilledByCurrency,
+				LinesByCurrency:            linesToBeBilledByCurrency,
+				ValidationIssuesByCurrency: validationIssuesByCurrency,
 			}, nil
 		},
 	)
@@ -317,10 +340,16 @@ type gatherInScopeLineInput struct {
 	ProgressiveBilling bool
 }
 
-type gatherInScopeLinesResult map[currencyx.FiatCode][]gatheringLineWithBillablePeriod
+type gatherInScopeLinesResult struct {
+	LinesByCurrency            map[currencyx.FiatCode][]gatheringLineWithBillablePeriod
+	ValidationIssuesByCurrency map[currencyx.FiatCode]billing.ValidationIssues
+}
 
 func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineInput) (gatherInScopeLinesResult, error) {
-	res := make(gatherInScopeLinesResult)
+	res := gatherInScopeLinesResult{
+		LinesByCurrency:            make(map[currencyx.FiatCode][]gatheringLineWithBillablePeriod),
+		ValidationIssuesByCurrency: make(map[currencyx.FiatCode]billing.ValidationIssues),
+	}
 
 	billableLineIDs := make(map[string]interface{})
 
@@ -332,10 +361,12 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			ProgressiveBilling: in.ProgressiveBilling,
 			Lines:              lines,
 		})
-		if err != nil && !billing.IsValidationIssueOnly(err) {
-			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		validationIssues, systemErr := billing.ToValidationIssues(err)
+		if systemErr != nil {
+			return gatherInScopeLinesResult{}, fmt.Errorf("checking gathering line billability: %w", systemErr)
 		}
-		if err != nil {
+		if len(validationIssues) > 0 {
+			res.ValidationIssuesByCurrency[currency] = validationIssues
 			s.logger.WarnContext(
 				ctx, "gathering line billability has validation issues; continuing with fallback results",
 				"namespace", invoice.Namespace,
@@ -366,7 +397,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			billableLineIDs[line.Line.ID] = struct{}{}
 		}
 
-		res[currency] = linesWithResolvedPeriods
+		res.LinesByCurrency[currency] = linesWithResolvedPeriods
 	}
 
 	// If the user has requested specific lines to be included, we need to filter the output to only include those lines
@@ -382,7 +413,7 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 		}
 
 		if len(nonBillableLineIDs) > 0 {
-			return nil, billing.ValidationError{
+			return gatherInScopeLinesResult{}, billing.ValidationError{
 				Err: fmt.Errorf("%w: %s", billing.ErrInvoiceLinesNotBillable, strings.Join(nonBillableLineIDs, ",")),
 			}
 		}
@@ -393,14 +424,15 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			return lineID, struct{}{}
 		})
 
-		for currency, lines := range res {
-			res[currency] = lo.Filter(lines, func(line gatheringLineWithBillablePeriod, _ int) bool {
+		for currency, lines := range res.LinesByCurrency {
+			res.LinesByCurrency[currency] = lo.Filter(lines, func(line gatheringLineWithBillablePeriod, _ int) bool {
 				_, ok := linesShouldBeIncluded[line.Line.ID]
 				return ok
 			})
 
-			if len(res[currency]) == 0 {
-				delete(res, currency)
+			if len(res.LinesByCurrency[currency]) == 0 {
+				delete(res.LinesByCurrency, currency)
+				delete(res.ValidationIssuesByCurrency, currency)
 			}
 		}
 	}
@@ -528,7 +560,7 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 		return false, fmt.Errorf("gathering in scope lines: %w", err)
 	}
 
-	res, found := inScopeLines[in.Invoice.Currency]
+	res, found := inScopeLines.LinesByCurrency[in.Invoice.Currency]
 	if !found {
 		return false, nil
 	}
@@ -727,6 +759,11 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 
 	// let's set the workflow apps as some checks such as CanDraftSyncAdvance depends on the apps
 	invoice.Workflow.Apps = profile.MergedProfile.Apps
+	validationIssues, err := in.ValidationIssues.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning validation issues: %w", err)
+	}
+	invoice.ValidationIssues = append(invoice.ValidationIssues, validationIssues...)
 
 	linesWithEngines, err := s.lineEngines.groupGatheringLinesByEngine(in.Lines)
 	if err != nil {
@@ -924,7 +961,11 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 			return billing.StandardInvoice{}, fmt.Errorf("validating standard invoice created input for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
 		}
 
+		var requestValidationError billing.ValidationError
 		lines, err := grouped.Engine.OnStandardInvoiceCreated(ctx, input)
+		if errors.As(err, &requestValidationError) {
+			return billing.StandardInvoice{}, err
+		}
 		validationIssues, systemErr := billing.ToValidationIssues(err)
 		if systemErr != nil {
 			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), systemErr)

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -12,15 +12,12 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
-	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
-	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -167,27 +164,9 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 				}
 			}
 
-			invoicesByCurrency := lo.SliceToMap(existingGatheringInvoices.Items, func(i billing.GatheringInvoice) (currencyx.FiatCode, gatheringInvoiceWithFeatureMeters) {
-				return i.Currency, gatheringInvoiceWithFeatureMeters{
-					Invoice: i,
-				}
+			invoicesByCurrency := lo.SliceToMap(existingGatheringInvoices.Items, func(invoice billing.GatheringInvoice) (currencyx.FiatCode, billing.GatheringInvoice) {
+				return invoice.Currency, invoice
 			})
-
-			// Let's resolve the feature meters for each gathering invoice line for downstream calculations.
-			for currency, gatheringInvoiceWithCurrency := range invoicesByCurrency {
-				featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, invoicesByCurrency[currency].Invoice.Lines.OrEmpty()...)
-				if err != nil {
-					// Quantity snapshotting surfaces validation issues with line identity,
-					// so only system errors abort line preparation here.
-					_, systemErr := billing.ToValidationIssues(err)
-					if systemErr != nil {
-						return nil, fmt.Errorf("resolving feature meters: %w", systemErr)
-					}
-				}
-
-				gatheringInvoiceWithCurrency.FeatureMeters = featureMeters
-				invoicesByCurrency[currency] = gatheringInvoiceWithCurrency
-			}
 
 			if len(invoicesByCurrency) != len(existingGatheringInvoices.Items) {
 				return nil, fmt.Errorf("customer has multiple gathering invoices for the same currency: %d", len(invoicesByCurrency))
@@ -244,8 +223,7 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 				// Step 1: Let's make sure we have lines properly split on the gathering invoice.
 				// Invariant: the gathering invoice is updated to contain the new lines if any were split.
 				prepareResults, err := s.prepareLinesToBill(ctx, prepareLinesToBillInput{
-					GatheringInvoice: gatheringInvoice.Invoice,
-					FeatureMeters:    gatheringInvoice.FeatureMeters,
+					GatheringInvoice: gatheringInvoice,
 					InScopeLines:     inScopeLines,
 				})
 				if err != nil {
@@ -329,13 +307,8 @@ type gatheringLineWithBillablePeriod struct {
 	Engine         billing.LineEngine
 }
 
-type gatheringInvoiceWithFeatureMeters struct {
-	Invoice       billing.GatheringInvoice
-	FeatureMeters billingfeaturemeter.FeatureMeters
-}
-
 type gatherInScopeLineInput struct {
-	GatheringInvoicesByCurrency map[currencyx.FiatCode]gatheringInvoiceWithFeatureMeters
+	GatheringInvoicesByCurrency map[currencyx.FiatCode]billing.GatheringInvoice
 	// If set restricts the lines to be included to these IDs, otherwise the AsOf is used
 	// to determine the lines to be included.
 	LinesToInclude     mo.Option[[]string]
@@ -353,67 +326,30 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
 
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
-		linesWithResolvedPeriods, err := slicesx.MapWithErr(invoice.Invoice.Lines.OrEmpty(), func(line billing.GatheringLine) (gatheringLineWithBillablePeriod, error) {
-			featureEntity, meterEntity, err := resolveRatingDependencies(line, invoice.FeatureMeters)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving rating dependencies[%s]: %w", line.ID, err)
-			}
-
-			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
-				Line:               line,
-				Feature:            featureEntity,
-				Meter:              meterEntity,
-				ProgressiveBilling: in.ProgressiveBilling,
-				AsOf:               in.AsOf,
-			})
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving billable period[%s]: %w", line.ID, err)
-			}
-
-			eng, err := s.lineEngines.Get(line.Engine)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("getting engine[%s]: %w", line.ID, err)
-			}
-
-			engineInput := billing.IsLineBillableAsOfInput{
-				Line:                   line,
-				AsOf:                   in.AsOf,
-				ProgressiveBilling:     in.ProgressiveBilling,
-				FeatureMeters:          invoice.FeatureMeters,
-				ResolvedBillablePeriod: result.BillablePeriod,
-			}
-			if err := engineInput.Validate(); err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("validating billable status input[%s]: %w", line.ID, err)
-			}
-
+		lines := invoice.Lines.OrEmpty()
+		billabilityResults, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            invoice,
+			AsOf:               in.AsOf,
+			ProgressiveBilling: in.ProgressiveBilling,
+			Lines:              lines,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		}
+		linesWithResolvedPeriods := lo.Map(billabilityResults, func(result gatheringLineBillabilityResult, index int) gatheringLineWithBillablePeriod {
 			if !result.Billable {
 				return gatheringLineWithBillablePeriod{
-					Line:   line,
-					Engine: eng,
-				}, nil
-			}
-
-			isBillable, err := eng.IsLineBillableAsOf(ctx, engineInput)
-			if err != nil {
-				return gatheringLineWithBillablePeriod{}, fmt.Errorf("checking billable status[%s]: %w", line.ID, err)
-			}
-
-			if !isBillable {
-				return gatheringLineWithBillablePeriod{
-					Line:   line,
-					Engine: eng,
-				}, nil
+					Line:   lines[index],
+					Engine: result.Engine,
+				}
 			}
 
 			return gatheringLineWithBillablePeriod{
-				Line:           line,
+				Line:           lines[index],
 				BillablePeriod: result.BillablePeriod,
-				Engine:         eng,
-			}, nil
+				Engine:         result.Engine,
+			}
 		})
-		if err != nil {
-			return nil, fmt.Errorf("gathering lines with resolved periods: %w", err)
-		}
 
 		linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
 			return !lo.IsEmpty(line.BillablePeriod)
@@ -568,7 +504,6 @@ func limitGatheringLinesForInvoice(lines []gatheringLineWithBillablePeriod, maxL
 type hasInvoicableLinesInput struct {
 	Invoice            billing.GatheringInvoice
 	AsOf               time.Time
-	FeatureMeters      billingfeaturemeter.FeatureMeters
 	ProgressiveBilling bool
 }
 
@@ -583,10 +518,6 @@ func (i hasInvoicableLinesInput) Validate() error {
 		errs = append(errs, fmt.Errorf("asOf time must not be zero"))
 	}
 
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
-	}
-
 	return errors.Join(errs...)
 }
 
@@ -596,11 +527,8 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 	}
 
 	inScopeLines, err := s.gatherInScopeLines(ctx, gatherInScopeLineInput{
-		GatheringInvoicesByCurrency: map[currencyx.FiatCode]gatheringInvoiceWithFeatureMeters{
-			in.Invoice.Currency: {
-				Invoice:       in.Invoice,
-				FeatureMeters: in.FeatureMeters,
-			},
+		GatheringInvoicesByCurrency: map[currencyx.FiatCode]billing.GatheringInvoice{
+			in.Invoice.Currency: in.Invoice,
 		},
 		AsOf:               in.AsOf,
 		ProgressiveBilling: in.ProgressiveBilling,
@@ -619,7 +547,6 @@ func (s *Service) hasInvoicableLines(ctx context.Context, in hasInvoicableLinesI
 
 type prepareLinesToBillInput struct {
 	GatheringInvoice billing.GatheringInvoice
-	FeatureMeters    billingfeaturemeter.FeatureMeters
 	InScopeLines     []gatheringLineWithBillablePeriod
 }
 
@@ -628,10 +555,6 @@ func (i prepareLinesToBillInput) Validate() error {
 
 	if i.GatheringInvoice.Lines.IsAbsent() {
 		errs = append(errs, fmt.Errorf("gathering invoice must have lines expanded"))
-	}
-
-	if i.FeatureMeters == nil {
-		errs = append(errs, fmt.Errorf("feature meters are required"))
 	}
 
 	for _, line := range i.InScopeLines {
@@ -677,9 +600,8 @@ func (s *Service) prepareLinesToBill(ctx context.Context, input prepareLinesToBi
 			}
 
 			engineInput := billing.SplitGatheringLineInput{
-				Line:          currentLine,
-				FeatureMeters: input.FeatureMeters,
-				SplitAt:       line.BillablePeriod.To,
+				Line:    currentLine,
+				SplitAt: line.BillablePeriod.To,
 			}
 			if err := engineInput.Validate(); err != nil {
 				return nil, fmt.Errorf("line[%s]: validating split input: %w", currentLine.ID, err)

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -354,9 +354,15 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
 		linesWithResolvedPeriods, err := slicesx.MapWithErr(invoice.Invoice.Lines.OrEmpty(), func(line billing.GatheringLine) (gatheringLineWithBillablePeriod, error) {
+			featureEntity, meterEntity, err := resolveRatingDependencies(line, invoice.FeatureMeters)
+			if err != nil {
+				return gatheringLineWithBillablePeriod{}, fmt.Errorf("resolving rating dependencies[%s]: %w", line.ID, err)
+			}
+
 			result, err := s.ratingService.ResolveBillablePeriod(rating.ResolveBillablePeriodInput{
 				Line:               line,
-				FeatureMeters:      invoice.FeatureMeters,
+				Feature:            featureEntity,
+				Meter:              meterEntity,
 				ProgressiveBilling: in.ProgressiveBilling,
 				AsOf:               in.AsOf,
 			})

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
-	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/cmpx"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -92,7 +91,8 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 			}
 
 			return createdInvoices, nil
-		})
+		},
+	)
 }
 
 func (s *Service) prepareBillableLines(ctx context.Context, input billing.PrepareBillableLinesInput, options billing.InvoicePendingLinesOptions) (*billing.PrepareBillableLinesResult, error) {
@@ -257,7 +257,8 @@ func (s *Service) prepareBillableLines(ctx context.Context, input billing.Prepar
 			return &billing.PrepareBillableLinesResult{
 				LinesByCurrency: linesToBeBilledByCurrency,
 			}, nil
-		})
+		},
+	)
 }
 
 // resolvePendingLineCollectionCutoff returns the effective AsOf cutoff used when selecting
@@ -323,8 +324,6 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 
 	billableLineIDs := make(map[string]interface{})
 
-	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
-
 	for currency, invoice := range in.GatheringInvoicesByCurrency {
 		lines := invoice.Lines.OrEmpty()
 		billabilityResults, err := s.areGatheringLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
@@ -333,8 +332,16 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 			ProgressiveBilling: in.ProgressiveBilling,
 			Lines:              lines,
 		})
-		if err != nil {
+		if err != nil && !billing.IsValidationIssueOnly(err) {
 			return nil, fmt.Errorf("checking gathering line billability: %w", err)
+		}
+		if err != nil {
+			s.logger.WarnContext(
+				ctx, "gathering line billability has validation issues; continuing with fallback results",
+				"namespace", invoice.Namespace,
+				"invoice_id", invoice.ID,
+				"error", err,
+			)
 		}
 		linesWithResolvedPeriods := lo.Map(billabilityResults, func(result gatheringLineBillabilityResult, index int) gatheringLineWithBillablePeriod {
 			if !result.Billable {
@@ -354,22 +361,6 @@ func (s *Service) gatherInScopeLines(ctx context.Context, in gatherInScopeLineIn
 		linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
 			return !lo.IsEmpty(line.BillablePeriod)
 		})
-
-		if !in.ProgressiveBilling {
-			// Somewhat of a hack: Since we are allowing subscriptions with different billing periods for ratecards, invoiceAt not necessarily equals
-			// to the line's period start and end time.
-
-			// So we have two kinds of progressive billing scenarios:
-			// 1. the line needs to be split into multiple lines
-			// 2. the line does not need to be split but it's invoiceAt is after the line's period end, when the line is technically billable, but
-			//    from the user's perspective as they are not requesting progressive billing we should not include it on the invoice.
-
-			linesWithResolvedPeriods = lo.Filter(linesWithResolvedPeriods, func(line gatheringLineWithBillablePeriod, _ int) bool {
-				invoiceAtTruncated := line.Line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
-
-				return invoiceAtTruncated.Before(asOfTruncated) || invoiceAtTruncated.Equal(asOfTruncated)
-			})
-		}
 
 		for _, line := range linesWithResolvedPeriods {
 			billableLineIDs[line.Line.ID] = struct{}{}
@@ -700,7 +691,8 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 		return nil, fmt.Errorf("fetching customer profile: %w", err)
 	}
 
-	invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(ctx,
+	invoiceNumber, err := s.sequenceService.GenerateInvoiceSequenceNumber(
+		ctx,
 		sequence.GenerationInput{
 			Namespace:    in.Customer.Namespace,
 			CustomerName: profile.Customer.Name,
@@ -933,8 +925,9 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 		}
 
 		lines, err := grouped.Engine.OnStandardInvoiceCreated(ctx, input)
-		if err != nil {
-			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		validationIssues, systemErr := billing.ToValidationIssues(err)
+		if systemErr != nil {
+			return billing.StandardInvoice{}, fmt.Errorf("standard invoice created for engine %s: %w", grouped.Engine.GetLineEngineType(), systemErr)
 		}
 
 		if err := invoice.Lines.ReplaceExact(billing.ReplaceExactLinesInput{
@@ -942,6 +935,16 @@ func (s *Service) invokeOnStandardInvoiceCreated(ctx context.Context, invoice bi
 			Replacement: lines,
 		}); err != nil {
 			return billing.StandardInvoice{}, fmt.Errorf("replacing standard invoice created lines for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		if len(validationIssues) > 0 {
+			component := billing.LineEngineValidationComponent(grouped.Engine.GetLineEngineType())
+			if err := invoice.MergeValidationIssues(
+				billing.NewLineEngineValidationError(grouped.Engine, validationIssues.AsError()),
+				component,
+			); err != nil {
+				return billing.StandardInvoice{}, fmt.Errorf("merging standard invoice created validation issues for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+			}
 		}
 	}
 

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -906,7 +906,7 @@ func (s Service) SimulateInvoice(ctx context.Context, input billing.SimulateInvo
 		}
 	}
 
-	_, err = s.featureMeterResolver.Resolve(ctx, input.Namespace, invoice.Lines.OrEmpty()...)
+	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Namespace, invoice.Lines.OrEmpty()...)
 	if err != nil {
 		if err := invoice.MergeValidationIssues(
 			billing.ValidationWithComponent(billing.ValidationComponentOpenMeterMetering, err),

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -201,16 +201,6 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 
 	now := clock.Now()
 
-	featureMeters, err := s.featureMeterResolver.Resolve(ctx, invoice.Namespace, invoice.Lines.OrEmpty()...)
-	if err != nil {
-		// The preview's quantity snapshotting surfaces validation issues with line
-		// identity, so only system errors abort live-data preparation here.
-		_, systemErr := billing.ToValidationIssues(err)
-		if systemErr != nil {
-			return nil, fmt.Errorf("resolving feature meters: %w", systemErr)
-		}
-	}
-
 	inScopeGatheringLines := make(billing.GatheringLines, 0, len(invoice.Lines.OrEmpty()))
 	for _, line := range invoice.Lines.OrEmpty() {
 		if line.DeletedAt != nil {
@@ -271,7 +261,6 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 		Invoice:            invoice,
 		AsOf:               now,
 		ProgressiveBilling: out.Workflow.Config.Invoicing.ProgressiveBilling,
-		FeatureMeters:      featureMeters,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("checking if has invoicable lines: %w", err)

--- a/openmeter/billing/service/lineengine.go
+++ b/openmeter/billing/service/lineengine.go
@@ -2,6 +2,7 @@ package billingservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -141,6 +142,72 @@ type GatheringLinesWithEngine struct {
 type StandardLinesWithEngine struct {
 	Engine billing.LineEngine
 	Lines  billing.StandardLines
+}
+
+type gatheringLineBillabilityResult struct {
+	billing.IsLineBillableAsOfResult
+	Engine billing.LineEngine
+}
+
+func (s *Service) areGatheringLinesBillableAsOf(ctx context.Context, input billing.AreLinesBillableAsOfInput) ([]gatheringLineBillabilityResult, error) {
+	if len(input.Lines) == 0 {
+		return []gatheringLineBillabilityResult{}, nil
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating billability input: %w", err)
+	}
+
+	linesWithEngines, err := s.lineEngines.groupGatheringLinesByEngine(input.Lines)
+	if err != nil {
+		return nil, fmt.Errorf("grouping gathering lines by engine: %w", err)
+	}
+
+	resultsByLineID := make(map[string]gatheringLineBillabilityResult, len(input.Lines))
+	var errs []error
+	for _, grouped := range linesWithEngines {
+		engineType := grouped.Engine.GetLineEngineType()
+		results, err := grouped.Engine.AreLinesBillableAsOf(ctx, billing.AreLinesBillableAsOfInput{
+			Invoice:            input.Invoice,
+			AsOf:               input.AsOf,
+			ProgressiveBilling: input.ProgressiveBilling,
+			Lines:              grouped.Lines,
+		})
+		if err != nil && !billing.IsValidationIssueOnly(err) {
+			return nil, fmt.Errorf("checking line billability with engine %s: %w", engineType, err)
+		}
+		errs = append(errs, err)
+
+		if len(results) != len(grouped.Lines) {
+			return nil, fmt.Errorf("engine %s returned %d billability results for %d inputs", engineType, len(results), len(grouped.Lines))
+		}
+
+		for index, result := range results {
+			lineID := grouped.Lines[index].ID
+			if err := result.Validate(); err != nil {
+				return nil, fmt.Errorf("validating line[%s] billability result from engine %s: %w", lineID, engineType, err)
+			}
+
+			resultsByLineID[lineID] = gatheringLineBillabilityResult{
+				IsLineBillableAsOfResult: result,
+				Engine:                   grouped.Engine,
+			}
+		}
+	}
+
+	results, err := lo.MapErr(input.Lines, func(line billing.GatheringLine, _ int) (gatheringLineBillabilityResult, error) {
+		result, ok := resultsByLineID[line.ID]
+		if !ok {
+			return gatheringLineBillabilityResult{}, fmt.Errorf("billability result for line[%s] is missing", line.ID)
+		}
+
+		return result, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results, errors.Join(errs...)
 }
 
 func (r *engineRegistry) groupGatheringLinesByEngine(lines billing.GatheringLines) ([]GatheringLinesWithEngine, error) {

--- a/openmeter/billing/service/lineengine.go
+++ b/openmeter/billing/service/lineengine.go
@@ -176,7 +176,7 @@ func (s *Service) areGatheringLinesBillableAsOf(ctx context.Context, input billi
 		if err != nil && !billing.IsValidationIssueOnly(err) {
 			return nil, fmt.Errorf("checking line billability with engine %s: %w", engineType, err)
 		}
-		errs = append(errs, err)
+		errs = append(errs, billing.NewLineEngineValidationError(grouped.Engine, err))
 
 		if len(results) != len(grouped.Lines) {
 			return nil, fmt.Errorf("engine %s returned %d billability results for %d inputs", engineType, len(results), len(grouped.Lines))

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -3,6 +3,7 @@ package billingservice
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -56,6 +58,80 @@ func TestAreGatheringLinesBillableAsOfPreservesInputOrderAcrossEngines(t *testin
 		invoiceEngine.inputs[0].Lines[1].ID,
 	})
 	require.Equal(t, "charge-1", chargeEngine.inputs[0].Lines[0].ID)
+}
+
+func TestAreGatheringLinesBillableAsOfPreservesResultsWithValidationIssues(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+		err:            billing.ValidationWithFieldPrefix("charges/charge-1", billing.ErrInvoiceLineFeatureNotFound),
+	}
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+	line := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeChargeUsageBased, false)
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+			ID:              line.InvoiceID,
+		},
+	}}
+
+	// Given an engine that can resolve billability while reporting a validation issue.
+	// When billing dispatches the ordered line batch.
+	results, err := svc.areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: invoice,
+		AsOf:    line.InvoiceAt,
+		Lines:   billing.GatheringLines{line},
+	})
+
+	// Then the result and the engine's original validation issue are preserved.
+	issues, systemErr := billing.ToValidationIssues(err)
+	require.NoError(t, systemErr)
+	require.Len(t, results, 1)
+	require.True(t, results[0].Billable)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
+		Path:     "/charges/charge-1",
+	}}, issues)
+}
+
+func TestGatherInScopeLinesContinuesWithBillabilityValidationIssues(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+		err:            billing.ValidationWithFieldPrefix("charges/charge-1", billing.ErrInvoiceLineFeatureNotFound),
+	}
+	svc := &Service{
+		lineEngines: newEngineRegistry(),
+		logger:      slog.New(slog.DiscardHandler),
+	}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+	line := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeChargeUsageBased, false)
+	invoice := billing.GatheringInvoice{
+		GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: line.Namespace},
+				ID:              line.InvoiceID,
+			},
+			Currency: line.Currency,
+		},
+		Lines: billing.NewGatheringInvoiceLines(billing.GatheringLines{line}),
+	}
+
+	// Given a gathering line with a usable billability result and a validation issue.
+	// When pending-line collection selects its in-scope lines.
+	results, err := svc.gatherInScopeLines(t.Context(), gatherInScopeLineInput{
+		GatheringInvoicesByCurrency: map[currencyx.FiatCode]billing.GatheringInvoice{
+			line.Currency: invoice,
+		},
+		AsOf:               line.InvoiceAt,
+		ProgressiveBilling: true,
+	})
+
+	// Then the validation issue does not abort selection.
+	require.NoError(t, err)
+	require.Len(t, results[line.Currency], 1)
+	require.Equal(t, line.ID, results[line.Currency][0].Line.ID)
 }
 
 func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {
@@ -142,6 +218,7 @@ func TestAreGatheringLinesBillableAsOfRequiresLinesFromInvoice(t *testing.T) {
 type billabilityLineEngine struct {
 	billingtestutils.NoopLineEngine
 	inputs []billing.AreLinesBillableAsOfInput
+	err    error
 }
 
 func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
@@ -155,7 +232,7 @@ func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input bi
 				To:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
 		}
-	}), nil
+	}), e.err
 }
 
 func TestDispatchSystemStandardLineDeletionsGroupsLinesByEngine(t *testing.T) {

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -5,14 +5,158 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+func TestAreGatheringLinesBillableAsOfPreservesInputOrderAcrossEngines(t *testing.T) {
+	invoiceEngine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+	}
+	chargeEngine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeChargeUsageBased},
+	}
+
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(invoiceEngine))
+	require.NoError(t, svc.RegisterLineEngine(chargeEngine))
+
+	lines := billing.GatheringLines{
+		newGatheringLineForLineEngineTest("invoice-1", billing.LineEngineTypeInvoice, false),
+		newGatheringLineForLineEngineTest("charge-1", billing.LineEngineTypeChargeUsageBased, false),
+		newGatheringLineForLineEngineTest("invoice-2", billing.LineEngineTypeInvoice, false),
+	}
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+			ID:              "invoice-1",
+		},
+	}}
+
+	results, err := svc.areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+		Invoice: invoice,
+		AsOf:    lines[0].InvoiceAt,
+		Lines:   lines,
+	})
+	require.NoError(t, err)
+	require.Same(t, invoiceEngine, results[0].Engine)
+	require.Same(t, chargeEngine, results[1].Engine)
+	require.Same(t, invoiceEngine, results[2].Engine)
+	require.Equal(t, []string{"invoice-1", "invoice-2"}, []string{
+		invoiceEngine.inputs[0].Lines[0].ID,
+		invoiceEngine.inputs[0].Lines[1].ID,
+	})
+	require.Equal(t, "charge-1", chargeEngine.inputs[0].Lines[0].ID)
+}
+
+func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {
+	engine := &billabilityLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{EngineType: billing.LineEngineTypeInvoice},
+	}
+	svc := &Service{lineEngines: newEngineRegistry()}
+	require.NoError(t, svc.RegisterLineEngine(engine))
+
+	// Given gathering lines with different scheduled invoice times.
+	firstLine := newGatheringLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, false)
+	secondLine := newGatheringLineForLineEngineTest("line-2", billing.LineEngineTypeInvoice, false)
+	secondLine.InvoiceAt = firstLine.InvoiceAt.Add(time.Hour)
+	invoice := billing.GatheringInvoice{
+		GatheringInvoiceBase: billing.GatheringInvoiceBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ID:              "invoice-1",
+			},
+		},
+		Lines: billing.NewGatheringInvoiceLines(billing.GatheringLines{firstLine, secondLine}),
+	}
+
+	// When the updated gathering invoice is checked for billability.
+	err := svc.checkIfGatheringLinesAreInvoicable(t.Context(), invoice, true)
+
+	// Then each line is evaluated separately at its own InvoiceAt.
+	require.NoError(t, err)
+	require.Len(t, engine.inputs, 2)
+	require.Equal(t, firstLine.InvoiceAt, engine.inputs[0].AsOf)
+	require.Equal(t, billing.GatheringLines{firstLine}, engine.inputs[0].Lines)
+	require.Equal(t, secondLine.InvoiceAt, engine.inputs[1].AsOf)
+	require.Equal(t, billing.GatheringLines{secondLine}, engine.inputs[1].Lines)
+}
+
+func TestAreGatheringLinesBillableAsOfRequiresLinesFromInvoice(t *testing.T) {
+	invoice := billing.GatheringInvoice{GatheringInvoiceBase: billing.GatheringInvoiceBase{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+			ID:              "invoice-1",
+		},
+	}}
+
+	tests := []struct {
+		name       string
+		mutateLine func(*billing.GatheringLine)
+		wantError  string
+	}{
+		{
+			name: "namespace mismatch",
+			mutateLine: func(line *billing.GatheringLine) {
+				line.Namespace = "other"
+			},
+			wantError: "namespace other does not match invoice namespace ns",
+		},
+		{
+			name: "invoice mismatch",
+			mutateLine: func(line *billing.GatheringLine) {
+				line.InvoiceID = "other"
+			},
+			wantError: "invoice ID other does not match invoice ID invoice-1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given a valid gathering line whose invoice ownership is changed.
+			line := newGatheringLineForLineEngineTest("line", billing.LineEngineTypeInvoice, false)
+			test.mutateLine(&line)
+
+			// When billing prepares the line-engine billability batch.
+			_, err := (&Service{}).areGatheringLinesBillableAsOf(t.Context(), billing.AreLinesBillableAsOfInput{
+				Invoice: invoice,
+				AsOf:    line.InvoiceAt,
+				Lines:   billing.GatheringLines{line},
+			})
+
+			// Then the line is rejected before engine dispatch.
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+type billabilityLineEngine struct {
+	billingtestutils.NoopLineEngine
+	inputs []billing.AreLinesBillableAsOfInput
+}
+
+func (e *billabilityLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
+	e.inputs = append(e.inputs, input)
+
+	return lo.Map(input.Lines, func(billing.GatheringLine, int) billing.IsLineBillableAsOfResult {
+		return billing.IsLineBillableAsOfResult{
+			Billable: true,
+			BillablePeriod: timeutil.ClosedPeriod{
+				From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		}
+	}), nil
+}
 
 func TestDispatchSystemStandardLineDeletionsGroupsLinesByEngine(t *testing.T) {
 	invoiceEngine := &recordingLineEngine{

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -92,7 +92,10 @@ func TestAreGatheringLinesBillableAsOfPreservesResultsWithValidationIssues(t *te
 		Severity: billing.ValidationIssueSeverityCritical,
 		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
 		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
-		Path:     "/charges/charge-1",
+		Component: billing.LineEngineValidationComponent(
+			billing.LineEngineTypeChargeUsageBased,
+		),
+		Path: "/charges/charge-1",
 	}}, issues)
 }
 
@@ -128,10 +131,19 @@ func TestGatherInScopeLinesContinuesWithBillabilityValidationIssues(t *testing.T
 		ProgressiveBilling: true,
 	})
 
-	// Then the validation issue does not abort selection.
+	// Then the validation issue does not abort selection and remains available for the standard invoice.
 	require.NoError(t, err)
-	require.Len(t, results[line.Currency], 1)
-	require.Equal(t, line.ID, results[line.Currency][0].Line.ID)
+	require.Len(t, results.LinesByCurrency[line.Currency], 1)
+	require.Equal(t, line.ID, results.LinesByCurrency[line.Currency][0].Line.ID)
+	require.Equal(t, billing.ValidationIssues{{
+		Severity: billing.ValidationIssueSeverityCritical,
+		Code:     billing.ErrInvoiceLineFeatureNotFound.Code,
+		Message:  billing.ErrInvoiceLineFeatureNotFound.Message,
+		Component: billing.LineEngineValidationComponent(
+			billing.LineEngineTypeChargeUsageBased,
+		),
+		Path: "/charges/charge-1",
+	}}, results.ValidationIssuesByCurrency[line.Currency])
 }
 
 func TestCheckIfGatheringLinesAreInvoicableUsesEachLineInvoiceAt(t *testing.T) {

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -53,7 +53,7 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 		}
 	}
 
-	_, err = s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, input.Lines...)
+	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, input.Lines...)
 	if err != nil {
 		return nil, billing.ValidationError{
 			Err: fmt.Errorf("resolving pending line feature meters: %w", err),

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -1276,6 +1276,7 @@ type CreateStandardInvoiceFromGatheringLinesInput struct {
 	Description *string
 
 	Lines                       GatheringLines
+	ValidationIssues            ValidationIssues
 	PostCreationCalculationHook PostCreationCalculationHook
 	ForceAsyncAdvance           bool
 }

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -181,6 +181,8 @@ func (s StandardInvoiceStatus) MatchesInvoiceStatus(status StandardInvoiceStatus
 }
 
 var failedStatuses = []StandardInvoiceStatus{
+	StandardInvoiceStatusDraftInvalidCreated,
+	StandardInvoiceStatusDraftInvalid,
 	StandardInvoiceStatusDraftSyncFailed,
 	StandardInvoiceStatusIssuingLineFinalizationFailed,
 	StandardInvoiceStatusIssuingSyncFailed,

--- a/openmeter/billing/stdinvoice_test.go
+++ b/openmeter/billing/stdinvoice_test.go
@@ -24,6 +24,12 @@ func TestListStandardInvoicesInputValidateRequiresNamespace(t *testing.T) {
 	require.ErrorContains(t, err, "namespace is required")
 }
 
+func TestStandardInvoiceStatusIsFailedIncludesValidationFailures(t *testing.T) {
+	require.True(t, StandardInvoiceStatusDraftInvalidCreated.IsFailed())
+	require.True(t, StandardInvoiceStatusDraftInvalid.IsFailed())
+	require.False(t, StandardInvoiceStatusDraftWaitingForCollection.IsFailed())
+}
+
 func TestSortLines(t *testing.T) {
 	lines := StandardLines{
 		{

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -22,8 +22,16 @@ func (e NoopLineEngine) GetLineEngineType() billing.LineEngineType {
 	return e.EngineType
 }
 
-func (NoopLineEngine) IsLineBillableAsOf(context.Context, billing.IsLineBillableAsOfInput) (bool, error) {
-	return true, nil
+func (NoopLineEngine) AreLinesBillableAsOf(_ context.Context, input billing.AreLinesBillableAsOfInput) ([]billing.IsLineBillableAsOfResult, error) {
+	results := make([]billing.IsLineBillableAsOfResult, len(input.Lines))
+	for index, line := range input.Lines {
+		results[index] = billing.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}
+	}
+
+	return results, nil
 }
 
 func (NoopLineEngine) GateInvoiceAssignment(context.Context, billing.GateInvoiceAssignmentInput) (billing.GateInvoiceAssignmentResult, error) {

--- a/openmeter/billing/validationissue.go
+++ b/openmeter/billing/validationissue.go
@@ -260,6 +260,18 @@ func ToValidationIssues(errIn error) (ValidationIssues, error) {
 	return issues, nil
 }
 
+// IsValidationIssueOnly reports whether the error tree contains validation
+// issues only and no system errors.
+func IsValidationIssueOnly(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, systemErr := ToValidationIssues(err)
+
+	return systemErr == nil
+}
+
 func (v ValidationIssues) RemoveMetaForCompare() ValidationIssues {
 	return lo.Map(v, func(issue ValidationIssue, _ int) ValidationIssue {
 		issue.CreatedAt = time.Time{}

--- a/openmeter/billing/validationissue_test.go
+++ b/openmeter/billing/validationissue_test.go
@@ -253,6 +253,45 @@ func TestValidationIssueParsing(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIsValidationIssueOnly(t *testing.T) {
+	validationErr := NewValidationError("invalid", "invalid")
+	systemErr := errors.New("system error")
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:     "validation issue",
+			err:      validationErr,
+			expected: true,
+		},
+		{
+			name:     "joined validation issues",
+			err:      errors.Join(validationErr, NewValidationWarning("warning", "warning")),
+			expected: true,
+		},
+		{
+			name: "system error",
+			err:  systemErr,
+		},
+		{
+			name: "mixed validation and system errors",
+			err:  errors.Join(validationErr, systemErr),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, IsValidationIssueOnly(test.err))
+		})
+	}
+}
+
 func TestValidationWithComponentPrecedence(t *testing.T) {
 	baseIssue := ValidationIssue{
 		Severity:  ValidationIssueSeverityWarning,

--- a/openmeter/ent/db/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased.go
@@ -101,7 +101,7 @@ type ChargeUsageBased struct {
 	// FeatureKey holds the value of the "feature_key" field.
 	FeatureKey string `json:"feature_key,omitempty"`
 	// FeatureID holds the value of the "feature_id" field.
-	FeatureID string `json:"feature_id,omitempty"`
+	FeatureID *string `json:"feature_id,omitempty"`
 	// RatingEngine holds the value of the "rating_engine" field.
 	RatingEngine usagebased.RatingEngine `json:"rating_engine,omitempty"`
 	// Price holds the value of the "price" field.
@@ -543,7 +543,8 @@ func (_m *ChargeUsageBased) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field feature_id", values[i])
 			} else if value.Valid {
-				_m.FeatureID = value.String
+				_m.FeatureID = new(string)
+				*_m.FeatureID = value.String
 			}
 		case chargeusagebased.FieldRatingEngine:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -804,8 +805,10 @@ func (_m *ChargeUsageBased) String() string {
 	builder.WriteString("feature_key=")
 	builder.WriteString(_m.FeatureKey)
 	builder.WriteString(", ")
-	builder.WriteString("feature_id=")
-	builder.WriteString(_m.FeatureID)
+	if v := _m.FeatureID; v != nil {
+		builder.WriteString("feature_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("rating_engine=")
 	builder.WriteString(fmt.Sprintf("%v", _m.RatingEngine))

--- a/openmeter/ent/db/chargeusagebased/where.go
+++ b/openmeter/ent/db/chargeusagebased/where.go
@@ -1810,6 +1810,16 @@ func FeatureIDHasSuffix(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldHasSuffix(FieldFeatureID, v))
 }
 
+// FeatureIDIsNil applies the IsNil predicate on the "feature_id" field.
+func FeatureIDIsNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldIsNull(FieldFeatureID))
+}
+
+// FeatureIDNotNil applies the NotNil predicate on the "feature_id" field.
+func FeatureIDNotNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldNotNull(FieldFeatureID))
+}
+
 // FeatureIDEqualFold applies the EqualFold predicate on the "feature_id" field.
 func FeatureIDEqualFold(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldEqualFold(FieldFeatureID, v))

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -344,6 +344,14 @@ func (_c *ChargeUsageBasedCreate) SetFeatureID(v string) *ChargeUsageBasedCreate
 	return _c
 }
 
+// SetNillableFeatureID sets the "feature_id" field if the given value is not nil.
+func (_c *ChargeUsageBasedCreate) SetNillableFeatureID(v *string) *ChargeUsageBasedCreate {
+	if v != nil {
+		_c.SetFeatureID(*v)
+	}
+	return _c
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_c *ChargeUsageBasedCreate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedCreate {
 	_c.mutation.SetRatingEngine(v)
@@ -694,9 +702,6 @@ func (_c *ChargeUsageBasedCreate) check() error {
 			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_key": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.FeatureID(); !ok {
-		return &ValidationError{Name: "feature_id", err: errors.New(`db: missing required field "ChargeUsageBased.feature_id"`)}
-	}
 	if v, ok := _c.mutation.FeatureID(); ok {
 		if err := chargeusagebased.FeatureIDValidator(v); err != nil {
 			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_id": %w`, err)}
@@ -733,9 +738,6 @@ func (_c *ChargeUsageBasedCreate) check() error {
 	}
 	if len(_c.mutation.CustomerIDs()) == 0 {
 		return &ValidationError{Name: "customer", err: errors.New(`db: missing required edge "ChargeUsageBased.customer"`)}
-	}
-	if len(_c.mutation.FeatureIDs()) == 0 {
-		return &ValidationError{Name: "feature", err: errors.New(`db: missing required edge "ChargeUsageBased.feature"`)}
 	}
 	if len(_c.mutation.TaxCodeIDs()) == 0 {
 		return &ValidationError{Name: "tax_code", err: errors.New(`db: missing required edge "ChargeUsageBased.tax_code"`)}
@@ -1091,7 +1093,7 @@ func (_c *ChargeUsageBasedCreate) createSpec() (*ChargeUsageBased, *sqlgraph.Cre
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.FeatureID = nodes[0]
+		_node.FeatureID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.TaxCodeIDs(); len(nodes) > 0 {
@@ -1471,6 +1473,12 @@ func (u *ChargeUsageBasedUpsert) SetFeatureID(v string) *ChargeUsageBasedUpsert 
 // UpdateFeatureID sets the "feature_id" field to the value that was provided on create.
 func (u *ChargeUsageBasedUpsert) UpdateFeatureID() *ChargeUsageBasedUpsert {
 	u.SetExcluded(chargeusagebased.FieldFeatureID)
+	return u
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsert) ClearFeatureID() *ChargeUsageBasedUpsert {
+	u.SetNull(chargeusagebased.FieldFeatureID)
 	return u
 }
 
@@ -1976,6 +1984,13 @@ func (u *ChargeUsageBasedUpsertOne) SetFeatureID(v string) *ChargeUsageBasedUpse
 func (u *ChargeUsageBasedUpsertOne) UpdateFeatureID() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsertOne) ClearFeatureID() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearFeatureID()
 	})
 }
 
@@ -2663,6 +2678,13 @@ func (u *ChargeUsageBasedUpsertBulk) SetFeatureID(v string) *ChargeUsageBasedUps
 func (u *ChargeUsageBasedUpsertBulk) UpdateFeatureID() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsertBulk) ClearFeatureID() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearFeatureID()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_query.go
+++ b/openmeter/ent/db/chargeusagebased_query.go
@@ -1236,7 +1236,10 @@ func (_q *ChargeUsageBasedQuery) loadFeature(ctx context.Context, query *Feature
 	ids := make([]string, 0, len(nodes))
 	nodeids := make(map[string][]*ChargeUsageBased)
 	for i := range nodes {
-		fk := nodes[i].FeatureID
+		if nodes[i].FeatureID == nil {
+			continue
+		}
+		fk := *nodes[i].FeatureID
 		if _, ok := nodeids[fk]; !ok {
 			ids = append(ids, fk)
 		}

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -340,6 +340,12 @@ func (_u *ChargeUsageBasedUpdate) SetNillableFeatureID(v *string) *ChargeUsageBa
 	return _u
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (_u *ChargeUsageBasedUpdate) ClearFeatureID() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearFeatureID()
+	return _u
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_u *ChargeUsageBasedUpdate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdate {
 	_u.mutation.SetRatingEngine(v)
@@ -630,9 +636,6 @@ func (_u *ChargeUsageBasedUpdate) check() error {
 	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.customer"`)
-	}
-	if _u.mutation.FeatureCleared() && len(_u.mutation.FeatureIDs()) > 0 {
-		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.feature"`)
 	}
 	if _u.mutation.TaxCodeCleared() && len(_u.mutation.TaxCodeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.tax_code"`)
@@ -1297,6 +1300,12 @@ func (_u *ChargeUsageBasedUpdateOne) SetNillableFeatureID(v *string) *ChargeUsag
 	return _u
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (_u *ChargeUsageBasedUpdateOne) ClearFeatureID() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearFeatureID()
+	return _u
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_u *ChargeUsageBasedUpdateOne) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdateOne {
 	_u.mutation.SetRatingEngine(v)
@@ -1600,9 +1609,6 @@ func (_u *ChargeUsageBasedUpdateOne) check() error {
 	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.customer"`)
-	}
-	if _u.mutation.FeatureCleared() && len(_u.mutation.FeatureIDs()) > 0 {
-		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.feature"`)
 	}
 	if _u.mutation.TaxCodeCleared() && len(_u.mutation.TaxCodeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.tax_code"`)

--- a/openmeter/ent/db/feature_query.go
+++ b/openmeter/ent/db/feature_query.go
@@ -791,9 +791,12 @@ func (_q *FeatureQuery) loadUsageBasedCharges(ctx context.Context, query *Charge
 	}
 	for _, n := range neighbors {
 		fk := n.FeatureID
-		node, ok := nodeids[fk]
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "feature_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "feature_id" returned %v for node %v`, fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "feature_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2948,7 +2948,7 @@ var (
 		{Name: "cost_basis_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "custom_currency_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
-		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_item_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_phase_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2988,7 +2988,7 @@ var (
 				Symbol:     "charge_usage_based_features_usage_based_charges",
 				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_usage_based_subscriptions_charges_usage_based",

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -65879,7 +65879,7 @@ func (m *ChargeUsageBasedMutation) FeatureID() (r string, exists bool) {
 // OldFeatureID returns the old "feature_id" field's value of the ChargeUsageBased entity.
 // If the ChargeUsageBased object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v string, err error) {
+func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldFeatureID is only allowed on UpdateOne operations")
 	}
@@ -65893,9 +65893,22 @@ func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v string, 
 	return oldValue.FeatureID, nil
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (m *ChargeUsageBasedMutation) ClearFeatureID() {
+	m.feature = nil
+	m.clearedFields[chargeusagebased.FieldFeatureID] = struct{}{}
+}
+
+// FeatureIDCleared returns if the "feature_id" field was cleared in this mutation.
+func (m *ChargeUsageBasedMutation) FeatureIDCleared() bool {
+	_, ok := m.clearedFields[chargeusagebased.FieldFeatureID]
+	return ok
+}
+
 // ResetFeatureID resets all changes to the "feature_id" field.
 func (m *ChargeUsageBasedMutation) ResetFeatureID() {
 	m.feature = nil
+	delete(m.clearedFields, chargeusagebased.FieldFeatureID)
 }
 
 // SetRatingEngine sets the "rating_engine" field.
@@ -66522,7 +66535,7 @@ func (m *ChargeUsageBasedMutation) ClearFeature() {
 
 // FeatureCleared reports if the "feature" edge to the Feature entity was cleared.
 func (m *ChargeUsageBasedMutation) FeatureCleared() bool {
-	return m.clearedfeature
+	return m.FeatureIDCleared() || m.clearedfeature
 }
 
 // FeatureIDs returns the "feature" edge IDs in the mutation.
@@ -67277,6 +67290,9 @@ func (m *ChargeUsageBasedMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebased.FieldDiscounts) {
 		fields = append(fields, chargeusagebased.FieldDiscounts)
 	}
+	if m.FieldCleared(chargeusagebased.FieldFeatureID) {
+		fields = append(fields, chargeusagebased.FieldFeatureID)
+	}
 	if m.FieldCleared(chargeusagebased.FieldUnitConfig) {
 		fields = append(fields, chargeusagebased.FieldUnitConfig)
 	}
@@ -67344,6 +67360,9 @@ func (m *ChargeUsageBasedMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebased.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case chargeusagebased.FieldFeatureID:
+		m.ClearFeatureID()
 		return nil
 	case chargeusagebased.FieldUnitConfig:
 		m.ClearUnitConfig()

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -3816,6 +3816,20 @@ func (u *ChargeUsageBasedUpdateOne) SetOrClearDiscounts(value **billing.Discount
 	return u.SetDiscounts(*value)
 }
 
+func (u *ChargeUsageBasedUpdate) SetOrClearFeatureID(value *string) *ChargeUsageBasedUpdate {
+	if value == nil {
+		return u.ClearFeatureID()
+	}
+	return u.SetFeatureID(*value)
+}
+
+func (u *ChargeUsageBasedUpdateOne) SetOrClearFeatureID(value *string) *ChargeUsageBasedUpdateOne {
+	if value == nil {
+		return u.ClearFeatureID()
+	}
+	return u.SetFeatureID(*value)
+}
+
 func (u *ChargeUsageBasedUpdate) SetOrClearUnitConfig(value **unitconfig.UnitConfig) *ChargeUsageBasedUpdate {
 	if value == nil {
 		return u.ClearUnitConfig()

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -62,7 +62,9 @@ func (ChargeUsageBased) Fields() []ent.Field {
 			NotEmpty().
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
-			}),
+			}).
+			Optional().
+			Nillable(),
 
 		field.Enum("rating_engine").
 			GoType(usagebased.RatingEngine("")),
@@ -152,8 +154,7 @@ func (ChargeUsageBased) Edges() []ent.Edge {
 		edge.From("feature", Feature.Type).
 			Field("feature_id").
 			Ref("usage_based_charges").
-			Unique().
-			Required(),
+			Unique(),
 		edge.From("tax_code", TaxCode.Type).
 			Ref("charge_usage_based").
 			Field("tax_code_id").

--- a/openmeter/ent/schema/feature.go
+++ b/openmeter/ent/schema/feature.go
@@ -84,7 +84,8 @@ func (Feature) Edges() []ent.Edge {
 		edge.To("entitlement", Entitlement.Type),
 		edge.To("ratecard", PlanRateCard.Type),
 		edge.To("addon_ratecard", AddonRateCard.Type),
-		edge.To("usage_based_charges", ChargeUsageBased.Type),
+		edge.To("usage_based_charges", ChargeUsageBased.Type).
+			Annotations(entsql.OnDelete(entsql.Restrict)),
 		edge.To("usage_based_runs", ChargeUsageBasedRuns.Type),
 		edge.To("flat_fee_charges", ChargeFlatFee.Type),
 		edge.From("meter", Meter.Type).

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -363,7 +363,6 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 
 	createdCharges, err := env.flatFeeService.Create(t.Context(), flatfee.CreateInput{
 		Namespace:     env.Namespace,
-		FeatureMeters: env.featureMeters,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -362,7 +362,7 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 	requireBalance(t, 100, 100)
 
 	createdCharges, err := env.flatFeeService.Create(t.Context(), flatfee.CreateInput{
-		Namespace:     env.Namespace,
+		Namespace: env.Namespace,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -290,11 +290,12 @@ func newTestEnv(t *testing.T) *testEnv {
 			},
 			collectorService,
 		),
-		Lineage:       lineageService,
-		MetaAdapter:   metaAdapter,
-		Locker:        locker,
-		RatingService: billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
-		Currencies:    currencyService,
+		Lineage:              lineageService,
+		MetaAdapter:          metaAdapter,
+		Locker:               locker,
+		FeatureMeterResolver: featureMeterResolver,
+		RatingService:        billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),
+		Currencies:           currencyService,
 	})
 	require.NoError(t, err)
 

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -517,7 +517,6 @@ func (e *testEnv) createUsageBasedChargeInCurrency(t *testing.T, unitPrice alpac
 
 	createdCharges, err := e.usageBasedService.Create(t.Context(), usagebased.CreateInput{
 		Namespace:     e.Namespace,
-		FeatureMeters: e.featureMeters,
 		Intents: []usagebased.Intent{
 			{
 				Intent: chargemeta.Intent{
@@ -565,7 +564,6 @@ func (e *testEnv) createFlatFeeChargeInCurrency(t *testing.T, amount alpacadecim
 
 	createdCharges, err := e.flatFeeService.Create(t.Context(), flatfee.CreateInput{
 		Namespace:     e.Namespace,
-		FeatureMeters: e.featureMeters,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -516,7 +516,7 @@ func (e *testEnv) createUsageBasedChargeInCurrency(t *testing.T, unitPrice alpac
 	t.Helper()
 
 	createdCharges, err := e.usageBasedService.Create(t.Context(), usagebased.CreateInput{
-		Namespace:     e.Namespace,
+		Namespace: e.Namespace,
 		Intents: []usagebased.Intent{
 			{
 				Intent: chargemeta.Intent{
@@ -563,7 +563,7 @@ func (e *testEnv) createFlatFeeChargeInCurrency(t *testing.T, amount alpacadecim
 	}
 
 	createdCharges, err := e.flatFeeService.Create(t.Context(), flatfee.CreateInput{
-		Namespace:     e.Namespace,
+		Namespace: e.Namespace,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/pkg/slicesx/map.go
+++ b/pkg/slicesx/map.go
@@ -48,6 +48,22 @@ func MapWithErr[T any, S any](s []T, f func(T) (S, error)) ([]S, error) {
 	return n, nil
 }
 
+// MapWithErrPreservingResults maps every element, preserves each returned result
+// at its input index, and joins all mapping errors.
+func MapWithErrPreservingResults[T any, S any](s []T, f func(T, int) (S, error)) ([]S, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	results := make([]S, len(s))
+	errs := make([]error, len(s))
+	for index, value := range s {
+		results[index], errs[index] = f(value, index)
+	}
+
+	return results, errors.Join(errs...)
+}
+
 func WrapMapFn[T, O any](fn func(T) (O, error)) func(T, int) (O, error) {
 	return func(t T, _ int) (O, error) {
 		return fn(t)

--- a/pkg/slicesx/map_test.go
+++ b/pkg/slicesx/map_test.go
@@ -1,6 +1,7 @@
 package slicesx
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -16,5 +17,32 @@ func TestMap(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatal("map failed")
+	}
+}
+
+func TestMapWithErrPreservingResults(t *testing.T) {
+	firstErr := errors.New("first error")
+	lastErr := errors.New("last error")
+
+	// Given a mapper that returns usable results alongside errors.
+	// When every input is mapped with its index.
+	results, err := MapWithErrPreservingResults([]int{10, 20, 30}, func(value, index int) (int, error) {
+		result := value + index
+		switch index {
+		case 0:
+			return result, firstErr
+		case 2:
+			return result, lastErr
+		default:
+			return result, nil
+		}
+	})
+
+	// Then all input-aligned results and both errors are returned.
+	if !reflect.DeepEqual([]int{10, 21, 32}, results) {
+		t.Fatalf("unexpected results: %v", results)
+	}
+	if !errors.Is(err, firstErr) || !errors.Is(err, lastErr) {
+		t.Fatalf("expected joined errors, got %v", err)
 	}
 }

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -131,6 +131,84 @@ func (s *CollectionTestSuite) TestUncollectableCollection() {
 	s.Len(invoices, 0)
 }
 
+func (s *CollectionTestSuite) TestCollectionWaitsForInvoiceAtAfterServicePeriodEnd() {
+	namespace := "ns-collection-waits-for-invoice-at"
+	ctx := s.T().Context()
+
+	appSandbox := s.InstallSandboxApp(s.T(), namespace)
+	customer := s.CreateTestCustomer(namespace, "test-customer")
+	s.Require().NotNil(customer)
+	s.ProvisionBillingProfile(ctx, namespace, appSandbox.GetID())
+
+	testFeature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+	defer testFeature.Cleanup()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: lo.Must(time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")),
+		To:   lo.Must(time.Parse(time.RFC3339, "2025-01-02T00:00:00Z")),
+	}
+	invoiceAt := lo.Must(time.Parse(time.RFC3339, "2025-02-01T00:00:00Z"))
+
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	testFeatureKey := testFeature.Feature.Key
+	s.MockStreamingConnector.AddSimpleEvent(testFeatureKey, 1, servicePeriod.From.Add(time.Hour))
+
+	// Given a non-progressively billed line whose service period ends before its invoice time.
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customer.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: []billing.GatheringLine{
+			{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Name: "UBP - unit",
+				}),
+				ServicePeriod: servicePeriod,
+				InvoiceAt:     invoiceAt,
+				ManagedBy:     billing.ManuallyManagedLine,
+				FeatureKey:    testFeatureKey,
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(1),
+				})),
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pendingLines.Lines, 1)
+
+	// When collection is attempted after service completion but before InvoiceAt.
+	clock.FreezeTime(servicePeriod.To)
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customer.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+
+	// Then the line remains on the gathering invoice and no standard invoice is created.
+	s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)
+	s.Empty(invoices)
+
+	gatheringInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: pendingLines.Invoice.GetInvoiceID(),
+		Expand:  billing.GatheringInvoiceExpands{billing.GatheringInvoiceExpandLines},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+	// When collection reaches InvoiceAt, the complete service period becomes billable.
+	clock.FreezeTime(invoiceAt)
+	invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customer.GetID(),
+		AsOf:     lo.ToPtr(invoiceAt),
+	})
+
+	// Then one standard invoice contains the full line.
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+	s.True(servicePeriod.Equal(invoices[0].Lines.OrEmpty()[0].Period))
+}
+
 func (s *CollectionTestSuite) TestGatheringLineUnitConfigSnapshotRoundTrip() {
 	// given:
 	// - a legacy (non-charges) usage-based gathering line whose rate card carries a unit_config

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1246,6 +1246,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,
@@ -1305,6 +1306,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,
@@ -1405,6 +1407,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -41,6 +41,7 @@ type mockCollectionCompletedLineEngine struct {
 	engineType ombilling.LineEngineType
 
 	gateInvoiceAssignment                 func(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error)
+	areLinesBillableAsOf                  func(ctx context.Context, input ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error)
 	buildStandardInvoiceLines             func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	buildStandardLinesForGatheringPreview func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	onStandardInvoiceCreated              func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
@@ -75,7 +76,11 @@ func (m *mockCollectionCompletedLineEngine) GetLineEngineType() ombilling.LineEn
 	return m.engineType
 }
 
-func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(_ context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(ctx context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+	if m.areLinesBillableAsOf != nil {
+		return m.areLinesBillableAsOf(ctx, batch)
+	}
+
 	return lo.Map(batch.Lines, func(line ombilling.GatheringLine, _ int) ombilling.IsLineBillableAsOfResult {
 		if batch.AsOf.Before(line.InvoiceAt) {
 			return ombilling.IsLineBillableAsOfResult{}
@@ -94,6 +99,70 @@ func (m *mockCollectionCompletedLineEngine) GateInvoiceAssignment(ctx context.Co
 	}
 
 	return m.gateInvoiceAssignment(ctx, input)
+}
+
+func (s *LineEngineTestSuite) TestBillabilityValidationIssuesPreventInvoiceAdvancement() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("ns-line-engine-billability-validation")
+	mockEngine := &mockCollectionCompletedLineEngine{engineType: ombilling.LineEngineTypeChargeFlatFee}
+	s.registerMockLineEngine(s.T(), mockEngine)
+	defer s.unregisterLineEngine(s.T(), mockEngine)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.FreezeTime(servicePeriod.To)
+	defer clock.UnFreeze()
+
+	mockEngine.areLinesBillableAsOf = func(_ context.Context, input ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+		return lo.Map(input.Lines, func(ombilling.GatheringLine, int) ombilling.IsLineBillableAsOfResult {
+			return ombilling.IsLineBillableAsOfResult{
+				Billable:       true,
+				BillablePeriod: servicePeriod,
+			}
+		}), ombilling.ValidationWithFieldPrefix("charges/charge-id", ombilling.ErrInvoiceLineFeatureNotFound)
+	}
+	mockEngine.buildStandardInvoiceLines = func(_ context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+		return mustAsNewStandardLines(input), nil
+	}
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	customerEntity := s.CreateTestCustomer(namespace, "test-subject")
+
+	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: ombilling.GatheringLines{{
+			GatheringLineBase: ombilling.GatheringLineBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: namespace,
+					Name:      "line with missing feature",
+				}),
+				ManagedBy:     ombilling.ManuallyManagedLine,
+				Engine:        mockEngine.GetLineEngineType(),
+				Currency:      currencyx.FiatCode(currency.USD),
+				ServicePeriod: servicePeriod,
+				InvoiceAt:     servicePeriod.To,
+				Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount: alpacadecimal.NewFromInt(10),
+				}),
+			},
+		}},
+	})
+	s.Require().NoError(err)
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, ombilling.InvoicePendingLinesInput{
+		Customer: customerEntity.GetID(),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	s.Equal(ombilling.StandardInvoiceStatusDraftInvalidCreated, invoices[0].Status)
+	s.Require().Len(invoices[0].ValidationIssues, 1)
+	s.Equal(ombilling.ErrInvoiceLineFeatureNotFound.Code, invoices[0].ValidationIssues[0].Code)
+	s.Equal("/charges/charge-id", invoices[0].ValidationIssues[0].Path)
+	s.Equal(ombilling.LineEngineValidationComponent(mockEngine.GetLineEngineType()), invoices[0].ValidationIssues[0].Component)
 }
 
 func (m *mockCollectionCompletedLineEngine) SplitGatheringLine(_ context.Context, _ ombilling.SplitGatheringLineInput) (ombilling.SplitGatheringLineResult, error) {

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -75,8 +75,17 @@ func (m *mockCollectionCompletedLineEngine) GetLineEngineType() ombilling.LineEn
 	return m.engineType
 }
 
-func (m *mockCollectionCompletedLineEngine) IsLineBillableAsOf(_ context.Context, input ombilling.IsLineBillableAsOfInput) (bool, error) {
-	return !lo.IsEmpty(input.ResolvedBillablePeriod), nil
+func (m *mockCollectionCompletedLineEngine) AreLinesBillableAsOf(_ context.Context, batch ombilling.AreLinesBillableAsOfInput) ([]ombilling.IsLineBillableAsOfResult, error) {
+	return lo.Map(batch.Lines, func(line ombilling.GatheringLine, _ int) ombilling.IsLineBillableAsOfResult {
+		if batch.AsOf.Before(line.InvoiceAt) {
+			return ombilling.IsLineBillableAsOfResult{}
+		}
+
+		return ombilling.IsLineBillableAsOfResult{
+			Billable:       true,
+			BillablePeriod: line.ServicePeriod,
+		}
+	}), nil
 }
 
 func (m *mockCollectionCompletedLineEngine) GateInvoiceAssignment(ctx context.Context, input ombilling.GateInvoiceAssignmentInput) (ombilling.GateInvoiceAssignmentResult, error) {

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -798,6 +798,52 @@ func (s *BaseSuite) MustGetChargeByID(chargeID meta.ChargeID) charges.Charge {
 	return charge
 }
 
+func (s *BaseSuite) RequireChargeStatus(chargeID meta.ChargeID, status any) charges.Charge {
+	s.T().Helper()
+
+	charge := s.MustGetChargeByID(chargeID)
+
+	var actualStatus string
+	switch charge.Type() {
+	case meta.ChargeTypeUsageBased:
+		usageBasedCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		actualStatus = string(usageBasedCharge.Status)
+	case meta.ChargeTypeFlatFee:
+		flatFeeCharge, err := charge.AsFlatFeeCharge()
+		s.NoError(err)
+		actualStatus = string(flatFeeCharge.Status)
+	case meta.ChargeTypeCreditPurchase:
+		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
+		s.NoError(err)
+		actualStatus = string(creditPurchaseCharge.Status)
+	default:
+		s.FailNowf("unsupported charge type", "charge type %s is not supported", charge.Type())
+	}
+
+	s.Equal(fmt.Sprint(status), actualStatus)
+
+	return charge
+}
+
+func (s *BaseSuite) RequireUsageBasedChargeStatus(chargeID meta.ChargeID, status usagebased.Status) usagebased.Charge {
+	s.T().Helper()
+
+	charge, err := s.RequireChargeStatus(chargeID, status).AsUsageBasedCharge()
+	s.NoError(err)
+
+	return charge
+}
+
+func (s *BaseSuite) RequireFlatFeeChargeStatus(chargeID meta.ChargeID, status flatfee.Status) flatfee.Charge {
+	s.T().Helper()
+
+	charge, err := s.RequireChargeStatus(chargeID, status).AsFlatFeeCharge()
+	s.NoError(err)
+
+	return charge
+}
+
 type CreateCreditPurchaseIntentInput struct {
 	Customer       customer.CustomerID
 	Currency       currencyx.Code

--- a/test/credits/credit_only_validation_test.go
+++ b/test/credits/credit_only_validation_test.go
@@ -96,6 +96,7 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusCreated)
 
 		clock.FreezeTime(servicePeriod.From)
+		defer clock.UnFreeze()
 		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
 		s.Require().NoError(err)
 
@@ -123,6 +124,7 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		// - advancement fails with a validation error and the charge is left untouched for a retry
 		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 
 		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
 		s.Require().Error(err)
@@ -152,6 +154,9 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		// - the customer is advanced again
 		// then:
 		// - the same advance succeeds and the charge starts its final realization
+		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
+		
 		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, meters))
 
 		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})

--- a/test/credits/credit_only_validation_test.go
+++ b/test/credits/credit_only_validation_test.go
@@ -1,0 +1,332 @@
+package credits
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+func TestCreditOnlyValidationSuite(t *testing.T) {
+	suite.Run(t, new(CreditOnlyValidationSuite))
+}
+
+// CreditOnlyValidationSuite covers charge advancement when a credit-only charge's
+// dependencies disappear after creation. Credit-only charges never create gathering
+// lines, so AdvanceCharges is their only exposure to missing meters.
+type CreditOnlyValidationSuite struct {
+	BaseSuite
+}
+
+func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterIsRetryable() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-usagebased-missing-meter-advance")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageChargeID meta.ChargeID
+		meters        []meter.Meter
+	)
+
+	s.Run("Given an active credit-only usage charge with usage", func() {
+		// given:
+		// - a credit-only usage charge is created before its service period
+		// when:
+		// - the service period starts and the charge is advanced
+		// then:
+		// - the charge is active and waits for the end of its service period
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "API requests",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "credit-only-missing-meter-api-requests",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().Len(created, 1)
+
+		usageChargeID, err = created[0].GetChargeID()
+		s.Require().NoError(err)
+		s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusCreated)
+
+		clock.FreezeTime(servicePeriod.From)
+		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().NoError(err)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActive)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(servicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		listed, err := s.MeterAdapter.ListMeters(ctx, meter.ListMetersParams{Namespace: ns})
+		s.Require().NoError(err)
+		meters = listed.Items
+	})
+
+	s.Run("When the meter is gone at the charge's due time", func() {
+		// given:
+		// - the charge is due for its final realization
+		// when:
+		// - the meter backing the feature is removed and the customer is advanced
+		// then:
+		// - advancement fails with a validation error and the charge is left untouched for a retry
+		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+		clock.FreezeTime(servicePeriod.To)
+
+		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().Error(err)
+		s.True(billing.IsValidationIssueOnly(err), "expected a validation-only error, got: %v", err)
+
+		issues, systemErr := billing.ToValidationIssues(err)
+		s.Require().NoError(systemErr)
+		s.Require().Len(issues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issues[0].Code)
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issues[0].Message,
+		)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActive)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(servicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+		s.Nil(usageCharge.State.CurrentRealizationRunID)
+		s.Empty(usageCharge.Realizations)
+		s.Empty(usageCharge.ValidationIssues)
+	})
+
+	s.Run("Then restoring the meter lets the charge realize normally", func() {
+		// given:
+		// - the meter is registered again
+		// when:
+		// - the customer is advanced again
+		// then:
+		// - the same advance succeeds and the charge starts its final realization
+		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, meters))
+
+		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().NoError(err)
+		s.Require().Len(advanced, 1)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		s.Empty(usageCharge.ValidationIssues)
+		s.Len(usageCharge.Realizations, 1)
+	})
+}
+
+func (s *CreditOnlyValidationSuite) TestFlatFeeCreditOnlyAdvancesWhenSiblingUsageMeterIsMissing() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-flatfee-sibling-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	usageServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	flatFeeServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-15T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(usageServicePeriod.From)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-only usage charge is active and not due until the end of its service period
+	// - a credit-only in-advance flat fee for the same customer becomes due first
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-sibling-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  flatFeeServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "monthly platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-sibling-platform-fee",
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(created, 2)
+
+	usageCharge, err := created[0].AsUsageBasedCharge()
+	s.Require().NoError(err)
+	s.Equal(usagebased.StatusActive, usageCharge.Status)
+	s.Require().NotNil(usageCharge.State.AdvanceAfter)
+	s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+
+	flatFeeCharge, err := created[1].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the usage meter disappears before the flat fee is advanced
+	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+	clock.FreezeTime(flatFeeServicePeriod.From)
+
+	advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+
+	// then:
+	// - the flat fee settles against credit without resolving meters for the not-due usage charge
+	s.Require().NoError(err)
+	s.Require().Len(advanced, 1)
+	advancedFlatFee, err := advanced[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
+	s.RequireFlatFeeChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusFinal)
+
+	reloadedUsageCharge := s.RequireUsageBasedChargeStatus(usageCharge.GetChargeID(), usagebased.StatusActive)
+	s.Require().NotNil(reloadedUsageCharge.State.AdvanceAfter)
+	s.True(usageServicePeriod.To.Equal(*reloadedUsageCharge.State.AdvanceAfter))
+	s.Empty(reloadedUsageCharge.ValidationIssues)
+}
+
+func (s *CreditOnlyValidationSuite) TestFlatFeeCreditOnlyIgnoresMissingMeterOnOwnFeature() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-flatfee-own-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-only in-advance flat fee references a metered feature and is not yet due
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "feature-backed platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-own-feature-platform-fee",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(created, 1)
+
+	flatFeeCharge, err := created[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the feature's meter disappears before the fee is due
+	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+	clock.FreezeTime(servicePeriod.From)
+
+	advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+
+	// then:
+	// - a flat fee never depends on the meter, so it settles against credit as usual
+	s.Require().NoError(err)
+	s.Require().Len(advanced, 1)
+	advancedFlatFee, err := advanced[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
+	s.Empty(s.RequireFlatFeeChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusFinal).ValidationIssues)
+}

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	pcfeature "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -142,6 +143,516 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 		// - every ledger balance is still identical to the pre-delete snapshot
 		s.RequireChargeStatus(usageBasedChargeID, usagebased.StatusDeleted)
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsMissingMeterValidationIssue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-missing-meter-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var invoice billing.StandardInvoice
+
+	s.Run("Given a charge-backed usage line whose feature initially has a meter", func() {
+		// given:
+		// - a metered feature can be resolved when a credit-then-invoice usage charge is created
+		// when:
+		// - charge creation persists the charge and its gathering line
+		// then:
+		// - the gathering line is owned by the usage-based charge line engine and is ready for later collection
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-missing-meter-collection",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-missing-meter-collection",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		s.RequireChargeStatus(usageBasedCharge.GetChargeID(), usagebased.StatusCreated)
+
+		lines := s.mustGatheringLinesForCharge(ns, cust.ID, usageBasedCharge.ID, false)
+		s.Require().Len(lines, 1)
+		s.Equal(billing.LineEngineTypeChargeUsageBased, lines[0].Engine)
+	})
+
+	s.Run("When the meter disappears collection should persist an invalid invoice", func() {
+		// given:
+		// - the persisted charge and gathering line still reference the feature
+		// when:
+		// - the meter backing that feature is removed and the line becomes collectible
+		// then:
+		// - collection returns and persists a draft.invalid_created invoice with a critical validation issue
+		err := s.MeterAdapter.ReplaceMeters(ctx, nil)
+		s.NoError(err)
+
+		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		s.Require().NotNil(invoice.Lines.OrEmpty()[0].UsageBased)
+		s.Nil(invoice.Lines.OrEmpty()[0].UsageBased.MeteredQuantity)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Contains(issue.Message, fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key))
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsMultipleMissingMeterValidationIssues() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-multiple-missing-meter-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	aiTokens, err := s.FeatureService.CreateFeature(ctx, pcfeature.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "AI tokens",
+		Key:       "ai-tokens",
+		MeterID:   apiRequestsTotal.Feature.MeterID,
+	})
+	s.NoError(err)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - two credit-then-invoice usage charges have gathering lines backed by different features
+	// - both features resolve to a meter when the charges are created
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "missing-meter-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "AI tokens",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "missing-meter-ai-tokens",
+				FeatureKey:        aiTokens.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(created, 2)
+
+	// when:
+	// - the shared meter disappears and both gathering lines become collectible
+	err = s.MeterAdapter.ReplaceMeters(ctx, nil)
+	s.NoError(err)
+	clock.FreezeTime(servicePeriod.To.Add(time.Second))
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+
+	// then:
+	// - collection persists one invalid invoice and keeps a distinct critical issue for each feature
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	invoice := invoices[0]
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+	s.Require().Len(invoice.Lines.OrEmpty(), 2)
+	s.Require().Len(invoice.ValidationIssues, 2)
+
+	issueMessages := make([]string, 0, len(invoice.ValidationIssues))
+	for _, issue := range invoice.ValidationIssues {
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		issueMessages = append(issueMessages, issue.Message)
+	}
+	s.ElementsMatch([]string{
+		fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key),
+		fmt.Sprintf("feature[%s] has no meter associated", aiTokens.Key),
+	}, issueMessages)
+
+	for _, line := range invoice.Lines.OrEmpty() {
+		s.Require().NotNil(line.UsageBased)
+		s.Nil(line.UsageBased.MeteredQuantity)
+	}
+
+	persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+	s.Require().Len(persistedInvoice.ValidationIssues, 2)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestAdvanceChargesIgnoresMissingMetersForUsageChargesThatAreNotDue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-advance-ignores-not-due-missing-meters")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	aiTokens, err := s.FeatureService.CreateFeature(ctx, pcfeature.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "AI tokens",
+		Key:       "ai-tokens",
+		MeterID:   apiRequestsTotal.Feature.MeterID,
+	})
+	s.NoError(err)
+
+	usageServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	flatFeeServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-15T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(usageServicePeriod.From)
+	defer clock.UnFreeze()
+
+	// given:
+	// - two usage charges are active and are not due until the end of their service period
+	usageCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "not-due-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "AI tokens",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "not-due-ai-tokens",
+				FeatureKey:        aiTokens.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(usageCharges, 2)
+
+	usageChargeIDs := make([]meta.ChargeID, 0, len(usageCharges))
+	for _, charge := range usageCharges {
+		usageCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(usagebased.StatusActive, usageCharge.Status)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+		usageChargeIDs = append(usageChargeIDs, usageCharge.GetChargeID())
+	}
+
+	// - an unrelated credit-then-invoice flat fee for the customer becomes due first
+	flatFeeCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  flatFeeServicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "monthly platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "due-platform-fee",
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(flatFeeCharges, 1)
+	flatFeeCharge, err := flatFeeCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the usage meters disappear before the unrelated flat fee is advanced
+	err = s.MeterAdapter.ReplaceMeters(ctx, nil)
+	s.NoError(err)
+	clock.FreezeTime(flatFeeServicePeriod.From)
+
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+
+	// then:
+	// - the due flat fee advances without resolving meters for the not-due usage charges
+	s.Require().NoError(err)
+	s.Require().Len(advancedCharges, 1)
+	advancedFlatFee, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusActive, advancedFlatFee.Status)
+	s.RequireChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusActive)
+
+	for _, usageChargeID := range usageChargeIDs {
+		charge := s.RequireChargeStatus(usageChargeID, usagebased.StatusActive)
+		usageCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+	}
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsActiveRealizationRunValidationIssue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-active-run-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	sandboxApp := s.InstallSandboxApp(t, ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	midPeriodInvoiceAt := datetime.MustParseTimeInLocation(t, "2026-01-16T00:00:00Z", time.UTC).AsTime()
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageBasedChargeID meta.ChargeID
+		partialInvoice     billing.StandardInvoice
+	)
+
+	s.Run("Given a credit-then-invoice usage charge", func() {
+		// given:
+		// - a metered usage charge is configured for progressive billing
+		// when:
+		// - the charge and its gathering line are created
+		// then:
+		// - the charge is ready for a partial realization during its service period
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-active-run-collection",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-active-run-collection",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		usageBasedChargeID = usageBasedCharge.GetChargeID()
+		s.RequireChargeStatus(usageBasedChargeID, usagebased.StatusCreated)
+	})
+
+	s.Run("When a partial invoice becomes invalid during app validation", func() {
+		// given:
+		// - usage exists for the first part of the service period
+		// - the invoicing app rejects the customer configuration during invoice validation
+		// when:
+		// - the partial invoice reaches its collection time
+		// then:
+		// - the invoice is persisted as draft.invalid and retains the charge's active realization run
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+		clock.FreezeTime(midPeriodInvoiceAt)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(midPeriodInvoiceAt),
+		})
+		s.NoError(err)
+		s.Require().Len(invoices, 1)
+		partialInvoice = invoices[0]
+
+		mockApp := s.SandboxApp.EnableMock(t)
+		defer s.SandboxApp.DisableMock()
+		mockApp.OnValidateStandardInvoice(billing.NewValidationError(
+			"missing_app_customer_data",
+			"customer has no data for the invoicing app",
+		))
+
+		clock.FreezeTime(partialInvoice.DefaultCollectionAtForStandardInvoice())
+		partialInvoice, err = s.BillingService.AdvanceInvoice(ctx, partialInvoice.GetInvoiceID())
+		s.NoError(err)
+		mockApp.AssertExpectations(t)
+
+		s.Equal(billing.StandardInvoiceStatusDraftInvalid, partialInvoice.Status)
+		s.Require().Len(partialInvoice.ValidationIssues, 1)
+		s.Equal("missing_app_customer_data", partialInvoice.ValidationIssues[0].Code)
+		s.Equal(billing.ComponentName("app.sandbox.invoiceCustomers.validate"), partialInvoice.ValidationIssues[0].Component)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(usagebased.RealizationRunTypePartialInvoice, currentRun.Type)
+		s.Equal(partialInvoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("Then final collection persists the active-run failure as an invalid invoice", func() {
+		// given:
+		// - the earlier draft.invalid partial invoice still owns the charge's active realization run
+		// when:
+		// - billing collects the remaining line at the end of the service period
+		// then:
+		// - collection persists the new invoice and records the line-engine failure as a critical validation issue
+		clock.FreezeTime(servicePeriod.To)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+
+		invoice := invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Contains(issue.Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Contains(persistedInvoice.ValidationIssues[0].Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
 	})
 }
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -6097,52 +6097,6 @@ func (s *CreditThenInvoiceTestSuite) shrinkCharge(ctx context.Context, customerI
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) RequireChargeStatus(chargeID meta.ChargeID, status any) charges.Charge {
-	s.T().Helper()
-
-	charge := s.MustGetChargeByID(chargeID)
-
-	var actualStatus string
-	switch charge.Type() {
-	case meta.ChargeTypeUsageBased:
-		usageBasedCharge, err := charge.AsUsageBasedCharge()
-		s.NoError(err)
-		actualStatus = string(usageBasedCharge.Status)
-	case meta.ChargeTypeFlatFee:
-		flatFeeCharge, err := charge.AsFlatFeeCharge()
-		s.NoError(err)
-		actualStatus = string(flatFeeCharge.Status)
-	case meta.ChargeTypeCreditPurchase:
-		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
-		s.NoError(err)
-		actualStatus = string(creditPurchaseCharge.Status)
-	default:
-		s.FailNowf("unsupported charge type", "charge type %s is not supported", charge.Type())
-	}
-
-	s.Equal(fmt.Sprint(status), actualStatus)
-
-	return charge
-}
-
-func (s *CreditThenInvoiceTestSuite) RequireUsageBasedChargeStatus(chargeID meta.ChargeID, status usagebased.Status) usagebased.Charge {
-	s.T().Helper()
-
-	charge, err := s.RequireChargeStatus(chargeID, status).AsUsageBasedCharge()
-	s.NoError(err)
-
-	return charge
-}
-
-func (s *CreditThenInvoiceTestSuite) RequireFlatFeeChargeStatus(chargeID meta.ChargeID, status flatfee.Status) flatfee.Charge {
-	s.T().Helper()
-
-	charge, err := s.RequireChargeStatus(chargeID, status).AsFlatFeeCharge()
-	s.NoError(err)
-
-	return charge
-}
-
 func (s *CreditThenInvoiceTestSuite) mustGetUsageBasedChargeByIDWithExpands(chargeID meta.ChargeID, expands meta.Expands) usagebased.Charge {
 	s.T().Helper()
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -223,6 +223,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.NoError(err)
 
 		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+		defer clock.UnFreeze()
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(servicePeriod.To),
@@ -340,6 +341,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		usageBasedChargeID = usageBasedCharge.GetChargeID()
 
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(servicePeriod.To),
@@ -371,6 +373,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		s.NoError(err)
 
 		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		defer clock.UnFreeze()
 		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
@@ -414,6 +417,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		// - the meter is restored and the invoice is retried
 		// then:
 		// - collection succeeds without replacing the run or duplicating its invoice association
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		defer clock.UnFreeze()
+		
 		err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{apiRequestsTotalMeter})
 		s.NoError(err)
 
@@ -768,6 +774,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
 		)
 		clock.FreezeTime(midPeriodInvoiceAt)
+		defer clock.UnFreeze()
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
@@ -809,6 +816,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		// then:
 		// - the assignment gate leaves the line gathering and records the blocking run on the charge
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	pcfeature "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -253,6 +254,184 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
 		s.Require().Len(persistedInvoice.ValidationIssues, 1)
 		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCollectionMissingMeterIsRetryable() {
+	// given:
+	// - a charge-backed usage invoice and its realization run are waiting for collection
+	// when:
+	// - the feature's required meter disappears before collection
+	// then:
+	// - the invoice fails with a persisted validation issue and succeeds when retried after meter restoration
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-waiting-for-collection-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	meters, err := s.MeterAdapter.ListMeters(ctx, meter.ListMetersParams{Namespace: ns})
+	s.NoError(err)
+	s.Require().Len(meters.Items, 1)
+	apiRequestsTotalMeter := meters.Items[0]
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageBasedChargeID meta.ChargeID
+		invoice            billing.StandardInvoice
+		runID              usagebased.RealizationRunID
+		lineID             billing.LineID
+	)
+
+	s.Run("given the charge invoice is waiting for collection", func() {
+		// given:
+		// - a metered credit-then-invoice usage charge has usage in its final service period
+		// when:
+		// - billing creates the invoice before its collection time
+		// then:
+		// - the invoice and its charge realization wait for collection
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-waiting-for-collection-missing-meter",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-waiting-for-collection-missing-meter",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		usageBasedChargeID = usageBasedCharge.GetChargeID()
+
+		clock.FreezeTime(servicePeriod.To)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, invoice.Status)
+		s.False(invoice.StatusDetails.Failed)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		lineID = invoice.Lines.OrEmpty()[0].GetLineID()
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		runID = currentRun.ID
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("when the required meter disappears during the wait", func() {
+		// given:
+		// - the persisted invoice and charge realization are waiting for collection
+		// when:
+		// - the feature's required meter disappears before collection
+		// then:
+		// - collection persists a retryable failed invoice and rolls the charge back to waiting
+		err := s.MeterAdapter.ReplaceMeters(ctx, nil)
+		s.NoError(err)
+
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.True(invoice.StatusDetails.Failed)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Equal("/charges/"+usageBasedChargeID.ID, issue.Path)
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issue.Message,
+		)
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.True(persistedInvoice.StatusDetails.Failed)
+		s.Require().NotNil(persistedInvoice.StatusDetails.AvailableActions.Retry)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(runID.ID, currentRun.ID.ID)
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("then restoring the meter allows the same invoice to retry", func() {
+		// given:
+		// - the failed invoice remains associated with the charge's waiting realization run
+		// when:
+		// - the meter is restored and the invoice is retried
+		// then:
+		// - collection succeeds without replacing the run or duplicating its invoice association
+		err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{apiRequestsTotalMeter})
+		s.NoError(err)
+
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+		s.False(invoice.StatusDetails.Failed)
+		s.Nil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Empty(invoice.ValidationIssues)
+		s.NotNil(invoice.QuantitySnapshotedAt)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(runID.ID, currentRun.ID.ID)
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+		s.Equal(alpacadecimal.NewFromInt(10), currentRun.MeteredQuantity)
 	})
 }
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -240,7 +240,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
 		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
 		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
-		s.Contains(issue.Message, fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key))
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issue.Message,
+		)
 
 		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),
@@ -352,8 +355,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		issueMessages = append(issueMessages, issue.Message)
 	}
 	s.ElementsMatch([]string{
-		fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key),
-		fmt.Sprintf("feature[%s] has no meter associated", aiTokens.Key),
+		fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+		fmt.Sprintf("feature[%s]: %s", aiTokens.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
 	}, issueMessages)
 
 	for _, line := range invoice.Lines.OrEmpty() {
@@ -619,13 +622,13 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(partialInvoice.ID, lo.FromPtr(currentRun.InvoiceID))
 	})
 
-	s.Run("Then final collection persists the active-run failure as an invalid invoice", func() {
+	s.Run("Then final collection excludes the blocked line and records the issue on the charge", func() {
 		// given:
 		// - the earlier draft.invalid partial invoice still owns the charge's active realization run
 		// when:
 		// - billing collects the remaining line at the end of the service period
 		// then:
-		// - collection persists the new invoice and records the line-engine failure as a critical validation issue
+		// - the assignment gate leaves the line gathering and records the blocking run on the charge
 		clock.FreezeTime(servicePeriod.To)
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -633,26 +636,28 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 			AsOf:     lo.ToPtr(servicePeriod.To),
 		})
 		s.Require().NoError(err)
-		s.Require().Len(invoices, 1)
+		s.Empty(invoices)
 
-		invoice := invoices[0]
-		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
-		s.Require().Len(invoice.Lines.OrEmpty(), 1)
-		s.Require().Len(invoice.ValidationIssues, 1)
-
-		issue := invoice.ValidationIssues[0]
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		s.Require().Len(charge.ValidationIssues, 1)
+		issue := charge.ValidationIssues[0]
 		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
-		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
-		s.Contains(issue.Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+		s.Equal(usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun, issue.Code)
+		s.Equal(usagebased.ValidationIssueComponentLineEngine, issue.Component)
+		s.Contains(issue.Message, "must be completed before")
+		s.Require().Len(partialInvoice.Lines.OrEmpty(), 1)
+		s.Equal(partialInvoice.ID, issue.Attributes["invoice_id"])
+		s.Equal(partialInvoice.Lines.OrEmpty()[0].ID, issue.Attributes["line_id"])
 
-		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
-			Invoice: invoice.GetInvoiceID(),
-			Expand:  billing.StandardInvoiceExpandAll,
+		gatheringLines := s.mustGatheringLinesForCharge(ns, cust.ID, usageBasedChargeID.ID, false)
+		s.Require().Len(gatheringLines, 1)
+
+		standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
+			Namespace: ns,
 		})
 		s.NoError(err)
-		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
-		s.Require().Len(persistedInvoice.ValidationIssues, 1)
-		s.Contains(persistedInvoice.ValidationIssues[0].Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+		s.Require().Len(standardInvoices.Items, 1)
+		s.Equal(partialInvoice.ID, standardInvoices.Items[0].ID)
 	})
 }
 

--- a/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.down.sql
+++ b/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.down.sql
@@ -1,0 +1,4 @@
+-- reverse: modify "charge_usage_based" feature foreign key
+ALTER TABLE "charge_usage_based" DROP CONSTRAINT "charge_usage_based_features_usage_based_charges", ADD CONSTRAINT "charge_usage_based_features_usage_based_charges" FOREIGN KEY ("feature_id") REFERENCES "features" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ALTER COLUMN "feature_id" SET NOT NULL;

--- a/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.up.sql
+++ b/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.up.sql
@@ -1,0 +1,4 @@
+-- modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ALTER COLUMN "feature_id" DROP NOT NULL;
+-- modify "charge_usage_based" feature foreign key
+ALTER TABLE "charge_usage_based" DROP CONSTRAINT "charge_usage_based_features_usage_based_charges", ADD CONSTRAINT "charge_usage_based_features_usage_based_charges" FOREIGN KEY ("feature_id") REFERENCES "features" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vP1Tw1GzBUtg4eaBa5aTImcQqtUn6z59OzODJ2pEt5w=
+h1:dl9qy1YR2XTlBKnZwVNvLwCiIKu2X1wacVJ0zLXP6dM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -278,3 +278,4 @@ h1:vP1Tw1GzBUtg4eaBa5aTImcQqtUn6z59OzODJ2pEt5w=
 20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=
 20260903102842_add_lineage_custom_currency_identity.up.sql h1:KHYAUoTB7vwPQ/wsLAoRCm5gQGml5L1t3QExsZdwKWE=
 20260906100323_add_charge_and_billing_validation_issues.up.sql h1:nHSiTwJq6s7c3SU1CV103bpnPf2Nsi3zLm6UIIyF8sA=
+20260909104736_make_usage_based_feature_id_optional.up.sql h1:yhB56cUSZHgNXSig3A6VKDt3ktG0E4LXHj1/vo1sz8I=


### PR DESCRIPTION
## Summary

- resolve and validate usage-based feature references at charge creation while preserving key-only references without pinning an ID
- resolve and persist the current feature ID when a charge becomes active, then use that pinned identity for later runs
- resolve missing IDs internally for API rendering without expanding the feature unless requested
- allow nullable usage charge feature IDs and explicitly restrict deleting referenced features

## Validation

- make test-nocache (8075 tests passed, 9 skipped)
- make lint-go-fast (0 issues)
- make migrate-check





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Usage-based charges can remain unlinked to a feature until activation.
  - Feature references can use a key, an explicit ID, or both; conflicting combinations are rejected.
  - Feature IDs follow activation and pinning rules.
  - Flat-fee features may be meterless.
  - Feature references can be resolved without requiring meters.

- **Bug Fixes**
  - Customer-charge expansion and filtering now reflect current feature references accurately.
  - Feature deletion is prevented while usage-based charges still reference it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62102860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/openmeter/-/pull-requests/openmeterio/openmeter/5106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until delayed cancellation events can no longer reconcile obsolete subscription state and truncate current billing work.

<details><summary><h3>Summary</h3></summary>

- Preserves feature keys before activation and snapshots the resolved feature identity when usage billing activates.
- Resolves missing IDs for API reads without persisting those projection-time resolutions.
- Adds batched billability and validation handling across billing line engines.
- Prevents deletion of features referenced by usage-based charges.
- Introduces a cancellation-event regression for delayed subscription events.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Q as Event queue
    participant H as Cancellation handler
    participant S as Current subscription
    participant B as Billing reconciliation
    Q->>H: Delayed cancellation event with old ActiveTo
    Note over S: Subscription was continued or updated
    H->>B: Sync old event view through old ActiveTo
    B->>B: Truncate or delete current billing work
```
</details>

<!-- /greptile_comment -->