### PR TITLE
fix(billing): ignore invoice at on standard lines

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -58,7 +58,9 @@ subscription intent.
 - a gathering invoice's next collection time is when the collector should
   reconsider its pending lines
 - a standard invoice's collection time is the cutoff used while snapshotting
-  quantities and completing collection
+  quantities and completing collection. Unless a line provides an explicit
+  collection deadline, metered standard lines use their service-period end plus
+  the configured collection interval
 
 Collection alignment may move the effective collection cutoff to an anchor.
 Do not use one of these timestamps as a substitute for another.

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -52,7 +52,9 @@ subscription intent.
 ## Time has distinct meanings
 
 - a line's service period is when the service was provided
-- `InvoiceAt` is when the line becomes eligible to be invoiced
+- `InvoiceAt` is when a gathering line becomes eligible to be invoiced. A
+  standard line retains the value only as historical metadata; standard-invoice
+  behavior and validation do not depend on it
 - a gathering invoice's next collection time is when the collector should
   reconsider its pending lines
 - a standard invoice's collection time is the cutoff used while snapshotting

--- a/openmeter/billing/service/invoicecalc/collectionat.go
+++ b/openmeter/billing/service/invoicecalc/collectionat.go
@@ -107,7 +107,7 @@ func resolveStandardLineCollectionAt(collectionConfig billing.CollectionConfig, 
 		return *line.OverrideCollectionPeriodEnd
 	}
 
