### PR TITLE
fix-clickhouse-events-schema-migration

### DIFF
--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -302,8 +302,17 @@ func (c *Connector) createEventsTable(ctx context.Context) error {
 		return fmt.Errorf("migrate events table: %w", err)
 	}
 
-	if err := c.config.ClickHouse.Exec(ctx, table.backfillStoreRowIDSQL()); err != nil {
-		return fmt.Errorf("backfill events table: %w", err)
+	// The synchronous backfill mutation is expensive, so only submit it when
+	// rows actually need it instead of on every connector startup.
+	var emptyStoreRowID uint64
+	if err := c.config.ClickHouse.QueryRow(ctx, table.countRowsWithEmptyStoreRowIDSQL()).Scan(&emptyStoreRowID); err != nil {
+		return fmt.Errorf("count events with empty store_row_id: %w", err)
+	}
+
+	if emptyStoreRowID > 0 {
+		if err := c.config.ClickHouse.Exec(ctx, table.backfillStoreRowIDSQL()); err != nil {
+			return fmt.Errorf("backfill events table: %w", err)
+		}
 	}
 
 	return nil

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -298,6 +298,10 @@ func (c *Connector) createEventsTable(ctx context.Context) error {
 		return fmt.Errorf("create events table: %w", err)
 	}
 
+	if err := c.config.ClickHouse.Exec(ctx, table.addStoreRowIDSQL()); err != nil {
+		return fmt.Errorf("migrate events table: %w", err)
+	}
+
 	return nil
 }
 

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -302,6 +302,10 @@ func (c *Connector) createEventsTable(ctx context.Context) error {
 		return fmt.Errorf("migrate events table: %w", err)
 	}
 
+	if err := c.config.ClickHouse.Exec(ctx, table.backfillStoreRowIDSQL()); err != nil {
+		return fmt.Errorf("backfill events table: %w", err)
+	}
+
 	return nil
 }
 

--- a/openmeter/streaming/clickhouse/connector_test.go
+++ b/openmeter/streaming/clickhouse/connector_test.go
@@ -46,6 +46,36 @@ func GetMockConnector(t *testing.T, opts ...MockConnectorOption) (*Connector, *M
 	return connector, mockClickhouse
 }
 
+func TestConnectorCreateEventsTable(t *testing.T) {
+	table := createEventsTable{Database: "testdb", EventsTableName: "events"}
+
+	t.Run("executes migration", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+		mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once()
+		mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once()
+		mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(nil).Once()
+
+		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
+
+		require.NoError(t, connector.createEventsTable(context.Background()))
+		mockCH.AssertExpectations(t)
+	})
+
+	t.Run("returns backfill error", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+		mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once()
+		mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once()
+		expectedErr := errors.New("backfill failed")
+		mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(expectedErr).Once()
+
+		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
+
+		err := connector.createEventsTable(context.Background())
+		require.ErrorIs(t, err, expectedErr)
+		mockCH.AssertExpectations(t)
+	})
+}
+
 // TestConnector_QueryMeter tests the queryMeter function
 func TestConnector_QueryMeter(t *testing.T) {
 	mockCH := NewMockClickHouse()

--- a/openmeter/streaming/clickhouse/connector_test.go
+++ b/openmeter/streaming/clickhouse/connector_test.go
@@ -57,7 +57,7 @@ func TestConnectorCreateEventsTable(t *testing.T) {
 
 		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
 
-		require.NoError(t, connector.createEventsTable(context.Background()))
+		require.NoError(t, connector.createEventsTable(t.Context()))
 		mockCH.AssertExpectations(t)
 	})
 
@@ -70,7 +70,7 @@ func TestConnectorCreateEventsTable(t *testing.T) {
 
 		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
 
-		err := connector.createEventsTable(context.Background())
+		err := connector.createEventsTable(t.Context())
 		require.ErrorIs(t, err, expectedErr)
 		mockCH.AssertExpectations(t)
 	})

--- a/openmeter/streaming/clickhouse/connector_test.go
+++ b/openmeter/streaming/clickhouse/connector_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -46,14 +47,64 @@ func GetMockConnector(t *testing.T, opts ...MockConnectorOption) (*Connector, *M
 	return connector, mockClickhouse
 }
 
