### PR TITLE
fix(billing): defer legacy feature validation

### DIFF
--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -179,7 +179,11 @@ the lifecycle operation.
   transaction and customer update lock
 - every invoice contains one fiat currency
 - a customer cannot have two active gathering invoices for the same currency
-- pending-line creation resolves every supplied feature; metered prices require the feature's meter
+- pending-line creation resolves every supplied feature, and metered prices
+  require the feature's meter. Legacy invoice-backed subscription reconciliation
+  may preserve an unresolved feature reference so stale subscription state can
+  still converge; collection reports the missing dependency as a critical
+  invoice validation issue
 - gathering-to-standard conversion preserves line IDs
 - line engines cannot silently change the identity or count of callback output
 - immutable invoice drift is recorded as validation issues rather than

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -947,6 +947,9 @@ func NewCreatePendingInvoiceLinesOptions(opts ...CreatePendingInvoiceLinesOption
 	return out
 }
 
+// WithBypassFeatureMeterValidation preserves unresolved feature references while
+// the legacy subscription reconciler creates gathering lines. Collection still
+// validates those dependencies and records critical issues on the invoice.
 func WithBypassFeatureMeterValidation() CreatePendingInvoiceLinesOption {
 	return func(o *CreatePendingInvoiceLinesOptions) {
 		o.BypassFeatureMeterValidation = true

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -931,6 +931,28 @@ func (c CreatePendingInvoiceLinesInput) Validate() error {
 	return errors.Join(errs...)
 }
 
+type CreatePendingInvoiceLinesOptions struct {
+	BypassFeatureMeterValidation bool
+}
+
+type CreatePendingInvoiceLinesOption func(*CreatePendingInvoiceLinesOptions)
+
+func NewCreatePendingInvoiceLinesOptions(opts ...CreatePendingInvoiceLinesOption) CreatePendingInvoiceLinesOptions {
+	var out CreatePendingInvoiceLinesOptions
+
+	for _, opt := range opts {
+		opt(&out)
+	}
+
+	return out
+}
+
+func WithBypassFeatureMeterValidation() CreatePendingInvoiceLinesOption {
+	return func(o *CreatePendingInvoiceLinesOptions) {
+		o.BypassFeatureMeterValidation = true
+	}
+}
+
 type CreatePendingInvoiceLinesResult struct {
 	Lines        []GatheringLine
 	Invoice      GatheringInvoice

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -116,7 +116,7 @@ type GatheringInvoiceService interface {
 	// Deleted lines are excluded unless they are manually managed, preserving explicit user intent during reconciliation.
 	GetGatheringLinesForSubscription(ctx context.Context, input GetLinesForSubscriptionInput) (GatheringLines, error)
 	// CreatePendingInvoiceLines creates pending invoice lines for a customer, if the lines are zero valued, the response is nil
-	CreatePendingInvoiceLines(ctx context.Context, input CreatePendingInvoiceLinesInput) (*CreatePendingInvoiceLinesResult, error)
+	CreatePendingInvoiceLines(ctx context.Context, input CreatePendingInvoiceLinesInput, opts ...CreatePendingInvoiceLinesOption) (*CreatePendingInvoiceLinesResult, error)
 
 	ListGatheringInvoices(ctx context.Context, input ListGatheringInvoicesInput) (pagination.Result[GatheringInvoice], error)
 	// ListCustomerIDsPendingCollection lists unique customers with gathering invoices due for automatic collection.

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -22,7 +22,9 @@ import (
 )
 
 // TODO[later]: Move this to gatheringinvoice.go
-func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput) (*billing.CreatePendingInvoiceLinesResult, error) {
+func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput, opts ...billing.CreatePendingInvoiceLinesOption) (*billing.CreatePendingInvoiceLinesResult, error) {
+	options := billing.NewCreatePendingInvoiceLinesOptions(opts...)
+
 	for i := range input.Lines {
 		input.Lines[i].Namespace = input.Customer.Namespace
 		input.Lines[i].Currency = input.Currency
@@ -53,10 +55,12 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 		}
 	}
 
-	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, input.Lines...)
-	if err != nil {
-		return nil, billing.ValidationError{
-			Err: fmt.Errorf("resolving pending line feature meters: %w", err),
+	if !options.BypassFeatureMeterValidation {
+		err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, input.Lines...)
+		if err != nil {
+			return nil, billing.ValidationError{
+				Err: fmt.Errorf("resolving pending line feature meters: %w", err),
+			}
 		}
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
@@ -327,7 +327,7 @@ func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID custome
 			Customer: customerID,
 			Currency: currency,
 			Lines:    lines,
-		})
+		}, billing.WithBypassFeatureMeterValidation())
 		if err != nil {
 			return fmt.Errorf("creating pending invoice lines: %w", err)
 		}

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -41,6 +41,77 @@ func TestSubscriptionHandlerScenarios(t *testing.T) {
 	suite.Run(t, new(SubscriptionHandlerTestSuite))
 }
 
