### PR TITLE
fix(api): serialize empty addon rate cards as [] instead of null

### DIFF
--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -231,7 +231,7 @@ func FromAPIUpsertAddonRequest(namespace string, addonID string, body apiv3.Upse
 // ToAPIBillingRateCards converts domain RateCards to v3 BillingRateCard slice.
 func ToAPIBillingRateCards(rcs productcatalog.RateCards) ([]apiv3.BillingRateCard, error) {
 	if len(rcs) == 0 {
-		return nil, nil
+		return make([]apiv3.BillingRateCard, 0), nil
 	}
 
 	result := make([]apiv3.BillingRateCard, 0, len(rcs))

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -12,6 +12,7 @@ import (
 	apiv3 "github.com/openmeterio/openmeter/api/v3"
 	"github.com/openmeterio/openmeter/openmeter/currencies"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -537,4 +538,43 @@ func TestFromAPIBillingRateCardPriceTypeErrors(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, models.IsGenericValidationError(err))
 	})
+}
+
+func TestToAPIBillingRateCards_EmptyInput(t *testing.T) {
+	result, err := ToAPIBillingRateCards(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+
+	// The v3 schema declares rateCards as a required, non-nullable array: an
+	// empty slice must marshal to [] and not null.
+	out, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(out))
+}
+
+func TestToAPIAddon_EmptyRateCards(t *testing.T) {
+	// A freshly created draft add-on has zero rate cards; the API must report
+	// rateCards as [] so typed clients relying on the required array type (e.g.
+	// rateCards.length) do not crash on null.
+	source := addon.Addon{
+		NamespacedID: models.NamespacedID{ID: "addon-1"},
+		AddonMeta: productcatalog.AddonMeta{
+			Key:          "extra-support",
+			Name:         "Extra Support",
+			Currency:     currencies.NewCurrencyReference(currencyx.Code("USD")),
+			InstanceType: productcatalog.AddonInstanceTypeSingle,
+		},
+		RateCards: addon.RateCards{},
+	}
+
+	result, err := ToAPIAddon(source)
+	require.NoError(t, err)
+
+	require.NotNil(t, result.RateCards)
+	assert.Empty(t, result.RateCards)
+
+	out, err := json.Marshal(result)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"rate_cards":[]`)
 }


### PR DESCRIPTION
### What

Removes a nil early-return from the v3 addons response converter so `rateCards` is always serialized as a JSON array. Adds two unit tests pinning the empty-input behavior (`[]`, not `null`).

### Why

`ToAPIBillingRateCards` returned `nil, nil` when the add-on had no rate cards, which marshals to `"rateCards": null`. The v3 API schema declares `rateCards` as a required, non-nullable array, so every addon endpoint (create, get, list, update, publish, archive) violated the contract for freshly created draft add-ons. Typed clients generated from the schema (e.g. `@openmeter/client`) expect `RateCard[]` and crash on `null` - reading `rateCards.length` throws.

### How

- `api/v3/handlers/addons/convert.go`: delete the `len(rcs) == 0 → nil` shortcut. The loop below already builds the slice with `make(..., 0, len(rcs))`, so empty input now yields an empty (non-nil) slice that marshals to `[]`.
- `api/v3/handlers/addons/convert_test.go`: add `TestToAPIBillingRateCards_EmptyInput` and `TestToAPIAddon_EmptyRateCards` asserting `NotNil` + `Empty` and that the marshaled JSON contains `"rate_cards":[]`.
- Input-side `FromAPI*` converters and the TypeSpec spec are untouched - the spec was already correct; this fixes the implementation to match it.

This mirrors the plans handler (`ToAPIBillingPlanPhase`), which already initializes its rate-card slice to an empty slice for the same reason.

Note: draft add-ons still surface the `addon_has_no_rate_cards` validation error in `validation_errors` - only the serialization changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty billing rate-card collections now return as empty JSON arrays instead of `null`.
  - Add-on responses consistently represent empty rate-card lists as non-null arrays.

- **Tests**
  - Added coverage for empty billing rate-card and add-on conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62187212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because the converter now matches the existing API schema and the behavior is covered at both conversion and response-serialization levels.

<h3>Summary</h3>

- Updates `ToAPIBillingRateCards` to return an initialized empty slice for empty input.
- Adds focused converter and full add-on serialization tests covering the empty collection behavior.

<sub>Reviews (4) · Last reviewed commit: ["fix(api): serialize empty addon rate car..."](https://github.com/openmeterio/openmeter/commit/3e3f45194b3b7d3b6dc8418af7b1d554fb767391)</sub>

<!-- /greptile_comment -->