### PR TITLE
test(billing): reproduce DLQ validation failures

### DIFF
--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -90,10 +90,7 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 				return nil, fmt.Errorf("get customer override: %w", err)
 			}
 
-			featureMeters, err := s.featureMeterResolver.Resolve(ctx, input.Customer.Namespace, chargesByType.usageBased...)
-			if err != nil {
-				return nil, fmt.Errorf("resolve feature meters: %w", err)
-			}
+			featureMeters := s.featureMeterResolver.ResolveLazy(ctx, input.Customer.Namespace, chargesByType.usageBased...)
 
 			for _, charge := range chargesByType.usageBased {
 				result, err := s.usageBasedService.AdvanceCharge(ctx, usagebased.AdvanceChargeInput{

--- a/openmeter/billing/charges/usagebased/charge_test.go
+++ b/openmeter/billing/charges/usagebased/charge_test.go
@@ -61,6 +61,14 @@ func TestChargeGetFeatureMeterRef(t *testing.T) {
 			},
 		},
 		{
+			name:   "active charge without a snapshot falls back to key",
+			status: StatusActive,
+			want: featuremeter.FeatureMeterRef{
+				IDOrKey:      ref.IDOrKey{Key: "feature-key"},
+				RequireMeter: true,
+			},
+		},
+		{
 			name:      "deleted charge resolves by snapshotted ID",
 			status:    StatusDeleted,
 			featureID: "feature-id",

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -1094,10 +1094,15 @@ func (s *CreditThenInvoiceStateMachine) StartInvoiceRun(
 		servicePeriodTo = meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
 		Charge:             s.Charge,
 		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               runType,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    servicePeriodTo,
@@ -1148,12 +1153,17 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
 		Charge:          s.Charge,
 		StoredAtLT:      storedAtLT,
 		ServicePeriodTo: currentRun.ServicePeriodTo,
 		Customer:        s.CustomerOverride,
-		FeatureMeter:    s.FeatureMeter,
+		FeatureMeter:    featureMeter,
 	})
 	if err != nil {
 		return fmt.Errorf("get detailed rating for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -692,7 +692,8 @@ func newCreditThenInvoiceStateMachineWithChargeForTest(t *testing.T, charge usag
 
 	out := &CreditThenInvoiceStateMachine{
 		stateMachine: &stateMachine{
-			Machine: machine,
+			Machine:       machine,
+			FeatureMeters: newFeatureMetersForChargeTest(charge),
 		},
 	}
 	out.configureStates()

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -409,10 +409,15 @@ func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) 
 		return fmt.Errorf("get stored at lt: %w", err)
 	}
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
 		Charge:             s.Charge,
 		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               usagebased.RealizationRunTypeFinalRealization,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To),
@@ -438,12 +443,17 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
 	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
 		Charge:          s.Charge,
 		StoredAtLT:      storedAtLT,
 		ServicePeriodTo: currentRun.ServicePeriodTo,
 		Customer:        s.CustomerOverride,
-		FeatureMeter:    s.FeatureMeter,
+		FeatureMeter:    featureMeter,
 	})
 	if err != nil {
 		return fmt.Errorf("get detailed rating for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -337,6 +337,7 @@ func newCreditsOnlyStateMachineWithChargeForTest(t *testing.T, charge usagebased
 			Machine:            machine,
 			Adapter:            adapter,
 			Runs:               runService,
+			FeatureMeters:      newFeatureMetersForChargeTest(charge),
 			CurrencyCalculator: cur,
 		},
 	}

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -303,13 +304,15 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 		return nil, err
 	}
 
+	featureMeters := e.service.featureMeterResolver.ResolveLazy(ctx, input.Invoice.Namespace, lo.Values(chargesByID)...)
+
 	for _, stdLine := range stdLines {
 		charge, ok := chargesByID[*stdLine.ChargeID]
 		if !ok {
 			return nil, fmt.Errorf("usage based charge[%s] not found for gathering preview line[%s]", *stdLine.ChargeID, stdLine.ID)
 		}
 
-		previewResult, err := e.buildGatheringPreviewRun(ctx, charge, stdLine)
+		previewResult, err := e.buildGatheringPreviewRun(ctx, charge, featureMeters, stdLine)
 		if err != nil {
 			return nil, fmt.Errorf("building gathering preview run for line[%s]: %w", stdLine.ID, err)
 		}
@@ -330,7 +333,7 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 	return stdLines, nil
 }
 
