### PR TITLE
refactor(billing): scope feature meter bypass to lines

### DIFF
--- a/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
@@ -328,7 +328,7 @@ func (u *updater) provisionUpcomingLines(ctx context.Context, customerID custome
 		_, err := u.billingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerID,
 			Currency: currency,
-			Lines:    lines,
+			Lines:    billing.NewCreatePendingInvoiceLines(lines),
 		})
 		if err != nil {
 			return fmt.Errorf("creating pending invoice lines: %w", err)

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -447,9 +447,9 @@ func (s *service) createGatheringLines(ctx context.Context, gatheringLinesToCrea
 		result, err := s.billingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: custAndCurrency.customerID,
 			Currency: custAndCurrency.currency,
-			Lines: lo.Map(lines, func(item gatheringLineWithCustomerID, _ int) billing.GatheringLine {
+			Lines: billing.NewCreatePendingInvoiceLines(lo.Map(lines, func(item gatheringLineWithCustomerID, _ int) billing.GatheringLine {
 				return item.gatheringLine
-			}),
+			})),
 		})
 		if err != nil {
 			return createGatheringLinesResult{}, fmt.Errorf("creating pending invoice lines for charges: %w", err)

--- a/openmeter/billing/charges/service/pendinglines.go
+++ b/openmeter/billing/charges/service/pendinglines.go
@@ -120,7 +120,7 @@ func mapPendingInvoiceLinesToChargeIntents(input charges.CreatePendingInvoiceLin
 	intents := make(charges.ChargeIntents, 0, len(input.Lines))
 
 	for idx, line := range input.Lines {
-		intent, err := mapPendingInvoiceLineToChargeIntent(input.Customer.ID, resolvedCurrency, line)
+		intent, err := mapPendingInvoiceLineToChargeIntent(input.Customer.ID, resolvedCurrency, line.GatheringLine)
 		if err != nil {
 			return nil, fmt.Errorf("line.%d: %w", idx, err)
 		}

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -102,10 +102,10 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	result, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			usageLine,
 			flatLine,
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Require().NotNil(result)
@@ -293,7 +293,7 @@ func (s *InvoicableChargesTestSuite) TestBillingCreatePendingInvoiceLinesResolve
 			result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 				Customer: cust.GetID(),
 				Currency: currencyx.FiatCode(USD),
-				Lines:    []billing.GatheringLine{line},
+				Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{line}),
 			})
 
 			s.Nil(result)
@@ -312,6 +312,92 @@ func (s *InvoicableChargesTestSuite) TestBillingCreatePendingInvoiceLinesResolve
 			s.Empty(listed.Items)
 		})
 	}
+}
+
+func (s *InvoicableChargesTestSuite) TestBillingCreatePendingInvoiceLinesBypassesFeatureMeterValidationPerLine() {
+	// given:
+	// - a meterless usage line trusted by subscription reconciliation
+	// - an ordinary usage line with a valid feature meter
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("billing-create-pending-line-bypass-feature-meter")
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID())
+
+	meterlessFeatureKey := "meterless-pending-line-feature"
+	_, err := s.FeatureService.CreateFeature(ctx, featurepkg.CreateFeatureInputs{
+		Namespace: ns,
+		Name:      meterlessFeatureKey,
+		Key:       meterlessFeatureKey,
+	})
+	s.Require().NoError(err)
+	meteredFeature := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	meterlessLine := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: ns,
+				Name:      "meterless usage",
+			}),
+			ManagedBy:     billing.ManuallyManagedLine,
+			Currency:      currencyx.FiatCode(USD),
+			ServicePeriod: servicePeriod,
+			InvoiceAt:     servicePeriod.To,
+			Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromInt(2),
+			})),
+			FeatureKey: meterlessFeatureKey,
+		},
+	}
+	meteredLine, err := meterlessLine.CloneForCreate(func(line *billing.GatheringLine) {
+		line.Name = "metered usage"
+		line.FeatureKey = meteredFeature.Feature.Key
+	})
+	s.Require().NoError(err)
+
+	// when:
+	// - both lines are created in one mixed batch and only the meterless line bypasses dependency validation
+	result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: cust.GetID(),
+		Currency: currencyx.FiatCode(USD),
+		Lines: billing.CreatePendingInvoiceLines{
+			{
+				GatheringLine:                meterlessLine,
+				BypassFeatureMeterValidation: true,
+			},
+			billing.NewCreatePendingInvoiceLine(meteredLine),
+		},
+	})
+
+	// then:
+	// - billing validates the ordinary line and persists both lines
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Require().Len(result.Lines, 2)
+	s.Equal(meterlessFeatureKey, result.Lines[0].FeatureKey)
+	s.Equal(meteredFeature.Feature.Key, result.Lines[1].FeatureKey)
+
+	// and:
+	// - bypassing one line does not disable validation for another line in the same batch
+	result, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: cust.GetID(),
+		Currency: currencyx.FiatCode(USD),
+		Lines: billing.CreatePendingInvoiceLines{
+			{
+				GatheringLine:                meterlessLine,
+				BypassFeatureMeterValidation: true,
+			},
+			billing.NewCreatePendingInvoiceLine(meterlessLine),
+		},
+	})
+	s.Nil(result)
+	s.Require().Error(err)
+	issue := requireFeatureMeterValidationIssue(s.T(), err, billing.ErrInvoiceLineFeatureHasNoMeters.Code)
+	s.Empty(issue.Path)
 }
 
 func (s *InvoicableChargesTestSuite) TestChargeCreatePendingInvoiceLinesRequiresFeatureMeter() {
@@ -359,7 +445,7 @@ func (s *InvoicableChargesTestSuite) TestChargeCreatePendingInvoiceLinesRequires
 	result, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines:    []billing.GatheringLine{line},
+		Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{line}),
 	})
 
 	s.Nil(result)
