### PR TITLE
fix-helm-postgres-sslmode

### DIFF
--- a/deploy/charts/openmeter/templates/configmap.yaml
+++ b/deploy/charts/openmeter/templates/configmap.yaml
@@ -23,7 +23,7 @@ aggregation:
 {{- if .Values.postgresql.enabled -}}
 postgres:
   autoMigrate: migration
-  url: postgres://application:application@{{ include "openmeter.fullname" . }}-postgres:5432/application
+  url: postgres://application:application@{{ include "openmeter.fullname" . }}-postgres:5432/application?sslmode=disable
 {{- end }}
 
 {{/* Overwrite svix config if self-hosted svix is used */}}


### PR DESCRIPTION
## Summary

- disable TLS negotiation for the bundled non-TLS PostgreSQL DSN
- prevent startup migrations from failing with `pq: SSL is not enabled on the server`

## Testing

- `git diff --check`
- Helm CLI unavailable on this machine; template output should be checked in CI

Fixes #4951


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62503558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the generated SSL mode accounts for TLS-enabled configurations of the bundled PostgreSQL dependency.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adeploy%2Fcharts%2Fopenmeter%2Ftemplates%2Fconfigmap.yaml%3A26%0AIf%20the%20bundled%20PostgreSQL%20is%20configured%20to%20use%20TLS%2C%20this%20URL%20still%20forces%20%60sslmode%3Ddisable%60%2C%20so%20OpenMeter%20connects%20without%20encryption.%20If%20PostgreSQL%20accepts%20only%20TLS%20connections%2C%20application%20startup%20and%20migrations%20will%20fail.%20The%20chart%20forwards%20additional%20%60postgresql%60%20values%20to%20the%20bundled%20dependency%2C%20so%20the%20generated%20URL%E2%80%99s%20SSL%20mode%20must%20account%20for%20that%20configuration.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**TLS configuration is ignored** <a href="https://github.com/openmeterio/openmeter/pull/5111#discussion_r3977027203">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
deploy/charts/openmeter/templates/configmap.yaml:26
If the bundled PostgreSQL is configured to use TLS, this URL still forces `sslmode=disable`, so OpenMeter connects without encryption. If PostgreSQL accepts only TLS connections, application startup and migrations will fail. The chart forwards additional `postgresql` values to the bundled dependency, so the generated URL’s SSL mode must account for that configuration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- The URL is consumed by both application connections and startup migrations.
- The new query parameter is valid in the rendered YAML and supported by the PostgreSQL URL parsers.
- Unconditionally disabling SSL conflicts with supported customizations of the bundled PostgreSQL deployment.

<sub>Reviews (1) · Last reviewed commit: ["fix-helm-postgres-sslmode"](https://github.com/openmeterio/openmeter/commit/eccd7a8112a1601def17cb162e1a782440eb1ff6)</sub>

<!-- /greptile_comment -->