-func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
+func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, featureMeters billingfeaturemeter.FeatureMeters, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
 	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf(
 			"usage based standard line[%s]: unsupported settlement mode for gathering preview: %s",
@@ -353,10 +356,15 @@ func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usageb
 		servicePeriodTo = meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
+	featureMeter, err := featureMeters.Get(charge)
+	if err != nil {
+		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+	}
+
 	return e.service.runs.BuildCreditThenInvoiceGatheringPreviewRun(ctx, usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunInput{
 		Charge:             charge,
 		CustomerOverride:   stateMachineConfig.CustomerOverride,
-		FeatureMeter:       stateMachineConfig.FeatureMeter,
+		FeatureMeter:       featureMeter,
 		Type:               runType,
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    servicePeriodTo,

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -32,7 +32,7 @@ type stateMachine struct {
 	Runs    *usagebasedrun.Service
 
 	CustomerOverride   billing.CustomerOverrideWithDetails
-	FeatureMeter       billingfeaturemeter.FeatureMeter
+	FeatureMeters      billingfeaturemeter.FeatureMeters
 	CurrencyCalculator currencyx.Currency
 	CostBasisResolver  costbasis.Resolver
 }
@@ -46,7 +46,7 @@ type StateMachineConfig struct {
 	Runs               *usagebasedrun.Service
 	Logger             *slog.Logger
 	CustomerOverride   billing.CustomerOverrideWithDetails
-	FeatureMeter       billingfeaturemeter.FeatureMeter
+	FeatureMeters      billingfeaturemeter.FeatureMeters
 	CurrencyCalculator currencyx.Currency
 	CostBasisResolver  costbasis.Resolver
 }
@@ -78,8 +78,8 @@ func (c StateMachineConfig) Validate() error {
 		errs = append(errs, fmt.Errorf("merged profile is required: %w", err))
 	}
 
-	if c.FeatureMeter.Meter == nil {
-		errs = append(errs, errors.New("feature meter is required"))
+	if c.FeatureMeters == nil {
+		errs = append(errs, errors.New("feature meters are required"))
 	}
 
 	if c.CurrencyCalculator == nil {
@@ -113,7 +113,7 @@ func newStateMachineBase(
 		Rater:              config.Rater,
 		Runs:               config.Runs,
 		CustomerOverride:   config.CustomerOverride,
-		FeatureMeter:       config.FeatureMeter,
+		FeatureMeters:      config.FeatureMeters,
 		CurrencyCalculator: config.CurrencyCalculator,
 		CostBasisResolver:  config.CostBasisResolver,
 	}
@@ -296,7 +296,12 @@ func (s *stateMachine) SyncFeatureIDFromFeatureMeter(ctx context.Context) error 
 		return nil
 	}
 
-	s.Charge.State.FeatureID = s.FeatureMeter.Feature.ID
+	featureMeter, err := s.FeatureMeters.Get(s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge.State.FeatureID = featureMeter.Feature.ID
 	return nil
 }
 

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -253,16 +253,7 @@ func (s *service) getStateMachineConfigForChargeWithHints(ctx context.Context, c
 
 	featureMeters, hasFeatureMetersHint := hints.FeatureMeters.Get()
 	if !hasFeatureMetersHint {
-		var err error
-		featureMeters, err = s.featureMeterResolver.Resolve(ctx, charge.Namespace, charge)
-		if err != nil {
-			return StateMachineConfig{}, fmt.Errorf("resolve feature meters: %w", err)
-		}
-	}
-
-	featureMeter, err := featureMeters.Get(charge)
-	if err != nil {
-		return StateMachineConfig{}, fmt.Errorf("resolve feature meter: %w", err)
+		featureMeters = s.featureMeterResolver.ResolveLazy(ctx, charge.Namespace, charge)
 	}
 
 	currency := charge.Intent.GetCurrency()
@@ -273,7 +264,7 @@ func (s *service) getStateMachineConfigForChargeWithHints(ctx context.Context, c
 		Rater:              s.rater,
 		Runs:               s.runs,
 		CustomerOverride:   customerOverride,
-		FeatureMeter:       featureMeter,
+		FeatureMeters:      featureMeters,
 		CurrencyCalculator: currency,
 		CostBasisResolver:  s.costbasisResolver,
 	}, nil

--- a/openmeter/billing/charges/usagebased/service/triggers_test.go
+++ b/openmeter/billing/charges/usagebased/service/triggers_test.go
@@ -35,9 +35,9 @@ func TestGetStateMachineConfigUsesAuthoritativeFeatureMeters(t *testing.T) {
 		// given:
 		// - Advancement receives an authoritative feature-meter collection containing the charge feature.
 		// when:
-		// - The state-machine configuration resolves the charge feature.
+		// - The state-machine configuration is assembled.
 		// then:
-		// - It uses the supplied snapshot without consulting the feature service.
+		// - It retains the supplied snapshot without consulting the feature service.
 		featureMeter := billingfeaturemeter.FeatureMeter{
 			Feature: feature.Feature{
 				ID:  "feature-id",
@@ -56,24 +56,62 @@ func TestGetStateMachineConfigUsesAuthoritativeFeatureMeters(t *testing.T) {
 			FeatureMeters:    mo.Some[billingfeaturemeter.FeatureMeters](featureMeters),
 		})
 		require.NoError(t, err)
-		require.Equal(t, featureMeter, config.FeatureMeter)
+
+		resolved, err := config.FeatureMeters.Get(charge)
+		require.NoError(t, err)
+		require.Equal(t, featureMeter, resolved)
 	})
 
 	t.Run("when the supplied collection omits the charge feature", func(t *testing.T) {
 		// given:
 		// - Advancement receives an authoritative feature-meter collection without the charge feature.
 		// when:
-		// - The state-machine configuration resolves the charge feature.
+		// - The state-machine configuration is assembled.
 		// then:
-		// - It returns the snapshot lookup error instead of falling back to the feature service.
-		_, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
+		// - It retains the supplied snapshot, and its lookup error does not fall back to the feature service.
+		config, err := (&service{}).getStateMachineConfigForChargeWithHints(t.Context(), charge, usagebased.AdvanceChargeInput{
 			CustomerOverride: mo.Some(billing.CustomerOverrideWithDetails{}),
 			FeatureMeters: mo.Some[billingfeaturemeter.FeatureMeters](featuremeterservice.FeatureMeterCollection{
 				ByKey: map[string]billingfeaturemeter.FeatureMeter{},
 			}),
 		})
+		require.NoError(t, err)
+
+		_, err = config.FeatureMeters.Get(charge)
 		require.ErrorContains(t, err, "feature[feature-key]: invoice line: feature not found")
 	})
+}
+
+func newFeatureMetersForChargeTest(charge usagebased.Charge) billingfeaturemeter.FeatureMeters {
+	reference := charge.GetFeatureMeterRef()
+	if reference == nil {
+		return featuremeterservice.FeatureMeterCollection{
+			ByKey: map[string]billingfeaturemeter.FeatureMeter{},
+			ByID:  map[string]billingfeaturemeter.FeatureMeter{},
+		}
+	}
+
+	featureID := reference.IDOrKey.ID
+	if featureID == "" {
+		featureID = "feature-id"
+	}
+
+	featureMeter := billingfeaturemeter.FeatureMeter{
+		Feature: feature.Feature{
+			ID:  featureID,
+			Key: reference.IDOrKey.Key,
+		},
+		Meter: &meter.Meter{},
+	}
+	collection := featuremeterservice.FeatureMeterCollection{
+		ByKey: map[string]billingfeaturemeter.FeatureMeter{},
+		ByID:  map[string]billingfeaturemeter.FeatureMeter{featureID: featureMeter},
+	}
+	if reference.IDOrKey.Key != "" {
+		collection.ByKey[reference.IDOrKey.Key] = featureMeter
+	}
+
+	return collection
 }
 
 func TestApplyBaseIntentPatchForOverriddenChargeShrinksDeletedEffectiveCharge(t *testing.T) {

--- a/openmeter/billing/featuremeter/README.md
+++ b/openmeter/billing/featuremeter/README.md
@@ -66,3 +66,18 @@ The service subpackage constructs billing validation issues directly. Higher
 level billing services own the validation component and remain responsible for
 deciding whether a workflow can continue with the returned collection and
 validation issues.
+
+## Why resolution is lazy
+
+Charge advancement also acts as reconciliation and can inspect charges that
+are not due. Determining that no transition can fire does not require their
+feature or meter, so eager catalog resolution would let an unused missing meter
+or catalog outage block otherwise independent work.
+
+The lazy collection snapshots feature references and usable owner identities
+when it is created, then resolves the snapshot once on the first `Get` or
+`Has`. This preserves a consistent view for the operation without repeating
+catalog queries. `Get` returns resolution failures when the dependency is
+actually consumed, while `Has` reports false after a failed resolution. Missing
+features and meters therefore remain validation failures on paths that need
+them, and catalog system errors remain fatal.

--- a/openmeter/billing/featuremeter/featuremeter.go
+++ b/openmeter/billing/featuremeter/featuremeter.go
@@ -1,10 +1,11 @@
 package featuremeter
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/ref"
-	"github.com/samber/lo"
 )
 
 type FeatureMeter struct {

--- a/openmeter/billing/featuremeter/featuremeter.go
+++ b/openmeter/billing/featuremeter/featuremeter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/ref"
+	"github.com/samber/lo"
 )
 
 type FeatureMeter struct {
@@ -70,4 +71,12 @@ type FeatureMeters interface {
 type FeatureMeterRef struct {
 	IDOrKey      ref.IDOrKey
 	RequireMeter bool
+}
+
+func (r *FeatureMeterRef) CloneIfPresent() *FeatureMeterRef {
+	if r == nil {
+		return nil
+	}
+
+	return lo.ToPtr(*r)
 }

--- a/openmeter/billing/featuremeter/service/lazy.go
+++ b/openmeter/billing/featuremeter/service/lazy.go
@@ -1,0 +1,81 @@
+package featuremeterservice
+
+import (
+	"context"
+
+	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	"github.com/openmeterio/openmeter/pkg/syncx"
+	"github.com/samber/lo"
+)
+
+type featureMeterReferenceSnapshot struct {
+	reference *billingfeaturemeter.FeatureMeterRef
+}
+
+func (s featureMeterReferenceSnapshot) GetFeatureMeterRef() *billingfeaturemeter.FeatureMeterRef {
+	return s.reference
+}
+
+type identifiedFeatureMeterReferenceSnapshot struct {
+	featureMeterReferenceSnapshot
+	identity billingfeaturemeter.FeatureReferenceIdentity
+}
+
+func (s identifiedFeatureMeterReferenceSnapshot) GetFeatureMeterOwner() billingfeaturemeter.FeatureReferenceIdentity {
+	return s.identity
+}
+
+type lazyFeatureMeters struct {
+	ctx     context.Context
+	resolve func(context.Context) (billingfeaturemeter.FeatureMeters, error)
+}
+
+func (l *lazyFeatureMeters) Get(reference billingfeaturemeter.FeatureReferenceGetter) (billingfeaturemeter.FeatureMeter, error) {
+	featureMeters, err := l.resolve(l.ctx)
+	if err != nil {
+		return billingfeaturemeter.FeatureMeter{}, err
+	}
+
+	return featureMeters.Get(reference)
+}
+
+func (l *lazyFeatureMeters) Has(reference billingfeaturemeter.FeatureReferenceGetter) bool {
+	featureMeters, err := l.resolve(l.ctx)
+	if err != nil {
+		return false
+	}
+
+	return featureMeters.Has(reference)
+}
+
+// ResolveLazy snapshots the requested references and resolves their feature-meter
+// collection when it is first queried.
+func (r Resolver) ResolveLazy[T billingfeaturemeter.FeatureReferenceGetter](ctx context.Context, namespace string, targets ...T) billingfeaturemeter.FeatureMeters {
+	references := lo.Map(targets, func(target T, _ int) billingfeaturemeter.FeatureReferenceGetter {
+		return snapshotFeatureMeterReference(target)
+	})
+
+	return &lazyFeatureMeters{
+		ctx: ctx,
+		resolve: syncx.OnceValues(func(ctx context.Context) (billingfeaturemeter.FeatureMeters, error) {
+			return r.Resolve(ctx, namespace, references...)
+		}),
+	}
+}
+
+func snapshotFeatureMeterReference(reference billingfeaturemeter.FeatureReferenceGetter) billingfeaturemeter.FeatureReferenceGetter {
+	snapshot := featureMeterReferenceSnapshot{reference: reference.GetFeatureMeterRef().CloneIfPresent()}
+	owner, ok := reference.(billingfeaturemeter.FeatureReferenceOwner)
+	if !ok {
+		return snapshot
+	}
+	identity := owner.GetFeatureMeterOwner()
+	if identity.Kind == "" || identity.ID == "" {
+		return snapshot
+	}
+
+	return identifiedFeatureMeterReferenceSnapshot{
+		featureMeterReferenceSnapshot: snapshot,
+		identity:                      identity,
+	}
+}

--- a/openmeter/billing/featuremeter/service/lazy.go
+++ b/openmeter/billing/featuremeter/service/lazy.go
@@ -3,9 +3,10 @@ package featuremeterservice
 import (
 	"context"
 
+	"github.com/samber/lo"
+
 	billingfeaturemeter "github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
 	"github.com/openmeterio/openmeter/pkg/syncx"
-	"github.com/samber/lo"
 )
 
 type featureMeterReferenceSnapshot struct {

--- a/openmeter/billing/featuremeter/service/lazy_test.go
+++ b/openmeter/billing/featuremeter/service/lazy_test.go
@@ -35,6 +35,12 @@ func TestResolverResolveLazy(t *testing.T) {
 	const namespace = "namespace"
 
 	t.Run("resolves once when first queried", func(t *testing.T) {
+		// given:
+		// - an unresolved feature reference and concurrent consumers
+		// when:
+		// - the lazy collection is queried for the first time
+		// then:
+		// - the feature is resolved once and reused by every consumer
 		var featureCalls atomic.Int32
 		var featureIDsOrKeys []string
 		resolver, err := New(Config{
@@ -82,6 +88,12 @@ func TestResolverResolveLazy(t *testing.T) {
 	})
 
 	t.Run("passes resolution failures through", func(t *testing.T) {
+		// given:
+		// - feature resolution returns a catalog error
+		// when:
+		// - the lazy collection is queried repeatedly
+		// then:
+		// - the original error is cached without querying meters
 		resolutionFailure := errors.New("catalog unavailable")
 		resolver, err := New(Config{
 			FeatureService: featureServiceStub{
@@ -111,6 +123,12 @@ func TestResolverResolveLazy(t *testing.T) {
 	})
 
 	t.Run("snapshots references and usable identities", func(t *testing.T) {
+		// given:
+		// - a mutable reference with a complete owner identity
+		// when:
+		// - a snapshot is taken and the source reference changes
+		// then:
+		// - the snapshot retains the original reference and owner path
 		target := &mutableIdentifiedFeatureMeterReference{
 			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "original"}},
 			identity: featuremeter.FeatureReferenceIdentity{
@@ -131,6 +149,12 @@ func TestResolverResolveLazy(t *testing.T) {
 	})
 
 	t.Run("drops incomplete identities", func(t *testing.T) {
+		// given:
+		// - a reference whose owner identity has no ID
+		// when:
+		// - the reference is snapshotted
+		// then:
+		// - the incomplete owner identity is omitted
 		target := &mutableIdentifiedFeatureMeterReference{
 			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}},
 			identity:  featuremeter.FeatureReferenceIdentity{Kind: featuremeter.FeatureReferenceKindCharges},

--- a/openmeter/billing/featuremeter/service/lazy_test.go
+++ b/openmeter/billing/featuremeter/service/lazy_test.go
@@ -1,0 +1,143 @@
+package featuremeterservice
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/featuremeter"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/ref"
+)
+
+type mutableIdentifiedFeatureMeterReference struct {
+	reference featuremeter.FeatureMeterRef
+	identity  featuremeter.FeatureReferenceIdentity
+}
+
+func (r *mutableIdentifiedFeatureMeterReference) GetFeatureMeterRef() *featuremeter.FeatureMeterRef {
+	return &r.reference
+}
+
+func (r *mutableIdentifiedFeatureMeterReference) GetFeatureMeterOwner() featuremeter.FeatureReferenceIdentity {
+	return r.identity
+}
+
+func TestResolverResolveLazy(t *testing.T) {
+	const namespace = "namespace"
+
+	t.Run("resolves once when first queried", func(t *testing.T) {
+		var featureCalls atomic.Int32
+		var featureIDsOrKeys []string
+		resolver, err := New(Config{
+			FeatureService: featureServiceStub{
+				listFeatures: func(_ context.Context, params feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+					featureCalls.Add(1)
+					featureIDsOrKeys = params.IDsOrKeys
+
+					return pagination.Result[feature.Feature]{Items: []feature.Feature{{ID: "feature-id", Key: "tokens"}}}, nil
+				},
+			},
+			MeterService: meterServiceStub{
+				listMeters: func(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+					return pagination.Result[meter.Meter]{}, nil
+				},
+			},
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		target := featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}})
+		resolved := resolver.ResolveLazy(t.Context(), namespace, target)
+		require.Zero(t, featureCalls.Load())
+
+		var waitGroup sync.WaitGroup
+		hasResults := make(chan bool, 10)
+		for range 10 {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				hasResults <- resolved.Has(target)
+			}()
+		}
+		waitGroup.Wait()
+		close(hasResults)
+		for has := range hasResults {
+			require.True(t, has)
+		}
+
+		featureMeter, err := resolved.Get(target)
+		require.NoError(t, err)
+		require.Equal(t, "feature-id", featureMeter.Feature.ID)
+		require.Equal(t, []string{"tokens"}, featureIDsOrKeys)
+		require.Equal(t, int32(1), featureCalls.Load())
+	})
+
+	t.Run("passes resolution failures through", func(t *testing.T) {
+		resolutionFailure := errors.New("catalog unavailable")
+		resolver, err := New(Config{
+			FeatureService: featureServiceStub{
+				listFeatures: func(context.Context, feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+					return pagination.Result[feature.Feature]{}, resolutionFailure
+				},
+			},
+			MeterService: meterServiceStub{
+				listMeters: func(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+					t.Fatal("meter service must not be called after feature resolution fails")
+
+					return pagination.Result[meter.Meter]{}, nil
+				},
+			},
+			Logger: slog.Default(),
+		})
+		require.NoError(t, err)
+
+		target := featureMeterRef(featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}})
+		resolved := resolver.ResolveLazy(t.Context(), namespace, target)
+		_, getErr := resolved.Get(target)
+		require.ErrorIs(t, getErr, resolutionFailure)
+		require.False(t, resolved.Has(target))
+
+		_, repeatedGetErr := resolved.Get(target)
+		require.Same(t, getErr, repeatedGetErr)
+	})
+
+	t.Run("snapshots references and usable identities", func(t *testing.T) {
+		target := &mutableIdentifiedFeatureMeterReference{
+			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "original"}},
+			identity: featuremeter.FeatureReferenceIdentity{
+				Kind: featuremeter.FeatureReferenceKindCharges,
+				ID:   "charge-id",
+			},
+		}
+
+		snapshot := snapshotFeatureMeterReference(target)
+		target.reference.IDOrKey.Key = "mutated"
+		target.identity.ID = "mutated"
+
+		require.Equal(t, "original", snapshot.GetFeatureMeterRef().IDOrKey.Key)
+		_, err := (FeatureMeterCollection{}).Get(snapshot)
+		issues, systemErr := billing.ToValidationIssues(err)
+		require.NoError(t, systemErr)
+		require.Equal(t, "/charges/charge-id", issues[0].Path)
+	})
+
+	t.Run("drops incomplete identities", func(t *testing.T) {
+		target := &mutableIdentifiedFeatureMeterReference{
+			reference: featuremeter.FeatureMeterRef{IDOrKey: ref.IDOrKey{Key: "tokens"}},
+			identity:  featuremeter.FeatureReferenceIdentity{Kind: featuremeter.FeatureReferenceKindCharges},
+		}
+
+		snapshot := snapshotFeatureMeterReference(target)
+		_, ok := snapshot.(featuremeter.FeatureReferenceOwner)
+		require.False(t, ok)
+	})
+}

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -181,6 +181,8 @@ func (s StandardInvoiceStatus) MatchesInvoiceStatus(status StandardInvoiceStatus
 }
 
 var failedStatuses = []StandardInvoiceStatus{
+	StandardInvoiceStatusDraftInvalidCreated,
+	StandardInvoiceStatusDraftInvalid,
 	StandardInvoiceStatusDraftSyncFailed,
 	StandardInvoiceStatusIssuingLineFinalizationFailed,
 	StandardInvoiceStatusIssuingSyncFailed,

--- a/openmeter/billing/stdinvoice_test.go
+++ b/openmeter/billing/stdinvoice_test.go
@@ -24,6 +24,12 @@ func TestListStandardInvoicesInputValidateRequiresNamespace(t *testing.T) {
 	require.ErrorContains(t, err, "namespace is required")
 }
 
+func TestStandardInvoiceStatusIsFailedIncludesValidationFailures(t *testing.T) {
+	require.True(t, StandardInvoiceStatusDraftInvalidCreated.IsFailed())
+	require.True(t, StandardInvoiceStatusDraftInvalid.IsFailed())
+	require.False(t, StandardInvoiceStatusDraftWaitingForCollection.IsFailed())
+}
+
 func TestSortLines(t *testing.T) {
 	lines := StandardLines{
 		{

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1246,6 +1246,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,
@@ -1305,6 +1306,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,
@@ -1405,6 +1407,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlowErrorHandling() {
 				// Then we should end up in draft_invalid state
 				require.Equal(s.T(), billing.StandardInvoiceStatusDraftInvalid, invoice.Status)
 				require.Equal(s.T(), billing.StandardInvoiceStatusDetails{
+					Failed: true,
 					AvailableActions: billing.StandardInvoiceAvailableActions{
 						Retry: &billing.StandardInvoiceAvailableActionDetails{
 							ResultingState: billing.StandardInvoiceStatusPaymentProcessingPending,

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -798,6 +798,52 @@ func (s *BaseSuite) MustGetChargeByID(chargeID meta.ChargeID) charges.Charge {
 	return charge
 }
 
+func (s *BaseSuite) RequireChargeStatus(chargeID meta.ChargeID, status any) charges.Charge {
+	s.T().Helper()
+
+	charge := s.MustGetChargeByID(chargeID)
+
+	var actualStatus string
+	switch charge.Type() {
+	case meta.ChargeTypeUsageBased:
+		usageBasedCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		actualStatus = string(usageBasedCharge.Status)
+	case meta.ChargeTypeFlatFee:
+		flatFeeCharge, err := charge.AsFlatFeeCharge()
+		s.NoError(err)
+		actualStatus = string(flatFeeCharge.Status)
+	case meta.ChargeTypeCreditPurchase:
+		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
+		s.NoError(err)
+		actualStatus = string(creditPurchaseCharge.Status)
+	default:
+		s.FailNowf("unsupported charge type", "charge type %s is not supported", charge.Type())
+	}
+
+	s.Equal(fmt.Sprint(status), actualStatus)
+
+	return charge
+}
+
+func (s *BaseSuite) RequireUsageBasedChargeStatus(chargeID meta.ChargeID, status usagebased.Status) usagebased.Charge {
+	s.T().Helper()
+
+	charge, err := s.RequireChargeStatus(chargeID, status).AsUsageBasedCharge()
+	s.NoError(err)
+
+	return charge
+}
+
+func (s *BaseSuite) RequireFlatFeeChargeStatus(chargeID meta.ChargeID, status flatfee.Status) flatfee.Charge {
+	s.T().Helper()
+
+	charge, err := s.RequireChargeStatus(chargeID, status).AsFlatFeeCharge()
+	s.NoError(err)
+
+	return charge
+}
+
 type CreateCreditPurchaseIntentInput struct {
 	Customer       customer.CustomerID
 	Currency       currencyx.Code

--- a/test/credits/credit_only_validation_test.go
+++ b/test/credits/credit_only_validation_test.go
@@ -156,7 +156,7 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		// - the same advance succeeds and the charge starts its final realization
 		clock.FreezeTime(servicePeriod.To)
 		defer clock.UnFreeze()
-		
+
 		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, meters))
 
 		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})

--- a/test/credits/credit_only_validation_test.go
+++ b/test/credits/credit_only_validation_test.go
@@ -96,6 +96,7 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusCreated)
 
 		clock.FreezeTime(servicePeriod.From)
+		defer clock.UnFreeze()
 		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
 		s.Require().NoError(err)
 
@@ -123,6 +124,7 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		// - advancement fails with a validation error and the charge is left untouched for a retry
 		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 
 		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
 		s.Require().Error(err)
@@ -152,6 +154,9 @@ func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterI
 		// - the customer is advanced again
 		// then:
 		// - the same advance succeeds and the charge starts its final realization
+		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
+		
 		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, meters))
 
 		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})

--- a/test/credits/credit_only_validation_test.go
+++ b/test/credits/credit_only_validation_test.go
@@ -1,0 +1,332 @@
+package credits
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+func TestCreditOnlyValidationSuite(t *testing.T) {
+	suite.Run(t, new(CreditOnlyValidationSuite))
+}
+
+// CreditOnlyValidationSuite covers charge advancement when a credit-only charge's
+// dependencies disappear after creation. Credit-only charges never create gathering
+// lines, so AdvanceCharges is their only exposure to missing meters.
+type CreditOnlyValidationSuite struct {
+	BaseSuite
+}
+
+func (s *CreditOnlyValidationSuite) TestUsageBasedCreditOnlyAdvanceMissingMeterIsRetryable() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-usagebased-missing-meter-advance")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageChargeID meta.ChargeID
+		meters        []meter.Meter
+	)
+
+	s.Run("Given an active credit-only usage charge with usage", func() {
+		// given:
+		// - a credit-only usage charge is created before its service period
+		// when:
+		// - the service period starts and the charge is advanced
+		// then:
+		// - the charge is active and waits for the end of its service period
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "API requests",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "credit-only-missing-meter-api-requests",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.Require().NoError(err)
+		s.Require().Len(created, 1)
+
+		usageChargeID, err = created[0].GetChargeID()
+		s.Require().NoError(err)
+		s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusCreated)
+
+		clock.FreezeTime(servicePeriod.From)
+		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().NoError(err)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActive)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(servicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		listed, err := s.MeterAdapter.ListMeters(ctx, meter.ListMetersParams{Namespace: ns})
+		s.Require().NoError(err)
+		meters = listed.Items
+	})
+
+	s.Run("When the meter is gone at the charge's due time", func() {
+		// given:
+		// - the charge is due for its final realization
+		// when:
+		// - the meter backing the feature is removed and the customer is advanced
+		// then:
+		// - advancement fails with a validation error and the charge is left untouched for a retry
+		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+		clock.FreezeTime(servicePeriod.To)
+
+		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().Error(err)
+		s.True(billing.IsValidationIssueOnly(err), "expected a validation-only error, got: %v", err)
+
+		issues, systemErr := billing.ToValidationIssues(err)
+		s.Require().NoError(systemErr)
+		s.Require().Len(issues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issues[0].Code)
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issues[0].Message,
+		)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActive)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(servicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+		s.Nil(usageCharge.State.CurrentRealizationRunID)
+		s.Empty(usageCharge.Realizations)
+		s.Empty(usageCharge.ValidationIssues)
+	})
+
+	s.Run("Then restoring the meter lets the charge realize normally", func() {
+		// given:
+		// - the meter is registered again
+		// when:
+		// - the customer is advanced again
+		// then:
+		// - the same advance succeeds and the charge starts its final realization
+		s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, meters))
+
+		advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+		s.Require().NoError(err)
+		s.Require().Len(advanced, 1)
+
+		usageCharge := s.RequireUsageBasedChargeStatus(usageChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		s.Empty(usageCharge.ValidationIssues)
+		s.Len(usageCharge.Realizations, 1)
+	})
+}
+
+func (s *CreditOnlyValidationSuite) TestFlatFeeCreditOnlyAdvancesWhenSiblingUsageMeterIsMissing() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-flatfee-sibling-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	usageServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	flatFeeServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-15T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(usageServicePeriod.From)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-only usage charge is active and not due until the end of its service period
+	// - a credit-only in-advance flat fee for the same customer becomes due first
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-sibling-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  flatFeeServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "monthly platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-sibling-platform-fee",
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(created, 2)
+
+	usageCharge, err := created[0].AsUsageBasedCharge()
+	s.Require().NoError(err)
+	s.Equal(usagebased.StatusActive, usageCharge.Status)
+	s.Require().NotNil(usageCharge.State.AdvanceAfter)
+	s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+
+	flatFeeCharge, err := created[1].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the usage meter disappears before the flat fee is advanced
+	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+	clock.FreezeTime(flatFeeServicePeriod.From)
+
+	advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+
+	// then:
+	// - the flat fee settles against credit without resolving meters for the not-due usage charge
+	s.Require().NoError(err)
+	s.Require().Len(advanced, 1)
+	advancedFlatFee, err := advanced[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
+	s.RequireFlatFeeChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusFinal)
+
+	reloadedUsageCharge := s.RequireUsageBasedChargeStatus(usageCharge.GetChargeID(), usagebased.StatusActive)
+	s.Require().NotNil(reloadedUsageCharge.State.AdvanceAfter)
+	s.True(usageServicePeriod.To.Equal(*reloadedUsageCharge.State.AdvanceAfter))
+	s.Empty(reloadedUsageCharge.ValidationIssues)
+}
+
+func (s *CreditOnlyValidationSuite) TestFlatFeeCreditOnlyIgnoresMissingMeterOnOwnFeature() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credit-only-flatfee-own-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-only in-advance flat fee references a metered feature and is not yet due
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "feature-backed platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "credit-only-own-feature-platform-fee",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(created, 1)
+
+	flatFeeCharge, err := created[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the feature's meter disappears before the fee is due
+	s.Require().NoError(s.MeterAdapter.ReplaceMeters(ctx, nil))
+	clock.FreezeTime(servicePeriod.From)
+
+	advanced, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
+
+	// then:
+	// - a flat fee never depends on the meter, so it settles against credit as usual
+	s.Require().NoError(err)
+	s.Require().Len(advanced, 1)
+	advancedFlatFee, err := advanced[0].AsFlatFeeCharge()
+	s.Require().NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
+	s.Empty(s.RequireFlatFeeChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusFinal).ValidationIssues)
+}

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	pcfeature "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -142,6 +143,516 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 		// - every ledger balance is still identical to the pre-delete snapshot
 		s.RequireChargeStatus(usageBasedChargeID, usagebased.StatusDeleted)
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsMissingMeterValidationIssue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-missing-meter-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var invoice billing.StandardInvoice
+
+	s.Run("Given a charge-backed usage line whose feature initially has a meter", func() {
+		// given:
+		// - a metered feature can be resolved when a credit-then-invoice usage charge is created
+		// when:
+		// - charge creation persists the charge and its gathering line
+		// then:
+		// - the gathering line is owned by the usage-based charge line engine and is ready for later collection
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-missing-meter-collection",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-missing-meter-collection",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		s.RequireChargeStatus(usageBasedCharge.GetChargeID(), usagebased.StatusCreated)
+
+		lines := s.mustGatheringLinesForCharge(ns, cust.ID, usageBasedCharge.ID, false)
+		s.Require().Len(lines, 1)
+		s.Equal(billing.LineEngineTypeChargeUsageBased, lines[0].Engine)
+	})
+
+	s.Run("When the meter disappears collection should persist an invalid invoice", func() {
+		// given:
+		// - the persisted charge and gathering line still reference the feature
+		// when:
+		// - the meter backing that feature is removed and the line becomes collectible
+		// then:
+		// - collection returns and persists a draft.invalid_created invoice with a critical validation issue
+		err := s.MeterAdapter.ReplaceMeters(ctx, nil)
+		s.NoError(err)
+
+		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		s.Require().NotNil(invoice.Lines.OrEmpty()[0].UsageBased)
+		s.Nil(invoice.Lines.OrEmpty()[0].UsageBased.MeteredQuantity)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Contains(issue.Message, fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key))
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsMultipleMissingMeterValidationIssues() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-multiple-missing-meter-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	aiTokens, err := s.FeatureService.CreateFeature(ctx, pcfeature.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "AI tokens",
+		Key:       "ai-tokens",
+		MeterID:   apiRequestsTotal.Feature.MeterID,
+	})
+	s.NoError(err)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - two credit-then-invoice usage charges have gathering lines backed by different features
+	// - both features resolve to a meter when the charges are created
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "missing-meter-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "AI tokens",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "missing-meter-ai-tokens",
+				FeatureKey:        aiTokens.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(created, 2)
+
+	// when:
+	// - the shared meter disappears and both gathering lines become collectible
+	err = s.MeterAdapter.ReplaceMeters(ctx, nil)
+	s.NoError(err)
+	clock.FreezeTime(servicePeriod.To.Add(time.Second))
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+
+	// then:
+	// - collection persists one invalid invoice and keeps a distinct critical issue for each feature
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	invoice := invoices[0]
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+	s.Require().Len(invoice.Lines.OrEmpty(), 2)
+	s.Require().Len(invoice.ValidationIssues, 2)
+
+	issueMessages := make([]string, 0, len(invoice.ValidationIssues))
+	for _, issue := range invoice.ValidationIssues {
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		issueMessages = append(issueMessages, issue.Message)
+	}
+	s.ElementsMatch([]string{
+		fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key),
+		fmt.Sprintf("feature[%s] has no meter associated", aiTokens.Key),
+	}, issueMessages)
+
+	for _, line := range invoice.Lines.OrEmpty() {
+		s.Require().NotNil(line.UsageBased)
+		s.Nil(line.UsageBased.MeteredQuantity)
+	}
+
+	persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+	s.Require().Len(persistedInvoice.ValidationIssues, 2)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestAdvanceChargesIgnoresMissingMetersForUsageChargesThatAreNotDue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-advance-ignores-not-due-missing-meters")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	aiTokens, err := s.FeatureService.CreateFeature(ctx, pcfeature.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      "AI tokens",
+		Key:       "ai-tokens",
+		MeterID:   apiRequestsTotal.Feature.MeterID,
+	})
+	s.NoError(err)
+
+	usageServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	flatFeeServicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-15T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(usageServicePeriod.From)
+	defer clock.UnFreeze()
+
+	// given:
+	// - two usage charges are active and are not due until the end of their service period
+	usageCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "API requests",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "not-due-api-requests",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  usageServicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				}),
+				Name:              "AI tokens",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "not-due-ai-tokens",
+				FeatureKey:        aiTokens.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(usageCharges, 2)
+
+	usageChargeIDs := make([]meta.ChargeID, 0, len(usageCharges))
+	for _, charge := range usageCharges {
+		usageCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(usagebased.StatusActive, usageCharge.Status)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+		usageChargeIDs = append(usageChargeIDs, usageCharge.GetChargeID())
+	}
+
+	// - an unrelated credit-then-invoice flat fee for the customer becomes due first
+	flatFeeCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  flatFeeServicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(10),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "monthly platform fee",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "due-platform-fee",
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(flatFeeCharges, 1)
+	flatFeeCharge, err := flatFeeCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+
+	// when:
+	// - the usage meters disappear before the unrelated flat fee is advanced
+	err = s.MeterAdapter.ReplaceMeters(ctx, nil)
+	s.NoError(err)
+	clock.FreezeTime(flatFeeServicePeriod.From)
+
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+
+	// then:
+	// - the due flat fee advances without resolving meters for the not-due usage charges
+	s.Require().NoError(err)
+	s.Require().Len(advancedCharges, 1)
+	advancedFlatFee, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusActive, advancedFlatFee.Status)
+	s.RequireChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusActive)
+
+	for _, usageChargeID := range usageChargeIDs {
+		charge := s.RequireChargeStatus(usageChargeID, usagebased.StatusActive)
+		usageCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Require().NotNil(usageCharge.State.AdvanceAfter)
+		s.True(usageServicePeriod.To.Equal(*usageCharge.State.AdvanceAfter))
+	}
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPersistsActiveRealizationRunValidationIssue() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-active-run-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	sandboxApp := s.InstallSandboxApp(t, ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	midPeriodInvoiceAt := datetime.MustParseTimeInLocation(t, "2026-01-16T00:00:00Z", time.UTC).AsTime()
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageBasedChargeID meta.ChargeID
+		partialInvoice     billing.StandardInvoice
+	)
+
+	s.Run("Given a credit-then-invoice usage charge", func() {
+		// given:
+		// - a metered usage charge is configured for progressive billing
+		// when:
+		// - the charge and its gathering line are created
+		// then:
+		// - the charge is ready for a partial realization during its service period
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-active-run-collection",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-active-run-collection",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		usageBasedChargeID = usageBasedCharge.GetChargeID()
+		s.RequireChargeStatus(usageBasedChargeID, usagebased.StatusCreated)
+	})
+
+	s.Run("When a partial invoice becomes invalid during app validation", func() {
+		// given:
+		// - usage exists for the first part of the service period
+		// - the invoicing app rejects the customer configuration during invoice validation
+		// when:
+		// - the partial invoice reaches its collection time
+		// then:
+		// - the invoice is persisted as draft.invalid and retains the charge's active realization run
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+		clock.FreezeTime(midPeriodInvoiceAt)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(midPeriodInvoiceAt),
+		})
+		s.NoError(err)
+		s.Require().Len(invoices, 1)
+		partialInvoice = invoices[0]
+
+		mockApp := s.SandboxApp.EnableMock(t)
+		defer s.SandboxApp.DisableMock()
+		mockApp.OnValidateStandardInvoice(billing.NewValidationError(
+			"missing_app_customer_data",
+			"customer has no data for the invoicing app",
+		))
+
+		clock.FreezeTime(partialInvoice.DefaultCollectionAtForStandardInvoice())
+		partialInvoice, err = s.BillingService.AdvanceInvoice(ctx, partialInvoice.GetInvoiceID())
+		s.NoError(err)
+		mockApp.AssertExpectations(t)
+
+		s.Equal(billing.StandardInvoiceStatusDraftInvalid, partialInvoice.Status)
+		s.Require().Len(partialInvoice.ValidationIssues, 1)
+		s.Equal("missing_app_customer_data", partialInvoice.ValidationIssues[0].Code)
+		s.Equal(billing.ComponentName("app.sandbox.invoiceCustomers.validate"), partialInvoice.ValidationIssues[0].Component)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(usagebased.RealizationRunTypePartialInvoice, currentRun.Type)
+		s.Equal(partialInvoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("Then final collection persists the active-run failure as an invalid invoice", func() {
+		// given:
+		// - the earlier draft.invalid partial invoice still owns the charge's active realization run
+		// when:
+		// - billing collects the remaining line at the end of the service period
+		// then:
+		// - collection persists the new invoice and records the line-engine failure as a critical validation issue
+		clock.FreezeTime(servicePeriod.To)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.Require().NoError(err)
+		s.Require().Len(invoices, 1)
+
+		invoice := invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Contains(issue.Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Contains(persistedInvoice.ValidationIssues[0].Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
 	})
 }
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -6097,52 +6097,6 @@ func (s *CreditThenInvoiceTestSuite) shrinkCharge(ctx context.Context, customerI
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) RequireChargeStatus(chargeID meta.ChargeID, status any) charges.Charge {
-	s.T().Helper()
-
-	charge := s.MustGetChargeByID(chargeID)
-
-	var actualStatus string
-	switch charge.Type() {
-	case meta.ChargeTypeUsageBased:
-		usageBasedCharge, err := charge.AsUsageBasedCharge()
-		s.NoError(err)
-		actualStatus = string(usageBasedCharge.Status)
-	case meta.ChargeTypeFlatFee:
-		flatFeeCharge, err := charge.AsFlatFeeCharge()
-		s.NoError(err)
-		actualStatus = string(flatFeeCharge.Status)
-	case meta.ChargeTypeCreditPurchase:
-		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
-		s.NoError(err)
-		actualStatus = string(creditPurchaseCharge.Status)
-	default:
-		s.FailNowf("unsupported charge type", "charge type %s is not supported", charge.Type())
-	}
-
-	s.Equal(fmt.Sprint(status), actualStatus)
-
-	return charge
-}
-
-func (s *CreditThenInvoiceTestSuite) RequireUsageBasedChargeStatus(chargeID meta.ChargeID, status usagebased.Status) usagebased.Charge {
-	s.T().Helper()
-
-	charge, err := s.RequireChargeStatus(chargeID, status).AsUsageBasedCharge()
-	s.NoError(err)
-
-	return charge
-}
-
-func (s *CreditThenInvoiceTestSuite) RequireFlatFeeChargeStatus(chargeID meta.ChargeID, status flatfee.Status) flatfee.Charge {
-	s.T().Helper()
-
-	charge, err := s.RequireChargeStatus(chargeID, status).AsFlatFeeCharge()
-	s.NoError(err)
-
-	return charge
-}
-
 func (s *CreditThenInvoiceTestSuite) mustGetUsageBasedChargeByIDWithExpands(chargeID meta.ChargeID, expands meta.Expands) usagebased.Charge {
 	s.T().Helper()
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -419,7 +419,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		// - collection succeeds without replacing the run or duplicating its invoice association
 		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
 		defer clock.UnFreeze()
-		
+
 		err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{apiRequestsTotalMeter})
 		s.NoError(err)
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -223,6 +223,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.NoError(err)
 
 		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+		defer clock.UnFreeze()
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(servicePeriod.To),
@@ -340,6 +341,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		usageBasedChargeID = usageBasedCharge.GetChargeID()
 
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(servicePeriod.To),
@@ -371,6 +373,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		s.NoError(err)
 
 		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		defer clock.UnFreeze()
 		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
@@ -414,6 +417,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCo
 		// - the meter is restored and the invoice is retried
 		// then:
 		// - collection succeeds without replacing the run or duplicating its invoice association
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		defer clock.UnFreeze()
+		
 		err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{apiRequestsTotalMeter})
 		s.NoError(err)
 
@@ -768,6 +774,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
 		)
 		clock.FreezeTime(midPeriodInvoiceAt)
