### PR TITLE
fix(billing): defer usage feature pinning until activation

### DIFF
--- a/openmeter/billing/charges/README.md
+++ b/openmeter/billing/charges/README.md
@@ -150,9 +150,15 @@ invoice validation issue.
   complete, not merely that rating or line creation finished.
 - Lifecycle entry points run in database transactions. Flat-fee and usage-based
   advancement and patching also take charge-scoped locks.
-- Charge creation resolves every supplied feature reference before persistence.
-  Usage-based features require a meter; flat-fee features are optional and may
-  be meterless.
+- Each concrete charge type resolves its supplied feature references before
+  persistence. Usage-based features require a meter; flat-fee features are
+  optional and may be meterless. A usage-based charge created by key persists
+  only the canonical key and snapshots its feature ID when it activates. An
+  explicitly supplied feature ID is pinned at creation and activation preserves
+  it; when both are supplied, the key must match the feature resolved by ID.
+- Customer-charge reads resolve the current feature by key when a preactivation
+  usage charge has no pinned ID. That ID is an API projection rather than
+  persisted state and may change until activation snapshots it.
 - Charge state machines do not expose invoice patches through a separate peek
   or drain operation. A caller must choose an invoice-aware
   `*UntilInvoicePatchesOrStable` operation, which stops at the first invoice

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -41,9 +40,8 @@ type FlatFeeService interface {
 }
 
 type CreateInput struct {
-	Namespace     string
-	Intents       []Intent
-	FeatureMeters billingfeaturemeter.FeatureMeters
+	Namespace string
+	Intents   []Intent
 }
 
 func (i CreateInput) Validate() error {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -29,6 +29,11 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		return nil, nil
 	}
 