@@ -412,9 +498,9 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreat
 	result, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			zeroFlatLine,
-		},
+		}),
 	})
 	s.Nil(result)
 	s.Require().Error(err)
@@ -454,9 +540,9 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRejectsNonManu
 	_, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			systemLine,
-		},
+		}),
 	})
 	s.Require().Error(err)
 	s.Contains(err.Error(), "managed by must be manual")
@@ -481,9 +567,9 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRejectsNonManu
 	_, err = s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			subscriptionLine,
-		},
+		}),
 	})
 	s.Require().Error(err)
 	s.Contains(err.Error(), "subscription is not allowed")
@@ -543,10 +629,10 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackParti
 	result, err := s.Charges.CreatePendingInvoiceLines(ctx, charges.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			usageLine,
 			zeroFlatLine,
-		},
+		}),
 	})
 	s.Nil(result)
 	s.Require().Error(err)

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -893,11 +893,29 @@ func (g GatheringLine) AsNewStandardLine(invoiceID string) (*StandardLine, error
 	return convertedLine, nil
 }
 
+type CreatePendingInvoiceLine struct {
+	GatheringLine
+
+	BypassFeatureMeterValidation bool `json:"-"`
+}
+
+func NewCreatePendingInvoiceLine(line GatheringLine) CreatePendingInvoiceLine {
+	return CreatePendingInvoiceLine{GatheringLine: line}
+}
+
+type CreatePendingInvoiceLines []CreatePendingInvoiceLine
+
+func NewCreatePendingInvoiceLines(lines []GatheringLine) CreatePendingInvoiceLines {
+	return lo.Map(lines, func(line GatheringLine, _ int) CreatePendingInvoiceLine {
+		return NewCreatePendingInvoiceLine(line)
+	})
+}
+
 type CreatePendingInvoiceLinesInput struct {
 	Customer customer.CustomerID `json:"customer"`
 	Currency currencyx.FiatCode  `json:"currency"`
 
-	Lines []GatheringLine `json:"lines"`
+	Lines CreatePendingInvoiceLines `json:"lines"`
 }
 
 func (c CreatePendingInvoiceLinesInput) Validate() error {
@@ -911,7 +929,9 @@ func (c CreatePendingInvoiceLinesInput) Validate() error {
 		errs = append(errs, fmt.Errorf("currency: %w", err))
 	}
 
-	for id, line := range c.Lines {
+	for id, createLine := range c.Lines {
+		line := createLine.GatheringLine
+
 		// Note: this is for validation purposes, as Line is copied, we are not altering the struct itself
 		line.Currency = c.Currency
 
@@ -929,31 +949,6 @@ func (c CreatePendingInvoiceLinesInput) Validate() error {
 	}
 
 	return errors.Join(errs...)
-}
-
-type CreatePendingInvoiceLinesOptions struct {
-	BypassFeatureMeterValidation bool
-}
-
-type CreatePendingInvoiceLinesOption func(*CreatePendingInvoiceLinesOptions)
-
-func NewCreatePendingInvoiceLinesOptions(opts ...CreatePendingInvoiceLinesOption) CreatePendingInvoiceLinesOptions {
-	var out CreatePendingInvoiceLinesOptions
-
-	for _, opt := range opts {
-		opt(&out)
-	}
-
-	return out
-}
-
-// WithBypassFeatureMeterValidation preserves unresolved feature references while
-// the legacy subscription reconciler creates gathering lines. Collection still
-// validates those dependencies and records critical issues on the invoice.
-func WithBypassFeatureMeterValidation() CreatePendingInvoiceLinesOption {
-	return func(o *CreatePendingInvoiceLinesOptions) {
-		o.BypassFeatureMeterValidation = true
-	}
 }
 
 type CreatePendingInvoiceLinesResult struct {

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -896,6 +896,9 @@ func (g GatheringLine) AsNewStandardLine(invoiceID string) (*StandardLine, error
 type CreatePendingInvoiceLine struct {
 	GatheringLine
 
+	// BypassFeatureMeterValidation preserves unresolved feature references while
+	// the legacy subscription reconciler creates gathering lines. Collection still
+	// validates those dependencies and records critical issues on the invoice.
 	BypassFeatureMeterValidation bool `json:"-"`
 }
 

--- a/openmeter/billing/httpdriver/invoice_test.go
+++ b/openmeter/billing/httpdriver/invoice_test.go
@@ -219,7 +219,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceSerialization() {
 	res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(
 				billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
@@ -230,7 +230,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceSerialization() {
 					PerUnitAmount: alpacadecimal.NewFromFloat(100),
 				},
 			),
-		},
+		}),
 	})
 	s.NoError(err)
 

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -80,7 +80,7 @@ func (h *handler) CreatePendingLine() CreatePendingLineHandler {
 					ID:        params.CustomerID,
 				},
 				Currency: currencyx.FiatCode(req.Currency),