+		defer clock.UnFreeze()
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
@@ -809,6 +816,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		// then:
 		// - the assignment gate leaves the line gathering and records the blocking run on the charge
 		clock.FreezeTime(servicePeriod.To)
+		defer clock.UnFreeze()
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	pcfeature "github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -253,6 +254,184 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
 		s.Require().Len(persistedInvoice.ValidationIssues, 1)
 		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceWaitingForCollectionMissingMeterIsRetryable() {
+	// given:
+	// - a charge-backed usage invoice and its realization run are waiting for collection
+	// when:
+	// - the feature's required meter disappears before collection
+	// then:
+	// - the invoice fails with a persisted validation issue and succeeds when retried after meter restoration
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-waiting-for-collection-missing-meter")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	meters, err := s.MeterAdapter.ListMeters(ctx, meter.ListMetersParams{Namespace: ns})
+	s.NoError(err)
+	s.Require().Len(meters.Items, 1)
+	apiRequestsTotalMeter := meters.Items[0]
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		usageBasedChargeID meta.ChargeID
+		invoice            billing.StandardInvoice
+		runID              usagebased.RealizationRunID
+		lineID             billing.LineID
+	)
+
+	s.Run("given the charge invoice is waiting for collection", func() {
+		// given:
+		// - a metered credit-then-invoice usage charge has usage in its final service period
+		// when:
+		// - billing creates the invoice before its collection time
+		// then:
+		// - the invoice and its charge realization wait for collection
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			10,
+			datetime.MustParseTimeInLocation(t, "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(1),
+					}),
+					Name:              "usage-based-waiting-for-collection-missing-meter",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-waiting-for-collection-missing-meter",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Require().Len(created, 1)
+
+		usageBasedCharge, err := created[0].AsUsageBasedCharge()
+		s.NoError(err)
+		usageBasedChargeID = usageBasedCharge.GetChargeID()
+
+		clock.FreezeTime(servicePeriod.To)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.NoError(err)
+		s.Require().Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, invoice.Status)
+		s.False(invoice.StatusDetails.Failed)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		lineID = invoice.Lines.OrEmpty()[0].GetLineID()
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		runID = currentRun.ID
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("when the required meter disappears during the wait", func() {
+		// given:
+		// - the persisted invoice and charge realization are waiting for collection
+		// when:
+		// - the feature's required meter disappears before collection
+		// then:
+		// - collection persists a retryable failed invoice and rolls the charge back to waiting
+		err := s.MeterAdapter.ReplaceMeters(ctx, nil)
+		s.NoError(err)
+
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+		s.True(invoice.StatusDetails.Failed)
+		s.Require().NotNil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Require().Len(invoice.ValidationIssues, 1)
+
+		issue := invoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
+		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
+		s.Equal("/charges/"+usageBasedChargeID.ID, issue.Path)
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issue.Message,
+		)
+
+		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand:  billing.StandardInvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
+		s.True(persistedInvoice.StatusDetails.Failed)
+		s.Require().NotNil(persistedInvoice.StatusDetails.AvailableActions.Retry)
+		s.Require().Len(persistedInvoice.ValidationIssues, 1)
+		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, persistedInvoice.ValidationIssues[0].Code)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationWaitingForCollection)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(runID.ID, currentRun.ID.ID)
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+	})
+
+	s.Run("then restoring the meter allows the same invoice to retry", func() {
+		// given:
+		// - the failed invoice remains associated with the charge's waiting realization run
+		// when:
+		// - the meter is restored and the invoice is retried
+		// then:
+		// - collection succeeds without replacing the run or duplicating its invoice association
+		err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{apiRequestsTotalMeter})
+		s.NoError(err)
+
+		invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+		s.False(invoice.StatusDetails.Failed)
+		s.Nil(invoice.StatusDetails.AvailableActions.Retry)
+		s.Empty(invoice.ValidationIssues)
+		s.NotNil(invoice.QuantitySnapshotedAt)
+
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		currentRun, err := charge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.Equal(runID.ID, currentRun.ID.ID)
+		s.Equal(lineID.ID, lo.FromPtr(currentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(currentRun.InvoiceID))
+		s.Equal(alpacadecimal.NewFromInt(10), currentRun.MeteredQuantity)
 	})
 }
 

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -240,7 +240,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
 		s.Equal(billing.ErrInvoiceLineFeatureHasNoMeters.Code, issue.Code)
 		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