+	featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
+	if err != nil {
+		return nil, err
+	}
+
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]flatfee.ChargeWithGatheringLine, error) {
 		now := clock.Now().UTC()
 		// Let's create all the flat fee charges in bulk
@@ -61,7 +66,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 			var featureID *string
 			if featureRef != nil {
-				featureMeter, err := input.FeatureMeters.Get(chargeIntent)
+				featureMeter, err := featureMeters.Get(chargeIntent)
 				if err != nil {
 					return flatfee.IntentWithInitialStatus{}, fmt.Errorf("resolve flat fee feature %+v: %w", *featureRef, err)
 				}

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -264,7 +264,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditThenInvo
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 
 	customCurrency := s.createTestCustomCurrency(ctx, ns)
-	featureMeters := s.createFeatureMeters(ctx, ns, "custom-cti-feature")
+	s.createFeatureMeters(ctx, ns, "custom-cti-feature")
 
 	clock.FreezeTime(usageBasedIntentServicePeriod.From)
 	defer clock.UnFreeze()
@@ -279,7 +279,6 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditThenInvo
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-cti", "custom-cti-feature", productcatalog.CreditThenInvoiceSettlementMode, &costBasisIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 
@@ -303,7 +302,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditOnlyReco
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 
 	customCurrency := s.createTestCustomCurrency(ctx, ns)
-	featureMeters := s.createFeatureMeters(ctx, ns, "custom-credit-only-feature")
+	s.createFeatureMeters(ctx, ns, "custom-credit-only-feature")
 
 	clock.FreezeTime(usageBasedIntentServicePeriod.From)
 	defer clock.UnFreeze()
@@ -313,7 +312,6 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesCustomCurrencyCreditOnlyReco
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(cust.ID, customCurrency, defaults.InvoicingTaxCodeID, "custom-credit-only", "custom-credit-only-feature", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 

--- a/openmeter/billing/charges/service/api.go
+++ b/openmeter/billing/charges/service/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/samber/lo"
@@ -16,12 +17,10 @@ import (
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
-	"github.com/openmeterio/openmeter/pkg/ref"
 )
 
 func (s *service) CreateCustomerCharge(ctx context.Context, input charges.CreateCustomerChargeInput) (charges.CustomerCharge, error) {
@@ -83,7 +82,7 @@ func (s *service) CreateCustomerCharge(ctx context.Context, input charges.Create
 	// The API response includes the realization view (the whole service period
 	// is outstanding on a fresh charge), so it is built here just like on the
 	// list path. No expands apply on the create path.
-	return buildCustomerCharge(created[0], customerChargeEntities{})
+	return s.buildCustomerCharge(ctx, created[0], customerChargeEntities{}, meta.ExpandNone)
 }
 
 func (s *service) DeleteCustomerCharge(ctx context.Context, input charges.DeleteCustomerChargeInput) error {
@@ -284,7 +283,7 @@ func (s *service) ListCustomerCharges(ctx context.Context, input charges.ListCus
 	}
 
 	customerCharges, err := lo.MapErr(listed.Items, func(charge charges.Charge, _ int) (charges.CustomerCharge, error) {
-		return buildCustomerCharge(charge, entities)
+		return s.buildCustomerCharge(ctx, charge, entities, listInput.Expands)
 	})
 	if err != nil {
 		return charges.ListCustomerChargesResult{}, err
@@ -304,7 +303,7 @@ func (s *service) ListCustomerCharges(ctx context.Context, input charges.ListCus
 // domain charge, the entities loaded for the applied expands, and the
 // resolved realization history of its type. Credit purchase charges only
 // receive the customer.
-func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities) (charges.CustomerCharge, error) {
+func (s *service) buildCustomerCharge(ctx context.Context, charge charges.Charge, entities customerChargeEntities, expands meta.Expands) (charges.CustomerCharge, error) {
 	out := charges.CustomerCharge{
 		Charge: charge,
 		// The listing is scoped to a single customer, so every charge on the
@@ -326,9 +325,23 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 
 		out.UsageBasedRealizations = resolved
 
-		if featureRef := ub.GetFeatureMeterRef(); featureRef != nil {
-			if feat, ok := entities.featuresByRef[featureRef.IDOrKey]; ok {
-				out.Feature = &feat
+		if entities.featureMeters != nil {
+			featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(ub))
+			if err == nil {
+				if ub.State.FeatureID == "" {
+					ub.State.FeatureID = featureMeter.Feature.ID
+					out.Charge = charges.NewCharge(ub)
+				}
+
+				if expands.Has(meta.ExpandFeature) {
+					out.Feature = &featureMeter.Feature
+				}
+			} else {
+				s.logger.WarnContext(ctx, "failed to resolve customer charge feature",
+					slog.String("namespace", ub.Namespace),
+					slog.String("charge_id", ub.ID),
+					slog.String("error", err.Error()),
+				)
 			}
 		}
 
@@ -350,9 +363,10 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 
 		out.FlatFeeRealizations = resolved
 
-		if featureRef := ff.GetFeatureRef(); featureRef != nil {
-			if feat, ok := entities.featuresByRef[*featureRef]; ok {
-				out.Feature = &feat
+		if expands.Has(meta.ExpandFeature) && entities.featureMeters != nil && ff.GetFeatureMeterRef() != nil {
+			featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(ff))
+			if err == nil {
+				out.Feature = &featureMeter.Feature
 			}
 		}
 
@@ -369,9 +383,10 @@ func buildCustomerCharge(charge charges.Charge, entities customerChargeEntities)
 // customerChargeReferences collects the entity references a page of charges
 // points at, so the facade bulk-loads each kind once.
 type customerChargeReferences struct {
-	featureReferences []billingfeaturemeter.FeatureReferenceGetter
-	subscriptionIDs   []string
-	invoiceIDs        []string
+	featureReferences   []billingfeaturemeter.FeatureReferenceGetter
+	hasMissingFeatureID bool
+	subscriptionIDs     []string
+	invoiceIDs          []string
 }
 
 func collectCustomerChargeReferences(items charges.Charges) (customerChargeReferences, error) {
@@ -379,7 +394,7 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 
 	for _, item := range items {
 		if item.GetFeatureMeterRef() != nil {
-			out.featureReferences = append(out.featureReferences, item)
+			out.featureReferences = append(out.featureReferences, billingfeaturemeter.WithoutMeters(item))
 		}
 
 		switch item.Type() {
@@ -391,6 +406,11 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 
 			if sub := ub.Intent.GetSubscription(); sub != nil {
 				out.subscriptionIDs = append(out.subscriptionIDs, sub.SubscriptionID)
+			}
+
+			// When the charge is created with feature key only, we need to resolve the feature ID.
+			if ub.State.FeatureID == "" {
+				out.hasMissingFeatureID = true
 			}
 
 			for _, run := range ub.Realizations {
@@ -431,7 +451,7 @@ func collectCustomerChargeReferences(items charges.Charges) (customerChargeRefer
 // one customer, so the customer is a single entity rather than a map.
 type customerChargeEntities struct {
 	customer          *customer.Customer
-	featuresByRef     map[ref.IDOrKey]feature.Feature
+	featureMeters     billingfeaturemeter.FeatureMeters
 	subscriptionsByID map[string]subscription.Subscription
 	invoiceLinesByID  map[string]billing.StandardInvoice
 }
@@ -447,8 +467,8 @@ func (s *service) loadCustomerChargeEntities(ctx context.Context, namespace stri
 		}
 	}
 
-	if expands.Has(meta.ExpandFeature) {
-		entities.featuresByRef, err = s.listCustomerChargeFeatures(ctx, namespace, refs.featureReferences)
+	if expands.Has(meta.ExpandFeature) || refs.hasMissingFeatureID {
+		entities.featureMeters, err = s.featureMeterResolver.Resolve(ctx, namespace, refs.featureReferences...)
 		if err != nil {
 			return customerChargeEntities{}, fmt.Errorf("loading features: %w", err)
 		}
@@ -491,44 +511,6 @@ func (s *service) getCustomerChargeCustomer(ctx context.Context, namespace strin
 	}
 
 	return lo.ToPtr(listed.Items[0]), nil
-}
-
-// listCustomerChargeFeatures bulk-loads the referenced features for the
-// feature expand. Refs mix resolved IDs (active charges) and keys (created
-// charges), which feature meter resolution handles natively.
-func (s *service) listCustomerChargeFeatures(ctx context.Context, namespace string, featureReferences []billingfeaturemeter.FeatureReferenceGetter) (map[ref.IDOrKey]feature.Feature, error) {
-	out := make(map[ref.IDOrKey]feature.Feature, len(featureReferences))
-	if len(featureReferences) == 0 {
-		return out, nil
-	}
-
-	featureMeters, err := s.featureMeterResolver.Resolve(ctx, namespace, featureReferences...)
-	if err != nil {
-		return nil, fmt.Errorf("resolving features: %w", err)
-	}
-
-	for _, featureReference := range featureReferences {
-		featureRef := featureReference.GetFeatureMeterRef()
-		if featureRef == nil {
-			continue
-		}
-
-		featureMeter, err := featureMeters.Get(featureReference)
-		if err != nil && !billing.IsValidationIssueOnly(err) {
-			return nil, fmt.Errorf("resolving feature %v: %w", featureRef.IDOrKey, err)
-		}
-
-		// Feature expansion is best-effort. A missing feature is omitted so
-		// the API retains its ID/key fallback, while other validation issues
-		// can still return a usable feature below.
-		if featureMeter.Feature.ID == "" {
-			continue
-		}
-
-		out[featureRef.IDOrKey] = featureMeter.Feature
-	}
-
-	return out, nil
 }
 
 // listCustomerChargeSubscriptions bulk-loads the referenced subscriptions for

--- a/openmeter/billing/charges/service/api_attach_test.go
+++ b/openmeter/billing/charges/service/api_attach_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -12,17 +13,18 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	billingfeaturemeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	currenciestestutils "github.com/openmeterio/openmeter/openmeter/currencies/testutils"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-// TestBuildCustomerCharge exercises the pure assembly step against an
+// TestBuildCustomerCharge exercises the assembly step against an
 // in-memory charge: the DB-backed facade suite cannot create a charge with a
 // subscription reference (FK to real subscription rows), so the
 // subscription/invoice attach wiring is covered here instead.
@@ -84,14 +86,24 @@ func TestBuildCustomerCharge(t *testing.T) {
 	}
 
 	entities := customerChargeEntities{
-		customer:          &customer.Customer{ManagedResource: models.ManagedResource{ID: "cust-1", Name: "Attach Customer"}},
-		featuresByRef:     map[ref.IDOrKey]feature.Feature{{ID: "feat-1"}: {ID: "feat-1", Name: "Attach Feature"}},
+		customer: &customer.Customer{ManagedResource: models.ManagedResource{ID: "cust-1", Name: "Attach Customer"}},
+		featureMeters: billingfeaturemeterservice.FeatureMeterCollection{
+			ByID: map[string]billingfeaturemeter.FeatureMeter{
+				"feat-1": {Feature: feature.Feature{ID: "feat-1", Name: "Attach Feature"}},
+			},
+		},
 		subscriptionsByID: map[string]subscription.Subscription{"sub-1": {NamespacedID: models.NamespacedID{Namespace: "ns", ID: "sub-1"}, Name: "Attach Subscription"}},
 		invoiceLinesByID:  map[string]billing.StandardInvoice{"line-1": {}},
 	}
+	service := &service{logger: slog.New(slog.DiscardHandler)}
 
 	// when attaching the loaded entities
-	out, err := buildCustomerCharge(charges.NewCharge(charge), entities)
+	out, err := service.buildCustomerCharge(t.Context(), charges.NewCharge(charge), entities, meta.Expands{
+		meta.ExpandCustomer,
+		meta.ExpandFeature,
+		meta.ExpandSubscription,
+		meta.ExpandRealizationInvoice,
+	})
 	require.NoError(t, err)
 
 	// then every expanded member resolves from its loaded entity, and the
@@ -110,7 +122,7 @@ func TestBuildCustomerCharge(t *testing.T) {
 	require.Nil(t, out.UsageBasedRealizations[1].Invoice, "the outstanding projection never has an invoice")
 
 	// and without loaded entities every expanded member stays nil
-	bare, err := buildCustomerCharge(charges.NewCharge(charge), customerChargeEntities{})
+	bare, err := service.buildCustomerCharge(t.Context(), charges.NewCharge(charge), customerChargeEntities{}, meta.ExpandNone)
 	require.NoError(t, err)
 	require.Nil(t, bare.Customer)
 	require.Nil(t, bare.Feature)

--- a/openmeter/billing/charges/service/api_list_test.go
+++ b/openmeter/billing/charges/service/api_list_test.go
@@ -75,16 +75,22 @@ func (s *CustomerChargeAPIListTestSuite) TestFeatureExpansionValidationPolicy() 
 
 		// when:
 		// - the customer charge facade expands the feature
-		featuresByRef, err := service.listCustomerChargeFeatures(
+		references, err := collectCustomerChargeReferences(charges.Charges{reference})
+		require.NoError(s.T(), err)
+		entities, err := service.loadCustomerChargeEntities(
 			s.T().Context(),
 			namespace,
-			[]billingfeaturemeter.FeatureReferenceGetter{reference},
+			"",
+			references,
+			meta.Expands{meta.ExpandFeature},
 		)
 
 		// then:
-		// - the resolver's validation issue does not discard its usable feature
+		// - feature-only resolution does not require a meter
 		require.NoError(s.T(), err)
-		require.Equal(s.T(), featureEntity, featuresByRef[reference.GetFeatureMeterRef().IDOrKey])
+		featureMeter, err := entities.featureMeters.Get(billingfeaturemeter.WithoutMeters(reference))
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), featureEntity, featureMeter.Feature)
 	})
 
 	s.Run("catalog system error aborts expansion", func() {
@@ -100,10 +106,14 @@ func (s *CustomerChargeAPIListTestSuite) TestFeatureExpansionValidationPolicy() 
 
 		// when:
 		// - the customer charge facade expands the feature
-		_, err := service.listCustomerChargeFeatures(
+		references, err := collectCustomerChargeReferences(charges.Charges{reference})
+		require.NoError(s.T(), err)
+		_, err = service.loadCustomerChargeEntities(
 			s.T().Context(),
 			namespace,
-			[]billingfeaturemeter.FeatureReferenceGetter{reference},
+			"",
+			references,
+			meta.Expands{meta.ExpandFeature},
 		)
 
 		// then:
@@ -131,7 +141,10 @@ func newCustomerChargeFeatureTestService(t *testing.T, features []feature.Featur
 	})
 	require.NoError(t, err)
 
-	return &service{featureMeterResolver: resolver}
+	return &service{
+		logger:               slog.New(slog.DiscardHandler),
+		featureMeterResolver: resolver,
+	}
 }
 
 func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
@@ -299,12 +312,17 @@ func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
 		// - feature expansion resolves that charge
 		references, err := collectCustomerChargeReferences(charges.Charges{staleCharge})
 		require.NoError(s.T(), err)
-		featuresByRef, err := s.Charges.listCustomerChargeFeatures(ctx, namespace, references.featureReferences)
+		entities, err := s.Charges.loadCustomerChargeEntities(ctx, namespace, cust.ID, references, meta.Expands{meta.ExpandFeature})
+		require.NoError(s.T(), err)
+		customerCharge, err := s.Charges.buildCustomerCharge(ctx, staleCharge, entities, meta.Expands{meta.ExpandFeature})
 
 		// then:
 		// - the missing feature is omitted so the facade can retain its ID-only fallback
 		require.NoError(s.T(), err)
-		require.Empty(s.T(), featuresByRef)
+		require.Nil(s.T(), customerCharge.Feature)
+		resolvedCharge, err := customerCharge.AsUsageBasedCharge()
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), usageCharge.State.FeatureID, resolvedCharge.State.FeatureID)
 	})
 
 	s.Run("the subscription side-loader serves the facade's bulk lookup", func() {
@@ -407,18 +425,17 @@ func (s *CustomerChargeAPIListTestSuite) TestListCustomerChargesExpands() {
 
 	s.Run("feature filters scope the listing", func() {
 		// given:
-		// - both charges reference the api-requests feature, created by key
-		//   (Create resolves and persists the feature ID)
+		// - both charges reference the api-requests feature by key without a pinned ID
 		// when:
 		// - listing filtered by feature id and by feature key
 		// then:
-		// - the matching feature returns every charge, a foreign one none
+		// - the ID does not match before activation, while the key returns every charge
 		byID := newListInput(meta.ExpandNone)
 		byID.FeatureID = &filter.FilterULID{FilterString: filter.FilterString{Eq: lo.ToPtr(feat.Feature.ID)}}
 
 		result, err := s.Charges.ListCustomerCharges(ctx, byID)
 		require.NoError(s.T(), err)
-		s.Len(result.Charges.Items, 2)
+		s.Empty(result.Charges.Items)
 
 		byKey := newListInput(meta.ExpandNone)
 		byKey.FeatureKey = &filter.FilterString{In: lo.ToPtr([]string{feat.Feature.Key, "another-feature"})}

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -156,11 +156,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			return nil, err
 		}
 
-		createFeatureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
-		if err != nil {
-			return nil, fmt.Errorf("resolve create feature meters: %w", err)
-		}
-
 		createdCharges := make([]charges.WithIndex[charges.Charge], 0, len(input.Intents))
 		gatheringLinesToCreate := make([]gatheringLineWithCustomerID, 0, len(input.Intents))
 
@@ -170,7 +165,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			Intents: lo.Map(intentsByType.FlatFee, func(intent charges.WithIndex[flatfee.Intent], _ int) flatfee.Intent {
 				return intent.Value
 			}),
-			FeatureMeters: createFeatureMeters,
 		})
 		if err != nil {
 			return nil, err
@@ -201,7 +195,6 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			Intents: lo.Map(intentsByType.UsageBased, func(intent charges.WithIndex[usagebased.Intent], _ int) usagebased.Intent {
 				return intent.Value
 			}),
-			FeatureMeters: createFeatureMeters,
 		})
 		if err != nil {
 			return nil, err

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -187,7 +187,7 @@ func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureID
 	createdCharge, err := createdCharges[0].AsUsageBasedCharge()
 	s.NoError(err)
 	s.Equal(meta.ChargeStatusCreated, meta.ChargeStatus(createdCharge.Status))
-	s.Equal(featureV1.ID, createdCharge.State.FeatureID)
+	s.Empty(createdCharge.State.FeatureID)
 
 	s.archiveFeature(ctx, ns, featureV1.ID)
 	featureV2 := s.createFeature(ctx, ns, featureKey, meterV2.ID)

--- a/openmeter/billing/charges/service/flatfee_costbasis_test.go
+++ b/openmeter/billing/charges/service/flatfee_costbasis_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/costbasis"
-	featuremeterservice "github.com/openmeterio/openmeter/openmeter/billing/featuremeter/service"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	dbchargeflatfeecostbasis "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeecostbasis"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -78,7 +77,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynamicCo
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "pinned", productcatalog.CreditThenInvoiceSettlementMode, &pinnedIntent),
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 3)
@@ -159,7 +157,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetrySafe
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-retry", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -289,7 +286,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeBeco
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-active", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -376,7 +372,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAndFia
 				Intents: []flatfee.Intent{
 					s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "mismatch-"+test.name, productcatalog.CreditThenInvoiceSettlementMode, &intent),
 				},
-				FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 			})
 			s.Require().ErrorContains(err, test.errorText)
 		})
@@ -407,7 +402,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeCrea
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().Error(err)
 	s.Require().Equal(0, s.countCostBases(namespace))
@@ -424,7 +418,6 @@ func (s *FlatFeeCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeRefe
 		Intents: []flatfee.Intent{
 			s.newFlatFeeIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "credit-only", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featuremeterservice.FeatureMeterCollection{},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)

--- a/openmeter/billing/charges/service/service.go
+++ b/openmeter/billing/charges/service/service.go
@@ -22,6 +22,7 @@ import (
 )
 
 type service struct {
+	logger  *slog.Logger
 	adapter charges.Adapter
 	// Note: if meta has a service layer, we should use it here instead of the adapter
 	metaAdapter          meta.Adapter
@@ -141,6 +142,7 @@ func New(config Config) (*service, error) {
 	}
 
 	svc := &service{
+		logger:                config.Logger,
 		adapter:               config.Adapter,
 		billingService:        config.BillingService,
 		invoiceUpdater:        invoiceUpdater,

--- a/openmeter/billing/charges/service/usagebased_costbasis_test.go
+++ b/openmeter/billing/charges/service/usagebased_costbasis_test.go
@@ -47,7 +47,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynami
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-modes")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "modes-feature")
+	s.createFeatureMeters(ctx, namespace, "modes-feature")
 	fiatCurrency := s.newFiatCurrency("USD")
 	pinnedCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
@@ -76,7 +76,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreatePersistsManualPinnedAndDynami
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "pinned", "modes-feature", productcatalog.CreditThenInvoiceSettlementMode, &pinnedIntent),
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic", "modes-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 3)
@@ -141,7 +140,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetryS
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-retry")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "retry-feature")
+	s.createFeatureMeters(ctx, namespace, "retry-feature")
 	currencyCostBasis, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
 		CurrencyID: currency.ID,
@@ -158,7 +157,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestSetResolvedDynamicCostBasisIsRetryS
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-retry", "retry-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -218,7 +216,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeB
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 	_ = s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "active-feature")
+	s.createFeatureMeters(ctx, namespace, "active-feature")
 	first, err := s.CurrencyService.CreateCostBasis(ctx, currencies.CreateCostBasisInput{
 		Namespace:  namespace,
 		CurrencyID: currency.ID,
@@ -245,7 +243,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestDynamicCostBasisResolvesWhenChargeB
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "dynamic-active", "active-feature", productcatalog.CreditThenInvoiceSettlementMode, &dynamicIntent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)
@@ -275,7 +272,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAnd
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-pinned-mismatch")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "mismatch-feature")
+	s.createFeatureMeters(ctx, namespace, "mismatch-feature")
 	otherCurrency, err := s.CurrencyService.CreateCurrency(ctx, currencies.CreateCurrencyInput{
 		Namespace: namespace,
 		CurrencyDetails: currencyx.CurrencyDetails{
@@ -331,7 +328,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestPinnedCostBasisMustMatchCurrencyAnd
 				Intents: []usagebased.Intent{
 					s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "mismatch-"+test.name, "mismatch-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 				},
-				FeatureMeters: featureMeters,
 			})
 			s.Require().ErrorContains(err, test.errorText)
 		})
@@ -351,7 +347,7 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeC
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-cost-basis-rollback")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "rollback-feature")
+	s.createFeatureMeters(ctx, namespace, "rollback-feature")
 	intent := costbasis.NewIntent(costbasis.ManualIntent{
 		FiatCurrency: s.newFiatCurrency("USD"),
 		Rate:         alpacadecimal.NewFromInt(2),
@@ -363,7 +359,6 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateRollsBackCostBasesWhenChargeC
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", "rollback-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "duplicate", "rollback-feature", productcatalog.CreditThenInvoiceSettlementMode, &intent),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().Error(err)
 	s.Require().Equal(0, s.countCostBases(namespace))
@@ -375,13 +370,12 @@ func (s *UsageBasedCostBasisCreateSuite) TestCreateWithoutCostBasisLeavesChargeR
 	defaults := s.ProvisionDefaultTaxCodes(ctx, namespace)
 	customer := s.CreateTestCustomer(namespace, "usage-based-without-cost-basis")
 	currency := s.createTestCustomCurrency(ctx, namespace)
-	featureMeters := s.createFeatureMeters(ctx, namespace, "credit-only-feature")
+	s.createFeatureMeters(ctx, namespace, "credit-only-feature")
 	created, err := s.Charges.usageBasedService.Create(ctx, usagebased.CreateInput{
 		Namespace: namespace,
 		Intents: []usagebased.Intent{
 			s.newUsageBasedIntent(customer.ID, currency, defaults.InvoicingTaxCodeID, "credit-only", "credit-only-feature", productcatalog.CreditOnlySettlementMode, nil),
 		},
-		FeatureMeters: featureMeters,
 	})
 	s.Require().NoError(err)
 	s.Require().Len(created, 1)

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -44,7 +44,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 		update := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetDiscounts(&baseIntent.Discounts).
-			SetFeatureID(charge.State.FeatureID).
+			SetOrClearFeatureID(lo.EmptyableToPtr(charge.State.FeatureID)).
 			SetOrClearIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 			SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
 			SetPrice(&baseIntent.Price).
@@ -438,13 +438,16 @@ func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, in
 		SetNillableDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 		SetNillableIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 		SetDiscounts(&baseIntent.Discounts).
-		SetFeatureID(intent.FeatureID).
 		SetRatingEngine(intent.RatingEngine).
 		SetPrice(&baseIntent.Price).
 		SetStatusDetailed(usagebased.Status(meta.ChargeStatusCreated)).
 		SetFeatureKey(baseIntent.FeatureKey).
 		SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
 		SetSettlementMode(baseIntent.SettlementMode)
+
+	if intent.FeatureID != "" {
+		create = create.SetFeatureID(intent.FeatureID)
+	}
 
 	if baseIntent.UnitConfig != nil {
 		create = create.SetUnitConfig(baseIntent.UnitConfig)

--- a/openmeter/billing/charges/usagebased/adapter/mapping.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapping.go
@@ -119,7 +119,7 @@ func fromDBBase(entity *entdb.ChargeUsageBased, chargeMeta meta.Charge) (usageba
 		State: usagebased.State{
 			CurrentRealizationRunID: entity.CurrentRealizationRunID,
 			AdvanceAfter:            entity.AdvanceAfter,
-			FeatureID:               entity.FeatureID,
+			FeatureID:               lo.FromPtr(entity.FeatureID),
 			RatingEngine:            entity.RatingEngine,
 			CostBasisID:             costBasisID,
 			ResolvedCostBasis:       resolvedCostBasis,

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -270,30 +270,9 @@ func (c Charge) GetCustomerID() customer.CustomerID {
 }
 
 func (c Charge) GetFeatureMeterRef() *billingfeaturemeter.FeatureMeterRef {
-	// TODO: consolidate intent and persisted-charge feature reference handling once
-	// their creation-time and lifecycle-specific resolution semantics share one model.
-	// State.FeatureID is the persisted resolved feature snapshot used by active
-	// charges; created/deleted fallbacks resolve by key.
-	var featureRef ref.IDOrKey
-	switch c.Status {
-	case StatusCreated:
-		featureRef = ref.IDOrKey{
-			Key: c.Intent.GetBaseIntent().FeatureKey,
-		}
-	case StatusDeleted:
-		if c.State.FeatureID != "" {
-			featureRef = ref.IDOrKey{
-				ID: c.State.FeatureID,
-			}
-		} else {
-			featureRef = ref.IDOrKey{
-				Key: c.Intent.GetBaseIntent().FeatureKey,
-			}
-		}
-	default:
-		featureRef = ref.IDOrKey{
-			ID: c.State.FeatureID,
-		}
+	featureRef := ref.IDOrKey{ID: c.State.FeatureID}
+	if featureRef.ID == "" {
+		featureRef = ref.IDOrKey{Key: c.Intent.GetBaseIntent().FeatureKey}
 	}
 
 	if lo.IsEmpty(featureRef) {
@@ -807,10 +786,6 @@ func (s State) Validate() error {
 
 	if s.CurrentRealizationRunID != nil && *s.CurrentRealizationRunID == "" {
 		errs = append(errs, fmt.Errorf("current realization run ID must be non-empty"))
-	}
-
-	if s.FeatureID == "" {
-		errs = append(errs, fmt.Errorf("feature id must be set"))
 	}
 
 	if err := s.RatingEngine.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -46,19 +46,14 @@ type UsageBasedService interface {
 }
 
 type CreateInput struct {
-	Namespace     string
-	Intents       []Intent
-	FeatureMeters billingfeaturemeter.FeatureMeters
+	Namespace string
+	Intents   []Intent
 }
 
 func (i CreateInput) Validate() error {
 	var errs []error
 	if i.Namespace == "" {
 		errs = append(errs, errors.New("namespace is required"))
-	}
-
-	if len(i.Intents) > 0 && i.FeatureMeters == nil {
-		errs = append(errs, errors.New("feature meters are required"))
 	}
 
 	for idx, intent := range i.Intents {
@@ -89,10 +84,6 @@ func (i CreateIntent) Validate() error {
 
 	if err := i.Intent.Validate(); err != nil {
 		errs = append(errs, err)
-	}
-
-	if i.FeatureID == "" {
-		errs = append(errs, errors.New("feature id is required"))
 	}
 
 	if err := i.RatingEngine.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -27,6 +27,11 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 		return nil, nil
 	}
 
+	featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Namespace, input.Intents...)
+	if err != nil {
+		return nil, err
+	}
+
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]usagebased.ChargeWithGatheringLine, error) {
 		now := clock.Now().UTC()
 		createIntents, err := slicesx.MapWithErr(input.Intents, func(intent usagebased.Intent) (usagebased.CreateIntent, error) {
@@ -47,19 +52,30 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 				}
 			}
 
-			featureMeter, err := input.FeatureMeters.Get(chargeIntent)
+			featureMeter, err := featureMeters.Get(chargeIntent)
 			if err != nil {
-				return usagebased.CreateIntent{}, fmt.Errorf("resolve usage based feature for key %+v: %w", chargeIntent.GetFeatureRef(), err)
+				return usagebased.CreateIntent{}, fmt.Errorf("resolve usage based feature %+v: %w", chargeIntent.GetFeatureRef(), err)
 			}
 
-			// note: we must set the feature key on the intent, because no other place is setting it
-			// and we want to persist it
+			if chargeIntent.FeatureID != "" && chargeIntent.FeatureKey != "" && chargeIntent.FeatureKey != featureMeter.Feature.Key {
+				return usagebased.CreateIntent{}, models.NewGenericValidationError(fmt.Errorf(
+					"feature key %q does not match key %q resolved from feature id %q",
+					chargeIntent.FeatureKey,
+					featureMeter.Feature.Key,
+					chargeIntent.FeatureID,
+				))
+			}
+
+			featureID := ""
+			if chargeIntent.FeatureID != "" {
+				featureID = featureMeter.Feature.ID
+			}
 			chargeIntent.FeatureKey = featureMeter.Feature.Key
 
 			return usagebased.CreateIntent{
 				Intent:            chargeIntent.AsOverridableIntent(),
 				Annotations:       chargeIntent.Annotations,
-				FeatureID:         featureMeter.Feature.ID,
+				FeatureID:         featureID,
 				RatingEngine:      s.rater.GetPreferredRatingEngineFor(chargeIntent),
 				ResolvedCostBasis: resolvedCostBasis,
 			}, nil

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -568,15 +568,9 @@ func (e *LineEngine) createManualInvoiceLines(ctx context.Context, input billing
 
 	namespace := input.Invoice.GetInvoiceID().Namespace
 	intents := lo.Map(created, func(line manualCreatedInvoiceLine, _ int) usagebased.Intent { return line.intent })
-	featureMeters, err := e.service.featureMeterResolver.Resolve(ctx, namespace, intents...)
-	if err != nil {
-		return nil, fmt.Errorf("resolving manually created usage-based charge feature meters: %w", err)
-	}
-
 	createdCharges, err := e.service.Create(ctx, usagebased.CreateInput{
-		Namespace:     namespace,
-		Intents:       intents,
-		FeatureMeters: featureMeters,
+		Namespace: namespace,
+		Intents:   intents,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating manually managed usage-based charges: %w", err)

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -292,6 +292,10 @@ func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
 }
 
 func (s *stateMachine) SyncFeatureIDFromFeatureMeter(ctx context.Context) error {
+	if s.Charge.State.FeatureID != "" {
+		return nil
+	}
+
 	s.Charge.State.FeatureID = s.FeatureMeter.Feature.ID
 	return nil
 }

--- a/openmeter/billing/featuremeter/featuremeter.go
+++ b/openmeter/billing/featuremeter/featuremeter.go
@@ -29,6 +29,32 @@ type FeatureReferenceGetter interface {
 	GetFeatureMeterRef() *FeatureMeterRef
 }
 
+type featureReferenceWithoutMeters struct {
+	reference FeatureReferenceGetter
+}
+
+func (r featureReferenceWithoutMeters) GetFeatureMeterRef() *FeatureMeterRef {
+	if r.reference == nil {
+		return nil
+	}
+
+	reference := r.reference.GetFeatureMeterRef()
+	if reference == nil {
+		return nil
+	}
+
+	withoutMeters := *reference
+	withoutMeters.RequireMeter = false
+
+	return &withoutMeters
+}
+
+// WithoutMeters returns a feature-only copy of a reference. The returned
+// reference deliberately does not retain the owner's identity.
+func WithoutMeters(reference FeatureReferenceGetter) FeatureReferenceGetter {
+	return featureReferenceWithoutMeters{reference: reference}
+}
+
 // FeatureReferenceOwner provides the stable identity of the billing entity that
 // owns a feature reference. Reference types without a stable identity must not
 // implement this interface.

--- a/openmeter/ent/db/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased.go
@@ -101,7 +101,7 @@ type ChargeUsageBased struct {
 	// FeatureKey holds the value of the "feature_key" field.
 	FeatureKey string `json:"feature_key,omitempty"`
 	// FeatureID holds the value of the "feature_id" field.
-	FeatureID string `json:"feature_id,omitempty"`
+	FeatureID *string `json:"feature_id,omitempty"`
 	// RatingEngine holds the value of the "rating_engine" field.
 	RatingEngine usagebased.RatingEngine `json:"rating_engine,omitempty"`
 	// Price holds the value of the "price" field.
@@ -543,7 +543,8 @@ func (_m *ChargeUsageBased) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field feature_id", values[i])
 			} else if value.Valid {
-				_m.FeatureID = value.String
+				_m.FeatureID = new(string)
+				*_m.FeatureID = value.String
 			}
 		case chargeusagebased.FieldRatingEngine:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -804,8 +805,10 @@ func (_m *ChargeUsageBased) String() string {
 	builder.WriteString("feature_key=")
 	builder.WriteString(_m.FeatureKey)
 	builder.WriteString(", ")
-	builder.WriteString("feature_id=")
-	builder.WriteString(_m.FeatureID)
+	if v := _m.FeatureID; v != nil {
+		builder.WriteString("feature_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteString(", ")
 	builder.WriteString("rating_engine=")
 	builder.WriteString(fmt.Sprintf("%v", _m.RatingEngine))

--- a/openmeter/ent/db/chargeusagebased/where.go
+++ b/openmeter/ent/db/chargeusagebased/where.go
@@ -1810,6 +1810,16 @@ func FeatureIDHasSuffix(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldHasSuffix(FieldFeatureID, v))
 }
 
+// FeatureIDIsNil applies the IsNil predicate on the "feature_id" field.
+func FeatureIDIsNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldIsNull(FieldFeatureID))
+}
+
+// FeatureIDNotNil applies the NotNil predicate on the "feature_id" field.
+func FeatureIDNotNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldNotNull(FieldFeatureID))
+}
+
 // FeatureIDEqualFold applies the EqualFold predicate on the "feature_id" field.
 func FeatureIDEqualFold(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldEqualFold(FieldFeatureID, v))

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -344,6 +344,14 @@ func (_c *ChargeUsageBasedCreate) SetFeatureID(v string) *ChargeUsageBasedCreate
 	return _c
 }
 
+// SetNillableFeatureID sets the "feature_id" field if the given value is not nil.
+func (_c *ChargeUsageBasedCreate) SetNillableFeatureID(v *string) *ChargeUsageBasedCreate {
+	if v != nil {
+		_c.SetFeatureID(*v)
+	}
+	return _c
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_c *ChargeUsageBasedCreate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedCreate {
 	_c.mutation.SetRatingEngine(v)
@@ -694,9 +702,6 @@ func (_c *ChargeUsageBasedCreate) check() error {
 			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_key": %w`, err)}
 		}
 	}
-	if _, ok := _c.mutation.FeatureID(); !ok {
-		return &ValidationError{Name: "feature_id", err: errors.New(`db: missing required field "ChargeUsageBased.feature_id"`)}
-	}
 	if v, ok := _c.mutation.FeatureID(); ok {
 		if err := chargeusagebased.FeatureIDValidator(v); err != nil {
 			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_id": %w`, err)}
@@ -733,9 +738,6 @@ func (_c *ChargeUsageBasedCreate) check() error {
 	}
 	if len(_c.mutation.CustomerIDs()) == 0 {
 		return &ValidationError{Name: "customer", err: errors.New(`db: missing required edge "ChargeUsageBased.customer"`)}
-	}
-	if len(_c.mutation.FeatureIDs()) == 0 {
-		return &ValidationError{Name: "feature", err: errors.New(`db: missing required edge "ChargeUsageBased.feature"`)}
 	}
 	if len(_c.mutation.TaxCodeIDs()) == 0 {
 		return &ValidationError{Name: "tax_code", err: errors.New(`db: missing required edge "ChargeUsageBased.tax_code"`)}
@@ -1091,7 +1093,7 @@ func (_c *ChargeUsageBasedCreate) createSpec() (*ChargeUsageBased, *sqlgraph.Cre
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		_node.FeatureID = nodes[0]
+		_node.FeatureID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.TaxCodeIDs(); len(nodes) > 0 {
@@ -1471,6 +1473,12 @@ func (u *ChargeUsageBasedUpsert) SetFeatureID(v string) *ChargeUsageBasedUpsert 
 // UpdateFeatureID sets the "feature_id" field to the value that was provided on create.
 func (u *ChargeUsageBasedUpsert) UpdateFeatureID() *ChargeUsageBasedUpsert {
 	u.SetExcluded(chargeusagebased.FieldFeatureID)
+	return u
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsert) ClearFeatureID() *ChargeUsageBasedUpsert {
+	u.SetNull(chargeusagebased.FieldFeatureID)
 	return u
 }
 
@@ -1976,6 +1984,13 @@ func (u *ChargeUsageBasedUpsertOne) SetFeatureID(v string) *ChargeUsageBasedUpse
 func (u *ChargeUsageBasedUpsertOne) UpdateFeatureID() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsertOne) ClearFeatureID() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearFeatureID()
 	})
 }
 
@@ -2663,6 +2678,13 @@ func (u *ChargeUsageBasedUpsertBulk) SetFeatureID(v string) *ChargeUsageBasedUps
 func (u *ChargeUsageBasedUpsertBulk) UpdateFeatureID() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// ClearFeatureID clears the value of the "feature_id" field.
+func (u *ChargeUsageBasedUpsertBulk) ClearFeatureID() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearFeatureID()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_query.go
+++ b/openmeter/ent/db/chargeusagebased_query.go
@@ -1236,7 +1236,10 @@ func (_q *ChargeUsageBasedQuery) loadFeature(ctx context.Context, query *Feature
 	ids := make([]string, 0, len(nodes))
 	nodeids := make(map[string][]*ChargeUsageBased)
 	for i := range nodes {
-		fk := nodes[i].FeatureID
+		if nodes[i].FeatureID == nil {
+			continue
+		}
+		fk := *nodes[i].FeatureID
 		if _, ok := nodeids[fk]; !ok {
 			ids = append(ids, fk)
 		}

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -340,6 +340,12 @@ func (_u *ChargeUsageBasedUpdate) SetNillableFeatureID(v *string) *ChargeUsageBa
 	return _u
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (_u *ChargeUsageBasedUpdate) ClearFeatureID() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearFeatureID()
+	return _u
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_u *ChargeUsageBasedUpdate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdate {
 	_u.mutation.SetRatingEngine(v)
@@ -630,9 +636,6 @@ func (_u *ChargeUsageBasedUpdate) check() error {
 	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.customer"`)
-	}
-	if _u.mutation.FeatureCleared() && len(_u.mutation.FeatureIDs()) > 0 {
-		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.feature"`)
 	}
 	if _u.mutation.TaxCodeCleared() && len(_u.mutation.TaxCodeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.tax_code"`)
@@ -1297,6 +1300,12 @@ func (_u *ChargeUsageBasedUpdateOne) SetNillableFeatureID(v *string) *ChargeUsag
 	return _u
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (_u *ChargeUsageBasedUpdateOne) ClearFeatureID() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearFeatureID()
+	return _u
+}
+
 // SetRatingEngine sets the "rating_engine" field.
 func (_u *ChargeUsageBasedUpdateOne) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdateOne {
 	_u.mutation.SetRatingEngine(v)
@@ -1600,9 +1609,6 @@ func (_u *ChargeUsageBasedUpdateOne) check() error {
 	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.customer"`)
-	}
-	if _u.mutation.FeatureCleared() && len(_u.mutation.FeatureIDs()) > 0 {
-		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.feature"`)
 	}
 	if _u.mutation.TaxCodeCleared() && len(_u.mutation.TaxCodeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeUsageBased.tax_code"`)

--- a/openmeter/ent/db/feature_query.go
+++ b/openmeter/ent/db/feature_query.go
@@ -791,9 +791,12 @@ func (_q *FeatureQuery) loadUsageBasedCharges(ctx context.Context, query *Charge
 	}
 	for _, n := range neighbors {
 		fk := n.FeatureID
-		node, ok := nodeids[fk]
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "feature_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "feature_id" returned %v for node %v`, fk, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "feature_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2948,7 +2948,7 @@ var (
 		{Name: "cost_basis_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "custom_currency_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
-		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_item_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_phase_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2988,7 +2988,7 @@ var (
 				Symbol:     "charge_usage_based_features_usage_based_charges",
 				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Restrict,
 			},
 			{
 				Symbol:     "charge_usage_based_subscriptions_charges_usage_based",

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -65879,7 +65879,7 @@ func (m *ChargeUsageBasedMutation) FeatureID() (r string, exists bool) {
 // OldFeatureID returns the old "feature_id" field's value of the ChargeUsageBased entity.
 // If the ChargeUsageBased object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v string, err error) {
+func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v *string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldFeatureID is only allowed on UpdateOne operations")
 	}
@@ -65893,9 +65893,22 @@ func (m *ChargeUsageBasedMutation) OldFeatureID(ctx context.Context) (v string, 
 	return oldValue.FeatureID, nil
 }
 
+// ClearFeatureID clears the value of the "feature_id" field.
+func (m *ChargeUsageBasedMutation) ClearFeatureID() {
+	m.feature = nil
+	m.clearedFields[chargeusagebased.FieldFeatureID] = struct{}{}
+}
+
+// FeatureIDCleared returns if the "feature_id" field was cleared in this mutation.
+func (m *ChargeUsageBasedMutation) FeatureIDCleared() bool {
+	_, ok := m.clearedFields[chargeusagebased.FieldFeatureID]
+	return ok
+}
+
 // ResetFeatureID resets all changes to the "feature_id" field.
 func (m *ChargeUsageBasedMutation) ResetFeatureID() {
 	m.feature = nil
+	delete(m.clearedFields, chargeusagebased.FieldFeatureID)
 }
 
 // SetRatingEngine sets the "rating_engine" field.
@@ -66522,7 +66535,7 @@ func (m *ChargeUsageBasedMutation) ClearFeature() {
 
 // FeatureCleared reports if the "feature" edge to the Feature entity was cleared.
 func (m *ChargeUsageBasedMutation) FeatureCleared() bool {
-	return m.clearedfeature
+	return m.FeatureIDCleared() || m.clearedfeature
 }
 
 // FeatureIDs returns the "feature" edge IDs in the mutation.
@@ -67277,6 +67290,9 @@ func (m *ChargeUsageBasedMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebased.FieldDiscounts) {
 		fields = append(fields, chargeusagebased.FieldDiscounts)
 	}
+	if m.FieldCleared(chargeusagebased.FieldFeatureID) {
+		fields = append(fields, chargeusagebased.FieldFeatureID)
+	}
 	if m.FieldCleared(chargeusagebased.FieldUnitConfig) {
 		fields = append(fields, chargeusagebased.FieldUnitConfig)
 	}
@@ -67344,6 +67360,9 @@ func (m *ChargeUsageBasedMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebased.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case chargeusagebased.FieldFeatureID:
+		m.ClearFeatureID()
 		return nil
 	case chargeusagebased.FieldUnitConfig:
 		m.ClearUnitConfig()

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -3816,6 +3816,20 @@ func (u *ChargeUsageBasedUpdateOne) SetOrClearDiscounts(value **billing.Discount
 	return u.SetDiscounts(*value)
 }
 
+func (u *ChargeUsageBasedUpdate) SetOrClearFeatureID(value *string) *ChargeUsageBasedUpdate {
+	if value == nil {
+		return u.ClearFeatureID()
+	}
+	return u.SetFeatureID(*value)
+}
+
+func (u *ChargeUsageBasedUpdateOne) SetOrClearFeatureID(value *string) *ChargeUsageBasedUpdateOne {
+	if value == nil {
+		return u.ClearFeatureID()
+	}
+	return u.SetFeatureID(*value)
+}
+
 func (u *ChargeUsageBasedUpdate) SetOrClearUnitConfig(value **unitconfig.UnitConfig) *ChargeUsageBasedUpdate {
 	if value == nil {
 		return u.ClearUnitConfig()

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -62,7 +62,9 @@ func (ChargeUsageBased) Fields() []ent.Field {
 			NotEmpty().
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
-			}),
+			}).
+			Optional().
+			Nillable(),
 
 		field.Enum("rating_engine").
 			GoType(usagebased.RatingEngine("")),
@@ -152,8 +154,7 @@ func (ChargeUsageBased) Edges() []ent.Edge {
 		edge.From("feature", Feature.Type).
 			Field("feature_id").
 			Ref("usage_based_charges").
-			Unique().
-			Required(),
+			Unique(),
 		edge.From("tax_code", TaxCode.Type).
 			Ref("charge_usage_based").
 			Field("tax_code_id").

--- a/openmeter/ent/schema/feature.go
+++ b/openmeter/ent/schema/feature.go
@@ -84,7 +84,8 @@ func (Feature) Edges() []ent.Edge {
 		edge.To("entitlement", Entitlement.Type),
 		edge.To("ratecard", PlanRateCard.Type),
 		edge.To("addon_ratecard", AddonRateCard.Type),
-		edge.To("usage_based_charges", ChargeUsageBased.Type),
+		edge.To("usage_based_charges", ChargeUsageBased.Type).
+			Annotations(entsql.OnDelete(entsql.Restrict)),
 		edge.To("usage_based_runs", ChargeUsageBasedRuns.Type),
 		edge.To("flat_fee_charges", ChargeFlatFee.Type),
 		edge.From("meter", Meter.Type).

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -363,7 +363,6 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 
 	createdCharges, err := env.flatFeeService.Create(t.Context(), flatfee.CreateInput{
 		Namespace:     env.Namespace,
-		FeatureMeters: env.featureMeters,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -362,7 +362,7 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 	requireBalance(t, 100, 100)
 
 	createdCharges, err := env.flatFeeService.Create(t.Context(), flatfee.CreateInput{
-		Namespace:     env.Namespace,
+		Namespace: env.Namespace,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -517,7 +517,6 @@ func (e *testEnv) createUsageBasedChargeInCurrency(t *testing.T, unitPrice alpac
 
 	createdCharges, err := e.usageBasedService.Create(t.Context(), usagebased.CreateInput{
 		Namespace:     e.Namespace,
-		FeatureMeters: e.featureMeters,
 		Intents: []usagebased.Intent{
 			{
 				Intent: chargemeta.Intent{
@@ -565,7 +564,6 @@ func (e *testEnv) createFlatFeeChargeInCurrency(t *testing.T, amount alpacadecim
 
 	createdCharges, err := e.flatFeeService.Create(t.Context(), flatfee.CreateInput{
 		Namespace:     e.Namespace,
-		FeatureMeters: e.featureMeters,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -516,7 +516,7 @@ func (e *testEnv) createUsageBasedChargeInCurrency(t *testing.T, unitPrice alpac
 	t.Helper()
 
 	createdCharges, err := e.usageBasedService.Create(t.Context(), usagebased.CreateInput{
-		Namespace:     e.Namespace,
+		Namespace: e.Namespace,
 		Intents: []usagebased.Intent{
 			{
 				Intent: chargemeta.Intent{
@@ -563,7 +563,7 @@ func (e *testEnv) createFlatFeeChargeInCurrency(t *testing.T, amount alpacadecim
 	}
 
 	createdCharges, err := e.flatFeeService.Create(t.Context(), flatfee.CreateInput{
-		Namespace:     e.Namespace,
+		Namespace: e.Namespace,
 		Intents: []flatfee.Intent{
 			{
 				Intent: chargemeta.Intent{

--- a/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.down.sql
+++ b/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.down.sql
@@ -1,0 +1,4 @@
+-- reverse: modify "charge_usage_based" feature foreign key
+ALTER TABLE "charge_usage_based" DROP CONSTRAINT "charge_usage_based_features_usage_based_charges", ADD CONSTRAINT "charge_usage_based_features_usage_based_charges" FOREIGN KEY ("feature_id") REFERENCES "features" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ALTER COLUMN "feature_id" SET NOT NULL;

--- a/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.up.sql
+++ b/tools/migrate/migrations/20260909104736_make_usage_based_feature_id_optional.up.sql
@@ -1,0 +1,4 @@
+-- modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ALTER COLUMN "feature_id" DROP NOT NULL;
+-- modify "charge_usage_based" feature foreign key
+ALTER TABLE "charge_usage_based" DROP CONSTRAINT "charge_usage_based_features_usage_based_charges", ADD CONSTRAINT "charge_usage_based_features_usage_based_charges" FOREIGN KEY ("feature_id") REFERENCES "features" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vP1Tw1GzBUtg4eaBa5aTImcQqtUn6z59OzODJ2pEt5w=
+h1:dl9qy1YR2XTlBKnZwVNvLwCiIKu2X1wacVJ0zLXP6dM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -278,3 +278,4 @@ h1:vP1Tw1GzBUtg4eaBa5aTImcQqtUn6z59OzODJ2pEt5w=
 20260901065710_add_billing_foreign_key_indexes.up.sql h1:+16cGxilIIhC0O2qqjKE9WcUndywZpDEX/gzq3Y8JQc=
 20260903102842_add_lineage_custom_currency_identity.up.sql h1:KHYAUoTB7vwPQ/wsLAoRCm5gQGml5L1t3QExsZdwKWE=
 20260906100323_add_charge_and_billing_validation_issues.up.sql h1:nHSiTwJq6s7c3SU1CV103bpnPf2Nsi3zLm6UIIyF8sA=
+20260909104736_make_usage_based_feature_id_optional.up.sql h1:yhB56cUSZHgNXSig3A6VKDt3ktG0E4LXHj1/vo1sz8I=


### PR DESCRIPTION
## Summary

- resolve and validate usage-based feature references at charge creation while preserving key-only references without pinning an ID
- resolve and persist the current feature ID when a charge becomes active, then use that pinned identity for later runs
- resolve missing IDs internally for API rendering without expanding the feature unless requested
- allow nullable usage charge feature IDs and explicitly restrict deleting referenced features

This replaces #5106 with the same feature-pinning change based directly on `main`.

## Validation

- `make generate`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service ./openmeter/billing/charges/usagebased/...`

No Jira ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usage-based charges can be created before a feature is fully linked, with the feature association resolved during activation.
  - Charges created with a feature ID retain that association, while key-based charges resolve the current matching feature until activation.
  - Flat-fee features can be used without meters.

- **Bug Fixes**
  - Improved feature matching and validation when both feature IDs and keys are provided.
  - Prevented deletion of features that still have usage-based charges.
  - Improved charge details and filtering when feature associations are unresolved or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62163398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/openmeter/-/pull-requests/openmeterio/openmeter/5108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not yet safe to merge because key-only create responses expose an empty feature reference and the schema rollback fails when newly valid preactivation rows exist.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fbilling%2Fcharges%2Fservice%2Fapi.go%3A85%0AWhen%20a%20usage%20charge%20is%20created%20using%20only%20a%20feature%20key%2C%20creation%20intentionally%20leaves%20its%20feature%20ID%20empty.%20This%20call%20builds%20the%20response%20with%20no%20feature%20entities%2C%20so%20the%20new%20resolution%20block%20does%20not%20run.%20The%20API%20converter%20then%20emits%20a%20feature%20reference%20with%20an%20empty%20ID%20instead%20of%20the%20current%20feature%20ID%2C%20leaving%20the%20create%20response%20with%20an%20unusable%20required%20feature%20reference.%0A%0A%23%23%23%20Issue%202%0Atools%2Fmigrate%2Fmigrations%2F20260909104736_make_usage_based_feature_id_optional.down.sql%3A4%0AKey-only%20preactivation%20charges%20now%20deliberately%20persist%20a%20NULL%20%60feature_id%60%2C%20but%20this%20down%20migration%20restores%20the%20%60NOT%20NULL%60%20constraint%20without%20first%20resolving%20or%20removing%20those%20rows.%20Rolling%20back%20while%20any%20such%20charge%20exists%20therefore%20fails%20with%20a%20PostgreSQL%20not-null%20violation%20and%20prevents%20the%20schema%20rollback.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Create Returns Empty Feature** <a href="https://github.com/openmeterio/openmeter/pull/5108#discussion_r3970334792">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Rollback Rejects Nullable Rows** <a href="https://github.com/openmeterio/openmeter/pull/5108#discussion_r3970334796">▶</a>

<details><summary><h3>Summary</h3></summary>

- Key-only references retain their canonical key during creation.
- Activation resolves and atomically persists the current feature identity before rating.
- Explicit feature IDs remain pinned across activation.
- The nullable schema and generated Ent accessors support preactivation charges.
- The create response currently misses the new read-time projection, and the rollback migration cannot handle the NULL rows introduced by the feature.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Create key-only usage charge] --> B[Validate feature and canonicalize key]
    B --> C[(Persist feature_id NULL)]
    C --> D{Operation}
    D -->|Create response| E[Build with empty feature entities]
    E --> F[Emit empty feature ID]
    D -->|List response| G[Resolve current feature by key]
    G --> H[Project current ID without persisting]
    D -->|Activate| I[Acquire charge lock and transaction]
    I --> J[Resolve current feature]
    J --> K[(Persist pinned feature_id)]
    K --> L[Rate subsequent runs by pinned ID]
```
</details>

<!-- /greptile_comment -->