-				Lines:    lineEntities,
+				Lines:    billing.NewCreatePendingInvoiceLines(lineEntities),
 			}, nil
 		},
 		func(ctx context.Context, request CreatePendingLineRequest) (CreatePendingLineResponse, error) {

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -116,7 +116,7 @@ type GatheringInvoiceService interface {
 	// Deleted lines are excluded unless they are manually managed, preserving explicit user intent during reconciliation.
 	GetGatheringLinesForSubscription(ctx context.Context, input GetLinesForSubscriptionInput) (GatheringLines, error)
 	// CreatePendingInvoiceLines creates pending invoice lines for a customer, if the lines are zero valued, the response is nil
-	CreatePendingInvoiceLines(ctx context.Context, input CreatePendingInvoiceLinesInput, opts ...CreatePendingInvoiceLinesOption) (*CreatePendingInvoiceLinesResult, error)
+	CreatePendingInvoiceLines(ctx context.Context, input CreatePendingInvoiceLinesInput) (*CreatePendingInvoiceLinesResult, error)
 
 	ListGatheringInvoices(ctx context.Context, input ListGatheringInvoicesInput) (pagination.Result[GatheringInvoice], error)
 	// ListCustomerIDsPendingCollection lists unique customers with gathering invoices due for automatic collection.

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -22,9 +22,7 @@ import (
 )
 
 // TODO[later]: Move this to gatheringinvoice.go
-func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput, opts ...billing.CreatePendingInvoiceLinesOption) (*billing.CreatePendingInvoiceLinesResult, error) {
-	options := billing.NewCreatePendingInvoiceLinesOptions(opts...)
-
+func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput) (*billing.CreatePendingInvoiceLinesResult, error) {
 	for i := range input.Lines {
 		input.Lines[i].Namespace = input.Customer.Namespace
 		input.Lines[i].Currency = input.Currency
@@ -37,7 +35,7 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 			}
 		}
 
-		if err := s.lineEngines.populateGatheringLineEngine(&input.Lines[i]); err != nil {
+		if err := s.lineEngines.populateGatheringLineEngine(&input.Lines[i].GatheringLine); err != nil {
 			return nil, fmt.Errorf("line[%d]: populating engine: %w", i, err)
 		}
 	}
@@ -55,12 +53,13 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 		}
 	}
 
-	if !options.BypassFeatureMeterValidation {
-		err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, input.Lines...)
-		if err != nil {
-			return nil, billing.ValidationError{
-				Err: fmt.Errorf("resolving pending line feature meters: %w", err),
-			}
+	linesRequiringFeatureMeterValidation := lo.Filter(input.Lines, func(line billing.CreatePendingInvoiceLine, _ int) bool {
+		return !line.BypassFeatureMeterValidation
+	})
+	err = s.featureMeterResolver.RequireFeatureMeters(ctx, input.Customer.Namespace, linesRequiringFeatureMeterValidation...)
+	if err != nil {
+		return nil, billing.ValidationError{
+			Err: fmt.Errorf("resolving pending line feature meters: %w", err),
 		}
 	}
 
@@ -106,7 +105,9 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 
 		gatheringInvoice := gatheringInvoiceUpsertResult.Invoice
 
-		linesToCreate, err := slicesx.MapWithErr(input.Lines, func(l billing.GatheringLine) (billing.GatheringLine, error) {
+		linesToCreate, err := slicesx.MapWithErr(input.Lines, func(createLine billing.CreatePendingInvoiceLine) (billing.GatheringLine, error) {
+			l := createLine.GatheringLine
+
 			l.Namespace = input.Customer.Namespace
 			l.Currency = input.Currency
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
@@ -326,8 +326,13 @@ func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID custome
 		_, err := u.billingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerID,
 			Currency: currency,
-			Lines:    lines,
-		}, billing.WithBypassFeatureMeterValidation())
+			Lines: lo.Map(lines, func(line billing.GatheringLine, _ int) billing.CreatePendingInvoiceLine {
+				return billing.CreatePendingInvoiceLine{
+					GatheringLine:                line,
+					BypassFeatureMeterValidation: true,
+				}
+			}),
+		})
 		if err != nil {
 			return fmt.Errorf("creating pending invoice lines: %w", err)
 		}

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1872,7 +1872,7 @@ func (n NoopBillingService) ListCustomerOverrides(ctx context.Context, input bil
 }
 
 // InvoiceLineService methods
-func (n NoopBillingService) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput, opts ...billing.CreatePendingInvoiceLinesOption) (*billing.CreatePendingInvoiceLinesResult, error) {
+func (n NoopBillingService) CreatePendingInvoiceLines(ctx context.Context, input billing.CreatePendingInvoiceLinesInput) (*billing.CreatePendingInvoiceLinesResult, error) {
 	return nil, nil
 }
 

--- a/test/app/custominvoicing/invocing_test.go
+++ b/test/app/custominvoicing/invocing_test.go
@@ -134,7 +134,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowHooksEnabled() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.HUF),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
@@ -174,7 +174,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowHooksEnabled() {
 							FeatureKey: "test",
 						},
 					},