-		s.Contains(issue.Message, fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key))
+		s.Equal(
+			fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+			issue.Message,
+		)
 
 		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),
@@ -352,8 +355,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		issueMessages = append(issueMessages, issue.Message)
 	}
 	s.ElementsMatch([]string{
-		fmt.Sprintf("feature[%s] has no meter associated", apiRequestsTotal.Feature.Key),
-		fmt.Sprintf("feature[%s] has no meter associated", aiTokens.Key),
+		fmt.Sprintf("feature[%s]: %s", apiRequestsTotal.Feature.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
+		fmt.Sprintf("feature[%s]: %s", aiTokens.Key, billing.ErrInvoiceLineFeatureHasNoMeters.Message),
 	}, issueMessages)
 
 	for _, line := range invoice.Lines.OrEmpty() {
@@ -619,13 +622,13 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 		s.Equal(partialInvoice.ID, lo.FromPtr(currentRun.InvoiceID))
 	})
 
-	s.Run("Then final collection persists the active-run failure as an invalid invoice", func() {
+	s.Run("Then final collection excludes the blocked line and records the issue on the charge", func() {
 		// given:
 		// - the earlier draft.invalid partial invoice still owns the charge's active realization run
 		// when:
 		// - billing collects the remaining line at the end of the service period
 		// then:
-		// - collection persists the new invoice and records the line-engine failure as a critical validation issue
+		// - the assignment gate leaves the line gathering and records the blocking run on the charge
 		clock.FreezeTime(servicePeriod.To)
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -633,26 +636,28 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceCollectionPe
 			AsOf:     lo.ToPtr(servicePeriod.To),
 		})
 		s.Require().NoError(err)
-		s.Require().Len(invoices, 1)
+		s.Empty(invoices)
 
-		invoice := invoices[0]
-		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
-		s.Require().Len(invoice.Lines.OrEmpty(), 1)
-		s.Require().Len(invoice.ValidationIssues, 1)
-
-		issue := invoice.ValidationIssues[0]
+		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusActiveRealizationProcessing)
+		s.Require().Len(charge.ValidationIssues, 1)
+		issue := charge.ValidationIssues[0]
 		s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
-		s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issue.Component)
-		s.Contains(issue.Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+		s.Equal(usagebased.ValidationIssueCodeInvoiceAssignmentBlockedActiveRun, issue.Code)
+		s.Equal(usagebased.ValidationIssueComponentLineEngine, issue.Component)
+		s.Contains(issue.Message, "must be completed before")
+		s.Require().Len(partialInvoice.Lines.OrEmpty(), 1)
+		s.Equal(partialInvoice.ID, issue.Attributes["invoice_id"])
+		s.Equal(partialInvoice.Lines.OrEmpty()[0].ID, issue.Attributes["line_id"])
 
-		persistedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
-			Invoice: invoice.GetInvoiceID(),
-			Expand:  billing.StandardInvoiceExpandAll,
+		gatheringLines := s.mustGatheringLinesForCharge(ns, cust.ID, usageBasedChargeID.ID, false)
+		s.Require().Len(gatheringLines, 1)
+
+		standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
+			Namespace: ns,
 		})
 		s.NoError(err)
