### PR TITLE
fix(billing): skip rating unresolved features

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -120,13 +120,14 @@ Simulation is read-only but still validates its lines' feature and meter
 dependencies. Critical validation issues are returned on the simulated invoice
 and mark it invalid instead of failing the simulation request.
 
-If quantity snapshotting discovers that a persisted feature no longer has its
-required meter association, collection still materializes the standard invoice
-in `draft.invalid_created` with the critical validation code
+If quantity snapshotting cannot resolve a persisted feature or discovers that
+the feature no longer has its required meter association, collection still
+materializes the standard invoice in `draft.invalid_created` with the critical
+validation code `invoice_line_feature_not_found` or
 `invoice_line_feature_has_no_meters`. The affected quantities stay
 unsnapshotted. Retry from this state re-enters `draft.created` for calculation
-and validation before returning through collection, so the repaired meter is
-queried again; repeated collection failures return to the same state.
+and validation before returning through collection, so the repaired dependency
+is resolved again; repeated collection failures return to the same state.
 Post-collection validation failures use `draft.invalid` and retry validation
 instead. Operational snapshot failures abort collection instead of persisting
 an incomplete invoice.

--- a/openmeter/billing/rating/service/detailedline.go
+++ b/openmeter/billing/rating/service/detailedline.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
@@ -72,10 +73,16 @@ func (s *service) GenerateDetailedLines(in rating.StandardLineAccessor, opts ...
 		if err != nil {
 			return rating.GenerateDetailedLinesResult{}, fmt.Errorf("getting metered usage: %w", err)
 		}
+		if meteredQuantity == nil {
+			return rating.GenerateDetailedLinesResult{}, errors.New("metered quantity is required")
+		}
 
 		preLinePeriodMeteredQuantity, err := in.GetMeteredPreLinePeriodQuantity()
 		if err != nil {
 			return rating.GenerateDetailedLinesResult{}, fmt.Errorf("getting pre line period metered usage: %w", err)
+		}
+		if preLinePeriodMeteredQuantity == nil {
+			return rating.GenerateDetailedLinesResult{}, errors.New("pre-line period metered quantity is required")
 		}
 
 		input.Usage = &rating.Usage{

--- a/openmeter/billing/rating/service/detailedline_test.go
+++ b/openmeter/billing/rating/service/detailedline_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestGenerateDetailedLinesRejectsMissingMeteredQuantities(t *testing.T) {
+	quantity := alpacadecimal.NewFromInt(1)
+
+	for _, tc := range []struct {
+		name                         string
+		meteredQuantity              *alpacadecimal.Decimal
+		meteredPreLinePeriodQuantity *alpacadecimal.Decimal
+		expectedError                string
+	}{
+		{
+			name:                         "current quantity",
+			meteredPreLinePeriodQuantity: &quantity,
+			expectedError:                "metered quantity is required",
+		},
+		{
+			name:            "pre-line period quantity",
+			meteredQuantity: &quantity,
+			expectedError:   "pre-line period metered quantity is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given: a metered line whose quantity snapshot is incomplete
+			line := &billing.StandardLine{
+				StandardLineBase: billing.StandardLineBase{
+					Currency: "USD",
+					Period: timeutil.ClosedPeriod{
+						From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+						To:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+					},
+				},
+				UsageBased: &billing.UsageBasedLine{
+					Price:                        productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: quantity}),
+					MeteredQuantity:              tc.meteredQuantity,
+					MeteredPreLinePeriodQuantity: tc.meteredPreLinePeriodQuantity,
+				},
+			}
+
+			// when: detailed-line calculation is invoked despite the incomplete snapshot
+			_, err := New(Config{}).GenerateDetailedLines(line)
+
+			// then: rating rejects the input instead of dereferencing a nil quantity
+			require.EqualError(t, err, tc.expectedError)
+		})
+	}
+}