-				},
+				}),
 			})
 		s.NoError(err, "failed to create pending invoice lines")
 		s.NotNil(res, "result should not be nil")
@@ -299,7 +299,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowPaymentStatusOnly() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.HUF),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
@@ -311,7 +311,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowPaymentStatusOnly() {
 						PerUnitAmount: alpacadecimal.NewFromFloat(600),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
-				},
+				}),
 			})
 		s.NoError(err, "failed to create pending invoice lines")
 		s.NotNil(res, "result should not be nil")

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -398,7 +398,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						// Covered case: Discount caused by maximum amount
 						GatheringLineBase: billing.GatheringLineBase{
@@ -530,7 +530,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		s.NoError(err)
@@ -1246,7 +1246,7 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -1261,7 +1261,7 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 						})),
 					},
 				},
-			},
+			}),
 		},
 	)
 	s.NoError(err)
@@ -1397,7 +1397,7 @@ func (s *StripeInvoiceTestSuite) TestDeletedAppFailsAdvancementButAllowsInvoiceD
 		_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
 					Period:        timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now.Add(-time.Hour)},
@@ -1408,7 +1408,7 @@ func (s *StripeInvoiceTestSuite) TestDeletedAppFailsAdvancementButAllowsInvoiceD
 					Currency:      currencyx.FiatCode(currency.USD),
 					PaymentTerm:   productcatalog.InArrearsPaymentTerm,
 				}),
-			},
+			}),
 		})
 		s.Require().NoError(err)
 
@@ -1588,7 +1588,7 @@ func (s *StripeInvoiceTestSuite) TestSendInvoice() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 					InvoiceAt:     periodStart,
@@ -1596,7 +1596,7 @@ func (s *StripeInvoiceTestSuite) TestSendInvoice() {
 					PerUnitAmount: alpacadecimal.NewFromFloat(10),
 					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 				}),
-			},
+			}),
 		},
 	)
 	s.NoError(err)

--- a/test/billing/adapter_test.go
+++ b/test/billing/adapter_test.go
@@ -1179,7 +1179,7 @@ func (s *BillingAdapterTestSuite) TestHardDeleteGatheringInvoiceLines() {
 		res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -1226,7 +1226,7 @@ func (s *BillingAdapterTestSuite) TestHardDeleteGatheringInvoiceLines() {
 						})),
 					},
 				},
-			},
+			}),
 		})
 		s.NoError(err)
 
@@ -1307,7 +1307,7 @@ func (s *BillingAdapterTestSuite) TestHardDeleteGatheringInvoiceLinesNegative() 
 		createdPendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -1356,7 +1356,7 @@ func (s *BillingAdapterTestSuite) TestHardDeleteGatheringInvoiceLinesNegative() 
 						})),
 					},
 				},
-			},
+			}),
 		})
 		s.NoError(err)
 

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -100,7 +100,7 @@ func (s *CollectionTestSuite) TestUncollectableCollection() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -117,7 +117,7 @@ func (s *CollectionTestSuite) TestUncollectableCollection() {
 					)),
 				},
 			},
-		},
+		}),
 	})
 
 	s.NoError(err)
@@ -159,7 +159,7 @@ func (s *CollectionTestSuite) TestCollectionWaitsForInvoiceAtAfterServicePeriodE
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 					Name: "UBP - unit",
@@ -172,7 +172,7 @@ func (s *CollectionTestSuite) TestCollectionWaitsForInvoiceAtAfterServicePeriodE
 					Amount: alpacadecimal.NewFromFloat(1),
 				})),
 			},
-		},
+		}),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(pendingLines.Lines, 1)
@@ -242,7 +242,7 @@ func (s *CollectionTestSuite) TestGatheringLineUnitConfigSnapshotRoundTrip() {
 	created, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: res.customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -258,7 +258,7 @@ func (s *CollectionTestSuite) TestGatheringLineUnitConfigSnapshotRoundTrip() {
 					UnitConfig: unitConfig,
 				},
 			},
-		},
+		}),
 	})
 	s.Require().NoError(err)
 	s.Len(created.Lines, 1)
@@ -308,7 +308,7 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 		res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customer.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -345,7 +345,7 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 						})),
 					},
 				},
-			},
+			}),
 		})
 		s.NoError(err)
 		s.Len(res.Lines, 2)
@@ -507,7 +507,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeOnly() {
 			pendingLineResult, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 				Customer: customer.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines:    []billing.GatheringLine{tc.line},
+				Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{tc.line}),
 			})
 			s.NoError(err)
 			s.Len(pendingLineResult.Lines, 1)
@@ -561,7 +561,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 	pendingLineResult, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
@@ -572,7 +572,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Len(pendingLineResult.Lines, 1)
@@ -677,7 +677,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEvent
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
@@ -688,7 +688,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEvent
 					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -776,7 +776,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_AutomaticCollectionWaitsForA
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
@@ -787,7 +787,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_AutomaticCollectionWaitsForA
 					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -839,7 +839,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceWaitsForLateE
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
@@ -850,7 +850,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceWaitsForLateE
 					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -918,7 +918,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 	pendingLineResult, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