+func (s *SubscriptionHandlerTestSuite) TestLegacyBackendCreatesGatheringLineBeforeSurfacingMissingFeature() {
+	ctx := s.testContext()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	const missingFeatureKey = "missing-feature"
+	itemKey := s.APIRequestsTotalFeature.Key
+
+	// Given a valid subscription and a stale event view whose usage item references a feature that no longer resolves.
+	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
+		{
+			PhaseMeta: s.phaseMeta("first-phase", ""),
+			RateCards: productcatalog.RateCards{
+				&productcatalog.UsageBasedRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:     itemKey,
+						Name:    itemKey,
+						Feature: productcatalog.NewFeatureReference(lo.ToPtr(s.APIRequestsTotalFeature.ID), lo.ToPtr(s.APIRequestsTotalFeature.Key)),
+						Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+							Amount: alpacadecimal.NewFromInt(1),
+						}),
+					},
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				},
+			},
+		},
+	})
+
+	item := subsView.Phases[0].ItemsByKey[itemKey][0]
+	for _, rateCard := range []productcatalog.RateCard{item.Spec.RateCard, item.SubscriptionItem.RateCard} {
+		s.Require().NoError(rateCard.ChangeMeta(func(meta productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+			meta.Key = missingFeatureKey
+			meta.Feature = productcatalog.NewFeatureReference(nil, lo.ToPtr(missingFeatureKey))
+
+			return meta, nil
+		}))
+	}
+	item.Feature = nil
+	subsView.Phases[0].ItemsByKey[itemKey][0] = item
+
+	// When the legacy billing backend synchronizes the event view.
+	err := s.Service.SyncByView(ctx, subsView, start.Add(time.Minute))
+
+	// Then synchronization succeeds and preserves the unresolved feature on a legacy gathering line.
+	s.Require().NoError(err)
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	lines := gatheringInvoice.Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	s.Equal(billing.LineEngineTypeInvoice, lines[0].Engine)
+	s.Equal(missingFeatureKey, lines[0].FeatureKey)
+
+	// And the unresolved feature is surfaced when the line reaches its first invoice.
+	clock.FreezeTime(start.AddDate(0, 1, 0))
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1)
+	invoice := invoices[0]
+	s.Equal(billing.StandardInvoiceStatusDraftInvalidCreated, invoice.Status)
+	issue, found := lo.Find(invoice.ValidationIssues, func(issue billing.ValidationIssue) bool {
+		return issue.Code == billing.ErrInvoiceLineFeatureNotFound.Code
+	})
+	s.Require().True(found)
+	s.Equal(billing.ValidationIssueSeverityCritical, issue.Severity)
+	s.Equal(billing.LineEngineValidationComponent(billing.LineEngineTypeInvoice), issue.Component)
+	s.Equal(fmt.Sprintf("/lines/%s", lines[0].ID), issue.Path)
+	s.Contains(issue.Message, missingFeatureKey)
+}
+
 func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 	ctx := s.testContext()
 	namespace := s.Namespace

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1872,7 +1872,7 @@ func (n NoopBillingService) ListCustomerOverrides(ctx context.Context, input bil
 }
 
 // InvoiceLineService methods
-func (n NoopBillingService) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput) (*billing.CreatePendingInvoiceLinesResult, error) {
+func (n NoopBillingService) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput, opts ...billing.CreatePendingInvoiceLinesOption) (*billing.CreatePendingInvoiceLinesResult, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Overview

Allow internal legacy subscription reconciliation to create gathering lines when their feature or meter cannot currently be resolved. Pending-line creation remains strict by default; subscription sync explicitly opts into deferred validation, allowing the first standard invoice to surface the existing critical validation issue.

## Notes for reviewer

- Adds a functional option to bypass feature-meter validation during pending-line creation.
- Uses the bypass only when legacy subscription sync provisions upcoming lines.
- Covers gathering-line persistence and draft.invalid_created behavior for a missing feature.

## Validation

- Focused subscription-sync regression test
- go test -tags=dynamic ./openmeter/billing/...
- Server package compile check
- make lint-go-fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to create pending invoice lines without immediately validating referenced feature meters.
  - Upcoming subscription invoice lines can be provisioned even when a feature reference is unavailable.

- **Bug Fixes**
  - Preserves affected lines for later invoicing, allowing unresolved feature issues to be surfaced as clear invoice validation errors.

- **Documentation**
  - Clarified how unresolved feature references are handled during subscription reconciliation and invoicing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62990600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable new issues or outstanding rule violations were identified.

<h3>Summary</h3>

- Adds an opt-in pending-line creation option; strict validation remains the default.
- Uses the bypass only when provisioning legacy subscription lines.
- Verifies that unresolved features later produce a critical validation issue on a draft-invalid invoice.
- Documents the deferred-validation lifecycle.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Legacy subscription reconciliation] --> B[Create pending invoice lines]
    B --> C[Bypass immediate feature-meter validation]
    C --> D[Persist gathering line]
    D --> E[Invoice pending lines]
    E --> F[Validate unresolved dependency]
    F --> G[Record critical validation issue]
    G --> H[draft.invalid_created]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["docs(billing): document deferred feature..."](https://github.com/openmeterio/openmeter/commit/469487e1e1d56a8bf26fdb3db222699bb22a72fc)</sub>

<!-- /greptile_comment -->