### PR TITLE
fix(sink): batch Redis deduplication checks

### DIFF
--- a/openmeter/dedupe/redisdedupe/redisdedupe.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe.go
@@ -183,13 +183,20 @@ func (d Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item)
 		return dedupe.CheckUniqueBatchResult{}, ErrNoDedupItems
 	}
 
-	keys := make([]string, 0, len(items))
+	keysPerItem := 1
+	if d.Mode == DedupeModeKeyHashMigration {
+		keysPerItem = 2
+	}
+
+	keys := make([]string, 0, len(items)*keysPerItem)
 	for _, item := range items {
 		switch d.Mode {
 		case DedupeModeRawKey:
 			keys = append(keys, item.Key())
-		case DedupeModeKeyHash, DedupeModeKeyHashMigration:
+		case DedupeModeKeyHash:
 			keys = append(keys, GetKeyHash(item.Key()))
+		case DedupeModeKeyHashMigration:
+			keys = append(keys, item.Key(), GetKeyHash(item.Key()))
 		}
 	}
 
@@ -198,7 +205,7 @@ func (d Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item)
 		return dedupe.CheckUniqueBatchResult{}, fmt.Errorf("failed to get multiple keys in redis: %w", err)
 	}
 
-	if len(cmdResults) != len(items) {
+	if len(cmdResults) != len(items)*keysPerItem {
 		return dedupe.CheckUniqueBatchResult{}, fmt.Errorf("failed to get all keys in redis")
 	}
 
@@ -207,13 +214,20 @@ func (d Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item)
 		AlreadyProcessedItems: make(dedupe.ItemSet, len(items)),
 	}
 