@@ -929,7 +929,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Len(pendingLineResult.Lines, 1)

--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -92,7 +92,7 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -119,7 +119,7 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 							})),
 						},
 					},
-				},
+				}),
 			})
 		s.NoError(err)
 		s.Len(res.Lines, 1)
@@ -222,7 +222,7 @@ func (s *DiscountsTestSuite) TestFlatPriceUsageDiscountIsNotPersisted() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -246,7 +246,7 @@ func (s *DiscountsTestSuite) TestFlatPriceUsageDiscountIsNotPersisted() {
 					})),
 				},
 			},
-		},
+		}),
 	})
 
 	// then:
@@ -345,7 +345,7 @@ func (s *DiscountsTestSuite) TestUnitDiscountProgressiveBilling() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -372,7 +372,7 @@ func (s *DiscountsTestSuite) TestUnitDiscountProgressiveBilling() {
 						})),
 					},
 				},
-			},
+			}),
 		})
 	s.NoError(err)
 	s.Len(res.Lines, 1)

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -230,7 +230,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Namespace: namespace,
 
@@ -251,7 +251,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 						PerUnitAmount: alpacadecimal.NewFromFloat(100),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
-				},
+				}),
 			},
 		)
 
@@ -264,7 +264,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.HUF),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
@@ -304,7 +304,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 							FeatureKey: "test",
 						},
 					},
-				},
+				}),
 			})
 
 		// Then we should have the items created
@@ -519,7 +519,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace: namespace,
 					Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
@@ -550,7 +550,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 					PerUnitAmount: alpacadecimal.NewFromFloat(200),
 					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 				}),
-			},
+			}),
 		})
 
 	// Then we should have the items created
@@ -699,7 +699,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Name:      "Test item1",
 						Namespace: namespace,
@@ -715,7 +715,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 						PerUnitAmount: alpacadecimal.NewFromFloat(100),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
-				},
+				}),
 			})
 
 		s.NoError(err)
@@ -764,7 +764,7 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 	res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(
 				billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
@@ -775,7 +775,7 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 					PerUnitAmount: alpacadecimal.NewFromFloat(100),
 				},
 			),
-		},
+		}),
 	})
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), res)
@@ -793,7 +793,7 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.HUF),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Namespace:     namespace,
 				Period:        timeutil.ClosedPeriod{From: now.Add(-24 * time.Hour), To: now},
@@ -802,7 +802,7 @@ func (s *InvoicingTestSuite) TestListCustomerIDsPendingCollectionReturnsUniqueCu
 				Name:          "Test item - HUF",
 				PerUnitAmount: alpacadecimal.NewFromFloat(100),
 			}),
-		},
+		}),
 	})
 	require.NoError(s.T(), err)
 
@@ -1729,7 +1729,7 @@ func (s *InvoicingTestSuite) createManualApprovalInvoice(
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Namespace:         namespace,
 				Period:            period,
@@ -1741,7 +1741,7 @@ func (s *InvoicingTestSuite) createManualApprovalInvoice(
 				PaymentTerm:       productcatalog.InArrearsPaymentTerm,
 				RateCardDiscounts: discounts,
 			}),
-		},
+		}),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(pendingLines.Lines, 1)
@@ -1955,7 +1955,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -2056,7 +2056,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		require.NoError(s.T(), err)
@@ -2826,7 +2826,7 @@ func (s *InvoicingTestSuite) TestUBPGraduatingFlatFeeTier1() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -2866,7 +2866,7 @@ func (s *InvoicingTestSuite) TestUBPGraduatingFlatFeeTier1() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		require.NoError(s.T(), err)
@@ -3142,7 +3142,7 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -3243,7 +3243,7 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		require.NoError(s.T(), err)
@@ -3642,7 +3642,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceRecalculation() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -3660,7 +3660,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceRecalculation() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		require.NoError(s.T(), err)
@@ -3809,7 +3809,7 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -3824,7 +3824,7 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 						})),
 					},
 				},
-			},
+			}),
 		},
 	)
 	s.NoError(err)
@@ -3928,7 +3928,7 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroPrice() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -3943,7 +3943,7 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroPrice() {
 						})),
 					},
 				},
-			},
+			}),
 		},
 	)
 	s.NoError(err)
@@ -4158,7 +4158,7 @@ func (s *InvoicingTestSuite) TestProgressiveBillLate() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -4188,7 +4188,7 @@ func (s *InvoicingTestSuite) TestProgressiveBillLate() {
 						})),
 				},
 			},
-		},
+		}),
 	})
 
 	s.NoError(err)
@@ -4250,7 +4250,7 @@ func (s *InvoicingTestSuite) TestPartialInvoiceLinesOptions() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -4297,7 +4297,7 @@ func (s *InvoicingTestSuite) TestPartialInvoiceLinesOptions() {
 					)),
 				},
 			},
-		},
+		}),
 	})
 
 	s.NoError(err)