-		s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, persistedInvoice.Status)
-		s.Require().Len(persistedInvoice.ValidationIssues, 1)
-		s.Contains(persistedInvoice.ValidationIssues[0].Message, usagebased.ErrActiveRealizationRunAlreadyExists.Error())
+		s.Require().Len(standardInvoices.Items, 1)
+		s.Equal(partialInvoice.ID, standardInvoices.Items[0].ID)
 	})
 }
 


### PR DESCRIPTION
## Summary

- add integration coverage for charge-backed usage lines whose feature meters disappear before collection
- cover multiple missing-meter features and unrelated not-due usage charges
- persist critical invoice validation issues instead of returning operational errors to the worker
- lazily resolve feature meters only when charge advancement consumes them
- keep failed invoice collection retryable after the missing meter is restored

This replaces #5045 and is stacked on #5108 so activation-time feature pinning lands first.

## Validation

- `make generate`
- `POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing ./openmeter/billing/charges/service ./openmeter/billing/charges/usagebased/... ./openmeter/billing/featuremeter/... ./test/billing ./test/credits`

No Jira ticket.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Feature-meter resolution now occurs only when needed, helping unrelated billing operations continue when unused meters are unavailable.
  - Feature-meter references remain consistent across billing operations, including usage-based charges and previews.