+// stubRowFunc adapts a Scan function to driver.Row.
+type stubRowFunc func(dest ...any) error
+
+func (f stubRowFunc) Scan(dest ...any) error {
+	return f(dest...)
+}
+
+func (f stubRowFunc) Err() error {
+	return nil
+}
+
+func (f stubRowFunc) ScanStruct(dest any) error {
+	return nil
+}
+
 func TestConnectorCreateEventsTable(t *testing.T) {
 	table := createEventsTable{Database: "testdb", EventsTableName: "events"}
 
-	t.Run("executes migration", func(t *testing.T) {
+	// stubRow satisfies driver.Row with a fixed value or error for Scan.
+	type stubRow struct {
+		value uint64
+		err   error
+	}
+
+	row := func(r stubRow) driver.Row {
+		return stubRowFunc(func(dest ...any) error {
+			if r.err != nil {
+				return r.err
+			}
+			if len(dest) > 0 {
+				if p, ok := dest[0].(*uint64); ok {
+					*p = r.value
+				}
+			}
+			return nil
+		})
+	}
+
+	t.Run("executes migration without backfill when table is fully populated", func(t *testing.T) {
 		mockCH := NewMockClickHouse()
 		mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once()
 		mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once()
-		mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(nil).Once()
+		mockCH.On("QueryRow", mock.Anything, table.countRowsWithEmptyStoreRowIDSQL(), mock.Anything).Return(row(stubRow{value: 0})).Once()
+
+		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
+
+		require.NoError(t, connector.createEventsTable(t.Context()))
+		mockCH.AssertExpectations(t)
+	})
+
+	t.Run("backfills rows with empty store_row_id", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+		mock.InOrder(
+			mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once(),
+			mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once(),
+			mockCH.On("QueryRow", mock.Anything, table.countRowsWithEmptyStoreRowIDSQL(), mock.Anything).Return(row(stubRow{value: 3})).Once(),
+			mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(nil).Once(),
+		)
 
 		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
 
@@ -63,15 +114,17 @@ func TestConnectorCreateEventsTable(t *testing.T) {
 
 	t.Run("returns backfill error", func(t *testing.T) {
 		mockCH := NewMockClickHouse()
-		mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once()
-		mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once()
-		expectedErr := errors.New("backfill failed")
-		mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(expectedErr).Once()
+		mock.InOrder(
+			mockCH.On("Exec", mock.Anything, table.toSQL(), mock.Anything).Return(nil).Once(),
+			mockCH.On("Exec", mock.Anything, table.addStoreRowIDSQL(), mock.Anything).Return(nil).Once(),
+			mockCH.On("QueryRow", mock.Anything, table.countRowsWithEmptyStoreRowIDSQL(), mock.Anything).Return(row(stubRow{value: 3})).Once(),
+			mockCH.On("Exec", mock.Anything, table.backfillStoreRowIDSQL(), mock.Anything).Return(errors.New("backfill failed")).Once(),
+		)
 
 		connector := &Connector{config: Config{ClickHouse: mockCH, Database: table.Database, EventsTableName: table.EventsTableName}}
 
 		err := connector.createEventsTable(t.Context())
-		require.ErrorIs(t, err, expectedErr)
+		require.ErrorContains(t, err, "backfill failed")
 		mockCH.AssertExpectations(t)
 	})
 }

--- a/openmeter/streaming/clickhouse/event_query.go
+++ b/openmeter/streaming/clickhouse/event_query.go
@@ -52,6 +52,10 @@ func (d createEventsTable) addStoreRowIDSQL() string {
 	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS store_row_id String", getTableName(d.Database, d.EventsTableName))
 }
 
+func (d createEventsTable) backfillStoreRowIDSQL() string {
+	return fmt.Sprintf("ALTER TABLE %s UPDATE store_row_id = toString(generateUUIDv4()) WHERE store_row_id = '' SETTINGS mutations_sync = 1", getTableName(d.Database, d.EventsTableName))
+}
+
 // Query Events Table
 type queryEventsTable struct {
 	Database        string

--- a/openmeter/streaming/clickhouse/event_query.go
+++ b/openmeter/streaming/clickhouse/event_query.go
@@ -48,6 +48,10 @@ func (d createEventsTable) toSQL() string {
 	return sql
 }
 
+func (d createEventsTable) addStoreRowIDSQL() string {
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS store_row_id String", getTableName(d.Database, d.EventsTableName))
+}
+
 // Query Events Table
 type queryEventsTable struct {
 	Database        string

--- a/openmeter/streaming/clickhouse/event_query.go
+++ b/openmeter/streaming/clickhouse/event_query.go
@@ -52,6 +52,10 @@ func (d createEventsTable) addStoreRowIDSQL() string {
 	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS store_row_id String", getTableName(d.Database, d.EventsTableName))
 }
 
+func (d createEventsTable) countRowsWithEmptyStoreRowIDSQL() string {
+	return fmt.Sprintf("SELECT count() FROM %s WHERE store_row_id = ''", getTableName(d.Database, d.EventsTableName))
+}
+
 func (d createEventsTable) backfillStoreRowIDSQL() string {
 	return fmt.Sprintf("ALTER TABLE %s UPDATE store_row_id = toString(generateUUIDv4()) WHERE store_row_id = '' SETTINGS mutations_sync = 1", getTableName(d.Database, d.EventsTableName))
 }

--- a/openmeter/streaming/clickhouse/event_query_test.go
+++ b/openmeter/streaming/clickhouse/event_query_test.go
@@ -35,12 +35,13 @@ func TestCreateEventsTable(t *testing.T) {
 }
 
 func TestCreateEventsTableAddsStoreRowID(t *testing.T) {
-	query := createEventsTable{
+	table := createEventsTable{
 		Database:        "openmeter",
 		EventsTableName: "om_events",
-	}.addStoreRowIDSQL()
+	}
 
-	assert.Equal(t, "ALTER TABLE openmeter.om_events ADD COLUMN IF NOT EXISTS store_row_id String", query)
+	assert.Equal(t, "ALTER TABLE openmeter.om_events ADD COLUMN IF NOT EXISTS store_row_id String", table.addStoreRowIDSQL())
+	assert.Equal(t, "ALTER TABLE openmeter.om_events UPDATE store_row_id = toString(generateUUIDv4()) WHERE store_row_id = '' SETTINGS mutations_sync = 1", table.backfillStoreRowIDSQL())
 }
 
 func TestQueryEventsTable(t *testing.T) {

--- a/openmeter/streaming/clickhouse/event_query_test.go
+++ b/openmeter/streaming/clickhouse/event_query_test.go
@@ -34,6 +34,15 @@ func TestCreateEventsTable(t *testing.T) {
 	}
 }
 
+func TestCreateEventsTableAddsStoreRowID(t *testing.T) {
+	query := createEventsTable{
+		Database:        "openmeter",
+		EventsTableName: "om_events",
+	}.addStoreRowIDSQL()
+
+	assert.Equal(t, "ALTER TABLE openmeter.om_events ADD COLUMN IF NOT EXISTS store_row_id String", query)
+}
+
 func TestQueryEventsTable(t *testing.T) {
 	subjectFilter := "customer-1"
 	idFilter := "event-id-1"


### PR DESCRIPTION
## Summary

- migrate existing ClickHouse event tables to add `store_row_id`
- keep fresh table creation unchanged while making upgrades safe
- add SQL regression coverage for the migration statement

## Testing

- `gofmt`
- `go test ./openmeter/streaming/clickhouse -run TestCreateEventsTable -count=1` (running locally)
- `git diff --check`

Fixes #4953


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event table setup now checks for events missing store row IDs before running a backfill, avoiding unnecessary migration work.
  * Setup failures are reported when checking for missing store row IDs or performing the backfill, improving visibility into migration issues.

* **Tests**
  * Added coverage for skipped backfills, required backfills, and migration error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62506332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding blocking or non-blocking findings.

<h3>Summary</h3>

- Adds `store_row_id` when it is missing.
- Counts historical rows requiring migration and runs a synchronous UUID backfill only when necessary.
- Propagates migration, count, and backfill failures during connector initialization.
- Adds SQL-generation and connector orchestration coverage.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Initialize ClickHouse connector] --> B[Create events table if missing]
    B --> C[Add store_row_id if missing]
    C --> D[Count rows with empty store_row_id]
    D -->|Count is zero| E[Initialization complete]
    D -->|Count is positive| F[Backfill distinct UUIDs synchronously]
    F --> E
```
</details>

<sub>Reviews (4) · Last reviewed commit: ["fix(streaming): skip events backfill mut..."](https://github.com/openmeterio/openmeter/commit/c4230329b96ddafb33762933722ef7851581c40a)</sub>

<!-- /greptile_comment -->