@@ -4357,7 +4357,7 @@ func (s *InvoicingTestSuite) TestSortLines() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -4397,7 +4397,7 @@ func (s *InvoicingTestSuite) TestSortLines() {
 					)),
 				},
 			},
-		},
+		}),
 	})
 
 	s.NoError(err)
@@ -4483,7 +4483,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
@@ -4492,7 +4492,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 				PerUnitAmount: alpacadecimal.NewFromFloat(10),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Len(pendingLines.Lines, 1)
@@ -4515,7 +4515,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 	pendingLines, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:    timeutil.ClosedPeriod{From: newPeriodStart, To: newPeriodEnd},
 				InvoiceAt: newPeriodStart,
@@ -4524,7 +4524,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 				PerUnitAmount: alpacadecimal.NewFromFloat(10),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Len(pendingLines.Lines, 1)
@@ -4582,7 +4582,7 @@ func (s *InvoicingTestSuite) TestDeleteGatheringInvoiceViaService() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Namespace: namespace,
 				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
@@ -4601,7 +4601,7 @@ func (s *InvoicingTestSuite) TestDeleteGatheringInvoiceViaService() {
 				PerUnitAmount: alpacadecimal.NewFromFloat(20),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	require.NoError(s.T(), err)
 	require.Len(s.T(), pendingLines.Lines, 2)
@@ -4671,7 +4671,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
@@ -4680,7 +4680,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 				PerUnitAmount: alpacadecimal.NewFromFloat(10),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	s.NoError(err)
 	s.Len(pendingLines.Lines, 1)
@@ -4707,7 +4707,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 	pendingLines, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customer.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:        timeutil.ClosedPeriod{From: clock.Now(), To: clock.Now().Add(time.Hour * 24)},
 				InvoiceAt:     clock.Now(),
@@ -4715,7 +4715,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 				PerUnitAmount: alpacadecimal.NewFromFloat(10),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	s.Error(err)
 	s.Nil(pendingLines)
@@ -4746,7 +4746,7 @@ func (s *InvoicingTestSuite) TestSnapshotQuantityMissingFeature() {
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: billing.GatheringLines{{
+		Lines: billing.NewCreatePendingInvoiceLines(billing.GatheringLines{{
 			GatheringLineBase: billing.GatheringLineBase{
 				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 					Namespace: namespace,
@@ -4760,7 +4760,7 @@ func (s *InvoicingTestSuite) TestSnapshotQuantityMissingFeature() {
 					Amount: alpacadecimal.NewFromInt(1),
 				})),
 			},
-		}},
+		}}),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(pendingLines.Lines, 1)
@@ -4930,7 +4930,7 @@ func (s *InvoicingTestSuite) TestSnapshotQuantityInvalidDatabaseState() {
 			billing.CreatePendingInvoiceLinesInput{
 				Customer: customerID,
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines: []billing.GatheringLine{
+				Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 					{
 						GatheringLineBase: billing.GatheringLineBase{
 							ManagedResource: models.ManagedResource{
@@ -4948,7 +4948,7 @@ func (s *InvoicingTestSuite) TestSnapshotQuantityInvalidDatabaseState() {
 							})),
 						},
 					},
-				},
+				}),
 			},
 		)
 		s.NoError(err)
@@ -5085,7 +5085,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceEmulation() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
 					Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
@@ -5095,7 +5095,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceEmulation() {
 					PerUnitAmount: alpacadecimal.NewFromFloat(100),
 					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 				}),
-			},
+			}),
 		})
 
 	// Then we should have the items created
@@ -5170,7 +5170,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 			res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines:    testLines,
+				Lines:    billing.NewCreatePendingInvoiceLines(testLines),
 			})
 			require.NoError(s.T(), err)
 			require.Len(s.T(), res.Lines, 2)
@@ -5265,7 +5265,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 			pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 				Customer: customerEntity.GetID(),
 				Currency: currencyx.FiatCode(currency.USD),
-				Lines:    testLines,
+				Lines:    billing.NewCreatePendingInvoiceLines(testLines),
 			})
 			require.NoError(s.T(), err)
 			require.Len(s.T(), pendingLines.Lines, 2)

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -134,7 +134,7 @@ func (s *LineEngineTestSuite) TestBillabilityValidationIssuesPreventInvoiceAdvan
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: ombilling.GatheringLines{{
+		Lines: ombilling.NewCreatePendingInvoiceLines(ombilling.GatheringLines{{
 			GatheringLineBase: ombilling.GatheringLineBase{
 				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 					Namespace: namespace,
@@ -149,7 +149,7 @@ func (s *LineEngineTestSuite) TestBillabilityValidationIssuesPreventInvoiceAdvan
 					Amount: alpacadecimal.NewFromInt(10),
 				}),
 			},
-		}},
+		}}),
 	})
 	s.Require().NoError(err)
 