- **Bug Fixes**
  - Missing-meter validation errors are surfaced when affected charges are processed and can be retried after restoration.
  - Credit-only charges can proceed when unrelated usage charges have missing meters.
  - Draft-invalid invoices are correctly classified as failed.

- **Tests**
  - Added coverage for missing meters, retries, charge status handling, and lazy resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62163592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding correctness or repository-rule issues identified.

<h3>Summary</h3>

- Resolves and caches feature-meter snapshots on first use during charge advancement and invoice gathering.
- Persists missing-meter validation issues on invalid invoices and keeps failed collection retryable.
- Classifies draft-invalid invoice states as failed.
- Adds unit and integration coverage for missing meters, multiple affected features, unrelated charges, and retry after restoration.
- The changes since the previous review fix the reported trailing whitespace and add test intent comments/import formatting.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Advance charge or collect invoice] --> B{Does this transition consume usage?}
  B -- No --> C[Continue without resolving feature meters]
  B -- Yes --> D[Resolve cached feature-meter snapshot]
  D --> E{Required meter available?}
  E -- Yes --> F[Rate usage and advance workflow]
  E -- No --> G[Create critical validation issue]
  G --> H[Persist failed, retryable invoice state]
  H --> I[Restore meter]
  I --> J[Retry same invoice and realization run]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix: address billing review feedback"](https://github.com/openmeterio/openmeter/commit/4d7c8f4b8f57368306e422eb752d638cdd089dbf)</sub>

<!-- /greptile_comment -->