-	collectionAt := line.InvoiceAt
+	collectionAt := line.Period.To
 
 	// If we have an intended collection period, we should try to honor that
 	if collectionConfig.Interval.IsPositive() {

--- a/openmeter/billing/service/invoicecalc/collectionat_test.go
+++ b/openmeter/billing/service/invoicecalc/collectionat_test.go
@@ -196,6 +196,8 @@ func TestGatheringInvoiceCollectionAt(t *testing.T) {
 func TestStandardInvoiceCollectionAt(t *testing.T) {
 	flatFeeLineWithOverride := newFlatFeeStandardLine(t, "2025-06-20T12:00:00Z")
 	flatFeeLineWithOverride.OverrideCollectionPeriodEnd = lo.ToPtr(mustTime(t, "2025-06-20T12:05:00Z"))
+	lineWithHistoricalInvoiceAt := newStandardLine(t, "2025-06-15T12:00:00Z")
+	lineWithHistoricalInvoiceAt.InvoiceAt = time.Time{}
 
 	tests := []struct {
 		name    string
@@ -204,12 +206,21 @@ func TestStandardInvoiceCollectionAt(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "uses latest non deleted invoice at and adds collection interval",
+			name: "uses latest non deleted period end and adds collection interval",
 			invoice: newStandardInvoice(
 				mustTime(t, "2025-06-10T00:00:00Z"),
 				datetime.MustParseDuration(t, "PT1H"),
 				newStandardLine(t, "2025-06-05T08:00:00Z"),
 				newStandardLine(t, "2025-06-15T12:00:00Z"),
+			),
+			want: mustTime(t, "2025-06-15T13:00:00Z"),
+		},
+		{
+			name: "ignores historical invoice at",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				lineWithHistoricalInvoiceAt,
 			),
 			want: mustTime(t, "2025-06-15T13:00:00Z"),
 		},
@@ -233,7 +244,7 @@ func TestStandardInvoiceCollectionAt(t *testing.T) {
 			want: mustTime(t, "2025-06-20T12:05:00Z"),
 		},
 		{
-			name: "ignores deleted lines when resolving latest invoice at",
+			name: "ignores deleted lines when resolving latest period end",
 			invoice: newStandardInvoice(
 				mustTime(t, "2025-06-10T00:00:00Z"),
 				datetime.MustParseDuration(t, "PT1H"),
@@ -252,7 +263,7 @@ func TestStandardInvoiceCollectionAt(t *testing.T) {
 			want: time.Time{},
 		},
 		{
-			name: "uses latest non deleted metered invoice at without interval when interval is zero",
+			name: "uses latest non deleted metered period end without interval when interval is zero",
 			invoice: newStandardInvoice(
 				mustTime(t, "2025-06-10T00:00:00Z"),
 				datetime.ISODuration{},

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -101,10 +101,6 @@ func (i StandardLineBase) Validate() error {
 		errs = append(errs, fmt.Errorf("period: %w", err))
 	}
 
-	if i.InvoiceAt.IsZero() {
-		errs = append(errs, errors.New("invoice at is required"))
-	}
-
 	if i.OverrideCollectionPeriodEnd != nil {
 		if i.OverrideCollectionPeriodEnd.IsZero() {
 			errs = append(errs, errors.New("overrideCollectionPeriodEnd must not be zero when set"))
@@ -744,12 +740,6 @@ func (i StandardLine) Validate() error {
 	}
 
 	if i.UsageBased.Price.Type() != productcatalog.FlatPriceType {
-		if i.InvoiceAt.
-			Truncate(streaming.MinimumWindowSizeDuration).
-			Before(i.Period.Truncate(streaming.MinimumWindowSizeDuration).To) {
-			errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinimumWindowSizeDuration).To))
-		}
-
 		if i.Period.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 			errs = append(errs, ValidationError{
 				Err: ErrInvoiceCreateUBPLinePeriodIsEmpty,
@@ -768,9 +758,9 @@ func (i StandardLine) Validate() error {
 	return errors.Join(errs...)
 }
 
-// NormalizeValues normalizes the values of the line to ensure they are matching the expected invariants:
+// NormalizeValues normalizes the values of the line for persistence:
 // - Period is truncated to the minimum window size duration
-// - InvoiceAt is truncated to the minimum window size duration
+// - the historical InvoiceAt value is truncated to the minimum window size duration
 // - UsageBased.Price is normalized to have the default inAdvance payment term for flat prices
 func (i StandardLine) WithNormalizedValues() (*StandardLine, error) {
 	out, err := i.Clone()

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -46,7 +46,7 @@ type StandardLineBase struct {
 	// InvoiceAt is retained only to display the original invoice-at timestamp
 	// when a gathering line is rendered into a standard invoice line. Standard
 	// line business logic must not treat it as the line's scheduling source; use
-	// the line's creation timestamp when a standard-line fallback is needed.
+	// the line's service period end when resolving its collection deadline.
 	InvoiceAt                   time.Time  `json:"invoiceAt"`
 	OverrideCollectionPeriodEnd *time.Time `json:"overrideCollectionPeriodEnd,omitempty"`
 

--- a/openmeter/billing/stdinvoiceline_test.go
+++ b/openmeter/billing/stdinvoiceline_test.go
@@ -74,6 +74,33 @@ func TestStandardLineValidateAllowsNonNegativeTotals(t *testing.T) {
 	require.NoError(t, line.Validate())
 }
 
+func TestStandardLineValidateIgnoresInvoiceAt(t *testing.T) {
+	t.Parallel()
+
+	line := validStandardLineForValidation()
+	line.UsageBased.Price = productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+		Amount: alpacadecimal.NewFromInt(1),
+	})
+	line.UsageBased.FeatureKey = "feature-key"
+
+	for name, invoiceAt := range map[string]time.Time{
+		"zero":                {},
+		"before period start": line.Period.From.Add(-time.Hour),
+		"inside period":       line.Period.From.Add(30 * time.Minute),
+		"at period end":       line.Period.To,
+		"after period end":    line.Period.To.Add(time.Hour),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			line := line
+			line.InvoiceAt = invoiceAt
+
+			require.NoError(t, line.Validate())
+		})
+	}
+}
+
 func TestStandardLineValidateRejectsNegativeTotals(t *testing.T) {
 	line := validStandardLineForValidation()
 	line.Totals.Total = alpacadecimal.NewFromInt(-1)

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch_test.go
@@ -256,7 +256,7 @@ func TestPatchLineUpdateApplyStandardLinePreservesOmittedFields(t *testing.T) {
 	originalDBState := line.DBState
 	originalInvoiceAt := line.InvoiceAt
 	updatedPeriod := line.Period
-	updatedPeriod.To = updatedPeriod.From.AddDate(0, 0, 15)
+	updatedPeriod.To = updatedPeriod.To.AddDate(0, 1, 0)
 	patch, err := NewUpdateLinePatch(NewUpdateLinePatchInput{
 		Line:          line.GetLineID(),
 		InvoiceID:     line.InvoiceID,
@@ -276,6 +276,7 @@ func TestPatchLineUpdateApplyStandardLinePreservesOmittedFields(t *testing.T) {
 	require.Equal(t, models.Metadata{"owner": "preserved"}, updated.Metadata)
 	require.Same(t, originalDBState, updated.DBState)
 	require.NotEqual(t, updatedPeriod, line.Period)
+	require.NoError(t, updated.Validate())
 }
 
 func TestParsePatchesGroupsUpdateByInvoiceID(t *testing.T) {


### PR DESCRIPTION
## Summary

- remove InvoiceAt validation from standard invoice lines
- retain InvoiceAt as historical compatibility metadata
- cover arbitrary historical InvoiceAt values and service-period extension
- document that only gathering lines use InvoiceAt for eligibility

## Validation

- go test ./openmeter/billing ./openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater
- golangci-lint run -v ./openmeter/billing ./openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater
- git diff --check

Jira: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standard invoice lines can now be validated regardless of the `InvoiceAt` timestamp, including timestamps outside the billing period.
  - Invoice line updates now preserve omitted fields and validate successfully when billing periods change.
  - Standard invoice collection timing now uses the billing period end when no explicit deadline is provided, even if `InvoiceAt` is unset.

- **Documentation**
  - Clarified `InvoiceAt` eligibility and its role as historical metadata for standard lines.
  - Documented the fallback collection deadline for metered lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62607939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issues remain.

<h3>Summary</h3>

- Removes standard-line validation constraints on `InvoiceAt`.
- Derives the default metered-line collection deadline from the service-period end while preserving explicit overrides.
- Adds coverage for arbitrary historical timestamps and updated service periods.
- Documents the distinct scheduling semantics of gathering and standard lines.

<sub>Reviews (2) · Last reviewed commit: ["fix(billing): derive collection from ser..."](https://github.com/openmeterio/openmeter/commit/e5a151a5ac04a98d40eb8ab602e5a5800d71af18)</sub>

<!-- /greptile_comment -->