--- a/openmeter/billing/service/invoicecalc/details_test.go
+++ b/openmeter/billing/service/invoicecalc/details_test.go
@@ -43,46 +43,56 @@ func TestRecalculateDetailedLinesAndTotalsSkipsEnginesWithoutCalculator(t *testi
 }
 
 func TestRecalculateDetailedLinesAndTotalsSkipsEngineWithSnapshotValidationIssue(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		severity billing.ValidationIssueSeverity
+	for _, issue := range []struct {
+		name string
+		code string
 	}{
-		{name: "critical issue from creation", severity: billing.ValidationIssueSeverityCritical},
-		{name: "warning issue downgraded for retry", severity: billing.ValidationIssueSeverityWarning},
+		{name: "feature not found", code: billing.ErrInvoiceLineFeatureNotFound.Code},
+		{name: "feature has no meters", code: billing.ErrInvoiceLineFeatureHasNoMeters.Code},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			// given: a line engine has incomplete output after quantity snapshotting failed
-			engineType := billing.LineEngineTypeInvoice
-			invoice := billing.StandardInvoice{
-				ValidationIssues: billing.ValidationIssues{
-					{
-						Severity:  tc.severity,
-						Code:      billing.ErrInvoiceLineFeatureHasNoMeters.Code,
-						Component: billing.LineEngineValidationComponent(engineType),
-					},
-				},
-				Lines: billing.NewStandardInvoiceLines([]*billing.StandardLine{
-					{
-						StandardLineBase: billing.StandardLineBase{
-							Engine: engineType,
-							Totals: totals.Totals{
-								Amount: alpacadecimal.NewFromInt(12),
-								Total:  alpacadecimal.NewFromInt(12),
+		t.Run(issue.name, func(t *testing.T) {
+			for _, severity := range []struct {
+				name  string
+				value billing.ValidationIssueSeverity
+			}{
+				{name: "critical issue from creation", value: billing.ValidationIssueSeverityCritical},
+				{name: "warning issue downgraded for retry", value: billing.ValidationIssueSeverityWarning},
+			} {
+				t.Run(severity.name, func(t *testing.T) {
+					// given: a line engine has incomplete output after quantity snapshotting failed
+					engineType := billing.LineEngineTypeInvoice
+					invoice := billing.StandardInvoice{
+						ValidationIssues: billing.ValidationIssues{
+							{
+								Severity:  severity.value,
+								Code:      issue.code,
+								Component: billing.LineEngineValidationComponent(engineType),
 							},
 						},
-					},
-				}),
+						Lines: billing.NewStandardInvoiceLines([]*billing.StandardLine{
+							{
+								StandardLineBase: billing.StandardLineBase{
+									Engine: engineType,
+									Totals: totals.Totals{
+										Amount: alpacadecimal.NewFromInt(12),
+										Total:  alpacadecimal.NewFromInt(12),
+									},
+								},
+							},
+						}),
+					}
+
+					// when: invoice calculation runs before collection has repaired the line
+					err := RecalculateDetailedLinesAndTotals(&invoice, StandardInvoiceCalculatorDependencies{
+						LineEngines: staticLineEngineResolver{},
+					})
+
+					// then: the incomplete engine output is preserved without invoking its calculator
+					require.NoError(t, err)
+					require.Equal(t, float64(12), invoice.Totals.Amount.InexactFloat64())
+					require.Equal(t, float64(12), invoice.Totals.Total.InexactFloat64())
+				})
 			}
-
-			// when: invoice calculation runs before collection has repaired the line
-			err := RecalculateDetailedLinesAndTotals(&invoice, StandardInvoiceCalculatorDependencies{
-				LineEngines: staticLineEngineResolver{},
-			})
-
-			// then: the incomplete engine output is preserved without invoking its calculator
-			require.NoError(t, err)
-			require.Equal(t, float64(12), invoice.Totals.Amount.InexactFloat64())
-			require.Equal(t, float64(12), invoice.Totals.Total.InexactFloat64())
 		})
 	}
 }

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -481,7 +481,8 @@ func (i *StandardInvoice) HasLineSnapshotValidationIssueForComponent(component C
 			return false
 		}
 
-		return issue.Code == ErrInvoiceLineFeatureHasNoMeters.Code ||
+		return issue.Code == ErrInvoiceLineFeatureNotFound.Code ||
+			issue.Code == ErrInvoiceLineFeatureHasNoMeters.Code ||
 			issue.Code == ErrInvoiceLineSnapshotFailed.Code
 	})
 

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -4721,6 +4721,121 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 	s.Nil(pendingLines)
 }
 
