### PR TITLE
feat(app_stripe): add webhook_schema_version column to app stripe table, adjust the webhook types

### DIFF
--- a/openmeter/app/stripe/README.md
+++ b/openmeter/app/stripe/README.md
@@ -25,3 +25,14 @@ load the app-owned signing secret.
 The derived namespace becomes trusted request context only after the Stripe signature has been
 verified with that secret. Namespace-free app lookup must not be reused for ordinary authenticated
 app operations, where the caller's namespace is already known and must constrain every query.
+
+## Webhook schema version
+
+Each Stripe app records the webhook event set its Stripe endpoint was registered with. Version 1
+covers setup-intent and invoice events; version 2 adds payment-intent, credit-note, refund, and
+`invoice.finalized` events. New installs persist `appservice.LatestWebhookSchemaVersion` and register
+the full event list. Existing apps stay on version 1 because there is no webhook update path, so any
+new event handling must tolerate apps that never deliver those events.
+
+Version 2 events are currently acknowledged without processing. Stripe disables an endpoint after
+sustained non-2xx responses, so a registered event must never be rejected as unsupported.

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -58,7 +58,8 @@ func (a *adapter) CreateStripeApp(ctx context.Context, input appstripe.CreateApp
 			SetAPIKey(input.APIKey.ID).
 			SetStripeWebhookID(input.StripeWebhookID).
 			SetWebhookSecret(input.WebhookSecret.ID).
-			SetMaskedAPIKey(input.MaskedAPIKey)
+			SetMaskedAPIKey(input.MaskedAPIKey).
+			SetWebhookSchemaVersion(input.WebhookSchemaVersion)
 
 		dbApp, err := appStripeCreateQuery.Save(ctx)
 		if err != nil {
@@ -696,10 +697,11 @@ func (a adapter) getStripeAppClient(ctx context.Context, appID app.AppID, logOpe
 // mapAppStripeData maps stripe app data from the database
 func mapAppStripeData(appID app.AppID, dbApp *entdb.AppStripe) appstripe.AppData {
 	appData := appstripe.AppData{
-		StripeAccountID: dbApp.StripeAccountID,
-		Livemode:        dbApp.StripeLivemode,
-		MaskedAPIKey:    dbApp.MaskedAPIKey,
-		StripeWebhookID: dbApp.StripeWebhookID,
+		StripeAccountID:      dbApp.StripeAccountID,
+		Livemode:             dbApp.StripeLivemode,
+		MaskedAPIKey:         dbApp.MaskedAPIKey,
+		StripeWebhookID:      dbApp.StripeWebhookID,
+		WebhookSchemaVersion: dbApp.WebhookSchemaVersion,
 	}
 
 	if dbApp.APIKey != nil {

--- a/openmeter/app/stripe/adapter/stripe_test.go
+++ b/openmeter/app/stripe/adapter/stripe_test.go
@@ -22,6 +22,7 @@ func TestDeleteStripeAppDataSoftDeletesAndSanitizesSecrets(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, before.APIKey)
 	require.NotNil(t, before.WebhookSecret)
+	require.Equal(t, 1, before.WebhookSchemaVersion)
 
 	err = env.adapter.DeleteStripeAppData(t.Context(), appstripe.DeleteStripeAppDataInput{AppID: appID})
 	require.NoError(t, err)
@@ -48,6 +49,7 @@ func TestDeleteStripeAppDataSoftDeletesAndSanitizesSecrets(t *testing.T) {
 	require.Equal(t, before.StripeLivemode, deletedData.Livemode)
 	require.Equal(t, before.MaskedAPIKey, deletedData.MaskedAPIKey)
 	require.Equal(t, before.StripeWebhookID, deletedData.StripeWebhookID)
+	require.Equal(t, before.WebhookSchemaVersion, deletedData.WebhookSchemaVersion)
 	require.Empty(t, deletedData.APIKey.ID)
 	require.Empty(t, deletedData.WebhookSecret.ID)
 

--- a/openmeter/app/stripe/client/appclient.go
+++ b/openmeter/app/stripe/client/appclient.go
@@ -58,6 +58,31 @@ const (
 	WebhookEventTypeInvoiceSent = "invoice.sent"
 	// Occurs whenever an invoice is voided.
 	WebhookEventTypeInvoiceVoided = "invoice.voided"
+
+	// Webhook schema version 2 events
+
+	// Occurs when a PaymentIntent has successfully completed payment.
+	WebhookEventTypePaymentIntentSucceeded = "payment_intent.succeeded"
+	// Occurs when a PaymentIntent is canceled.
+	WebhookEventTypePaymentIntentCanceled = "payment_intent.canceled"
+	// Occurs when a PaymentIntent has failed the attempt to create a payment method or a payment.
+	WebhookEventTypePaymentIntentPaymentFailed = "payment_intent.payment_failed"
+	// Occurs when a PaymentIntent transitions to requires_action state.
+	WebhookEventTypePaymentIntentRequiresAction = "payment_intent.requires_action"
+	// Occurs whenever a credit note is created.
+	WebhookEventTypeCreditNoteCreated = "credit_note.created"
+	// Occurs whenever a credit note is updated.
+	WebhookEventTypeCreditNoteUpdated = "credit_note.updated"
+	// Occurs whenever a credit note is voided.
+	WebhookEventTypeCreditNoteVoided = "credit_note.voided"
+	// Occurs whenever a refund is created.
+	WebhookEventTypeRefundCreated = "refund.created"
+	// Occurs whenever a refund is updated.
+	WebhookEventTypeRefundUpdated = "refund.updated"
+	// Occurs whenever a refund fails.
+	WebhookEventTypeRefundFailed = "refund.failed"
+	// Occurs whenever a draft invoice is finalized.
+	WebhookEventTypeInvoiceFinalized = "invoice.finalized"
 )
 
 // StripeAppClient is a client for the stripe API for an installed app.

--- a/openmeter/app/stripe/client/client.go
+++ b/openmeter/app/stripe/client/client.go
@@ -78,7 +78,8 @@ func NewStripeClient(config StripeClientConfig) (StripeClient, error) {
 	}, nil
 }
 
-// SetupWebhook setups a stripe webhook to handle setup intents and save the payment method
+// SetupWebhook registers the Stripe webhook endpoint for an app. The registered event set is
+// tracked by appservice.LatestWebhookSchemaVersion; bump it whenever this list changes.
 func (c *stripeClient) SetupWebhook(ctx context.Context, input SetupWebhookInput) (StripeWebhookEndpoint, error) {
 	if err := input.Validate(); err != nil {
 		return StripeWebhookEndpoint{}, fmt.Errorf("invalid input: %w", err)
@@ -101,6 +102,19 @@ func (c *stripeClient) SetupWebhook(ctx context.Context, input SetupWebhookInput
 			lo.ToPtr(WebhookEventTypeInvoicePaymentSucceeded),
 			lo.ToPtr(WebhookEventTypeInvoiceSent),
 			lo.ToPtr(WebhookEventTypeInvoiceVoided),
+
+			// Schema version 2
+			lo.ToPtr(WebhookEventTypePaymentIntentSucceeded),
+			lo.ToPtr(WebhookEventTypePaymentIntentCanceled),
+			lo.ToPtr(WebhookEventTypePaymentIntentPaymentFailed),
+			lo.ToPtr(WebhookEventTypePaymentIntentRequiresAction),
+			lo.ToPtr(WebhookEventTypeCreditNoteCreated),
+			lo.ToPtr(WebhookEventTypeCreditNoteUpdated),
+			lo.ToPtr(WebhookEventTypeCreditNoteVoided),
+			lo.ToPtr(WebhookEventTypeRefundCreated),
+			lo.ToPtr(WebhookEventTypeRefundUpdated),
+			lo.ToPtr(WebhookEventTypeRefundFailed),
+			lo.ToPtr(WebhookEventTypeInvoiceFinalized),
 		},
 		URL:         lo.ToPtr(input.WebhookURL),
 		Description: lo.ToPtr("OpenMeter Stripe Webhook, do not delete or modify manually"),

--- a/openmeter/app/stripe/httpdriver/webhook.go
+++ b/openmeter/app/stripe/httpdriver/webhook.go
@@ -438,6 +438,24 @@ func (h *handler) AppStripeWebhook() AppStripeWebhookHandler {
 					NamespaceId: request.AppID.Namespace,
 					AppId:       request.AppID.ID,
 				}, nil
+			case stripeclient.WebhookEventTypePaymentIntentSucceeded,
+				stripeclient.WebhookEventTypePaymentIntentCanceled,
+				stripeclient.WebhookEventTypePaymentIntentPaymentFailed,
+				stripeclient.WebhookEventTypePaymentIntentRequiresAction,
+				stripeclient.WebhookEventTypeCreditNoteCreated,
+				stripeclient.WebhookEventTypeCreditNoteUpdated,
+				stripeclient.WebhookEventTypeCreditNoteVoided,
+				stripeclient.WebhookEventTypeRefundCreated,
+				stripeclient.WebhookEventTypeRefundUpdated,
+				stripeclient.WebhookEventTypeRefundFailed,
+				stripeclient.WebhookEventTypeInvoiceFinalized:
+				// FIXME: handle schema version 2 events in a follow-up PR.
+				// They must be acknowledged until then, otherwise Stripe disables the endpoint
+				// after repeated non-2xx responses.
+				return AppStripeWebhookResponse{
+					NamespaceId: request.AppID.Namespace,
+					AppId:       request.AppID.ID,
+				}, nil
 			}
 
 			return AppStripeWebhookResponse{}, models.NewGenericValidationError(

--- a/openmeter/app/stripe/service/const.go
+++ b/openmeter/app/stripe/service/const.go
@@ -5,3 +5,7 @@ const (
 	InvoiceIDAttributeName       = "invoice.id"
 	InvoiceStatusAttributeName   = "invoice.status"
 )
+
+// LatestWebhookSchemaVersion is persisted on newly installed Stripe apps and identifies the
+// webhook event set SetupWebhook registered. Bump it whenever that event list changes.
+const LatestWebhookSchemaVersion = 2

--- a/openmeter/app/stripe/service/factory.go
+++ b/openmeter/app/stripe/service/factory.go
@@ -131,12 +131,13 @@ func (s *Service) InstallAppWithAPIKey(ctx context.Context, input app.AppFactory
 			Type:        app.AppTypeStripe,
 		},
 
-		StripeAccountID: stripeAccount.StripeAccountID,
-		Livemode:        livemode,
-		APIKey:          apiKeySecretID,
-		MaskedAPIKey:    s.generateMaskedSecretAPIKey(input.APIKey),
-		StripeWebhookID: stripeWebhookEndpoint.EndpointID,
-		WebhookSecret:   webhookSecretID,
+		StripeAccountID:      stripeAccount.StripeAccountID,
+		Livemode:             livemode,
+		APIKey:               apiKeySecretID,
+		MaskedAPIKey:         s.generateMaskedSecretAPIKey(input.APIKey),
+		StripeWebhookID:      stripeWebhookEndpoint.EndpointID,
+		WebhookSecret:        webhookSecretID,
+		WebhookSchemaVersion: LatestWebhookSchemaVersion,
 	}
 
 	if err := createStripeAppInput.Validate(); err != nil {

--- a/openmeter/app/stripe/types.go
+++ b/openmeter/app/stripe/types.go
@@ -24,12 +24,13 @@ const (
 type CreateAppStripeInput struct {
 	app.CreateAppInput
 
-	StripeAccountID string
-	Livemode        bool
-	APIKey          secretentity.SecretID
-	MaskedAPIKey    string
-	StripeWebhookID string
-	WebhookSecret   secretentity.SecretID
+	StripeAccountID      string
+	Livemode             bool
+	APIKey               secretentity.SecretID
+	MaskedAPIKey         string
+	StripeWebhookID      string
+	WebhookSecret        secretentity.SecretID
+	WebhookSchemaVersion int
 }
 
 func (i CreateAppStripeInput) Validate() error {
@@ -89,6 +90,10 @@ func (i CreateAppStripeInput) Validate() error {
 
 	if i.WebhookSecret.Key != WebhookSecretKey {
 		errs = append(errs, errors.New("webhookSecret has an invalid semantic key"))
+	}
+
+	if i.WebhookSchemaVersion < 1 {
+		errs = append(errs, errors.New("webhookSchemaVersion must be at least 1"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -418,6 +423,9 @@ type AppData struct {
 	MaskedAPIKey    string                `json:"maskedApiKey"`
 	StripeWebhookID string                `json:"stripeWebhookId"`
 	WebhookSecret   secretentity.SecretID `json:"-"`
+	// WebhookSchemaVersion records the event set the Stripe endpoint was registered with.
+	// It is fixed at install time because there is no webhook update path.
+	WebhookSchemaVersion int `json:"webhookSchemaVersion"`
 }
 
 func (d AppData) Validate() error {

--- a/openmeter/app/stripe/types_test.go
+++ b/openmeter/app/stripe/types_test.go
@@ -37,6 +37,7 @@ func TestCreateAppStripeInputValidateBindsSecretsToApp(t *testing.T) {
 			"webhook-secret-id",
 			WebhookSecretKey,
 		),
+		WebhookSchemaVersion: 1,
 	}
 
 	for _, testCase := range []struct {
@@ -51,6 +52,13 @@ func TestCreateAppStripeInputValidateBindsSecretsToApp(t *testing.T) {
 			name: "missing app id",
 			mutate: func(input *CreateAppStripeInput) {
 				input.ID = nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "webhook schema version below one",
+			mutate: func(input *CreateAppStripeInput) {
+				input.WebhookSchemaVersion = 0
 			},
 			wantErr: true,
 		},

--- a/openmeter/ent/db/appstripe.go
+++ b/openmeter/ent/db/appstripe.go
@@ -38,6 +38,8 @@ type AppStripe struct {
 	StripeWebhookID string `json:"stripe_webhook_id,omitempty"`
 	// WebhookSecret holds the value of the "webhook_secret" field.
 	WebhookSecret *string `json:"-"`
+	// WebhookSchemaVersion holds the value of the "webhook_schema_version" field.
+	WebhookSchemaVersion int `json:"webhook_schema_version,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AppStripeQuery when eager-loading is set.
 	Edges        AppStripeEdges `json:"edges"`
@@ -82,6 +84,8 @@ func (*AppStripe) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case appstripe.FieldStripeLivemode:
 			values[i] = new(sql.NullBool)
+		case appstripe.FieldWebhookSchemaVersion:
+			values[i] = new(sql.NullInt64)
 		case appstripe.FieldID, appstripe.FieldNamespace, appstripe.FieldStripeAccountID, appstripe.FieldAPIKey, appstripe.FieldMaskedAPIKey, appstripe.FieldStripeWebhookID, appstripe.FieldWebhookSecret:
 			values[i] = new(sql.NullString)
 		case appstripe.FieldCreatedAt, appstripe.FieldUpdatedAt, appstripe.FieldDeletedAt:
@@ -170,6 +174,12 @@ func (_m *AppStripe) assignValues(columns []string, values []any) error {
 				_m.WebhookSecret = new(string)
 				*_m.WebhookSecret = value.String
 			}
+		case appstripe.FieldWebhookSchemaVersion:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field webhook_schema_version", values[i])
+			} else if value.Valid {
+				_m.WebhookSchemaVersion = int(value.Int64)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -245,6 +255,9 @@ func (_m *AppStripe) String() string {
 	builder.WriteString(_m.StripeWebhookID)
 	builder.WriteString(", ")
 	builder.WriteString("webhook_secret=<sensitive>")
+	builder.WriteString(", ")
+	builder.WriteString("webhook_schema_version=")
+	builder.WriteString(fmt.Sprintf("%v", _m.WebhookSchemaVersion))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/appstripe/appstripe.go
+++ b/openmeter/ent/db/appstripe/appstripe.go
@@ -34,6 +34,8 @@ const (
 	FieldStripeWebhookID = "stripe_webhook_id"
 	// FieldWebhookSecret holds the string denoting the webhook_secret field in the database.
 	FieldWebhookSecret = "webhook_secret"
+	// FieldWebhookSchemaVersion holds the string denoting the webhook_schema_version field in the database.
+	FieldWebhookSchemaVersion = "webhook_schema_version"
 	// EdgeCustomerApps holds the string denoting the customer_apps edge name in mutations.
 	EdgeCustomerApps = "customer_apps"
 	// EdgeApp holds the string denoting the app edge name in mutations.
@@ -69,6 +71,7 @@ var Columns = []string{
 	FieldMaskedAPIKey,
 	FieldStripeWebhookID,
 	FieldWebhookSecret,
+	FieldWebhookSchemaVersion,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -98,6 +101,10 @@ var (
 	StripeWebhookIDValidator func(string) error
 	// WebhookSecretValidator is a validator for the "webhook_secret" field. It is called by the builders before save.
 	WebhookSecretValidator func(string) error
+	// DefaultWebhookSchemaVersion holds the default value on creation for the "webhook_schema_version" field.
+	DefaultWebhookSchemaVersion int
+	// WebhookSchemaVersionValidator is a validator for the "webhook_schema_version" field. It is called by the builders before save.
+	WebhookSchemaVersionValidator func(int) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -158,6 +165,11 @@ func ByStripeWebhookID(opts ...sql.OrderTermOption) OrderOption {
 // ByWebhookSecret orders the results by the webhook_secret field.
 func ByWebhookSecret(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldWebhookSecret, opts...).ToFunc()
+}
+
+// ByWebhookSchemaVersion orders the results by the webhook_schema_version field.
+func ByWebhookSchemaVersion(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldWebhookSchemaVersion, opts...).ToFunc()
 }
 
 // ByCustomerAppsCount orders the results by customer_apps count.

--- a/openmeter/ent/db/appstripe/where.go
+++ b/openmeter/ent/db/appstripe/where.go
@@ -115,6 +115,11 @@ func WebhookSecret(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldEQ(FieldWebhookSecret, v))
 }
 
+// WebhookSchemaVersion applies equality check predicate on the "webhook_schema_version" field. It's identical to WebhookSchemaVersionEQ.
+func WebhookSchemaVersion(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldEQ(FieldWebhookSchemaVersion, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldEQ(FieldNamespace, v))
@@ -663,6 +668,46 @@ func WebhookSecretEqualFold(v string) predicate.AppStripe {
 // WebhookSecretContainsFold applies the ContainsFold predicate on the "webhook_secret" field.
 func WebhookSecretContainsFold(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldContainsFold(FieldWebhookSecret, v))
+}
+
+// WebhookSchemaVersionEQ applies the EQ predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionEQ(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldEQ(FieldWebhookSchemaVersion, v))
+}
+
+// WebhookSchemaVersionNEQ applies the NEQ predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionNEQ(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNEQ(FieldWebhookSchemaVersion, v))
+}
+
+// WebhookSchemaVersionIn applies the In predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionIn(vs ...int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldIn(FieldWebhookSchemaVersion, vs...))
+}
+
+// WebhookSchemaVersionNotIn applies the NotIn predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionNotIn(vs ...int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNotIn(FieldWebhookSchemaVersion, vs...))
+}
+
+// WebhookSchemaVersionGT applies the GT predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionGT(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldGT(FieldWebhookSchemaVersion, v))
+}
+
+// WebhookSchemaVersionGTE applies the GTE predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionGTE(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldGTE(FieldWebhookSchemaVersion, v))
+}
+
+// WebhookSchemaVersionLT applies the LT predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionLT(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldLT(FieldWebhookSchemaVersion, v))
+}
+
+// WebhookSchemaVersionLTE applies the LTE predicate on the "webhook_schema_version" field.
+func WebhookSchemaVersionLTE(v int) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldLTE(FieldWebhookSchemaVersion, v))
 }
 
 // HasCustomerApps applies the HasEdge predicate on the "customer_apps" edge.

--- a/openmeter/ent/db/appstripe_create.go
+++ b/openmeter/ent/db/appstripe_create.go
@@ -125,6 +125,20 @@ func (_c *AppStripeCreate) SetNillableWebhookSecret(v *string) *AppStripeCreate 
 	return _c
 }
 
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (_c *AppStripeCreate) SetWebhookSchemaVersion(v int) *AppStripeCreate {
+	_c.mutation.SetWebhookSchemaVersion(v)
+	return _c
+}
+
+// SetNillableWebhookSchemaVersion sets the "webhook_schema_version" field if the given value is not nil.
+func (_c *AppStripeCreate) SetNillableWebhookSchemaVersion(v *int) *AppStripeCreate {
+	if v != nil {
+		_c.SetWebhookSchemaVersion(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *AppStripeCreate) SetID(v string) *AppStripeCreate {
 	_c.mutation.SetID(v)
@@ -216,6 +230,10 @@ func (_c *AppStripeCreate) defaults() {
 		v := appstripe.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.WebhookSchemaVersion(); !ok {
+		v := appstripe.DefaultWebhookSchemaVersion
+		_c.mutation.SetWebhookSchemaVersion(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := appstripe.DefaultID()
 		_c.mutation.SetID(v)
@@ -268,6 +286,14 @@ func (_c *AppStripeCreate) check() error {
 	if v, ok := _c.mutation.WebhookSecret(); ok {
 		if err := appstripe.WebhookSecretValidator(v); err != nil {
 			return &ValidationError{Name: "webhook_secret", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_secret": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.WebhookSchemaVersion(); !ok {
+		return &ValidationError{Name: "webhook_schema_version", err: errors.New(`db: missing required field "AppStripe.webhook_schema_version"`)}
+	}
+	if v, ok := _c.mutation.WebhookSchemaVersion(); ok {
+		if err := appstripe.WebhookSchemaVersionValidator(v); err != nil {
+			return &ValidationError{Name: "webhook_schema_version", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_schema_version": %w`, err)}
 		}
 	}
 	return nil
@@ -345,6 +371,10 @@ func (_c *AppStripeCreate) createSpec() (*AppStripe, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.WebhookSecret(); ok {
 		_spec.SetField(appstripe.FieldWebhookSecret, field.TypeString, value)
 		_node.WebhookSecret = &value
+	}
+	if value, ok := _c.mutation.WebhookSchemaVersion(); ok {
+		_spec.SetField(appstripe.FieldWebhookSchemaVersion, field.TypeInt, value)
+		_node.WebhookSchemaVersion = value
 	}
 	if nodes := _c.mutation.CustomerAppsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -521,6 +551,24 @@ func (u *AppStripeUpsert) ClearWebhookSecret() *AppStripeUpsert {
 	return u
 }
 
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (u *AppStripeUpsert) SetWebhookSchemaVersion(v int) *AppStripeUpsert {
+	u.Set(appstripe.FieldWebhookSchemaVersion, v)
+	return u
+}
+
+// UpdateWebhookSchemaVersion sets the "webhook_schema_version" field to the value that was provided on create.
+func (u *AppStripeUpsert) UpdateWebhookSchemaVersion() *AppStripeUpsert {
+	u.SetExcluded(appstripe.FieldWebhookSchemaVersion)
+	return u
+}
+
+// AddWebhookSchemaVersion adds v to the "webhook_schema_version" field.
+func (u *AppStripeUpsert) AddWebhookSchemaVersion(v int) *AppStripeUpsert {
+	u.Add(appstripe.FieldWebhookSchemaVersion, v)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -683,6 +731,27 @@ func (u *AppStripeUpsertOne) UpdateWebhookSecret() *AppStripeUpsertOne {
 func (u *AppStripeUpsertOne) ClearWebhookSecret() *AppStripeUpsertOne {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.ClearWebhookSecret()
+	})
+}
+
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (u *AppStripeUpsertOne) SetWebhookSchemaVersion(v int) *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.SetWebhookSchemaVersion(v)
+	})
+}
+
+// AddWebhookSchemaVersion adds v to the "webhook_schema_version" field.
+func (u *AppStripeUpsertOne) AddWebhookSchemaVersion(v int) *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.AddWebhookSchemaVersion(v)
+	})
+}
+
+// UpdateWebhookSchemaVersion sets the "webhook_schema_version" field to the value that was provided on create.
+func (u *AppStripeUpsertOne) UpdateWebhookSchemaVersion() *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.UpdateWebhookSchemaVersion()
 	})
 }
 
@@ -1015,6 +1084,27 @@ func (u *AppStripeUpsertBulk) UpdateWebhookSecret() *AppStripeUpsertBulk {
 func (u *AppStripeUpsertBulk) ClearWebhookSecret() *AppStripeUpsertBulk {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.ClearWebhookSecret()
+	})
+}
+
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (u *AppStripeUpsertBulk) SetWebhookSchemaVersion(v int) *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.SetWebhookSchemaVersion(v)
+	})
+}
+
+// AddWebhookSchemaVersion adds v to the "webhook_schema_version" field.
+func (u *AppStripeUpsertBulk) AddWebhookSchemaVersion(v int) *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.AddWebhookSchemaVersion(v)
+	})
+}
+
+// UpdateWebhookSchemaVersion sets the "webhook_schema_version" field to the value that was provided on create.
+func (u *AppStripeUpsertBulk) UpdateWebhookSchemaVersion() *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.UpdateWebhookSchemaVersion()
 	})
 }
 