-	for i, cmdResult := range cmdResults {
-		if cmdResult != nil {
-			result.AlreadyProcessedItems[items[i]] = struct{}{}
-			continue
+	for i, item := range items {
+		unique := true
+		for _, value := range cmdResults[i*keysPerItem : (i+1)*keysPerItem] {
+			if value != nil {
+				unique = false
+				break
+			}
 		}
 
-		result.UniqueItems[items[i]] = struct{}{}
+		if unique {
+			result.UniqueItems[item] = struct{}{}
+		} else {
+			result.AlreadyProcessedItems[item] = struct{}{}
+		}
 	}
 
 	return result, nil

--- a/openmeter/dedupe/redisdedupe/redisdedupe_test.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe_test.go
@@ -1,0 +1,149 @@
+package redisdedupe
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
+)
+
+type lookupHook struct {
+	keys    map[string]bool
+	calls   int
+	err     error
+	latency time.Duration
+}
+
+func (h *lookupHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (h *lookupHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+
+func (h *lookupHook) ProcessHook(_ redis.ProcessHook) redis.ProcessHook {
+	return func(_ context.Context, cmd redis.Cmder) error {
+		h.calls++
+		if h.latency > 0 {
+			time.Sleep(h.latency)
+		}
+		if h.err != nil {
+			return h.err
+		}
+		switch cmd := cmd.(type) {
+		case *redis.SliceCmd:
+			values := make([]any, len(cmd.Args())-1)
+			for i, arg := range cmd.Args()[1:] {
+				if h.keys[arg.(string)] {
+					values[i] = ""
+				}
+			}
+			cmd.SetVal(values)
+		case *redis.IntCmd:
+			var count int64
+			for _, arg := range cmd.Args()[1:] {
+				if h.keys[arg.(string)] {
+					count++
+				}
+			}
+			cmd.SetVal(count)
+		default:
+			return errors.New("unexpected Redis command")
+		}
+		return nil
+	}
+}
+
+func TestCheckUniqueBatch(t *testing.T) {
+	for _, mode := range []DedupeMode{DedupeModeRawKey, DedupeModeKeyHash, DedupeModeKeyHashMigration} {
+		t.Run(string(mode), func(t *testing.T) {
+			items := []dedupe.Item{
+				{Namespace: "ns", Source: "source", ID: "new"},
+				{Namespace: "ns", Source: "source", ID: "raw"},
+				{Namespace: "ns", Source: "source", ID: "hashed"},
+				{Namespace: "ns", Source: "source", ID: "both"},
+				{Namespace: "other", Source: "source", ID: "both"},
+			}
+			hook := &lookupHook{keys: map[string]bool{
+				items[1].Key():             true,
+				GetKeyHash(items[2].Key()): true,
+				items[3].Key():             true,
+				GetKeyHash(items[3].Key()): true,
+			}}
+			client := redis.NewClient(&redis.Options{})
+			t.Cleanup(func() { require.NoError(t, client.Close()) })
+			client.AddHook(hook)
+			d := Deduplicator{Redis: client, Mode: mode}
+
+			result, err := d.CheckUniqueBatch(t.Context(), items)
+			require.NoError(t, err)
+			require.Equal(t, 1, hook.calls)
+			require.Contains(t, result.UniqueItems, items[0])
+			require.Contains(t, result.UniqueItems, items[4])
+			require.Contains(t, result.AlreadyProcessedItems, items[3])
+			for _, item := range items {
+				unique, err := d.CheckUnique(t.Context(), item)
+				require.NoError(t, err)
+				_, batchUnique := result.UniqueItems[item]
+				require.Equal(t, unique, batchUnique, item.ID)
+				_, processed := result.AlreadyProcessedItems[item]
+				require.NotEqual(t, batchUnique, processed)
+			}
+
+			hook.err = errors.New("redis unavailable")
+			_, err = d.CheckUniqueBatch(t.Context(), items)
+			require.ErrorIs(t, err, hook.err)
+			_, err = d.CheckUniqueBatch(t.Context(), nil)
+			require.ErrorIs(t, err, ErrNoDedupItems)
+		})
+	}
+}
+
+func BenchmarkUniquenessChecks(b *testing.B) {
+	items := make([]dedupe.Item, 1000)
+	for i := range items {
+		items[i] = dedupe.Item{Namespace: "ns", Source: "source", ID: strconv.Itoa(i)}
+	}
+	for _, batched := range []bool{false, true} {
+		name := "per-message-plus-batch"
+		if batched {
+			name = "batch-only"
+		}
+		b.Run(name, func(b *testing.B) {
+			client := redis.NewClient(&redis.Options{})
+			b.Cleanup(func() { require.NoError(b, client.Close()) })
+			hook := &lookupHook{latency: time.Millisecond}
+			client.AddHook(hook)
+			d := Deduplicator{Redis: client, Mode: DedupeModeRawKey}
+			b.ResetTimer()
+			for b.Loop() {
+				if !batched {
+					for _, item := range items {
+						_, err := d.CheckUnique(b.Context(), item)
+						if err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+				_, err := d.CheckUniqueBatch(b.Context(), items)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(hook.calls)/float64(b.N), "redis-calls/batch")
+		})
+	}
+}
+
+func TestCheckUniqueBatchInvalidMode(t *testing.T) {
+	client := redis.NewClient(&redis.Options{})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	client.AddHook(&lookupHook{})
+	d := Deduplicator{Redis: client, Mode: DedupeMode("invalid")}
+	_, err := d.CheckUniqueBatch(t.Context(), []dedupe.Item{{ID: "id"}})
+	require.Error(t, err)
+}

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -303,27 +303,15 @@ func (s *Sink) flush(ctx context.Context) error {
 	ctx, flushSpan := s.config.Tracer.Start(ctx, "flush", trace.WithSpanKind(trace.SpanKindConsumer), trace.WithAttributes(attribute.Int("size", len(messages))))
 	defer flushSpan.End()
 
-	// Dedupe messages so if we have multiple messages in the same batch
-	dedupedMessages := dedupeSinkMessages(messages)
-
-	// If deduplicator is set, let's reexecute the deduplication to decrease the number of messages double persisted
-	if s.config.Deduplicator != nil && len(dedupedMessages) > 0 {
-		dedupeResults, err := s.config.Deduplicator.CheckUniqueBatch(ctx, lo.Map(dedupedMessages, func(message sinkmodels.SinkMessage, _ int) dedupe.Item {
-			return message.GetDedupeItem()
-		}))
-		if err != nil {
-			return fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
-		}
-
-		updatedDedupedMessages := make([]sinkmodels.SinkMessage, 0, len(dedupedMessages))
-		for _, message := range dedupedMessages {
-			if _, ok := dedupeResults.UniqueItems[message.GetDedupeItem()]; ok {
-				updatedDedupedMessages = append(updatedDedupedMessages, message)
-			}
-		}
-
-		dedupedMessages = updatedDedupedMessages
+	dedupeCtx, dedupeSpan := s.config.Tracer.Start(ctx, "deduplicate-and-resolve-meters")
+	dedupedMessages, err := s.deduplicateAndResolveMeters(dedupeCtx, messages)
+	if err != nil {
+		dedupeSpan.RecordError(err)
+		dedupeSpan.SetStatus(codes.Error, "deduplication and meter resolution failure")
+		dedupeSpan.End()
+		return err
 	}
+	dedupeSpan.End()
 
 	// 1. Persist to storage
 	if len(dedupedMessages) > 0 {
@@ -443,7 +431,8 @@ func (s *Sink) persistToStorage(ctx context.Context, messages []sinkmodels.SinkM
 		case sinkmodels.DROP:
 			// Skip event from batch
 			if s.config.LogDroppedEvents {
-				logger.WarnContext(ctx, "event dropped",
+				logger.WarnContext(
+					ctx, "event dropped",
 					slog.String("namespace", message.Namespace),
 					slog.String("event", string(message.KafkaMessage.Value)),
 					slog.Any("error", message.Status.DropError),
@@ -498,7 +487,8 @@ func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage)
 			// later but if any error was transient let's retry the message if it's sent again.
 
 			if s.config.LogDroppedEvents {
-				logger.WarnContext(ctx, "event dropped",
+				logger.WarnContext(
+					ctx, "event dropped",
 					slog.String("namespace", message.Namespace),
 					slog.String("event", string(message.KafkaMessage.Value)),
 					slog.Any("error", message.Status.DropError),
@@ -526,7 +516,8 @@ func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage)
 			}
 
 			if len(existingItems) > 0 {
-				logger.ErrorContext(ctx, "dedupe: some items already existed in redis",
+				logger.ErrorContext(
+					ctx, "dedupe: some items already existed in redis",
 					"items", lo.Map(existingItems, func(item dedupe.Item, _ int) string {
 						return item.Key()
 					}),
@@ -728,7 +719,8 @@ func (s *Sink) Run(ctx context.Context) error {
 
 				s.buffer.Add(*sinkMessage)
 
-				logger.DebugContext(ctx, "event added to buffer",
+				logger.DebugContext(
+					ctx, "event added to buffer",
 					"partition", e.TopicPartition.Partition,
 					"offset", e.TopicPartition.Offset,
 					"event", sinkMessage.Serialized,
@@ -909,7 +901,8 @@ func (s *Sink) parseMessage(ctx context.Context, e *kafka.Message) (*sinkmodels.
 		if sinkMessage.IngestedAt == nil && header.Key == kafkaingest.HeaderKeyIngestedAt {
 			ingestedAt, err := kafkaingest.FromIngestedAt(string(header.Value))
 			if err != nil {
-				s.config.Logger.ErrorContext(ctx, "failed to parse Kafka message header",
+				s.config.Logger.ErrorContext(
+					ctx, "failed to parse Kafka message header",
 					"kafka.message.header.key", kafkaingest.HeaderKeyIngestedAt,
 					"error", err,
 				)
@@ -922,7 +915,8 @@ func (s *Sink) parseMessage(ctx context.Context, e *kafka.Message) (*sinkmodels.
 	if sinkMessage.Namespace == "" {
 		sinkMessage.Status = sinkmodels.ProcessingStatus{
 			State: sinkmodels.DROP,
-			DropError: fmt.Errorf("failed to get namespace as header (%q) for Kafka Message is missing: %s",
+			DropError: fmt.Errorf(
+				"failed to get namespace as header (%q) for Kafka Message is missing: %s",
 				kafkaingest.HeaderKeyNamespace,
 				e.TopicPartition.String(),
 			),
@@ -955,34 +949,50 @@ func (s *Sink) parseMessage(ctx context.Context, e *kafka.Message) (*sinkmodels.
 
 	sinkMessage.Serialized = &kafkaCloudEvent
 
-	// Dedupe, this stores key in store which means if sink fails and restarts it will not process the same message again
-	// Dedupe is an optional dependency, so we check if it's set
-	if s.config.Deduplicator != nil {
-		isUnique, err := s.config.Deduplicator.CheckUnique(ctx, sinkMessage.GetDedupeItem())
+	return sinkMessage, nil
+}
+
+func (s *Sink) deduplicateAndResolveMeters(ctx context.Context, messages []sinkmodels.SinkMessage) ([]sinkmodels.SinkMessage, error) {
+	// Remove duplicates from the same batch to prevent logic errors
+	candidates := dedupeSinkMessages(messages)
+
+	// Check if the messages are unique using the deduplicator
+	var alreadyProcessed dedupe.ItemSet
+	if s.config.Deduplicator != nil && len(candidates) > 0 {
+		result, err := s.config.Deduplicator.CheckUniqueBatch(ctx, lo.Map(candidates, func(message sinkmodels.SinkMessage, _ int) dedupe.Item {
+			return message.GetDedupeItem()
+		}))
 		if err != nil {
-			// Stop processing, non-recoverable error
-			return sinkMessage, fmt.Errorf("failed to check uniqueness of kafka message: %w", err)
+			return nil, fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
 		}
 
-		if !isUnique {
-			sinkMessage.Status = sinkmodels.ProcessingStatus{
+		alreadyProcessed = result.AlreadyProcessedItems
+	}
+
+	for i := range messages {
+		message := &messages[i]
+		if message.Status.State != sinkmodels.OK {
+			continue
+		}
+
+		if _, ok := alreadyProcessed[message.GetDedupeItem()]; ok {
+			message.Status = sinkmodels.ProcessingStatus{
 				State:     sinkmodels.DROP,
 				DropError: errors.New("skipping non unique message"),
 			}
-
-			return sinkMessage, nil
+			continue
 		}
+
+		meters, err := s.meterCache.GetAffectedMeters(ctx, message)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get affected meters: %w", err)
+		}
+
+		message.Meters = meters
 	}
 
-	// Let's resolve affected meters
-	affectedMeters, err := s.meterCache.GetAffectedMeters(ctx, sinkMessage)
-	if err != nil {
-		return sinkMessage, fmt.Errorf("failed to get affected meters: %w", err)
-	}
-
-	sinkMessage.Meters = affectedMeters
-
-	return sinkMessage, err
+	// Final deduplication to remove duplicates from the same batch including REDIS checks
+	return dedupeSinkMessages(messages), nil
 }
 
 func (s *Sink) Close() error {

--- a/openmeter/sink/sink_test.go
+++ b/openmeter/sink/sink_test.go
@@ -1,0 +1,204 @@
+package sink
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
+	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest"
+	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
+)
+
+type batchDeduplicator struct {
+	dedupe.Deduplicator
+	calls     int
+	items     []dedupe.Item
+	processed dedupe.ItemSet
+	err       error
+}
+
+func (d *batchDeduplicator) CheckUniqueBatch(_ context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+	d.calls++
+	d.items = items
+	result := dedupe.CheckUniqueBatchResult{UniqueItems: dedupe.ItemSet{}, AlreadyProcessedItems: d.processed}
+	for _, item := range items {
+		if _, ok := d.processed[item]; !ok {
+			result.UniqueItems[item] = struct{}{}
+		}
+	}
+	return result, d.err
+}
+
+func TestDeduplicateAndResolveMeters(t *testing.T) {
+	affectedMeter := &meter.Meter{Key: "usage"}
+	newMessage := sinkmodels.SinkMessage{
+		Namespace:  "ns",
+		Serialized: &serializer.CloudEventsKafkaPayload{Id: "new", Source: "source", Type: "usage"},
+	}
+	oldMessage := sinkmodels.SinkMessage{
+		Namespace:  "ns",
+		Serialized: &serializer.CloudEventsKafkaPayload{Id: "old", Source: "source", Type: "usage"},
+	}
+	invalidMessage := sinkmodels.SinkMessage{
+		Status: sinkmodels.ProcessingStatus{State: sinkmodels.DROP, DropError: errors.New("invalid")},
+	}
+	resolvedNew := sinkmodels.SinkMessage{
+		Namespace:  "ns",
+		Serialized: &serializer.CloudEventsKafkaPayload{Id: "new", Source: "source", Type: "usage"},
+		Meters:     []*meter.Meter{affectedMeter},
+	}
+	resolvedOld := sinkmodels.SinkMessage{
+		Namespace:  "ns",
+		Serialized: &serializer.CloudEventsKafkaPayload{Id: "old", Source: "source", Type: "usage"},
+		Meters:     []*meter.Meter{affectedMeter},
+	}
+	droppedOld := sinkmodels.SinkMessage{
+		Namespace:  "ns",
+		Serialized: &serializer.CloudEventsKafkaPayload{Id: "old", Source: "source", Type: "usage"},
+		Status:     sinkmodels.ProcessingStatus{State: sinkmodels.DROP, DropError: errors.New("skipping non unique message")},
+	}
+	redisError := errors.New("redis unavailable")
+
+	tests := []struct {
+		name string
+		// Includes repeated and dropped messages whose offsets must still be handled.
+		inputMessages []sinkmodels.SinkMessage
+		// Models identities already persisted before this batch reaches the sink.
+		previouslyProcessedItems dedupe.ItemSet
+		// In-batch deduplication must still work without an external deduplicator.
+		deduplicatorDisabled bool
+		// Returned messages eligible for ClickHouse insertion, with duplicates removed and meters resolved.
+		expectedStorageBatch []sinkmodels.SinkMessage
+		// The original slice after mutation, including dropped messages, used by metrics and flush callbacks.
+		expectedMessagesAfterProcessing []sinkmodels.SinkMessage
+		// Identities sent in the single batch lookup; empty means no lookup should occur.
+		expectedDedupeLookupItems []dedupe.Item
+		// Injected lookup failure that must propagate as the returned error's cause.
+		deduplicatorError error
+	}{
+		{
+			name:                            "same message multiple times in the batch",
+			inputMessages:                   []sinkmodels.SinkMessage{newMessage, newMessage, newMessage},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{resolvedNew},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{resolvedNew, resolvedNew, resolvedNew},
+			expectedDedupeLookupItems:       []dedupe.Item{newMessage.GetDedupeItem()},
+		},
+		{
+			name:                            "already processed message",
+			inputMessages:                   []sinkmodels.SinkMessage{oldMessage},
+			previouslyProcessedItems:        dedupe.ItemSet{oldMessage.GetDedupeItem(): {}},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{droppedOld},
+			expectedDedupeLookupItems:       []dedupe.Item{oldMessage.GetDedupeItem()},
+		},
+		{
+			name:                            "no duplicates",
+			inputMessages:                   []sinkmodels.SinkMessage{newMessage, oldMessage},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{resolvedNew, resolvedOld},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{resolvedNew, resolvedOld},
+			expectedDedupeLookupItems:       []dedupe.Item{newMessage.GetDedupeItem(), oldMessage.GetDedupeItem()},
+		},
+		{
+			name:                            "mixed unique repeated already processed and invalid messages",
+			inputMessages:                   []sinkmodels.SinkMessage{newMessage, oldMessage, newMessage, invalidMessage},
+			previouslyProcessedItems:        dedupe.ItemSet{oldMessage.GetDedupeItem(): {}},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{resolvedNew},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{resolvedNew, droppedOld, resolvedNew, invalidMessage},
+			expectedDedupeLookupItems:       []dedupe.Item{newMessage.GetDedupeItem(), oldMessage.GetDedupeItem()},
+		},
+		{
+			name:                            "all messages already processed including repeated messages",
+			inputMessages:                   []sinkmodels.SinkMessage{oldMessage, oldMessage},
+			previouslyProcessedItems:        dedupe.ItemSet{oldMessage.GetDedupeItem(): {}},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{droppedOld, droppedOld},
+			expectedDedupeLookupItems:       []dedupe.Item{oldMessage.GetDedupeItem()},
+		},
+		{
+			name:                            "disabled deduplicator still removes duplicates within the batch",
+			inputMessages:                   []sinkmodels.SinkMessage{newMessage, oldMessage, newMessage},
+			previouslyProcessedItems:        dedupe.ItemSet{oldMessage.GetDedupeItem(): {}},
+			deduplicatorDisabled:            true,
+			expectedStorageBatch:            []sinkmodels.SinkMessage{resolvedNew, resolvedOld},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{resolvedNew, resolvedOld, resolvedNew},
+		},
+		{
+			name:                            "all invalid messages",
+			inputMessages:                   []sinkmodels.SinkMessage{invalidMessage},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{invalidMessage},
+		},
+		{
+			name:                            "empty batch",
+			inputMessages:                   []sinkmodels.SinkMessage{},
+			expectedStorageBatch:            []sinkmodels.SinkMessage{},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{},
+		},
+		{
+			name:                            "Redis failure leaves messages unchanged",
+			inputMessages:                   []sinkmodels.SinkMessage{newMessage, oldMessage},
+			expectedMessagesAfterProcessing: []sinkmodels.SinkMessage{newMessage, oldMessage},
+			expectedDedupeLookupItems:       []dedupe.Item{newMessage.GetDedupeItem(), oldMessage.GetDedupeItem()},
+			deduplicatorError:               redisError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given a batch and the previously processed event identities
+			messages := make([]sinkmodels.SinkMessage, len(tc.inputMessages))
+			for i, message := range tc.inputMessages {
+				messages[i] = message
+				if message.Serialized != nil {
+					serialized := *message.Serialized
+					messages[i].Serialized = &serialized
+				}
+			}
+			d := &batchDeduplicator{processed: tc.previouslyProcessedItems, err: tc.deduplicatorError}
+			s := &Sink{
+				config: SinkConfig{Deduplicator: d},
+				meterCache: &NamespacedMeterCache{
+					logger:     slog.New(slog.DiscardHandler),
+					namespaces: map[string]MetersByType{"ns": {"usage": {affectedMeter}}},
+				},
+			}
+			if tc.deduplicatorDisabled {
+				s.config.Deduplicator = nil
+			}
+
+			// when deduplicating the batch and resolving affected meters
+			batch, err := s.deduplicateAndResolveMeters(t.Context(), messages)
+
+			// then storage output and the original callback messages match their expected states
+			require.ErrorIs(t, err, tc.deduplicatorError)
+			require.Equal(t, tc.expectedStorageBatch, batch)
+			require.Equal(t, tc.expectedMessagesAfterProcessing, messages)
+			require.Equal(t, tc.expectedDedupeLookupItems, d.items)
+			if len(tc.expectedDedupeLookupItems) == 0 {
+				require.Zero(t, d.calls)
+			} else {
+				require.Equal(t, 1, d.calls)
+			}
+		})
+	}
+}
+
+func TestParseMessageDoesNotCheckRedis(t *testing.T) {
+	d := &batchDeduplicator{}
+	s := &Sink{config: SinkConfig{Deduplicator: d}}
+	message, err := s.parseMessage(t.Context(), &kafka.Message{
+		Headers: []kafka.Header{{Key: kafkaingest.HeaderKeyNamespace, Value: []byte("ns")}},
+		Value:   []byte(`{"id":"id","source":"source","subject":"subject","type":"usage","time":1}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, sinkmodels.OK, message.Status.State)
+	require.NotNil(t, message.Serialized)
+	require.Zero(t, d.calls)
+}


### PR DESCRIPTION
## Overview

The sink worker performs a synchronous Redis EXISTS call for every valid Kafka message, then repeats deduplication with a batch lookup during flush. Remove the per-message checks and use one batch lookup before ClickHouse insertion to reduce serial Redis waiting as batches accumulate.

The batch lookup checks both raw and hashed keys in migration mode. Previously processed messages are marked as dropped in the original slice used by metrics and flush callbacks, and affected meters are resolved after deduplication. Persistence, offset storage, and Redis write ordering remain unchanged.

## Notes for reviewer

- Add a trace span for batch deduplication and meter resolution.
- Table-driven tests cover repeated messages, previously processed messages, unique and mixed batches, disabled deduplication, invalid/empty batches, and Redis failures. Additional tests verify key-mode compatibility and that parsing makes no Redis calls.
- Focused sink and deduplication tests pass with `-tags=dynamic`; the full configured linter passes for both package trees.
- A synthetic 1,000-item benchmark with 1 ms latency per Redis command reduces dedupe calls from 1,001 to 1 and measured time from approximately 1.18 s to 1.73 ms. This measures deduplication only, not end-to-end ClickHouse throughput.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved batch processing to identify duplicate events more efficiently and consistently.
  * Events already processed or repeated within the same batch are now filtered before storage.
  * Enhanced compatibility during deduplication key migrations by checking both supported key formats.
  * Meter resolution is performed for the complete batch before persistence, improving processing consistency.
* **Reliability**
  * Improved handling and propagation of deduplication lookup errors.
  * Added validation for unsupported deduplication modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63071797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the batched deduplication path preserves existing persistence, offset, Redis-write, and retry semantics.

<h3>Summary</h3>

- Extends Redis migration-mode batch lookups to check both raw and hashed keys in one MGET.
- Marks previously processed messages in the original batch while returning a deduplicated storage batch.
- Adds tracing around batch deduplication and meter resolution.
- Adds table-driven coverage for sink batch behavior, Redis key modes, failures, and the absence of Redis calls during parsing.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K as Kafka consumer
    participant S as Sink buffer
    participant R as Redis
    participant M as Meter cache
    participant C as ClickHouse

    K->>S: Parse and buffer messages
    Note over K,S: No per-message Redis lookup
    S->>S: Remove in-batch duplicates
    S->>R: MGET deduplication keys
    R-->>S: Previously processed identities
    S->>S: Mark matching original messages DROP
    S->>M: Resolve meters for remaining messages
    M-->>S: Affected meters
    S->>S: Build final unique storage batch
    S->>C: Batch insert
    C-->>S: Insert acknowledged
    S->>K: Store offsets
    S->>R: SET NX processed keys
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(sink): batch Redis deduplication che..."](https://github.com/openmeterio/openmeter/commit/433e19f31d2bbb4c19018d65ab0cfd08a110430a)</sub>

<!-- /greptile_comment -->