+func (s *InvoicingTestSuite) TestSnapshotQuantityMissingFeature() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("ns-snapshot-quantity-missing-feature")
+	now := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	servicePeriod := timeutil.ClosedPeriod{
+		From: now.Add(-time.Hour),
+		To:   now,
+	}
+
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+
+	testFeature := s.SetupApiRequestsTotalFeature(ctx, namespace)
+	defer testFeature.Cleanup()
+
+	customerEntity := s.CreateTestCustomer(namespace, "test-customer")
+
+	// given:
+	// - a valid metered gathering line whose persisted feature reference becomes orphaned
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.FiatCode(currency.USD),
+		Lines: billing.GatheringLines{{
+			GatheringLineBase: billing.GatheringLineBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: namespace,
+					Name:      "metered line with missing feature",
+				}),
+				ManagedBy:     billing.ManuallyManagedLine,
+				ServicePeriod: servicePeriod,
+				InvoiceAt:     servicePeriod.To,
+				FeatureKey:    testFeature.Feature.Key,
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(1),
+				})),
+			},
+		}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(pendingLines.Lines, 1)
+	pendingLineID := pendingLines.Lines[0].ID
+	usageBasedConfigID := pendingLines.Lines[0].UBPConfigID
+
+	_, err = s.TestDB.PGDriver.DB().ExecContext(ctx,
+		`UPDATE billing_invoice_usage_based_line_configs SET feature_key = $1 WHERE id = $2`,
+		"missing-feature",
+		usageBasedConfigID,
+	)
+	s.Require().NoError(err)
+
+	// when:
+	// - billing collects the line after the feature can no longer be resolved
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer:          customerEntity.GetID(),
+		ForceAsyncAdvance: true,
+	})
+
+	// then:
+	// - calculation is skipped and the incomplete line is persisted for retry
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	invoice := invoices[0]
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+	s.Nil(invoice.QuantitySnapshotedAt)
+	s.Require().Len(invoice.Lines.OrEmpty(), 1)
+	s.Nil(invoice.Lines.OrEmpty()[0].UsageBased.MeteredQuantity)
+	standardUsageBasedConfigID := invoice.Lines.OrEmpty()[0].UsageBased.ConfigID
+	s.Require().Len(invoice.ValidationIssues, 1)
+	issue := invoice.ValidationIssues[0]
+	s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+	s.Equal(billing.ErrInvoiceLineFeatureNotFound.Code, issue.Code)
+	s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeInvoice), issue.Component)
+	s.Equal(fmt.Sprintf("/lines/%s", pendingLineID), issue.Path)
+
+	// when:
+	// - collection is retried while the feature is still missing
+	clock.SetTime(invoice.DefaultCollectionAtForStandardInvoice().Add(time.Minute))
+	queuedBillingService := s.BillingService.WithAdvancementStrategy(billing.QueuedAdvancementStrategy)
+	invoice, err = queuedBillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftCreated, invoice.Status)
+	s.Require().Len(invoice.ValidationIssues, 1)
+	s.Equal(billing.ValidationIssueSeverityWarning, invoice.ValidationIssues[0].Severity)
+
+	invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+	s.Require().Len(invoice.ValidationIssues, 1)
+	s.Equal(billing.ValidationIssueSeverityCritical, invoice.ValidationIssues[0].Severity)
+	s.Nil(invoice.QuantitySnapshotedAt)
+
+	// when:
+	// - the feature reference is repaired and collection is retried
+	_, err = s.TestDB.PGDriver.DB().ExecContext(ctx,
+		`UPDATE billing_invoice_usage_based_line_configs SET feature_key = $1 WHERE id = $2`,
+		testFeature.Feature.Key,
+		standardUsageBasedConfigID,
+	)
+	s.Require().NoError(err)
+
+	invoice, err = s.BillingService.RetryInvoice(ctx, invoice.GetInvoiceID())
+
+	// then:
+	// - quantity snapshotting and detailed-line calculation complete normally
+	s.Require().NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, invoice.Status)
+	s.Empty(invoice.ValidationIssues)
+	s.NotNil(invoice.QuantitySnapshotedAt)
+	s.Require().Len(invoice.Lines.OrEmpty(), 1)
+	s.NotNil(invoice.Lines.OrEmpty()[0].UsageBased.MeteredQuantity)
+}
+
 func (s *InvoicingTestSuite) TestSnapshotQuantityInvalidDatabaseState() {
 	// given:
 	// - a metered feature and gathering usage line ready for collection


### PR DESCRIPTION
## Overview

Prevent the billing worker from calculating detailed lines when quantity snapshotting cannot resolve a line's feature.

- classify a missing feature as an incomplete line snapshot
- persist the standard invoice as draft.invalid_created for retry
- reject missing metered quantities in rating instead of panicking
- cover initial failure, repeated failure, and recovery after repairing the feature reference
- document the missing-feature lifecycle alongside missing-meter handling

## Notes for reviewer

Billability still uses its non-progressive fallback so the line can be collected into a durable invalid invoice. The fix is at the invoice calculation boundary: detailed-line calculation is skipped until collection successfully repairs the quantity snapshot.

## Validation

- go test ./openmeter/billing/rating/service ./openmeter/billing/service/invoicecalc
- POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/billing -run '^TestInvoicing$/^TestSnapshotQuantityMissingFeature$' -count=1
- golangci-lint formatting, fast, and full billing-package checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invoice processing now handles missing persisted features more reliably, preserving the invoice in an invalid draft state with clear validation details and retry support.
  - Missing metered quantities now produce descriptive errors instead of causing processing failures.
  - Repaired feature references can be retried and successfully continue through quantity snapshotting and invoice calculation.

- **Documentation**
  - Updated billing documentation to describe invoice behavior when feature references or meter associations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62604723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the unresolved-feature path now avoids incomplete rating while preserving the established retry and recovery lifecycle.

<h3>Summary</h3>

- Classifies `invoice_line_feature_not_found` as incomplete snapshot output so detailed-line rating is skipped.
- Returns explicit errors when rating receives missing metered quantities instead of dereferencing nil pointers.
- Persists affected invoices as `draft.invalid_created` and retries snapshotting after dependency repair.
- Adds unit, invoice-calculation, and PostgreSQL-backed lifecycle coverage and updates billing documentation.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  G[Gathering metered line] --> R{Resolve feature and meter}
  R -->|Missing feature| I[draft.invalid_created]
  I --> T[Retry to draft.created]
  T --> R
  R -->|Still missing| I
  R -->|Dependency repaired| S[Snapshot quantities]
  S --> C[Calculate detailed lines and totals]
  C --> V[Validate and continue invoice workflow]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(billing): skip rating unresolved fea..."](https://github.com/openmeterio/openmeter/commit/e1f129d1172934f5ab7d929eb77e788df2ea83a0)</sub>

<!-- /greptile_comment -->