@@ -437,7 +437,7 @@ func (s *LineEngineTestSuite) createInvoiceAssignmentGateFixture(
 	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
 		Customer: customerEntity.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines:    lines,
+		Lines:    ombilling.NewCreatePendingInvoiceLines(lines),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(pendingLines.Lines, len(lines))
@@ -506,7 +506,7 @@ func (s *LineEngineTestSuite) createMeteredDraftInvoiceWaitingForCollectionForAp
 			ID:        customerEntity.ID,
 		},
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []ombilling.GatheringLine{{
+		Lines: ombilling.NewCreatePendingInvoiceLines([]ombilling.GatheringLine{{
 			GatheringLineBase: ombilling.GatheringLineBase{
 				ManagedResource: models.ManagedResource{
 					NamespacedModel: models.NamespacedModel{Namespace: namespace},
@@ -521,7 +521,7 @@ func (s *LineEngineTestSuite) createMeteredDraftInvoiceWaitingForCollectionForAp
 					Amount: alpacadecimal.NewFromFloat(1),
 				})),
 			},
-		}},
+		}}),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(pendingLines.Lines, 1)
@@ -661,7 +661,7 @@ func (s *LineEngineTestSuite) TestGatheringPreviewUsesPreviewLineEngineCallback(
 			ID:        customerEntity.ID,
 		},
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []ombilling.GatheringLine{{
+		Lines: ombilling.NewCreatePendingInvoiceLines([]ombilling.GatheringLine{{
 			GatheringLineBase: ombilling.GatheringLineBase{
 				ManagedResource: models.ManagedResource{
 					NamespacedModel: models.NamespacedModel{Namespace: namespace},
@@ -676,7 +676,7 @@ func (s *LineEngineTestSuite) TestGatheringPreviewUsesPreviewLineEngineCallback(
 					Amount: alpacadecimal.NewFromFloat(1),
 				})),
 			},
-		}},
+		}}),
 	})
 	s.Require().NoError(err)
 

--- a/test/billing/schemamigration_test.go
+++ b/test/billing/schemamigration_test.go
@@ -116,7 +116,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 		_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -163,7 +163,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 						})),
 					},
 				},
-			},
+			}),
 		})
 		s.NoError(err)
 
@@ -218,7 +218,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 		result, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: customerEntity.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -235,7 +235,7 @@ func (s *SchemaMigrationTestSuite) TestSchemaLevel1Migration() {
 						})),
 					},
 				},
-			},
+			}),
 		})
 		s.Require().NoError(err)
 

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -488,7 +488,7 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: in.Customer.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(
 					billing.NewFlatFeeLineInput{
 						Namespace:     namespace,
@@ -519,7 +519,7 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 						PaymentTerm: productcatalog.InArrearsPaymentTerm,
 					},
 				),
-			},
+			}),
 		})
 
 	require.NoError(s.T(), err)

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -210,7 +210,7 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customer.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				{
 					GatheringLineBase: billing.GatheringLineBase{
 						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -236,7 +236,7 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 						})),
 					},
 				},
-			},
+			}),
 		},
 	)
 
@@ -297,7 +297,7 @@ func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, custom
 		billing.CreatePendingInvoiceLinesInput{
 			Customer: customer.GetID(),
 			Currency: currencyx.FiatCode(currency.USD),
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Period: timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
 
@@ -312,7 +312,7 @@ func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, custom
 					PerUnitAmount: alpacadecimal.NewFromFloat(100),
 					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 				}),
-			},
+			}),
 		},
 	)
 

--- a/test/billing/taxcode_dual_write_test.go
+++ b/test/billing/taxcode_dual_write_test.go
@@ -525,7 +525,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotTaxCodeIntoLinesOnAdvance() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Namespace:     ns,
 				Period:        timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
@@ -535,7 +535,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotTaxCodeIntoLinesOnAdvance() {
 				PerUnitAmount: alpacadecimal.NewFromFloat(100),
 				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 			}),
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -571,7 +571,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotLineOwnCodeTakesPrecedence() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -590,7 +590,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotLineOwnCodeTakesPrecedence() {
 					})),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -629,7 +629,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotPreservesExistingTaxCodeID() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -649,7 +649,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotPreservesExistingTaxCodeID() {
 					})),
 				},
 			},
-		},
+		}),
 	})
 	s.NoError(err)
 

--- a/test/billing/ubpflatfee_test.go
+++ b/test/billing/ubpflatfee_test.go
@@ -60,9 +60,9 @@ func (s *UBPFlatFeeLineTestSuite) TestPendingLineCreation() {
 		res, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: cust.GetID(),
 			Currency: "USD",
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				lineIn,
-			},
+			}),
 		})
 
 		s.NoError(err)
@@ -160,7 +160,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPercentageDiscount() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: "USD",
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:    period,
 				InvoiceAt: period.To,
@@ -177,7 +177,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPercentageDiscount() {
 					},
 				},
 			}),
-		},
+		}),
 	})
 	s.NoError(err)
 
@@ -239,7 +239,7 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 		_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: cust.GetID(),
 			Currency: "USD",
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Period:    period,
 					InvoiceAt: period.To,
@@ -256,7 +256,7 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 						},
 					},
 				}),
-			},
+			}),
 		})
 		s.Error(err)
 	})
@@ -265,7 +265,7 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 		_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: cust.GetID(),
 			Currency: "USD",
-			Lines: []billing.GatheringLine{
+			Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Period: timeutil.ClosedPeriod{
 						From: period.From,
@@ -277,7 +277,7 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 					PerUnitAmount: alpacadecimal.NewFromInt(100),
 					PaymentTerm:   productcatalog.InArrearsPaymentTerm,
 				}),