--- a/openmeter/ent/db/appstripe_update.go
+++ b/openmeter/ent/db/appstripe_update.go
@@ -123,6 +123,27 @@ func (_u *AppStripeUpdate) ClearWebhookSecret() *AppStripeUpdate {
 	return _u
 }
 
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (_u *AppStripeUpdate) SetWebhookSchemaVersion(v int) *AppStripeUpdate {
+	_u.mutation.ResetWebhookSchemaVersion()
+	_u.mutation.SetWebhookSchemaVersion(v)
+	return _u
+}
+
+// SetNillableWebhookSchemaVersion sets the "webhook_schema_version" field if the given value is not nil.
+func (_u *AppStripeUpdate) SetNillableWebhookSchemaVersion(v *int) *AppStripeUpdate {
+	if v != nil {
+		_u.SetWebhookSchemaVersion(*v)
+	}
+	return _u
+}
+
+// AddWebhookSchemaVersion adds value to the "webhook_schema_version" field.
+func (_u *AppStripeUpdate) AddWebhookSchemaVersion(v int) *AppStripeUpdate {
+	_u.mutation.AddWebhookSchemaVersion(v)
+	return _u
+}
+
 // AddCustomerAppIDs adds the "customer_apps" edge to the AppStripeCustomer entity by IDs.
 func (_u *AppStripeUpdate) AddCustomerAppIDs(ids ...int) *AppStripeUpdate {
 	_u.mutation.AddCustomerAppIDs(ids...)
@@ -222,6 +243,11 @@ func (_u *AppStripeUpdate) check() error {
 			return &ValidationError{Name: "webhook_secret", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_secret": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.WebhookSchemaVersion(); ok {
+		if err := appstripe.WebhookSchemaVersionValidator(v); err != nil {
+			return &ValidationError{Name: "webhook_schema_version", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_schema_version": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -263,6 +289,12 @@ func (_u *AppStripeUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.WebhookSecretCleared() {
 		_spec.ClearField(appstripe.FieldWebhookSecret, field.TypeString)
+	}
+	if value, ok := _u.mutation.WebhookSchemaVersion(); ok {
+		_spec.SetField(appstripe.FieldWebhookSchemaVersion, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedWebhookSchemaVersion(); ok {
+		_spec.AddField(appstripe.FieldWebhookSchemaVersion, field.TypeInt, value)
 	}
 	if _u.mutation.CustomerAppsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -423,6 +455,27 @@ func (_u *AppStripeUpdateOne) ClearWebhookSecret() *AppStripeUpdateOne {
 	return _u
 }
 
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (_u *AppStripeUpdateOne) SetWebhookSchemaVersion(v int) *AppStripeUpdateOne {
+	_u.mutation.ResetWebhookSchemaVersion()
+	_u.mutation.SetWebhookSchemaVersion(v)
+	return _u
+}
+
+// SetNillableWebhookSchemaVersion sets the "webhook_schema_version" field if the given value is not nil.
+func (_u *AppStripeUpdateOne) SetNillableWebhookSchemaVersion(v *int) *AppStripeUpdateOne {
+	if v != nil {
+		_u.SetWebhookSchemaVersion(*v)
+	}
+	return _u
+}
+
+// AddWebhookSchemaVersion adds value to the "webhook_schema_version" field.
+func (_u *AppStripeUpdateOne) AddWebhookSchemaVersion(v int) *AppStripeUpdateOne {
+	_u.mutation.AddWebhookSchemaVersion(v)
+	return _u
+}
+
 // AddCustomerAppIDs adds the "customer_apps" edge to the AppStripeCustomer entity by IDs.
 func (_u *AppStripeUpdateOne) AddCustomerAppIDs(ids ...int) *AppStripeUpdateOne {
 	_u.mutation.AddCustomerAppIDs(ids...)
@@ -535,6 +588,11 @@ func (_u *AppStripeUpdateOne) check() error {
 			return &ValidationError{Name: "webhook_secret", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_secret": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.WebhookSchemaVersion(); ok {
+		if err := appstripe.WebhookSchemaVersionValidator(v); err != nil {
+			return &ValidationError{Name: "webhook_schema_version", err: fmt.Errorf(`db: validator failed for field "AppStripe.webhook_schema_version": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -593,6 +651,12 @@ func (_u *AppStripeUpdateOne) sqlSave(ctx context.Context) (_node *AppStripe, er
 	}
 	if _u.mutation.WebhookSecretCleared() {
 		_spec.ClearField(appstripe.FieldWebhookSecret, field.TypeString)
+	}
+	if value, ok := _u.mutation.WebhookSchemaVersion(); ok {
+		_spec.SetField(appstripe.FieldWebhookSchemaVersion, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedWebhookSchemaVersion(); ok {
+		_spec.AddField(appstripe.FieldWebhookSchemaVersion, field.TypeInt, value)
 	}
 	if _u.mutation.CustomerAppsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -380,6 +380,7 @@ var (
 		{Name: "masked_api_key", Type: field.TypeString},
 		{Name: "stripe_webhook_id", Type: field.TypeString},
 		{Name: "webhook_secret", Type: field.TypeString, Nullable: true},
+		{Name: "webhook_schema_version", Type: field.TypeInt, Default: 1},
 	}
 	// AppStripesTable holds the schema information for the "app_stripes" table.
 	AppStripesTable = &schema.Table{

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -7544,28 +7544,30 @@ func (m *AppCustomerMutation) ResetEdge(name string) error {
 // AppStripeMutation represents an operation that mutates the AppStripe nodes in the graph.
 type AppStripeMutation struct {
 	config
-	op                   Op
-	typ                  string
-	id                   *string
-	namespace            *string
-	created_at           *time.Time
-	updated_at           *time.Time
-	deleted_at           *time.Time
-	stripe_account_id    *string
-	stripe_livemode      *bool
-	api_key              *string
-	masked_api_key       *string
-	stripe_webhook_id    *string
-	webhook_secret       *string
-	clearedFields        map[string]struct{}
-	customer_apps        map[int]struct{}
-	removedcustomer_apps map[int]struct{}
-	clearedcustomer_apps bool
-	app                  *string
-	clearedapp           bool
-	done                 bool
-	oldValue             func(context.Context) (*AppStripe, error)
-	predicates           []predicate.AppStripe
+	op                        Op
+	typ                       string
+	id                        *string
+	namespace                 *string
+	created_at                *time.Time
+	updated_at                *time.Time
+	deleted_at                *time.Time
+	stripe_account_id         *string
+	stripe_livemode           *bool
+	api_key                   *string
+	masked_api_key            *string
+	stripe_webhook_id         *string
+	webhook_secret            *string
+	webhook_schema_version    *int
+	addwebhook_schema_version *int
+	clearedFields             map[string]struct{}
+	customer_apps             map[int]struct{}
+	removedcustomer_apps      map[int]struct{}
+	clearedcustomer_apps      bool
+	app                       *string
+	clearedapp                bool
+	done                      bool
+	oldValue                  func(context.Context) (*AppStripe, error)
+	predicates                []predicate.AppStripe
 }
 
 var _ ent.Mutation = (*AppStripeMutation)(nil)
@@ -8071,6 +8073,62 @@ func (m *AppStripeMutation) ResetWebhookSecret() {
 	delete(m.clearedFields, appstripe.FieldWebhookSecret)
 }
 
+// SetWebhookSchemaVersion sets the "webhook_schema_version" field.
+func (m *AppStripeMutation) SetWebhookSchemaVersion(i int) {
+	m.webhook_schema_version = &i
+	m.addwebhook_schema_version = nil
+}
+
+// WebhookSchemaVersion returns the value of the "webhook_schema_version" field in the mutation.
+func (m *AppStripeMutation) WebhookSchemaVersion() (r int, exists bool) {
+	v := m.webhook_schema_version
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldWebhookSchemaVersion returns the old "webhook_schema_version" field's value of the AppStripe entity.
+// If the AppStripe object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AppStripeMutation) OldWebhookSchemaVersion(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldWebhookSchemaVersion is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldWebhookSchemaVersion requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldWebhookSchemaVersion: %w", err)
+	}
+	return oldValue.WebhookSchemaVersion, nil
+}
+
+// AddWebhookSchemaVersion adds i to the "webhook_schema_version" field.
+func (m *AppStripeMutation) AddWebhookSchemaVersion(i int) {
+	if m.addwebhook_schema_version != nil {
+		*m.addwebhook_schema_version += i
+	} else {
+		m.addwebhook_schema_version = &i
+	}
+}
+
+// AddedWebhookSchemaVersion returns the value that was added to the "webhook_schema_version" field in this mutation.
+func (m *AppStripeMutation) AddedWebhookSchemaVersion() (r int, exists bool) {
+	v := m.addwebhook_schema_version
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetWebhookSchemaVersion resets all changes to the "webhook_schema_version" field.
+func (m *AppStripeMutation) ResetWebhookSchemaVersion() {
+	m.webhook_schema_version = nil
+	m.addwebhook_schema_version = nil
+}
+
 // AddCustomerAppIDs adds the "customer_apps" edge to the AppStripeCustomer entity by ids.
 func (m *AppStripeMutation) AddCustomerAppIDs(ids ...int) {
 	if m.customer_apps == nil {
@@ -8198,7 +8256,7 @@ func (m *AppStripeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AppStripeMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.namespace != nil {
 		fields = append(fields, appstripe.FieldNamespace)
 	}
@@ -8229,6 +8287,9 @@ func (m *AppStripeMutation) Fields() []string {
 	if m.webhook_secret != nil {
 		fields = append(fields, appstripe.FieldWebhookSecret)
 	}
+	if m.webhook_schema_version != nil {
+		fields = append(fields, appstripe.FieldWebhookSchemaVersion)
+	}
 	return fields
 }
 
@@ -8257,6 +8318,8 @@ func (m *AppStripeMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeWebhookID()
 	case appstripe.FieldWebhookSecret:
 		return m.WebhookSecret()
+	case appstripe.FieldWebhookSchemaVersion:
+		return m.WebhookSchemaVersion()
 	}
 	return nil, false
 }
@@ -8286,6 +8349,8 @@ func (m *AppStripeMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldStripeWebhookID(ctx)
 	case appstripe.FieldWebhookSecret:
 		return m.OldWebhookSecret(ctx)
+	case appstripe.FieldWebhookSchemaVersion:
+		return m.OldWebhookSchemaVersion(ctx)
 	}
 	return nil, fmt.Errorf("unknown AppStripe field %s", name)
 }
@@ -8365,6 +8430,13 @@ func (m *AppStripeMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetWebhookSecret(v)
 		return nil
+	case appstripe.FieldWebhookSchemaVersion:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetWebhookSchemaVersion(v)
+		return nil
 	}
 	return fmt.Errorf("unknown AppStripe field %s", name)
 }
@@ -8372,13 +8444,21 @@ func (m *AppStripeMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *AppStripeMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addwebhook_schema_version != nil {
+		fields = append(fields, appstripe.FieldWebhookSchemaVersion)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *AppStripeMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case appstripe.FieldWebhookSchemaVersion:
+		return m.AddedWebhookSchemaVersion()
+	}
 	return nil, false
 }
 
@@ -8387,6 +8467,13 @@ func (m *AppStripeMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *AppStripeMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case appstripe.FieldWebhookSchemaVersion:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddWebhookSchemaVersion(v)
+		return nil
 	}
 	return fmt.Errorf("unknown AppStripe numeric field %s", name)
 }
@@ -8464,6 +8551,9 @@ func (m *AppStripeMutation) ResetField(name string) error {
 		return nil
 	case appstripe.FieldWebhookSecret:
 		m.ResetWebhookSecret()
+		return nil
+	case appstripe.FieldWebhookSchemaVersion:
+		m.ResetWebhookSchemaVersion()
 		return nil
 	}
 	return fmt.Errorf("unknown AppStripe field %s", name)

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -402,6 +402,12 @@ func init() {
 	appstripeDescWebhookSecret := appstripeFields[5].Descriptor()
 	// appstripe.WebhookSecretValidator is a validator for the "webhook_secret" field. It is called by the builders before save.
 	appstripe.WebhookSecretValidator = appstripeDescWebhookSecret.Validators[0].(func(string) error)
+	// appstripeDescWebhookSchemaVersion is the schema descriptor for webhook_schema_version field.
+	appstripeDescWebhookSchemaVersion := appstripeFields[6].Descriptor()
+	// appstripe.DefaultWebhookSchemaVersion holds the default value on creation for the webhook_schema_version field.
+	appstripe.DefaultWebhookSchemaVersion = appstripeDescWebhookSchemaVersion.Default.(int)
+	// appstripe.WebhookSchemaVersionValidator is a validator for the "webhook_schema_version" field. It is called by the builders before save.
+	appstripe.WebhookSchemaVersionValidator = appstripeDescWebhookSchemaVersion.Validators[0].(func(int) error)
 	// appstripeDescID is the schema descriptor for id field.
 	appstripeDescID := appstripeMixinFields0[0].Descriptor()
 	// appstripe.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/app_stripe.go
+++ b/openmeter/ent/schema/app_stripe.go
@@ -33,6 +33,7 @@ func (AppStripe) Fields() []ent.Field {
 		field.String("masked_api_key").NotEmpty(),
 		field.String("stripe_webhook_id").NotEmpty(),
 		field.String("webhook_secret").Optional().Nillable().NotEmpty().Sensitive(),
+		field.Int("webhook_schema_version").Default(1).Min(1),
 	}
 }
 

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v80/webhook"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -2202,6 +2204,38 @@ func (n NoopLLMCostService) DeleteOverride(ctx context.Context, input llmcost.De
 
 func (n NoopLLMCostService) ListOverrides(ctx context.Context, input llmcost.ListOverridesInput) (pagination.Result[llmcost.Price], error) {
 	return pagination.Result[llmcost.Price]{}, nil
+}
+
+func TestAppStripeWebhookAcknowledgesSchemaV2Events(t *testing.T) {
+	const appID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+	path := "/api/v1/apps/" + appID + "/stripe/webhook"
+
+	// NoopAppStripeService returns an empty webhook secret, so payloads are signed with an empty key.
+	post := func(t *testing.T, eventType string) (int, string) {
+		testServer, _ := getTestServer(t)
+		payload := []byte(`{"id":"evt_1","type":"` + eventType + `","api_version":"` + stripe.APIVersion + `","livemode":false,"created":1,"data":{"object":{}}}`)
+		signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{Payload: payload, Secret: ""})
+
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(signed.Payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Stripe-Signature", signed.Header)
+		w := httptest.NewRecorder()
+		testServer.ServeHTTP(w, req)
+
+		return w.Code, w.Body.String()
+	}
+
+	t.Run("registered schema v2 events are acknowledged without processing", func(t *testing.T) {
+		for _, eventType := range []string{"payment_intent.succeeded", "credit_note.voided", "invoice.finalized"} {
+			code, body := post(t, eventType)
+			require.Equal(t, http.StatusCreated, code, body)
+		}
+	})
+
+	t.Run("unregistered events are rejected", func(t *testing.T) {
+		code, body := post(t, "customer.created")
+		require.Equal(t, http.StatusBadRequest, code, body)
+	})
 }
 
 func TestAppStripeWebhookOversizedPayload(t *testing.T) {

--- a/test/app/stripe/appstripe.go
+++ b/test/app/stripe/appstripe.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"
+	appstripeservice "github.com/openmeterio/openmeter/openmeter/app/stripe/service"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
@@ -74,6 +75,10 @@ func (s *AppHandlerTestSuite) TestCreate(ctx context.Context, t *testing.T) {
 
 	require.NoError(t, err, "Create stripe app must not return error")
 	require.NotNil(t, createApp.App, "Create stripe app must return app")
+
+	stripeApp, ok := createApp.App.(appstripe.App)
+	require.True(t, ok, "Create stripe app must return a stripe app")
+	require.Equal(t, appstripeservice.LatestWebhookSchemaVersion, stripeApp.WebhookSchemaVersion)
 
 	// Create with same Stripe account ID should return conflict
 	_, err = s.Env.App().InstallApp(ctx, app.InstallAppV3Input{

--- a/tools/migrate/migrations/20260911165152_add_app_stripe_webhook_schema_version.down.sql
+++ b/tools/migrate/migrations/20260911165152_add_app_stripe_webhook_schema_version.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "app_stripes" table
+ALTER TABLE "app_stripes" DROP COLUMN "webhook_schema_version";

--- a/tools/migrate/migrations/20260911165152_add_app_stripe_webhook_schema_version.up.sql
+++ b/tools/migrate/migrations/20260911165152_add_app_stripe_webhook_schema_version.up.sql
@@ -1,0 +1,2 @@
+-- modify "app_stripes" table
+ALTER TABLE "app_stripes" ADD COLUMN "webhook_schema_version" bigint NOT NULL DEFAULT 1;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:dl9qy1YR2XTlBKnZwVNvLwCiIKu2X1wacVJ0zLXP6dM=
+h1:hQL8vrE4Kn/ZEE+oG5XpIU+ZGuYw2OdhM0+0ns0cg+I=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -279,3 +279,4 @@ h1:dl9qy1YR2XTlBKnZwVNvLwCiIKu2X1wacVJ0zLXP6dM=
 20260903102842_add_lineage_custom_currency_identity.up.sql h1:KHYAUoTB7vwPQ/wsLAoRCm5gQGml5L1t3QExsZdwKWE=
 20260906100323_add_charge_and_billing_validation_issues.up.sql h1:nHSiTwJq6s7c3SU1CV103bpnPf2Nsi3zLm6UIIyF8sA=
 20260909104736_make_usage_based_feature_id_optional.up.sql h1:yhB56cUSZHgNXSig3A6VKDt3ktG0E4LXHj1/vo1sz8I=
+20260911165152_add_app_stripe_webhook_schema_version.up.sql h1:/vFLdVkBeP50PF+fApPxTwcFWbSzQwP4efCAuHAim94=


### PR DESCRIPTION
Ticket: OM-515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Stripe installations now register webhook schema version 2, covering payment intents, credit notes, refunds, and finalized invoices.
  * Stripe app details now retain the webhook schema version for visibility and compatibility.

* **Bug Fixes**
  * Newly supported Stripe webhook events are acknowledged successfully instead of being rejected as unsupported.
  * Existing Stripe installations remain compatible with their previously registered webhook event set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63182533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking maintainability gap around keeping the persisted schema version synchronized with its exact Stripe event set.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aopenmeter%2Fapp%2Fstripe%2Fservice%2Fconst.go%3A11%0A%60LatestWebhookSchemaVersion%60%20and%20the%20enabled%20Stripe%20event%20list%20are%20maintained%20separately.%20The%20tests%20confirm%20that%20installations%20persist%20the%20constant%20and%20acknowledge%20three%20representative%20events%2C%20but%20they%20do%20not%20fail%20if%20the%20event%20list%20changes%20without%20a%20version%20bump%2C%20or%20vice%20versa.%20This%20can%20leave%20the%20stored%20compatibility%20marker%20out%20of%20sync%20with%20the%20endpoint%E2%80%99s%20actual%20configuration.%20Define%20the%20versioned%20event%20set%20in%20one%20shared%20location%20or%20add%20an%20exhaustive%20test%20tying%20version%202%20to%20the%20exact%20registered%20list.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=openmeterio%2Fopenmeter&pr=5124&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Schema Version Can Drift** <a href="https://github.com/openmeterio/openmeter/pull/5124#discussion_r3991980178">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
openmeter/app/stripe/service/const.go:11
`LatestWebhookSchemaVersion` and the enabled Stripe event list are maintained separately. The tests confirm that installations persist the constant and acknowledge three representative events, but they do not fail if the event list changes without a version bump, or vice versa. This can leave the stored compatibility marker out of sync with the endpoint’s actual configuration. Define the versioned event set in one shared location or add an exhaustive test tying version 2 to the exact registered list.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds and backfills the `webhook_schema_version` database column.
- Registers payment-intent, credit-note, refund, and invoice-finalized events for new installations.
- Acknowledges the new event types without processing to keep Stripe endpoints healthy.
- Propagates the stored version through Stripe app persistence and adds focused validation and integration coverage.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Existing[Existing Stripe app] -->|Migration backfill| V1[Schema version 1]
  Install[New Stripe app installation] --> Register[Register Stripe webhook]
  Register --> Events[Version 1 and version 2 event set]
  Events --> Persist[Persist schema version 2]
  Stripe[Stripe delivery] --> Verify[Verify signature and decode event]
  Verify --> Legacy[Process existing event types]
  Verify --> New[Acknowledge version 2 event types]
  New --> Created[HTTP 201 without processing]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["feat: add webhook\_schema\_version column ..."](https://github.com/openmeterio/openmeter/commit/71fd775dfeda64a7de58e97f45686f12f83758f7)</sub>

<!-- /greptile_comment -->