-			},
+			}),
 		})
 		s.NoError(err)
 	})

--- a/test/billing/unitconfig_legacy_test.go
+++ b/test/billing/unitconfig_legacy_test.go
@@ -73,7 +73,7 @@ func (s *legacyUnitConfigRatingSuite) TestRatesConvertedQuantity() {
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -89,7 +89,7 @@ func (s *legacyUnitConfigRatingSuite) TestRatesConvertedQuantity() {
 					UnitConfig: unitConfig,
 				},
 			},
-		},
+		}),
 	})
 	s.Require().NoError(err)
 
@@ -178,7 +178,7 @@ func (s *legacyUnitConfigRatingSuite) TestSurfacesQuantityDetailOnV3InvoiceAPI()
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: cust.GetID(),
 		Currency: currencyx.FiatCode(currency.USD),
-		Lines: []billing.GatheringLine{
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{
 			{
 				GatheringLineBase: billing.GatheringLineBase{
 					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -194,7 +194,7 @@ func (s *legacyUnitConfigRatingSuite) TestSurfacesQuantityDetailOnV3InvoiceAPI()
 					UnitConfig: unitConfig,
 				},
 			},
-		},
+		}),
 	})
 	s.Require().NoError(err)
 

--- a/test/credits/creditpurchase_costbasis_test.go
+++ b/test/credits/creditpurchase_costbasis_test.go
@@ -139,7 +139,7 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementLifecycle() {
 		_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 			Customer: fixture.customerID,
 			Currency: currencyx.FiatCode(fixture.settlementCurrency),
-			Lines:    []billing.GatheringLine{*created.GatheringLineToCreate},
+			Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{*created.GatheringLineToCreate}),
 		})
 		s.Require().NoError(err)
 
@@ -304,7 +304,7 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoiceSettlementResolutionFai
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: fixture.customerID,
 		Currency: currencyx.FiatCode(fixture.settlementCurrency),
-		Lines:    []billing.GatheringLine{*created.GatheringLineToCreate},
+		Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{*created.GatheringLineToCreate}),
 	})
 	s.Require().NoError(err)
 

--- a/test/credits/creditpurchase_settlement_test.go
+++ b/test/credits/creditpurchase_settlement_test.go
@@ -34,7 +34,7 @@ func (s *CreditPurchaseCostBasisSuite) TestDynamicInvoicePurchaseRoundingToZeroI
 	s.Nil(created.Charge.State.ResolvedCostBasis)
 	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
 		Customer: fixture.customerID, Currency: currencyx.FiatCode(fixture.settlementCurrency),
-		Lines: []billing.GatheringLine{*created.GatheringLineToCreate},
+		Lines: billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{*created.GatheringLineToCreate}),
 	})
 	s.Require().NoError(err)
 

--- a/test/customer/subject.go
+++ b/test/customer/subject.go
@@ -394,7 +394,7 @@ func (s *CustomerHandlerTestSuite) TestMultiSubjectIntegrationFlow(ctx context.C
 			ID:        createdCustomer.ID,
 		},
 		Currency: currencyx.FiatCode("USD"),
-		Lines:    []billing.GatheringLine{pendingLine},
+		Lines:    billing.NewCreatePendingInvoiceLines([]billing.GatheringLine{pendingLine}),
 	})
 	require.NoError(t, err, "creating pending invoice lines should succeed")
 	require.NotNil(t, result)


### PR DESCRIPTION
## Overview

Moves pending invoice-line feature-meter bypass from a call-wide functional option to trusted per-line creation metadata. Ordinary HTTP and charge callers use option-free constructors, while legacy subscription reconciliation explicitly marks only the affected lines. The bypass field is excluded from JSON payloads.

Adds focused mixed-batch coverage proving bypassed meterless lines are accepted while ordinary lines in the same batch remain validated.

## Notes for reviewer

The existing billing domain documentation already describes the legacy reconciliation exception, so no documentation update was required.

Validation completed:
- focused billing feature-meter integration tests
- legacy subscription reconciliation regression test
- affected-package compile checks
- repository fast Go linter
- repository formatting and import-order check



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63054162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with the previous documentation finding fully addressed and no new actionable findings.

<h3>Summary</h3>

- Adds option-free constructors for ordinary pending invoice lines and excludes bypass metadata from JSON.
- Adds mixed-batch coverage for bypassed and normally validated lines.
- The latest revision restores the explanation of the legacy exception and deferred collection validation, fully addressing the previous finding.
- No new actionable issues were identified.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[HTTP and charge callers] --> B[Ordinary line constructors]
  C[Legacy subscription reconciliation] --> D[Explicit per-line bypass]
  B --> E[Create pending invoice lines]
  D --> E
  E --> F[Validate feature meters for non-bypassed lines]
  F --> G[Persist gathering lines]
  G --> H[Collection validates dependencies]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["docs(billing): explain feature meter val..."](https://github.com/openmeterio/openmeter/commit/32b678bade8ed10b94d8a09f14181d7a7b8a38cc)</sub>

<!-- /greptile_comment -->